### PR TITLE
Use pre-packaged Alpine packages from edge repo for faster builds

### DIFF
--- a/docker/airflow/1.10.4/Dockerfile
+++ b/docker/airflow/1.10.4/Dockerfile
@@ -42,6 +42,9 @@ ENV ASTRONOMER_GROUP=${ASTRONOMER_GROUP}
 RUN addgroup -S ${ASTRONOMER_GROUP} \
 	&& adduser -S -G ${ASTRONOMER_GROUP} ${ASTRONOMER_USER}
 
+RUN echo @edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+    echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
 # Install packages
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \
@@ -55,39 +58,43 @@ RUN apk update \
 		libxml2-dev \
 		libxslt-dev \
 		linux-headers \
-		mariadb-dev \
 		nodejs \
 		nodejs-npm \
-		postgresql-dev \
 		python3-dev \
 		tzdata \
-		libsodium \
-		libsodium-dev \
 	&& apk add --no-cache \
 		bash \
 		ca-certificates \
 		cyrus-sasl \
+		cython3@edge \
+		freetds \
 		krb5-libs \
-		mariadb-connector-c \
-		postgresql \
+		py3-bcrypt@edge \
+		py3-cassandra-driver@edge-testing'>='3 \
+		py3-cryptography@edge \
+		py3-fastavro@edge-testing \
+		py3-grpcio@edge-testing \
+		py3-mysqlclient \
+		py3-numpy-dev@edge-community \
+		py3-numpy@edge-community \
+		py3-pandas@edge-testing \
+		py3-psycopg2 \
+		py3-pycryptodome@edge-community \
+		py3-pynacl@edge \
+		py3-typed-ast@edge-testing \
 		python3 \
 		tini \
 	&& update-ca-certificates \
 	&& cp /usr/share/zoneinfo/UTC /etc/localtime \
 	&& pip3 install --no-cache-dir --upgrade pip==19.2.1 \
 	&& pip3 install --no-cache-dir --upgrade setuptools==41.0.1 \
-	&& pip3 install --no-cache-dir cython \
-	&& pip3 install --no-cache-dir numpy \
-	&& pip3 install --no-cache-dir flask==1.0.0 \
-	# https://pynacl.readthedocs.io/en/stable/install/
-	&& SODIUM_INSTALL=system pip3 install --no-cache-dir pynacl==1.3.0 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 install --no-cache-dir "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl" \
 	&& cd /usr/lib/python3.7/site-packages/airflow/www_rbac \
 	&& npm install \
 	&& npm run build \
 	&& rm -rf node_modules \
-	&& apk del .build-deps \
+	&& apk del .build-deps py3-numpy-dev \
 	&& ln -sf /usr/bin/python3 /usr/bin/python \
 	&& ln -sf /usr/bin/pip3 /usr/bin/pip
 

--- a/docker/airflow/1.10.4/Dockerfile
+++ b/docker/airflow/1.10.4/Dockerfile
@@ -42,9 +42,10 @@ ENV ASTRONOMER_GROUP=${ASTRONOMER_GROUP}
 RUN addgroup -S ${ASTRONOMER_GROUP} \
 	&& adduser -S -G ${ASTRONOMER_GROUP} ${ASTRONOMER_USER}
 
-RUN echo @edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
-    echo @edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
+RUN echo @edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories \
+	&& echo @edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories \
+	&& echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
+
 # Install packages
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
Alpine has added lots of new python packages in their edge repos that we
can use to not have to build the big ones (numpy, panda, grpcio) form
source. This change took the image build time down to 12 minutes for me
on my laptop.