### PR TITLE
bump elastic and kibana to 7.2.0

### DIFF
--- a/docker/vendor/elasticsearch/Dockerfile
+++ b/docker/vendor/elasticsearch/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.1.1
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:7.2.0
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1

--- a/docker/vendor/kibana/Dockerfile
+++ b/docker/vendor/kibana/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.elastic.co/kibana/kibana-oss:7.1.1
+FROM docker.elastic.co/kibana/kibana-oss:7.2.0
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1


### PR DESCRIPTION
```
{
name: "flailing-quetzal-elasticsearch-client-bf977b95c-h7wbn",
cluster_name: "astronomer",
cluster_uuid: "N4GbB-okSQ6zNbuGHyPrzw",
version: {
number: "7.2.0",
build_flavor: "oss",
build_type: "docker",
build_hash: "508c38a",
build_date: "2019-06-20T15:54:18.811730Z",
build_snapshot: false,
lucene_version: "8.0.0",
minimum_wire_compatibility_version: "6.8.0",
minimum_index_compatibility_version: "6.0.0-beta1"
},
tagline: "You Know, for Search"
}
```

and 
```
kubectl get pods --namespace andrii-dev | grep elastic
flailing-quetzal-elasticsearch-client-bf977b95c-h7wbn      1/1       Running   0          5m
flailing-quetzal-elasticsearch-client-bf977b95c-r99qb      1/1       Running   0          5m
flailing-quetzal-elasticsearch-data-0                      1/1       Running   0          5m
flailing-quetzal-elasticsearch-data-1                      1/1       Running   0          4m
flailing-quetzal-elasticsearch-exporter-8496dc79b8-987j5   1/1       Running   0          5m
flailing-quetzal-elasticsearch-master-0                    1/1       Running   0          5m
flailing-quetzal-elasticsearch-master-1                    1/1       Running   0          4m
flailing-quetzal-elasticsearch-master-2                    1/1       Running   0          3m
flailing-quetzal-elasticsearch-nginx-558c9f84f8-h7cd8      1/1       Running   0          5m
```