### PR TITLE
Fix typo in #509

### DIFF
--- a/docker/airflow/1.10.5/Dockerfile
+++ b/docker/airflow/1.10.5/Dockerfile
@@ -48,7 +48,7 @@ RUN echo @edge-community http://dl-cdn.alpinelinux.org/alpine/edge/community >> 
 
 # Force pip to install these specific versions when ever it installs a module
 ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
-COPY include/pip-constriants.txt /usr/local/share/astronomer-pip-constraints.txt
+COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 
 # Install packages
 RUN apk update \


### PR DESCRIPTION
I'm running a local build now this time. 

Confirmed it's got past that stage:

```
Step 24/33 : ENV PIP_CONSTRAINT=/usr/local/share/astronomer-pip-constraints.txt
 ---> Running in 5f1d5cd53571
Removing intermediate container 5f1d5cd53571
 ---> ce377aee091d
Step 25/33 : COPY include/pip-constraints.txt /usr/local/share/astronomer-pip-constraints.txt
 ---> d1619334ae29
```