### PR TITLE
Override safeToEvict settings for emptyDir pods

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -107,6 +107,9 @@ data:
           keda:
             enabled: false
 
+          # This is here for upgrading to 0.11.2+ of Airflow.
+          safeToEvict: true
+
         # Scheduler configuration.
         scheduler:
 
@@ -117,6 +120,9 @@ data:
             # PDB configuration
             config:
               maxUnavailable: 1
+
+          # This is here for upgrading to 0.11.2+ of Airflow.
+          safeToEvict: true
 
           # Airflow Local Settings.
           airflowLocalSettings: |
@@ -149,6 +155,11 @@ data:
               ephemeral-storage: "2Gi"
             requests:
               ephemeral-storage: "1Gi"
+
+        # Redis settings
+        redis:
+          # This is here for upgrading to 0.11.2+ of Airflow.
+          safeToEvict: true
 
         # Pgbouncer settings
         pgbouncer:


### PR DESCRIPTION
This PR overrides the `safeToEvict` settings for the `emptyDir` pods in the Airflow Chart. This is to support deployments being upgraded that won't have the defaults in place.