### PR TITLE
Reconfigure fluentd

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: astronomerinc/ap-registry
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   es:
     repository: astronomerinc/ap-elasticsearch
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
   init:
     repository: astronomerinc/ap-base

--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -179,6 +179,10 @@ data:
       @type elasticsearch_dynamic
       @log_level info
       include_timestamp true
+      reconnect_on_error true
+      reload_on_failure true
+      reload_connections false
+      request_timeout 120s
       host "#{ENV['OUTPUT_HOST']}"
       port "#{ENV['OUTPUT_PORT']}"
       index_name fluentd.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}

--- a/charts/fluentd/templates/fluentd-daemonset.yaml
+++ b/charts/fluentd/templates/fluentd-daemonset.yaml
@@ -45,14 +45,21 @@ spec:
         args:
           - "ruby /wait-for-istio-proxy.rb && /usr/local/bin/fluentd ${FLUENTD_ARGS}"
         {{- end }}
+        # This liveness probe is an imitation of how it's done by GCP
         livenessProbe:
           exec:
             command:
-            - /bin/bash
+            - /bin/sh
             - -c
-            - if (( $(ruby -e "require 'net/http';require 'uri';uri = URI.parse('http://127.0.0.1:{{ .Values.ports.promScrape }}/metrics');response
-              = Net::HTTP.get_response(uri);puts response.body" | grep 'fluentd_output_status_buffer_queue_length{'
-              | awk '{ print ($NF > {{ .Values.livenessProbeConfig.bufferSizeUnhealthy }}) }') )); then exit 1; fi; exit 0
+            - |
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-    buffers ]; then
+                exit 1;
+              fi; touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck     -print -quit)" ]; then
+                rm -rf /var/log/fluentd-buffers;
+                exit 1;
+              fi; touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-    liveness -print -quit)" ]; then
+                exit 1;
+              fi;
           failureThreshold: {{ .Values.livenessProbeConfig.failureThreshold }}
           initialDelaySeconds: {{ .Values.livenessProbeConfig.initialDelaySeconds5 }}
           periodSeconds: {{ .Values.livenessProbeConfig.periodSeconds5 }}

--- a/charts/fluentd/templates/fluentd-daemonset.yaml
+++ b/charts/fluentd/templates/fluentd-daemonset.yaml
@@ -52,12 +52,18 @@ spec:
             - /bin/sh
             - -c
             - |
-              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300}; STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900}; if [ ! -e /var/log/fluentd-    buffers ]; then
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+              STUCK_THRESHOLD_SECONDS=${STUCK_THRESHOLD_SECONDS:-900};
+              if [ ! -e /var/log/fluentd-buffers ]; then
                 exit 1;
-              fi; touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck     -print -quit)" ]; then
+              fi;
+              touch -d "${STUCK_THRESHOLD_SECONDS} seconds ago" /tmp/marker-stuck;
+              if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-stuck -print -quit)" ]; then
                 rm -rf /var/log/fluentd-buffers;
                 exit 1;
-              fi; touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness; if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-    liveness -print -quit)" ]; then
+              fi;
+              touch -d "${LIVENESS_THRESHOLD_SECONDS} seconds ago" /tmp/marker-liveness;
+              if [ -z "$(find /var/log/fluentd-buffers -type d -newer /tmp/marker-liveness -print -quit)" ]; then
                 exit 1;
               fi;
           failureThreshold: {{ .Values.livenessProbeConfig.failureThreshold }}

--- a/charts/fluentd/templates/fluentd-daemonset.yaml
+++ b/charts/fluentd/templates/fluentd-daemonset.yaml
@@ -38,6 +38,13 @@ spec:
       containers:
       - name: fluentd
         image: {{ template "fluentd.image" . }}
+        {{- if .Values.global.istioEnabled }}
+        command:
+          - "/bin/bash"
+          - "-c"
+        args:
+          - "ruby /wait-for-istio-proxy.rb && /usr/local/bin/fluentd ${FLUENTD_ARGS}"
+        {{- end }}
         livenessProbe:
           exec:
             command:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: astronomerinc/ap-fluentd
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -15,10 +15,9 @@ elasticsearch:
   buffer_queue_limit: 8
 
 livenessProbeConfig:
-  bufferSizeUnhealthy: 8
   failureThreshold: 3
-  initialDelaySeconds: 30
-  periodSeconds: 15
+  initialDelaySeconds: 600
+  periodSeconds: 60
   successThreshold: 1
   timeoutSeconds: 5
 

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: astronomerinc/ap-kibana
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -33,6 +33,10 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.fullname" . }}
+      # See https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md
+      # Version 0.27.0
+      securityContext:
+        runAsUser: 101
       containers:
         - name: nginx
           image: {{ template "nginx.image" . }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -8,7 +8,7 @@ tolerations: []
 images:
   nginx:
     repository: astronomerinc/ap-nginx
-    tag: 0.11.0
+    tag: 0.11.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend


### PR DESCRIPTION
Requires https://github.com/astronomer/ap-vendor/pull/2 (expect CI to fail until this is merged and new images pushed)
Closes https://github.com/astronomer/issues/issues/533

Changes:
- security update for nginx requires runAsUser (see 0.27.0 https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md)
- Handle istio-proxy startup race condition using a startup script
- Handle K8s-specific config changes for FluentD https://github.com/uken/fluent-plugin-elasticsearch#stopped-to-send-events-on-k8s-why
- Reconfigure FluentD liveness probe to match how GCP does it

Update: now requires secrets in ap-vendor and re-run of ap-vendor pipeline