### PR TITLE
Upgrade kubed to v0.11.0

### DIFF
--- a/docker/vendor/kubed/Dockerfile
+++ b/docker/vendor/kubed/Dockerfile
@@ -13,12 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM appscode/kubed:0.10.0
+FROM appscode/kubed:v0.11.0
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
-
-RUN set -ex \
-    && apk upgrade --no-cache musl


### PR DESCRIPTION
Bug:
https://github.com/astronomer/issues/issues/470

0.11.0 patch notes:
"Kubed v0.11.0 updates Kubernetes dependencies to 1.14.0 and fixes a memory leak issue #357, #304 in k8s.io/client-go. Kubed now requires Kubernetes 1.11.x or later versions. To install/upgrade, please follow the deployment guide here ."

we are on 1.14 kube. I launched a deployment using this image and the webserver came up.