### PR TITLE
bump grafana

### DIFF
--- a/bin/clair-scan.sh
+++ b/bin/clair-scan.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Make sure you installed and run
+# docker run -p 5432:5432 -d --name db arminc/clair-db:latest
+# and
+# docker run -p 6060:6060 --link db:postgres -d --name clair arminc/clair-local-scan:latest
+
+RELEASE_TAG=master
+declare -a TARGET_IMAGES=("ap-base"
+                          "ap-airflow"
+                          "ap-alertmanager"
+                          "ap-cadvisor"
+                          "ap-curator"
+                          "ap-elasticsearch"
+                          "ap-elasticsearch-exporter"
+                          "ap-fluentd"
+                          "ap-grafana"
+                          "ap-kibana"
+                          "ap-kube-replicator"
+                          "ap-kube-state"
+                          "ap-nginx"
+                          "ap-nginx-es"
+                          "ap-pgbouncer"
+                          "ap-pgbouncer-exporter"
+                          "ap-prisma"
+                          "ap-prometheus"
+                          "ap-redis"
+                          "ap-registry"
+                          "ap-statsd-exporter")
+
+
+for i in "${TARGET_IMAGES[@]}"
+do
+   image="astronomerinc/$i:$RELEASE_TAG"
+   echo "scanning: $image"
+   docker pull $image > results.log
+   clair-scanner --ip=192.168.1.199 $image &> "${i}_results.txt"
+   high_count=`grep High ${i}_results.txt | wc -l`
+   medium_count=`grep Medium ${i}_results.txt | wc -l`
+   low_count=`grep Low ${i}_results.txt | wc -l`
+   negligible_count=`grep Negligible ${i}_results.txt | wc -l`
+   unknown_count=`grep Unknown ${i}_results.txt | wc -l`
+   echo "Docker image \"$image\" have: ${high_count//[[:space:]]/} High / ${medium_count//[[:space:]]/} Medium / ${low_count//[[:space:]]/} Low"
+done

--- a/docker/vendor/grafana/Dockerfile
+++ b/docker/vendor/grafana/Dockerfile
@@ -12,8 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-FROM grafana/grafana:6.0.0
+FROM grafana/grafana:6.3.0-beta4
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1

--- a/docker/vendor/nginx/Dockerfile
+++ b/docker/vendor/nginx/Dockerfile
@@ -21,5 +21,6 @@ LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
 USER root
-RUN apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y
+RUN apt-get update && apt-get dist-upgrade -y && apt-get clean && apt-get autoremove -y && apt-get --purge remove -y gdb
+# respect original Dockerfile https://github.com/kubernetes/ingress-nginx/blob/master/rootfs/Dockerfile
 USER www-data

--- a/docker/vendor/nginx/Dockerfile
+++ b/docker/vendor/nginx/Dockerfile
@@ -19,3 +19,7 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+
+USER root
+RUN apt-get update && apt-get dist-upgrade -y && apt-get autoremove -y
+USER www-data

--- a/docker/vendor/nginx/Dockerfile
+++ b/docker/vendor/nginx/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.22.0
+FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.0
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1


### PR DESCRIPTION
v6.3.0-beta4
Docker: Switch base image to ubuntu:latest from debian:stretch to avoid security issues.

**before this change:**
- `2019/08/02 17:12:23 [ERRO] ▶ Image [grafana/grafana:6.0.0] contains 99 unapproved vulnerabilities`

**after this change:**
- `2019/08/02 17:08:42 [ERRO] ▶ Image [ap-grafana:latest] contains 35 unapproved vulnerabilities` 8 medium and 18 Low
```
| Unapproved | Medium CVE-2019-12904       | libgcrypt20  | 1.8.1-4ubuntu1.1         | In Libgcrypt 1.8.4, the C implementation of AES is             |
| Unapproved | Medium CVE-2019-11922       | libzstd      | 1.3.3+dfsg-2ubuntu1      | A race condition in the one-pass compression functions         |
| Unapproved | Medium CVE-2018-19591       | glibc        | 2.27-3ubuntu1            | In the GNU C Library (aka glibc or libc6) through 2.28,        |
| Unapproved | Medium CVE-2018-11237       | glibc        | 2.27-3ubuntu1            | An AVX-512-optimized implementation of the mempcpy             |
| Unapproved | Medium CVE-2018-11236       | glibc        | 2.27-3ubuntu1            | stdlib/canonicalize.c in the GNU C Library (aka glibc          |
| Unapproved | Medium CVE-2018-20839       | systemd      | 237-3ubuntu10.24         | systemd 242 changes the VT1 mode upon a logout, which          |
| Unapproved | Medium CVE-2018-20217       | krb5         | 1.16-2ubuntu0.1          | A Reachable Assertion issue was discovered in the KDC          |
| Unapproved | Medium CVE-2019-13050       | gnupg2       | 2.2.4-1ubuntu1.2         | Interaction between the sks-keyserver code through 1.2.0       |
``` 