### PR TITLE
Sync Airflow permissions when starting the webserver

### DIFF
--- a/docker/airflow/1.10.3/Dockerfile
+++ b/docker/airflow/1.10.3/Dockerfile
@@ -78,7 +78,7 @@ RUN apk update \
 	&& pip3 install --no-cache-dir numpy \
 	&& pip3 install --no-cache-dir flask==1.0.0 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
-	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.0.2/astronomer_fab_security_manager-1.0.2-py3-none-any.whl" \
+	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.1.0/astronomer_fab_security_manager-1.1.0-py3-none-any.whl" \
 	&& cd /usr/lib/python3.6/site-packages/airflow/www_rbac \
 	&& npm install \
 	&& npm run build \

--- a/docker/airflow/1.10.3/include/entrypoint
+++ b/docker/airflow/1.10.3/include/entrypoint
@@ -29,5 +29,9 @@ if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower
   done
 fi
 
+if [[ $CMD == "webserver" ]]; then
+  airflow sync_perm
+fi
+
 # Run the original command
 exec "$@"


### PR DESCRIPTION
This will come more in to play in Airflow in the future where this
command will ensure that all the dag-level access control is crrect in
the DB for new dags, but right now we want this to add the extra missing
permissions we added in astronomer/astronomer-fab-securitymanager#4

Closes astronomer/astronomer#353