### PR TITLE
Constrain the version of pymssql to a working one

### DIFF
--- a/docker/airflow/1.10.5/include/pip-constraints.txt
+++ b/docker/airflow/1.10.5/include/pip-constraints.txt
@@ -1,2 +1,3 @@
 # Constraint the version pip will install, if it ever needs to install a module
 azure-storage-blob<12.0
+pymssql<3.0

--- a/docker/airflow/debian-1.10.5/include/pip-constraints.txt
+++ b/docker/airflow/debian-1.10.5/include/pip-constraints.txt
@@ -1,2 +1,3 @@
 # Constraint the version pip will install, if it ever needs to install a module
 azure-storage-blob<12.0
+pymssql<3.0


### PR DESCRIPTION
Pymssql just released 3.0 which is _purposefully_ non functional and
just displays a "this project is discontinued" message, which would be
fine, apart from the fact that the airflow dep was too broad so this got
installed.

Whoops