### PR TITLE
Disable airflow builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ pipeline:
     image: astronomerio/ap-build:0.1.2
     commands:
       - make update-platform-docker-tags
-      - make update-airflow-onbuild-docker-tags
+      # - make update-airflow-onbuild-docker-tags
     environment:
       - ASTRONOMER_VERSION=0.0.0
     when:
@@ -42,20 +42,20 @@ pipeline:
       event: push
       branch: [ master, release-* ]
 
-  build-airflow:
-    group: build
-    image: astronomerio/ap-build:0.1.2
-    commands:
-      - make build-airflow
-    environment:
-      - ASTRONOMER_VERSION=0.0.0
-      - ASTRONOMER_REF=${DRONE_BRANCH}
-      - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      event: push
-      branch: [ master, release-* ]
+  # build-airflow:
+  #   group: build
+  #   image: astronomerio/ap-build:0.1.2
+  #   commands:
+  #     - make build-airflow
+  #   environment:
+  #     - ASTRONOMER_VERSION=0.0.0
+  #     - ASTRONOMER_REF=${DRONE_BRANCH}
+  #     - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   when:
+  #     event: push
+  #     branch: [ master, release-* ]
 
   push-platform:
     group: push
@@ -73,21 +73,21 @@ pipeline:
       event: push
       branch: [ master, release-* ]
 
-  push-airflow:
-    group: push
-    image: astronomerio/ap-build:0.1.2
-    commands:
-      - docker login -u $${DOCKER_USERNAME} -p $${DOCKER_PASSWORD}
-      - make push-airflow-ref
-    environment:
-      - ASTRONOMER_VERSION=0.0.0
-      - ASTRONOMER_REF=${DRONE_BRANCH}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets: [ docker_username, docker_password ]
-    when:
-      event: push
-      branch: [ master, release-* ]
+  # push-airflow:
+  #   group: push
+  #   image: astronomerio/ap-build:0.1.2
+  #   commands:
+  #     - docker login -u $${DOCKER_USERNAME} -p $${DOCKER_PASSWORD}
+  #     - make push-airflow-ref
+  #   environment:
+  #     - ASTRONOMER_VERSION=0.0.0
+  #     - ASTRONOMER_REF=${DRONE_BRANCH}
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   secrets: [ docker_username, docker_password ]
+  #   when:
+  #     event: push
+  #     branch: [ master, release-* ]
 
   scan-platform:
     group: push
@@ -167,7 +167,7 @@ pipeline:
     commands:
       - make update-platform-git-tags
       - make update-platform-docker-tags
-      - make update-airflow-onbuild-docker-tags
+      # - make update-airflow-onbuild-docker-tags
     when:
       event: deployment
       branch: [ master, release-* ]
@@ -219,19 +219,19 @@ pipeline:
       event: tag
       branch: [ master, release-* ]
 
-  build-airflow:
-    group: build
-    image: astronomerio/ap-build:0.1.2
-    commands:
-      - make build-airflow
-    environment:
-      - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
-      - ASTRONOMER_VERSION=${DRONE_TAG##v}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      event: tag
-      branch: [ master, release-* ]
+  # build-airflow:
+  #   group: build
+  #   image: astronomerio/ap-build:0.1.2
+  #   commands:
+  #     - make build-airflow
+  #   environment:
+  #     - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
+  #     - ASTRONOMER_VERSION=${DRONE_TAG##v}
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   when:
+  #     event: tag
+  #     branch: [ master, release-* ]
 
   push-platform:
     group: push
@@ -249,21 +249,21 @@ pipeline:
       event: tag
       branch: [ master, release-* ]
 
-  push-airflow:
-    group: push
-    image: astronomerio/ap-build:0.1.2
-    commands:
-      - docker login -u $${DOCKER_USERNAME} -p $${DOCKER_PASSWORD}
-      - make push-airflow
-    environment:
-      - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
-      - ASTRONOMER_VERSION=${DRONE_TAG##v}
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    secrets: [ docker_username, docker_password ]
-    when:
-      event: tag
-      branch: [ master, release-* ]
+  # push-airflow:
+  #   group: push
+  #   image: astronomerio/ap-build:0.1.2
+  #   commands:
+  #     - docker login -u $${DOCKER_USERNAME} -p $${DOCKER_PASSWORD}
+  #     - make push-airflow
+  #   environment:
+  #     - BUILD_NUMBER=${DRONE_BUILD_NUMBER}
+  #     - ASTRONOMER_VERSION=${DRONE_TAG##v}
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #   secrets: [ docker_username, docker_password ]
+  #   when:
+  #     event: tag
+  #     branch: [ master, release-* ]
 
   notify:
     image: plugins/slack

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DRONE_REPOSITORIES := astronomer commander db-bootstrapper default-backend houst
 GITHUB_ORG := astronomer
 
 # Airflow versions
-AIRFLOW_VERSIONS := 1.10.5 debian-1.10.5
+# AIRFLOW_VERSIONS := 1.10.5 debian-1.10.5
 
 # Vendor components
 VENDOR_COMPONENTS := alertmanager cadvisor curator elasticsearch elasticsearch-exporter fluentd grafana kibana kubed kube-state nginx nginx-es pgbouncer pgbouncer-exporter prisma prometheus redis registry statsd-exporter
@@ -30,12 +30,12 @@ VENDOR_COMPONENTS := alertmanager cadvisor curator elasticsearch elasticsearch-e
 .PHONY: build
 build: check-env
 	$(MAKE) build-platform
-	$(MAKE) build-airflow
+	# $(MAKE) build-airflow
 
 .PHONY: push
 push: check-env clean-images build
 	$(MAKE) push-platform
-	$(MAKE) push-airflow
+	# $(MAKE) push-airflow
 
 #
 # Platform build/push


### PR DESCRIPTION
This PR comments out all the Airflow related stuff in the `Makefile` and `.drone.yml` files. I've moved our Airflow `Dockerfile`s over to the new home for our Certified Airflow Docker Images - https://github.com/astronomer/ap-airflow.

This repository still needs to live a while longer while we migrate, so just keeping things minimal until we completely separate it all out.

I went ahead and manually pushed up 6 tags from the builds in this repo to get things started while we automate building them:
- `astronomerinc/ap-airflow:1.10.5-alpine`
- `astronomerinc/ap-airflow:1.10.5-alpine-onbuild`
- `astronomerinc/ap-airflow:1.10.5-alpine3.10`
- `astronomerinc/ap-airflow:1.10.5-alpine3.10-onbuild`
- `astronomerinc/ap-airflow:1.10.5-buster`
- `astronomerinc/ap-airflow:1.10.5-buster-onbuild`