### PR TITLE
pin flask to version 1.0.0

### DIFF
--- a/docker/airflow/1.10.3/Dockerfile
+++ b/docker/airflow/1.10.3/Dockerfile
@@ -76,6 +76,7 @@ RUN apk update \
 	&& pip3 install --no-cache-dir --upgrade setuptools==39.0.1 \
 	&& pip3 install --no-cache-dir cython \
 	&& pip3 install --no-cache-dir numpy \
+	&& pip3 install --no-cache-dir flask==1.0.0 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.0.2/astronomer_fab_security_manager-1.0.2-py3-none-any.whl" \
 	&& cd /usr/lib/python3.6/site-packages/airflow/www_rbac \


### PR DESCRIPTION
this is to fix the werkzeug bug. this should be resolved in Airflow 1.10.4