### PR TITLE
Move BUILD_NUMBER out of early layer

### DIFF
--- a/bin/build-airflow
+++ b/bin/build-airflow
@@ -1,21 +1,29 @@
 #!/usr/bin/env bash
 
+set -e
+
+# Validate parameters
+: "${REPOSITORY?}"
+: "${AIRFLOW_VERSIONS?}"
+: "${ASTRONOMER_VERSION?}"
+: "${BUILD_NUMBER?}"
+
 # Build and tag images
 function build_image() {
     docker_dir="docker/airflow/${1}"
     docker_file="${docker_dir}/Dockerfile"
     component_name="ap-airflow"
-    build_opts="--build-arg BUILD_NUMBER=${BUILD_NUMBER}"
+    build_opts=(--label "io.astronomer.docker.build.number=$BUILD_NUMBER")
     version="${ASTRONOMER_VERSION}-${1}"
 
     # Build normal components
     if [ -f "${docker_file}" ]; then
         # If we're building with and ASTRONOMER_REF, add pre-release label
         if [ -v ASTRONOMER_REF ]; then
-            build_opts="${build_opts} --label io.astronomer.docker.pre-release=true"
+            build_opts+=(-label io.astronomer.docker.pre-release=true)
         fi
 
-        docker build ${build_opts} -t "${REPOSITORY}/${component_name}:${version}" -f "${docker_file}" "${docker_dir}" || exit 1
+        docker build "${build_opts[@]}" -t "${REPOSITORY}/${component_name}:${version}" -f "${docker_file}" "${docker_dir}" || exit 1
 
         # If we're building with and ASTRONOMER_REF, also tag image with that branch name (master, release-*)
         if [ -v ASTRONOMER_REF ]; then
@@ -31,7 +39,7 @@ function build_image() {
 
     # Build onbuild components
     if [ -f "${onbuild_docker_file}" ]; then
-        docker build ${build_opts} -t "${REPOSITORY}/${component_name}:${version}-onbuild" -f "${onbuild_docker_file}" "${onbuild_docker_dir}" || exit 1
+        docker build "${build_opts[@]}" -t "${REPOSITORY}/${component_name}:${version}-onbuild" -f "${onbuild_docker_file}" "${onbuild_docker_dir}" || exit 1
 
         if [ -v ASTRONOMER_REF ]; then
             docker tag "${REPOSITORY}/${component_name}:${version}-onbuild" "${REPOSITORY}/${component_name}:${ASTRONOMER_REF}-${1}-onbuild"

--- a/docker/airflow/1.10.5/Dockerfile
+++ b/docker/airflow/1.10.5/Dockerfile
@@ -16,8 +16,6 @@
 FROM alpine:3.10
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-ARG BUILD_NUMBER=-1
-LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="alpine"
 LABEL io.astronomer.docker.module="airflow"

--- a/docker/airflow/1.10.5/onbuild/Dockerfile
+++ b/docker/airflow/1.10.5/onbuild/Dockerfile
@@ -16,9 +16,7 @@
 FROM astronomerinc/ap-airflow:0.10.3-alpha.6-1.10.5
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
-LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker.airflow.onbuild=true
 
 # Install alpine packages

--- a/docker/airflow/debian-1.10.5/Dockerfile
+++ b/docker/airflow/debian-1.10.5/Dockerfile
@@ -21,9 +21,7 @@ LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG ASTRONOMER_USER="astro"
 ARG ASTRONOMER_UID="50000"
-ARG BUILD_NUMBER=-1
 
-LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.distro="debian"
 LABEL io.astronomer.docker.module="airflow"

--- a/docker/airflow/debian-1.10.5/onbuild/Dockerfile
+++ b/docker/airflow/debian-1.10.5/onbuild/Dockerfile
@@ -16,9 +16,7 @@
 FROM astronomerinc/ap-airflow:0.10.3-alpha.6-debian-1.10.5
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
-ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
-LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 LABEL io.astronomer.docker.airflow.onbuild=true
 
 ONBUILD COPY packages.txt .


### PR DESCRIPTION
It doesn't make much difference on CI (as we don't share any layers
between builds) but locally this makes a massive difference - with the
old way each build with a new BUILD_NUMBER would cause every layer below
it to blow the cache -- we can avoid that by setting the label via
`docker build` directly.