### PR TITLE
[#416] Add mappings for new Statsd metrics

### DIFF
--- a/docker/vendor/statsd-exporter/include/mappings.yml
+++ b/docker/vendor/statsd-exporter/include/mappings.yml
@@ -24,3 +24,49 @@ mappings:
     name: "airflow_scheduler_heartbeat"
     labels:
       type: counter
+
+  - match: airflow.dag.*.*.duration
+    name: "airflow_task_duration"
+    labels:
+      dag_id: "$1"
+      task_id: "$2"
+
+  - match: airflow.dagrun.duration.success.*
+    name: "airflow_dagrun_duration"
+    labels:
+      dag_id: "$1"
+
+  - match: airflow.dagrun.duration.failed.*
+    name: "airflow_dagrun_failed"
+    labels:
+      dag_id: "$1"
+
+  - match: airflow.dagrun.schedule_delay.*
+    name: "airflow_dagrun_schedule_delay"
+    labels:
+      dag_id: "$1"
+
+  - match: airflow.dag_processing.last_runtime.*
+      name: "airflow_dag_processing_last_runtime"
+      labels:
+        dag_file: "$1"
+
+  - match: airflow.dag_processing.last_run.seconds_ago.*
+      name: "airflow_dag_processing_last_run_seconds_ago"
+      labels:
+        dag_file: "$1"
+
+  - match: airflow.pool.open_slots.*
+      name: "airflow_pool_open_slots"
+      labels:
+        pool: "$1"
+
+  - match: airflow.pool.used_slots.*
+      name: "airflow_pool_used_slots"
+      labels:
+        pool: "$1"
+
+  - match: airflow.pool.starving_tasks.*
+      name: "airflow_pool_starving_tasks"
+      labels:
+        pool: "$1"


### PR DESCRIPTION
**Issue**: https://github.com/astronomer/astronomer/issues/416

This PR adds mappings to new metrics so that we no longer have metrics as follows:

![image](https://user-images.githubusercontent.com/8811558/64203292-ff90d000-ce8a-11e9-83a2-2ace5bdefa1d.png)

Instead stuff like dag_id, task_id would become labels.