### PR TITLE
Replace cron with a shell script that sleeps

### DIFF
--- a/docker/airflow/1.10.4/Dockerfile
+++ b/docker/airflow/1.10.4/Dockerfile
@@ -105,8 +105,8 @@ RUN mkdir -p ${AIRFLOW_HOME}/logs
 # Copy entrypoint to root
 COPY include/entrypoint /
 
-# Copy cron scripts
-COPY include/clean-airflow-logs /etc/periodic/15min/clean-airflow-logs
+# Copy "cron" scripts
+COPY include/clean-airflow-logs /usr/local/bin/clean-airflow-logs
 
 # Ensure our user has ownership to AIRFLOW_HOME
 RUN chown -R ${ASTRONOMER_USER}:${ASTRONOMER_GROUP} ${AIRFLOW_HOME}

--- a/docker/airflow/1.10.4/include/clean-airflow-logs
+++ b/docker/airflow/1.10.4/include/clean-airflow-logs
@@ -1,6 +1,20 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -e
 
 DIRECTORY=${AIRFLOW_HOME:-/usr/local/airflow}
 RETENTION=${ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS:-15}
-echo "Trimming worker logs to ${RETENTION} days."
-find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+
+trap "exit" INT TERM
+
+EVERY=$((15*60))
+
+echo "Cleaning logs every $EVERY seconds"
+
+while true; do
+  seconds=$(( $(date -u +%s) % EVERY))
+  [[ $seconds -lt 1 ]] || sleep $((EVERY - seconds))
+
+  echo "Trimming airflow logs to ${RETENTION} days."
+  find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+done

--- a/docker/airflow/1.10.4/include/entrypoint
+++ b/docker/airflow/1.10.4/include/entrypoint
@@ -2,6 +2,11 @@
 
 set -e
 
+# Compatibility with older helm charts that used to run crond.
+if [[ "$1" == "crond" ]]; then
+  exec /usr/local/bin/clean-airflow-logs
+fi
+
 # Airflow subcommand
 CMD=$2
 


### PR DESCRIPTION
Cron _really_ doesn't like to run as any user other than root, and since
we only have a single job we want to run on an easily calculated
schedule we can replace it with a small shell script, then we don't have
to run our gc containers as root.

To make this work with the existing helm charts we catch "crond"
invocations in /entrypoint and run our script instead.