### PR TITLE
Add 0.11 migration script

### DIFF
--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -38,7 +38,7 @@ git clone https://github.com/astronomer/migration-script.git
 cd migration-script
 ./pre-0-11-upgrade.sh <release name> <namespace>
 ```
-- This script will write some .yaml files to your local directory. These are very important to back up, and can be used to restore deployments in the event that something goes wrong.
+- This script will write some .yaml files to your local directory. These are very important to back up, and can be used to restore deployments in the event that something goes wrong. These files include secrets.
 - If there is a failure, copy the output and report to Astronomer support
 - The point of this script is to persist helm configuration data
 

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -1,0 +1,91 @@
+# Astronomer 0.11 upgrade guide
+
+
+## Schedule a change window
+
+- This upgrade will cause users to lose their Airflow secrets if they push a deployment, reconfigure a deployment, or make a new deployment while the following procedure is underway
+- This procedure is expected to interrupt task execution for a few minutes on each deployment
+- Scheduling 4 hours is recommended in order to Astronomer support to be able to resolve any potential issues in time. Please plan with Astronomer for support availability.
+
+## Environment preparation
+
+Install some command line tools:
+
+- kubectl (version appropriate for your cluster's version)
+- [helm (version 2.16.1)](https://github.com/helm/helm/releases/tag/v2.16.1)
+- [jq](https://stedolan.github.io/jq/download/)
+
+## Collect installation-specific information
+
+- Namespace in which the Astronomer platform is installed (example: 'astronomer')
+- Helm release name of the Astronomer platform (example: 'astronomer')
+- You can confirm the namespace with
+```
+kubectl get pods -n <namespace here>
+```
+- In the above output, you should see the Astronomer platform's Pods
+- You can confirm the release name with
+```
+helm list <release name>
+```
+
+## Migration script
+
+- You will want to perform this step, then the following 'Helm upgrade' step one after the other while users are not changing anything such as new deployments or deployment configuration changes
+- Clone this repository, change directory into it, and run the script
+```
+git clone https://github.com/astronomer/migration-script.git
+cd migration-script
+./pre-0-11-upgrade.sh
+```
+- This script will write some .yaml files to your local directory. These are very important to back up, and can be used to restore deployments in the event that something goes wrong.
+- If there is a failure, copy the output and report to Astronomer support
+- The point of this script is to persist helm configuration data
+
+## Helm upgrade
+
+- Perform the upgrade using Helm
+```
+git clone https://github.com/astronomer/astronomer.git
+git checkout v0.11.1
+cd astronomer
+helm dep update
+helm upgrade --reuse-values --version "v0.11.1" --namespace <the current namespace> <the current release name> .
+```
+
+## Check that it worked
+
+Here are a few things we can do to make sure everything worked as expected:
+
+- Watch the pods stabilize
+```
+watch kubectl get pods -n <release namespace>
+```
+- Find the houston pods
+```
+_ kubectl get pods -n astronomer | grep houston
+```
+- An example output is:
+```
+astronomer-houston-84945966d8-jc54j                       1/1     Running     0          3d
+astronomer-houston-cleanup-deployments-1580083200-p8dk5   0/1     Completed   0          21h
+astronomer-houston-expire-deployments-1580083200-jxsxj    0/1     Completed   0          21h
+astronomer-houston-upgrade-deployments-lw9kc              0/1     Completed   0          3d21h
+```
+- Ensure that the database migration worked by checking the logs of the main Houston pod
+```
+# Use the pod name corresponding to your result of finding the houston pods
+kubectl logs -n <release namespace> astronomer-houston-84945966d8-jc54j
+```
+- Ensure that the Airflow deployments upgrade worked (or watch it run) by checking the logs of the upgrade-deployments houston pod
+```
+# Use the pod name corresponding to your result of finding the houston pods
+kubectl logs -f -n <release namespace> astronomer-houston-upgrade-deployments-lw9kc
+```
+- Ensure that the Airflow deployments upgrade worked by checking Helm
+```
+# all should be at 0.11.0 after the upgrade-deployments Houston pod is done (above)
+helm list | grep airflow
+```
+- Ensure that the script in this repository did its job by going into any airflow deployment's UI, clicking "Admin" > "Variables" and making sure that the variables are still there. If you are not using Airflow secrets, it will not show any variables.
+- Tasks should resume normal success rate within a few minutes

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -47,6 +47,7 @@ cd migration-script
 - Perform the upgrade using Helm
 ```
 git clone https://github.com/astronomer/astronomer.git
