### PR TITLE
Fix release script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -45,6 +45,7 @@ echo "Releasing chart..."
 # gcloud configurations.
 export BOTO_CONFIG=/dev/null
 
+set +x
 echo ${GCP_TOKEN} > /tmp/gcs_token.json
 gcloud auth activate-service-account --key-file=/tmp/gcs_token.json
 


### PR DESCRIPTION
<!--
Thank you for contributing to Astronomer!
-->

Don't output GCP_TOKEN in CI script. This CI pipeline is not publicly accessible at the moment.