### PR TITLE
HA Prometheus service

### DIFF
--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -35,11 +35,11 @@ spec:
       port: {{ $.Values.ports.http }}
       targetPort: {{ $.Values.ports.http }}
 {{ end }}
+---
 ################################
 ## Prometheus Service
 ## load balancing between all pods
 #################################
----
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -51,6 +51,7 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 spec:
+  sessionAffinity: ClientIP
   type: ClusterIP
   selector:
     tier: monitoring

--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -1,3 +1,4 @@
+{{- if gt (int .Values.replicas) 1 }}
 ################################
 ## Prometheus Service(s)
 ## each one pointing to a different
@@ -35,6 +36,7 @@ spec:
       port: {{ $.Values.ports.http }}
       targetPort: {{ $.Values.ports.http }}
 {{ end }}
+{{- end }}
 ---
 ################################
 ## Prometheus Service

--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -1,5 +1,7 @@
 ################################
 ## Prometheus Service(s)
+## each one pointing to a different
+## Prometheus pod
 #################################
 {{ range $i, $e := until (int .Values.replicas) }}
 {{- if gt $i 0 }}
@@ -8,15 +10,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  # The fist service is named without a xxx-0
-  # Then the rest are named xxx-1, xxx-2, etc.
-  # This is in order to protect backwards
-  # compatibility
-  {{- if eq $i 0 }}
-  name: {{ template "prometheus.fullname" $ }}
-  {{- else }}
   name: {{ template "prometheus.fullname" $ }}-{{ $i }}
-  {{- end }}
   labels:
     tier: monitoring
     component: {{ template "prometheus.name" $ }}
@@ -41,3 +35,29 @@ spec:
       port: {{ $.Values.ports.http }}
       targetPort: {{ $.Values.ports.http }}
 {{ end }}
+################################
+## Prometheus Service
+## load balancing between all pods
+#################################
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ template "prometheus.fullname" $ }}
+  labels:
+    tier: monitoring
+    component: {{ template "prometheus.name" $ }}
+    chart: {{ template "prometheus.chart" $ }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+spec:
+  type: ClusterIP
+  selector:
+    tier: monitoring
+    component: {{ template "prometheus.name" $ }}
+    release: {{ $.Release.Name }}
+  ports:
+    - name: prometheus-data
+      protocol: TCP
+      port: {{ $.Values.ports.http }}
+      targetPort: {{ $.Values.ports.http }}


### PR DESCRIPTION
Closes: https://github.com/astronomer/issues/issues/748

History: we use prometheus to monitor. It has been restarting, and we had data gaps. To avoid this, we added a replica, and set up services have one service per pod. For applications that can't acceNow the replica has collected data up to the retention window, so we can add it into the default service.

This change switches the default prometheus services from pointing to the first replica to load balancing between replicas. It also maintains the pod-specific services, which have a different use case.

- the main service is load balanced, so it will be more available, but there may be gaps in the data where the routed pod was historically restarting. This is for the use case of viewing metrics more reliably than we do now.
- the other services (e.g. astronomer-prometheus-0) can be used by applications intolerant to data gaps.

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [x]  Chart.yaml version and appVersion updated to match VERSION
- [x]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
