### PR TITLE
ElasticSearch reconfiguration

### DIFF
--- a/charts/elasticsearch/Chart.yaml
+++ b/charts/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 0.11.1
+version: 0.11.2
 description: A Helm chart to deploy the Astronomer Platform Elasticsearch module
 keywords:
   - astronomer

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -3,16 +3,16 @@
 Expand the name of the chart.
 */}}
 {{- define "elasticsearch.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 53 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 44 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create a default fully qualified app name.
-We truncate at 53 chars (63 - len("-discovery")) because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
+We truncate at 44 chars (63 - len("-headless-discovery")) because some Kubernetes name fields are limited to 63 (by the DNS naming spec).
 */}}
 {{- define "elasticsearch.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 53 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 44 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -93,7 +93,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
-          value: {{ template "elasticsearch.fullname" . }}-discovery
+          value: {{ template "elasticsearch.fullname" . }}-headless-discovery
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -125,6 +125,17 @@ spec:
             path: /_cluster/health?local=true
             port: {{ .Values.common.ports.http }}
           initialDelaySeconds: 90
+        {{- if gt (.Capabilities.KubeVersion.Minor | atoi) 15 }}
+        # This feature is available in Kubernetes 1.16+
+        startupProbe:
+          httpGet:
+            # without local=true, we are waiting for this pod's
+            # es-master to report that the cluster is ready.
+            path: /_cluster/health
+            port: {{ .Values.common.ports.http }}
+          failureThreshold: 30
+          periodSeconds: 10
+        {{- end }}
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -115,7 +115,9 @@ spec:
           protocol: TCP
         readinessProbe:
           httpGet:
-            path: /_cluster/health
+            # local: If true, the request retrieves information from the local node only.
+            # Defaults to false, which means information is retrieved from the master node.
+            path: /_cluster/health?local=true
             port: {{ .Values.common.ports.http }}
           initialDelaySeconds: 5
         livenessProbe:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -125,7 +125,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
-          value: {{ template "elasticsearch.fullname" . }}-discovery
+          value: {{ template "elasticsearch.fullname" . }}-headless-discovery
         - name: ES_JAVA_OPTS
           value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }}"
         {{- range $key, $value :=  .Values.common.env }}

--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -45,9 +45,12 @@ data:
       ping_schedule: "5s"
 
     discovery:
-      zen:
-        ping.unicast.hosts: ${DISCOVERY_SERVICE}
-        minimum_master_nodes: ${NUMBER_OF_MASTERS:2}
+      seed_hosts:
+        {{- $releaseName := $.Release.Name }}
+        {{- $replicas := .Values.master.replicas }}
+        {{- range $i, $e := until (int $replicas) }}
+        - {{ $releaseName }}-elasticsearch-master-{{ $i }}
+        {{- end }}
 
     # Disable scripting for security.
     script.allowed_types: none

--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -46,11 +46,7 @@ data:
 
     discovery:
       seed_hosts:
-        {{- $releaseName := $.Release.Name }}
-        {{- $replicas := .Values.master.replicas }}
-        {{- range $i, $e := until (int $replicas) }}
-        - {{ $releaseName }}-elasticsearch-master-{{ $i }}
-        {{- end }}
+        - {{ template "elasticsearch.fullname" . }}-headless-discovery
 
     # Disable scripting for security.
     script.allowed_types: none

--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -38,6 +38,12 @@ data:
         enabled: ${HTTP_CORS_ENABLE}
         allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
 
+    # Setting the ping schedule explictly ensures that
+    # tcp_keep_alive configuration does not cause components
+    # to have their connections terminated.
+    transport:
+      ping_schedule: "5s"
+
     discovery:
       zen:
         ping.unicast.hosts: ${DISCOVERY_SERVICE}

--- a/charts/elasticsearch/templates/master/es-master-service.yaml
+++ b/charts/elasticsearch/templates/master/es-master-service.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
     role: master
 spec:
+  clusterIP: None
   selector:
     component: {{ template "elasticsearch.name" . }}
     release: {{ .Release.Name }}

--- a/charts/elasticsearch/templates/master/es-master-service.yaml
+++ b/charts/elasticsearch/templates/master/es-master-service.yaml
@@ -12,8 +12,11 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     role: master
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     component: {{ template "elasticsearch.name" . }}
     release: {{ .Release.Name }}

--- a/charts/elasticsearch/templates/master/es-master-service.yaml
+++ b/charts/elasticsearch/templates/master/es-master-service.yaml
@@ -12,8 +12,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
     role: master
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   clusterIP: None
   publishNotReadyAddresses: true

--- a/charts/elasticsearch/templates/master/es-master-service.yaml
+++ b/charts/elasticsearch/templates/master/es-master-service.yaml
@@ -4,7 +4,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "elasticsearch.fullname" . }}-discovery
+  name: {{ template "elasticsearch.fullname" . }}-headless-discovery
   labels:
     tier: logging
     component: {{ template "elasticsearch.name" . }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -141,11 +141,13 @@ spec:
         - containerPort: {{ .Values.common.ports.transport }}
           name: transport
           protocol: TCP
-        # readinessProbe:
-        #   httpGet:
-        #     path: /_cluster/health?local=true
-        #     port: {{ .Values.common.ports.http }}
-        #   initialDelaySeconds: 5
+        readinessProbe:
+          httpGet:
+            # local: If true, the request retrieves information from the local node only.
+            # Defaults to false, which means information is retrieved from the master node.
+            path: /_cluster/health?local=true
+            port: {{ .Values.common.ports.http }}
+          initialDelaySeconds: 5
         livenessProbe:
           tcpSocket:
             port: {{ .Values.common.ports.transport }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -124,7 +124,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
-          value: {{ template "elasticsearch.fullname" . }}-discovery
+          value: {{ template "elasticsearch.fullname" . }}-headless-discovery
         - name: ES_JAVA_OPTS
           value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }}"
         {{- range $key, $value :=  .Values.common.env }}


### PR DESCRIPTION
<!--
Thank you for contributing to Astronomer!
-->

Closes: https://github.com/astronomer/issues/issues/784

- make es-master service headless by setting spec.clusterIP: None
- rename service because spec.clusterIP is immutable
- change ping schedule so that Linux default TCP keep alive of 2 hours does not cause data nodes to disconnect from the master once every two hours
- reconfigure discovery for elastic search 7
- enable readiness probe for elasticsearch masters
- enable startup probes for elasticsearch clients

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [x]  Chart.yaml version and appVersion updated to match VERSION
- [x]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
