### PR TITLE
Ensure we export KUBECONFIG when creating kind cluster

### DIFF
--- a/bin/setup-kind
+++ b/bin/setup-kind
@@ -50,6 +50,9 @@ if ! [[ $? -eq 0 ]]; then
   kind create cluster --image kindest/node:${KUBE_VERSION}
 fi
 
+# Set KUBECONFIG to point at the new kind cluster
+export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+
 set -e
 set +x
 


### PR DESCRIPTION
This PR ensures the `KUBECONFIG` is set. Someone running this fresh, may not have the config set up yet. This ensures it for the following commands, otherwise you get an error.

<!--
Thank you for contributing to Astronomer!
-->

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [ ]  Chart.yaml version and appVersion updated to match VERSION
- [ ]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
