### PR TITLE
Standardize how we enable postgresql

### DIFF
--- a/charts/postgresql/Chart.yaml
+++ b/charts/postgresql/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: postgresql
-version: 0.11.1
+version: 0.11.2
 description: A Helm chart to deploy an in-cluster database for Astronomer
 labels:
   component: postgresql

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -11,7 +11,7 @@ tags:
   logging: false
   monitoring: false
   kubed: true
-  postgresql: true
+  # postgresql: true
 
 global:
   # Base domain for all subdomains exposed through ingress
@@ -155,7 +155,3 @@ kubeState:
     requests:
       cpu: "0m"
       memory: "0Mi"
-
-# Configuration for postgresql subchart
-postgresql:
-  enabled: true

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -50,6 +50,6 @@ dependencies:
   # In-cluster DB, not recommended
   # for production
   - name: postgresql
-    condition: postgresql.enabled
+    condition: global.postgresqlEnabled
     tags:
       - postgresql

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,10 @@ global:
   # Enables necessary components for Velero (Velero, Grafana Dashboard, Prometheus Alerts)
   veleroEnabled: false
 
+  # Enable default postgresql database.
+  # This is not recommended for production.
+  postgresqlEnabled: true
+
   # Set nodeSelector, affinity, and tolerations values for platform and deployment related pods.
   # This allows for separation of platform and airflow pods between kubernetes node pools.
   # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui, prisma,
@@ -294,11 +298,3 @@ kubed:
     limits:
       cpu: "2"
       memory: "1024Mi"
-
-#################################
-## Postgresql Config
-#################################
-# Not recommended to use an in-cluster
-# database for production.
-postgresql:
-  enabled: true


### PR DESCRIPTION
This PR standardizes the way we enable/disable the new postgresql subchart. I was digging into this comment https://github.com/astronomer/astronomer/pull/546/files#r375550051, and came across it.

Everything seems to work as expected in this format.

<!--
Thank you for contributing to Astronomer!
-->

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [x]  Chart.yaml version and appVersion updated to match VERSION
- [x]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
