### PR TITLE
Create a pip constraints file to fix Snowflake/Azure isssue

### DIFF
--- a/docker/airflow/1.10.5/Dockerfile
+++ b/docker/airflow/1.10.5/Dockerfile
@@ -46,6 +46,10 @@ RUN echo @edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community >> 
 	&& echo @edge-testing http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories \
 	&& echo @edge http://dl-cdn.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories
 
+# Force pip to install these specific versions when ever it installs a module
+ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
+COPY include/pip-constriants.txt /usr/local/share/astronomer-pip-constraints.txt
+
 # Install packages
 RUN apk update \
 	&& apk add --no-cache --virtual .build-deps \

--- a/docker/airflow/1.10.5/include/pip-constraints.txt
+++ b/docker/airflow/1.10.5/include/pip-constraints.txt
@@ -1,0 +1,2 @@
+# Constraint the version pip will install, if it ever needs to install a module
+azure-storage-blob<12.0


### PR DESCRIPTION
This file (and the env var) makes pip install this specific version of
the module when ever it might be installed.

See https://pip.pypa.io/en/stable/user_guide/#constraints-files for more
info on this feature

The env var is like setting
`--constraint=/usr/local/share/astronomer-pip-constraints.txt`
automatically on every pip command