### PR TITLE
Add a debian-based Airflow image

### DIFF
--- a/docker/airflow/1.10.5/Dockerfile
+++ b/docker/airflow/1.10.5/Dockerfile
@@ -19,6 +19,7 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"
 LABEL io.astronomer.docker.component="airflow"
 LABEL io.astronomer.docker.airflow.version="1.10.5"

--- a/docker/airflow/debian-1.10.5/Dockerfile
+++ b/docker/airflow/debian-1.10.5/Dockerfile
@@ -1,0 +1,164 @@
+#
+# Copyright 2019 Astronomer Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ARG APT_DEPS_IMAGE="airflow-apt-deps"
+ARG PYTHON_BASE_IMAGE="python:3.7-slim"
+
+FROM ${PYTHON_BASE_IMAGE} as airflow-apt-deps
+
+LABEL maintainer="Astronomer <humans@astronomer.io>"
+
+ARG ASTRONOMER_USER="astro"
+ARG ASTRONOMER_UID="50000"
+ARG BUILD_NUMBER=-1
+
+LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.distro="debian"
+LABEL io.astronomer.docker.module="airflow"
+LABEL io.astronomer.docker.component="airflow"
+LABEL io.astronomer.docker.uid="${ASTRONOMER_UID}"
+
+
+ARG ORG="astronomer"
+
+
+ENV AIRFLOW_REPOSITORY="https://github.com/${ORG}/airflow"
+ENV AIRFLOW_HOME="/usr/local/airflow"
+ENV PYTHONPATH=${PYTHONPATH:+${PYTHONPATH}:}${AIRFLOW_HOME}
+
+ENV ASTRONOMER_USER=${ASTRONOMER_USER}
+ENV ASTRONOMER_UID=${ASTRONOMER_UID}
+
+# Need to repeat the empty argument here otherwise it will not be set for this stage
+# But the default value carries from the one set before FROM
+ARG PYTHON_BASE_IMAGE
+ENV PYTHON_BASE_IMAGE=${PYTHON_BASE_IMAGE}
+
+# Make sure noninteractie debian install is used and language variables set
+ENV DEBIAN_FRONTEND=noninteractive LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    LC_CTYPE=C.UTF-8 LC_MESSAGES=C.UTF-8
+
+# By increasing this number we can do force build of all dependencies
+ARG DEPENDENCIES_EPOCH_NUMBER="1"
+# Increase the value below to force renstalling of all dependencies
+ENV DEPENDENCIES_EPOCH_NUMBER=${DEPENDENCIES_EPOCH_NUMBER}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+           apt-utils \
+           curl \
+           libmariadb3 \
+           dumb-init \
+           freetds-bin \
+           git \
+           gosu \
+           libffi6 \
+           libkrb5-3 \
+           libpq5 \
+           libsasl2-2 \
+           libsasl2-modules \
+           libssl1.1 \
+           locales  \
+           netcat \
+           rsync \
+           sasl2-bin \
+           sudo \
+    && apt-get autoremove -yqq --purge \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip==19.2.3
+
+RUN useradd --uid $ASTRONOMER_UID --create-home ${ASTRONOMER_USER}
+
+# From the airflow image on master
+
+#######################################################
+######## Installed dependencies - now installing Airflow
+#######################################################
+
+FROM ${APT_DEPS_IMAGE} as devel
+SHELL ["/bin/bash", "-o", "pipefail", "-e", "-u", "-x", "-c"]
+
+ENV PIP_NO_CACHE_DIR="true"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        default-libmysqlclient-dev \
+        libffi-dev \
+        libkrb5-dev \
+        libpq-dev \
+        libsasl2-dev \
+        libssl-dev \
+        nodejs \
+        npm \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG VERSION="1.10.5-1"
+ARG SUBMODULES="async,azure_blob_storage,azure_cosmos,azure_container_instances,celery,crypto,elasticsearch,gcp,kubernetes,mysql,postgres,s3,emr,redis,slack,ssh,statsd,virtualenv"
+ENV AIRFLOW_MODULE="git+${AIRFLOW_REPOSITORY}@${VERSION}#egg=apache-airflow[${SUBMODULES}]"
+
+# Pip install airflow and astro security manager
+RUN pip install "${AIRFLOW_MODULE}" \
+  && pip install "https://github.com/astronomer/astronomer-fab-securitymanager/releases/download/v1.2.1/astronomer_fab_security_manager-1.2.1-py3-none-any.whl"
+
+RUN cd usr/local/lib/python3.7/site-packages/airflow/www_rbac \
+  && npm install \
+  && npm run prod \
+  && rm -rf node_modules
+
+
+####################
+# Installing node node_modules
+###############
+
+## move this to same layer as airflow because its from tag.
+
+FROM ${APT_DEPS_IMAGE} as main
+
+LABEL io.astronomer.docker.airflow.version="1.10.5"
+
+RUN apt-get update \
+    && apt-get upgrade -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy all installed python modules. This gets us the compiled without needing dev installed
+COPY --from=devel /usr/local/lib/python3.7/site-packages /usr/local/lib/python3.7/site-packages
+COPY --from=devel /usr/local/bin /usr/local/bin
+
+
+# Create logs directory so we can own it when we mount volumes
+RUN install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}" \
+    && install --directory --owner="${ASTRONOMER_USER}" "${AIRFLOW_HOME}/logs"
+
+COPY include/sudoers /etc/sudoers.d/astro
+RUN visudo --check --file=/etc/sudoers.d/astro
+
+# Copy entrypoint to root
+COPY include/entrypoint /
+
+# Though this is set here we currently override this in the helm template, so
+# this _might_ not have any effect once deployed. The /entrypoint script copes
+# with this
+USER ${ASTRONOMER_USER}
+
+# Switch to AIRFLOW_HOME
+WORKDIR ${AIRFLOW_HOME}
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--", "/entrypoint"]
+CMD ["airflow", "--help"]