+cd astronomer
 git checkout v0.11.1
 cd astronomer
 helm dep update

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -36,7 +36,7 @@ helm list <release name>
 ```
 git clone https://github.com/astronomer/migration-script.git
 cd migration-script
-./pre-0-11-upgrade.sh
+./pre-0-11-upgrade.sh <release name> <namespace>
 ```
 - This script will write some .yaml files to your local directory. These are very important to back up, and can be used to restore deployments in the event that something goes wrong.
 - If there is a failure, copy the output and report to Astronomer support

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -58,6 +58,12 @@ helm delete --purge <release name>
 helm install -f ./astronomer.yaml --version "v0.11.1" --namespace <the namespace> --name <the current release name> .
 ```
 
+- Check that your DNS record points to the right place
+```
+kubectl get svc -n <the namespace>
+```
+- Find the name of the LoadBalancer (e.g. a2a1d2730421911eab3e102ea6916f09-2139587190.us-east-1.elb.amazonaws.com), and make sure your domain name has a CNAME record pointing to this load balancer.
+
 ## Check that it worked
 
 Here are a few things we can do to make sure everything worked as expected:

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -42,15 +42,20 @@ cd migration-script
 - If there is a failure, copy the output and report to Astronomer support
 - The point of this script is to persist helm configuration data
 
-## Helm upgrade
+## Platform upgrade
 
-- Perform the upgrade using Helm
+- Back up the platform configuration
 ```
 git clone https://github.com/astronomer/astronomer.git
 cd astronomer
 git checkout v0.11.1
-helm dep update
-helm upgrade --reuse-values --version "v0.11.1" --namespace <the current namespace> <the current release name> .
+helm get values <release name> > astronomer.yaml
+```
+- Confirm values are in astronomer.yaml
+- Delete then re-install the platform
+```
+helm delete --purge <release name>
+helm install -f ./astronomer.yaml --version "v0.11.1" --namespace <the namespace> --name <the current release name> .
 ```
 
 ## Check that it worked

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -49,7 +49,6 @@ cd migration-script
 git clone https://github.com/astronomer/astronomer.git
 cd astronomer
 git checkout v0.11.1
-cd astronomer
 helm dep update
 helm upgrade --reuse-values --version "v0.11.1" --namespace <the current namespace> <the current release name> .
 ```

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -56,6 +56,7 @@ helm get values <release name> > astronomer.yaml
 ```
 helm delete --purge <release name>
 helm install -f ./astronomer.yaml --version "v0.11.1" --namespace <the namespace> --name <the current release name> .
+helm upgrade --reuse-values --version="v0.11.1" --namespace <the namespace> <the current release name> .
 ```
 
 - Check that your DNS record points to the right place

