### PR TITLE
Cap redis install below 3.0.0

### DIFF
--- a/docker/airflow/1.10.1/Dockerfile
+++ b/docker/airflow/1.10.1/Dockerfile
@@ -73,6 +73,7 @@ RUN apk update \
 	&& pip3 install --no-cache-dir cython \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir flask-appbuilder==1.11.1 \
+	&& pip3 install --no-cache-dir "redis>=2.6,<3" \
 	&& apk del .build-deps \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip

--- a/docker/airflow/1.10.1/Dockerfile
+++ b/docker/airflow/1.10.1/Dockerfile
@@ -73,7 +73,7 @@ RUN apk update \
 	&& pip3 install --no-cache-dir cython \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir flask-appbuilder==1.11.1 \
-	&& pip3 install --no-cache-dir "redis>=2.6,<3" \
+	&& pip3 install --no-cache-dir "redis>=2.10.5,<3" \
 	&& apk del .build-deps \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip

--- a/docker/airflow/1.9.0/Dockerfile
+++ b/docker/airflow/1.9.0/Dockerfile
@@ -67,6 +67,7 @@ RUN apk update \
 	&& pip3 install --no-cache-dir cython \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "sqlalchemy>=1.1.15,<1.2.0" \
+	&& pip3 install --no-cache-dir "redis>=2.10.5,<3" \
 	&& pip3 uninstall -y snakebite \
 	&& apk del .build-deps \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
Installs redis in Dockerfile to avoid Celery `iteritems()` issue brought by Redis 3.X

https://github.com/celery/celery/pull/5216