### PR TITLE
Fixing assumed default namespace in migration script

### DIFF
--- a/bin/migration-scripts/pre-0-11-upgrade.sh
+++ b/bin/migration-scripts/pre-0-11-upgrade.sh
@@ -87,7 +87,7 @@ function get_helm_values_of_release {
 function get_deployments {
   set +e
   echo "Looking for Astronomer deployments..."
-  export RELEASE_NAMES=$(helm list | grep airflow | grep astronomer | awk '{ print $1 }')
+  export RELEASE_NAMES=$(helm list | grep airflow | grep $NAMESPACE | awk '{ print $1 }')
   if ! [[ $? -eq 0 ]]; then
     echo "Did not find any Astronomer deployments"
     exit 1


### PR DESCRIPTION
Script assumed namespace was 'astronomer' when getting list of airflow release names.  Changed to supplied namespace variable.

<!--
Thank you for contributing to Astronomer!
-->