--- a/bin/migration-scripts/pre-0-11-upgrade.sh
+++ b/bin/migration-scripts/pre-0-11-upgrade.sh
@@ -116,6 +116,7 @@ function ensure_fernet_key_for_all_deployments {
     # Get the namespace
     get_namespace_of_release $release
     echo "  Determined namespace is : $namespace_of_release_result"
+    helm get $release_name > $release_name-full-backup.yaml
     # Find the secret's actual value
     fernet=$(kubectl get secret -n $namespace_of_release_result \
       ${release}-fernet-key -o jsonpath="{.data.fernet-key}" | base64 --decode)
@@ -145,7 +146,6 @@ function add_fernet_to_values {
   set -e
   get_chart_version $release_name
   echo "    Begin fernet key persistence procedure for $release_name, airflow chart version $version_result"
-  helm get $release_name > $release_name-full-backup.yaml
   helm get values $release_name > $release_name.yaml
   echo "    Upgrading helm chart."
   set -x

--- a/bin/migration-scripts/pre-0-11-upgrade.sh
+++ b/bin/migration-scripts/pre-0-11-upgrade.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+
+set -e
+
+function check_cli_tools_installed {
+  for executable in $@; do
+    which $executable > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echo "$executable is in PATH"
+    else
+      echo "Please ensure $executable is installed and in PATH"
+      exit 1
+    fi
+  done
+}
+
+function check_helm_version_client {
+  echo "Checking the version of Helm installed on the client (where this script is executed)..."
+  set +e
+  helm version | grep Client | grep $1 > /dev/null
+  if ! [[ $? -eq 0 ]]; then
+    echo ""
+    echo "==============="
+    echo "Action required:"
+    echo "Please install Helm 2.16.1"
+    echo "Link: https://github.com/helm/helm/releases/tag/v2.16.1"
+    exit 1
+  else
+    echo "Confirmed Helm 2.16.1 is installed."
+  fi
+  set -e
+}
+
+# Sanity checks to confirm some assumptions
+# about the environment
+function kube_checks {
+  set +e
+  echo "Checking kube authentication..."
+  namespaces=$(kubectl get namespaces)
+  if ! [[ $? -eq 0 ]]; then
+    echo "Failed to run 'kubectl get namespaces'. Please check kubectl configuration."
+    exit 1
+  else
+    echo "kubectl is installed and we can access a kube cluster."
+  fi
+  echo "$namespaces" | grep $NAMESPACE > /dev/null
+  if ! [[ $? -eq 0 ]]; then
+    echo "Failed find the namespace $NAMESPACE"
+    exit 1
+  else
+    echo "Confirmed the presence of the namespace $NAMESPACE"
+  fi
+  set -e
+  echo "Checking that the release $RELEASE_NAME corresponds to the namespace $NAMESPACE"
+  get_namespace_of_release $RELEASE_NAME
+  if ! [[ "$namespace_of_release_result" = "$NAMESPACE" ]]; then
+    echo "ERROR did not find the namespace of helm release $RELEASE_NAME to be $NAMESPACE, but instead found it to be $namespace_of_release_result"
+    exit 1
+  else
+    echo "Confirmed! Found that Helm release $RELEASE_NAME is in namespace $NAMESPACE"
+  fi
+}
+
+function get_namespace_of_release {
+  namespace_of_release_result=$(helm status $1 | grep -i namespace | head -n 1 | awk '{ print $2 }')
+  if ! [[ $? -eq 0 ]]; then
+    echo "Failed to find the namespace of release $1"
+    exit 1
+  fi
+  kubectl get namespaces | grep "$namespace_of_release_result" > /dev/null
+  if ! [[ $? -eq 0 ]]; then
+    echo "Failed to find the namespace of release $1: ERROR did not find a namespace $namespace_of_release_result in Kubernetes"
+    exit 1
+  fi
+}
+
+function get_helm_values_of_release {
+  set +e
+  export values_result=$(helm get values --output json $1)
+  if ! [[ $? -eq 0 ]]; then
+    echo "Did not find a Helm release $1"
+    exit 1
+  fi
+  set -e
+}
+
+function get_deployments {
+  set +e
+  echo "Looking for Astronomer deployments..."
+  export RELEASE_NAMES=$(helm list | grep airflow | grep astronomer | awk '{ print $1 }')
+  if ! [[ $? -eq 0 ]]; then
+    echo "Did not find any Astronomer deployments"
+    exit 1
+  fi
+  echo "Found Astronomer deployments."
+  echo "Confirming these Helm releases are indeed Astronomer Airflow deployments..."
+  for release in $RELEASE_NAMES; do
+    executor=$(helm get values $release --output json | jq '.executor' | grep -E 'CeleryExecutor|KubernetesExecutor|LocalExecutor')
+    if ! [[ $? -eq 0 ]]; then
+      echo "Did not find an executor for $release, aborting because we expected this would be an Astronomer deployment"
+      exit 1
+    fi
+    echo "    $release: $executor"
+  done
+  echo "We found an executor for all Helm release names, so we can be confident these are Astronomer Airflow deployments."
+  set -e
+}
+
+function ensure_fernet_key_for_all_deployments {
+  # Find all the Astronomer Airflow deployments
+  get_deployments
+  echo "The fernet key is a secret that is used to encrypt other secrets in the Airflow DB."
+  echo "For all deployments, ensuring that we persist the fernet key..."
+  for release in $RELEASE_NAMES; do
+    echo "Processing $release:"
+    # Get the namespace
+    get_namespace_of_release $release
+    echo "  Determined namespace is : $namespace_of_release_result"
+    # Find the secret's actual value
+    fernet=$(kubectl get secret -n $namespace_of_release_result \
+      ${release}-fernet-key -o jsonpath="{.data.fernet-key}" | base64 --decode)
+    decoded_length=$(echo "$fernet" | base64 --decode | wc | awk '{ print $3 }')
+    if ! [[ "$decoded_length" = "32" ]]; then
+      echo "ERROR: expected to find a fernet key when base64 decoded to have length 32, but we found length $decoded_length"
+      exit 1
+    else
+      echo "  Found the fernet key from the namespace"
+    fi
+    # Check if this matches the helm config
+    get_helm_values_of_release $release
+    configured_fernet=$(echo "$values_result" | jq '.fernetKey' --raw-output)
+    if [[ "$configured_fernet" = "$fernet" ]]; then
+      echo "  This fernet key is already configured in Helm"
+    else
+      echo "  Detected that the fernet key needs to be added to the Helm values."
+      add_fernet_to_values $release $namespace_of_release_result $fernet
+    fi
+  done
+}
+
+function add_fernet_to_values {
+  release_name=$1
+  release_namespace=$2
+  fernet_key=$3
+  set -e
+  get_chart_version $release_name
+  echo "    Begin fernet key persistence procedure for $release_name, airflow chart version $version_result"
+  helm get $release_name > $release_name-full-backup.yaml
+  helm get values $release_name > $release_name.yaml
+  echo "    Upgrading helm chart."
+  set -x
+  helm upgrade -f ./$release_name.yaml --set fernetKey="$fernet_key" --version "$version_result" --namespace $release_namespace $release_name astronomer/airflow
+  set +x
+  echo "    Done."
+}
+
+function get_chart_version {
+  version_result=$(helm list $1 | grep $1 | awk '{ print $9 }' | cut -d '-' -f2)
+}
+
+function main {
+  export RELEASE_NAME=$1
+  export NAMESPACE=$2
+
+  # Pre-flight checks
+  check_helm_version_client '2.16.1'
+  check_cli_tools_installed helm kubectl jq
+  kube_checks
+
+  # Initialize helm
+  helm init --client-only
+  # Install airflow chart
+  helm repo add astronomer https://helm.astronomer.io
+  helm repo update
+
+  ensure_fernet_key_for_all_deployments
+}
+
+main 'astronomer' 'astronomer'

--- a/bin/migration-scripts/pre-0-11-upgrade.sh
+++ b/bin/migration-scripts/pre-0-11-upgrade.sh
@@ -116,7 +116,7 @@ function ensure_fernet_key_for_all_deployments {
     # Get the namespace
     get_namespace_of_release $release
     echo "  Determined namespace is : $namespace_of_release_result"
-    helm get $release_name > $release_name-full-backup.yaml
+    helm get $release > $release-full-backup.yaml
     # Find the secret's actual value
     fernet=$(kubectl get secret -n $namespace_of_release_result \
       ${release}-fernet-key -o jsonpath="{.data.fernet-key}" | base64 --decode)

--- a/bin/migration-scripts/pre-0-11-upgrade.sh
+++ b/bin/migration-scripts/pre-0-11-upgrade.sh
@@ -176,4 +176,4 @@ function main {
   ensure_fernet_key_for_all_deployments
 }
 
-main 'astronomer' 'astronomer'
+main $1 $2


### PR DESCRIPTION
Tomorrow, let's test this procedure for:

- the lowest expected astronomer version single-namespace mode
- the lowest expected astronomer version normal namespaces
- 0.10.3 astronomer version single-namespace mode
- 0.10.3 normal namespaces

before we run the procedure for each we will do the following:
- deploy 3 of each executor
- make use of Airflow secrets feature

after we run the procedure we will do the following:
- as described in the last section of the README in this PR

Do not release to customers until after we have the above QA performed
