### PR TITLE
Pin ap-astro-ui version

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: latest
+    tag: 0.12.0
     pullPolicy: Always
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
Pins `ap-astro-ui` tag version to `0.12.0`.
