### PR TITLE
Remove hardcoded service name

### DIFF
--- a/charts/postgresql/templates/astronomer-bootstrap-secret.yaml
+++ b/charts/postgresql/templates/astronomer-bootstrap-secret.yaml
@@ -7,5 +7,5 @@ kind: Secret
 metadata:
   name: astronomer-bootstrap
 data:
-  connection: {{ printf "postgres://%s:%s@astronomer-postgresql.%s.svc.cluster.local:%s" .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword .Release.Namespace ( .Values.postgresql.servicePort | toString ) | b64enc | quote }}
+  connection: {{ printf "postgres://%s:%s@%s-postgresql.%s.svc.cluster.local:%s" .Values.postgresql.postgresqlUsername .Values.postgresql.postgresqlPassword .Release.Name .Release.Namespace ( .Values.postgresql.servicePort | toString ) | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
if user install astronomer chart using another release name, this fix will make it possible.