--- a/docker/airflow/debian-1.10.5/include/clean-airflow-logs
+++ b/docker/airflow/debian-1.10.5/include/clean-airflow-logs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+DIRECTORY=${AIRFLOW_HOME:-/usr/local/airflow}
+RETENTION=${ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION_DAYS:-15}
+
+trap "exit" INT TERM
+
+EVERY=$((15*60))
+
+echo "Cleaning logs every $EVERY seconds"
+
+while true; do
+  seconds=$(( $(date -u +%s) % EVERY))
+  [[ $seconds -lt 1 ]] || sleep $((EVERY - seconds))
+
+  echo "Trimming airflow logs to ${RETENTION} days."
+  find "${DIRECTORY}"/logs -mtime +"${RETENTION}" -name '*.log' -delete
+done

--- a/docker/airflow/debian-1.10.5/include/entrypoint
+++ b/docker/airflow/debian-1.10.5/include/entrypoint
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+
+# Sudo _explicitly_ filters out PYTHONPATH, even when env_reset is disabled. but we want it
+[[ $UID == ${ASTRONOMER_UID:-1000} ]] || exec sudo -H -u ${ASTRONOMER_USER} PYTHONPATH=$PYTHONPATH "$0" "$@"
+# Make sure logs folder is writable by the right user.
+[ -O "$AIRFLOW_HOME/logs" ] || sudo chown $ASTRONOMER_USER "$AIRFLOW_HOME/logs"
+
+# Airflow subcommand
+CMD=$2
+
+# Wait for postgres then init the db
+if [[ -n $AIRFLOW__CORE__SQL_ALCHEMY_CONN  ]] && [[ $CMD =~ ^(webserver|scheduler|worker)$ ]]; then
+  # Wait for database port to open up
+  HOST=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
+  PORT=$(echo "${AIRFLOW__CORE__SQL_ALCHEMY_CONN}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  echo "Waiting for host: ${HOST} ${PORT}"
+  while ! nc -w 1 -z "${HOST}" "${PORT}"; do
+    sleep 0.001
+  done
+
+  echo "Initializing airflow database..."
+  airflow initdb || true
+fi
+
+if [[ -n $AIRFLOW__CELERY__BROKER_URL ]] && [[ $CMD =~ ^(scheduler|worker|flower)$ ]]; then
+  # Wait for database port to open up
+  HOST=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $3}' | awk -F@ '{print $2}')
+  PORT=$(echo "${AIRFLOW__CELERY__BROKER_URL}" | awk -F: '{print $4}' | awk -F/ '{print $1}')
+  echo "Waiting for host: ${HOST} ${PORT}"
+  while ! nc -w 1 -z "${HOST}" "${PORT}"; do
+    sleep 0.001
+  done
+fi
+
+# Run the original command
+exec "$@"

--- a/docker/airflow/debian-1.10.5/include/sudoers
+++ b/docker/airflow/debian-1.10.5/include/sudoers
@@ -1,0 +1,6 @@
+# Our astro platform currentl forces RunAs uid 100. As a temporary workaround
+# we give that user (`_apt`) permission to switch to astro.
+astro ALL=(ALL) NOPASSWD: ALL
+_apt ALL=(astro) SETENV:NOPASSWD: /entrypoint *
+
+Defaults>astro !env_reset

--- a/docker/airflow/debian-1.10.5/onbuild/Dockerfile
+++ b/docker/airflow/debian-1.10.5/onbuild/Dockerfile
@@ -1,0 +1,36 @@
+#
+# Copyright 2019 Astronomer Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM test_debian_reg:latest
+LABEL maintainer="Astronomer <humans@astronomer.io>"
+
+ARG BUILD_NUMBER=-1
+LABEL io.astronomer.docker=true
+LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
+LABEL io.astronomer.docker.airflow.onbuild=true
+
+ONBUILD COPY packages.txt .
+ONBUILD USER root
+ONBUILD RUN if [[ -s packages.txt ]]; then \
+    apt-get update && cat packages.txt | xargs apt-get install -y --no-install-recommends \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*; \
+  fi
+# Install python packages
+ONBUILD COPY requirements.txt .
+ONBUILD RUN pip install --no-cache-dir -q -r requirements.txt
+ONBUILD USER astro
+# Copy entire project directory
+ONBUILD COPY . .


### PR DESCRIPTION
This makes use of a multi-stage build to install dev dependencies in on image and only copy the resulting (compiled/installed) python modules in to the final run time image.

I picked a new userid (50000) fairly at random to run as, and added labels so
we can update the platform to know what UID to put in the Security Context, and
not have to pull the sudo tricks we do here.