### PR TITLE
Add node exporter subchart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,9 @@ build:
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
 	# Install external charts
-	for chart in $$(ls ${TEMP}/astronomer/charts); do
-	if [[ -f ${TEMP}/astronomer/charts/$$chart/requirements.yaml ]]; then
-	helm dep update ${TEMP}/astronomer/charts/$$chart
-	fi
-	done
+	helm dep update ${TEMP}/astronomer/charts/postgresql
+	helm dep update ${TEMP}/astronomer/charts/keda
+	helm dep update ${TEMP}/astronomer/charts/node-exporter
 	helm package ${TEMP}/astronomer
 
 .PHONY: build-index

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,19 @@ lint:
 	rm ${TEMP}/prometheus_alerts.yaml
 
 .PHONY: build
+.ONESHELL:
 build:
 	set -xe
 	helm repo add kedacore https://kedacore.github.io/charts
 	rm -rf ${TEMP}/astronomer || true
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
-	# Install the external chart
-	helm dependency update ${TEMP}/astronomer/charts/postgresql
-	helm dependency update ${TEMP}/astronomer/charts/keda
+	# Install external charts
+	for chart in $$(ls ${TEMP}/astronomer/charts); do
+	if [[ -f ${TEMP}/astronomer/charts/$$chart/requirements.yaml ]]; then
+	helm dep update ${TEMP}/astronomer/charts/$$chart
+	fi
+	done
 	helm package ${TEMP}/astronomer
 
 .PHONY: build-index

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,11 @@ build:
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
 	# Install external charts
-	helm dep update ${TEMP}/astronomer/charts/postgresql
-	helm dep update ${TEMP}/astronomer/charts/keda
-	helm dep update ${TEMP}/astronomer/charts/node-exporter
+	for chart in $$(ls ${TEMP}/astronomer/charts); do
+	if test -f ${TEMP}/astronomer/charts/$$chart/requirements.yaml; then
+	helm dep update ${TEMP}/astronomer/charts/$$chart
+	fi
+	done
 	helm package ${TEMP}/astronomer
 
 .PHONY: build-index

--- a/charts/node-exporter/.helmignore
+++ b/charts/node-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/node-exporter/Chart.yaml
+++ b/charts/node-exporter/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+name: node-exporter
+version: 0.11.2
+description: Monitor nodes
+keywords:
+  - node-exporter
+  - metrics

--- a/charts/node-exporter/Chart.yaml
+++ b/charts/node-exporter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: node-exporter
-version: 0.11.2
+version: 0.12.0
 description: Monitor nodes
 keywords:
   - node-exporter

--- a/charts/node-exporter/requirements.lock
+++ b/charts/node-exporter/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: prometheus-node-exporter
+  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: 1.8.1
+digest: sha256:5a70012eb5ace19b86d4e1838a4f58b1cf9987c041d1149ce1160ad8bc1cb9f4
+generated: "2020-02-13T10:42:14.184845-05:00"

--- a/charts/node-exporter/requirements.yaml
+++ b/charts/node-exporter/requirements.yaml
@@ -1,0 +1,7 @@
+dependencies:
+- name: prometheus-node-exporter
+  # When updating this version, check the default image version in
+  # the prometheus-node-exporter's Helm values. Ensure that ap-node-exporter
+  # in ap-vendor FROMs that image.
+  version: 1.8.1
+  repository: "@stable"

--- a/charts/node-exporter/values.yaml
+++ b/charts/node-exporter/values.yaml
@@ -1,0 +1,15 @@
+prometheus-node-exporter:
+  service:
+    type: ClusterIP
+    port: 9100
+    targetPort: 9100
+    # By default, the prometheus annotation is on the service,
+    # but I do not think this is the intended configuration.
+    # https://github.com/helm/charts/issues/20736
+    annotations: {}
+  podAnnotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9100"
+  image:
+    repository: astronomerinc/ap-node-exporter
+    tag: 0.0.1

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -5,4 +5,3 @@ postgresql:
   postgresqlUsername: postgres
   postgresqlPassword: postgres
   servicePort: 5432
-

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -188,6 +188,20 @@ data:
             regex: 'fluentd_tail_file_.*'
             action: drop
 
+      {{- if .Values.global.nodeExporterEnabled }}
+      - job_name: node-exporter
+        scrape_interval: 30s
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_name]
+            action: keep
+            regex: "^{{ .Release.Name }}-prometheus-node-exporter-.*"
+      {{- end }}
+
       - job_name: airflow
         scrape_interval: 5s # Faster scrape to power dashboards
         kubernetes_sd_configs:

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -26,6 +26,10 @@ dependencies:
     condition: global.kubeStateEnabled
     tags:
       - monitoring
+  - name: node-exporter
+    condition: global.nodeExporterEnabled
+    tags:
+      - monitoring
 
   # Logging stack
   - name: elasticsearch

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,8 @@ global:
   # This is not recommended for production.
   postgresqlEnabled: true
 
+  nodeExporterEnabled: true
+
   # Used to enable Celery autoscaling
   kedaEnabled: true
 

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,7 @@ global:
   # This is not recommended for production.
   postgresqlEnabled: true
 
+  # Enables a node exporter DaemonSet for node-level metrics
   nodeExporterEnabled: true
 
   # Used to enable Celery autoscaling


### PR DESCRIPTION
<!--
Thank you for contributing to Astronomer!
-->

This adds nodes metrics to our metrics stack.

Related issues:
- https://github.com/astronomer/issues/issues/784
- https://github.com/astronomer/issues/issues/769

This was tested locally on kind using this kind configuration:

![image](https://user-images.githubusercontent.com/7516283/74484110-fec28800-4e85-11ea-9073-662ddf2fd659.png)

Here is evidence that all nodes became prom targets:
![image](https://user-images.githubusercontent.com/7516283/74484153-0c780d80-4e86-11ea-9032-56815d18fcf9.png)

Here are the pods that were running:
![image](https://user-images.githubusercontent.com/7516283/74484194-1ef24700-4e86-11ea-92d3-1fb2a2abaa5a.png)

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [x]  Chart.yaml version and appVersion updated to match VERSION
- [x]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
