### PR TITLE
Adding Prometheus alert rules

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -117,26 +117,6 @@ data:
             summary: {{ printf "%q" "{{ $value }} airflow schedulers are not heartbeating" }}
             description: "If more than 5 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires."
 
-        - alert: CpuThrottlingWarning
-          expr: 100 * (increase(container_cpu_cfs_throttled_periods_total{namespace="{{ .Release.Name }}", container_name=~".{1,1000}"}[5m]) / increase(container_cpu_cfs_periods_total{namespace="{{ .Release.Name }}", container_name=~".{1,1000}"}[5m])) > 50
-          for: 5m
-          labels:
-            tier: platform
-            severity: warning
-          annotations:
-            summary: {{ printf "%q" "{{ $labels.pod_name }} ({{ $labels.container_name }}) is getting throttled {{ $value }}% of the time, should check next business day" }}
-            description: "Half or more of the time in the past 5 minutes, one or more platform components are experiencing some CPU throttling."
-
-        - alert: CpuThrottlingSevere
-          expr: 100 * (increase(container_cpu_cfs_throttled_periods_total{namespace="{{ .Release.Name }}", container_name=~".{1,1000}"}[5m]) / increase(container_cpu_cfs_periods_total{namespace="{{ .Release.Name }}", container_name=~".{1,1000}"}[5m])) > 80
-          for: 5m
-          labels:
-            tier: platform
-            severity: urgent
-          annotations:
-            summary: {{ printf "%q" "{{ $labels.pod_name }} ({{ $labels.container_name }}) is getting throttled {{ $value }}% of the time" }}
-            description: "In the past 5 minutes, one or more components in the platform namespace are experiencing throttling 80% or more of the time"
-
         - alert: FluentdQueueLarge
           expr: avg(fluentd_status_buffer_queue_length) > 2
           for: 15m
@@ -147,57 +127,6 @@ data:
           annotations:
             summary: {{ printf "%q" "Average Fluentd buffer queue length is {{ $value }}" }}
             description: "Check on Elastic Search client and try restarting Fluentd pods"
-
-        - alert: PrometheusDiskUsage
-          expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-{{ template "prometheus.fullname" . }}-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-{{ template "prometheus.fullname" . }}-.*"} * 100) < 10
-          for: 5m
-          labels:
-            tier: platform
-            component: prometheus
-          annotations:
-            summary: "Prometheus High Disk Usage"
-            description: {{ printf "%q" "Prometheus has {{ $value }}% of disk space available" }}
-
-        - alert: RegistryDiskUsage
-          expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-{{ .Release.Name }}-registry-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-{{ .Release.Name }}-registry-.*"} * 100) < 10
-          for: 5m
-          labels:
-            tier: platform
-            component: registry
-          annotations:
-            summary: "Docker Registry High Disk Usage"
-            description: "Docker Registry has less than 10% disk space available."
-
-        - alert: ElasticsearchDiskUsage
-          expr: (sum(kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-{{ .Release.Name }}-elasticsearch-data-.*"}) / sum(kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-{{ .Release.Name }}-elasticsearch-data-.*"}) * 100) < 10
-          for: 5m
-          labels:
-            tier: platform
-            component: elasticsearch
-          annotations:
-            summary: "Elasticsearch High Disk Usage"
-            description: "Elasticsearch has less than 10% disk space available."
-
-        - alert: IngessCertificateExpiration
-          expr: avg(nginx_ingress_controller_ssl_expire_time_seconds) by (host) - time() < 604800
-          for: 10s
-          labels:
-            tier: platform
-            component: ingress
-          annotations:
-            summary: "TLS Certificate Expiring Soon"
-            {{/* We want '{{ $labels.host }}' to be evaluted by prometheus, not helm, so we have to escape it once */ -}}
-            description: {{ printf "%q" "The TLS Certificate for {{ $labels.host }} is expiring in less than a week." }}
-
-        - alert: PrometheusNotConnectedToAlertmanagers
-          expr: prometheus_notifications_alertmanagers_discovered{job="prometheus"} < 1
-          for: 10m
-          labels:
-            tier: platform
-            component: prometheus
-          annotations:
-            summary: "Prometheus is not connected to any Alertmanagers"
-            description: "Prometheus is not connected to any Alertmanagers"
 
         - alert: NginxIngressHighFailureRate
           expr: |
@@ -237,51 +166,6 @@ data:
           annotations:
             summary: "A container in the platform namespace uses more than 80% of the memory limit"
             description: {{ printf "%q" "{{ $labels.container }} in {{ $labels.pod }} is using {{ printf \"%.2f\" $value }}% of available memory." }}
-
-        - alert: PlatformContainerRestarting
-          expr: |
-            rate(kube_pod_container_status_restarts_total{namespace="astronomer", container!="curator"}[90s]) * 60 > 0
-          labels:
-            tier: platform
-            severity: warning
-          annotations:
-            summary: "A container has restarted in the Astronomer platform namespace"
-            description: {{ printf "%q" "The container {{ $labels.container }} in pod {{ $labels.pod }} has restarted at least once" }}
-
-        - alert: PlatformContainerRestartingContinuously
-          expr: |
-            rate(kube_pod_container_status_restarts_total{namespace="astronomer", pod!~".*elasticsearch-curator.*"}[600s]) * 60 > 0
-          for: 10m
-          labels:
-            tier: platform
-            severity: urgent
-          annotations:
-            summary: "A container in the Astronomer platform namespace is stuck crash looping"
-            description: {{ printf "%q" "The container {{ $labels.container }} in pod {{ $labels.pod }} is stuck crash looping" }}
-
-        - alert: KubePodNotReadyInDeployment
-          expr: |
-            sum by (namespace, pod) (kube_pod_status_phase{namespace=~".*-.*-.*-[0-9]{4}", job="kube-state", phase=~"Pending|Unknown"}) > 0
-          for: 1h
-          labels:
-            tier: platform
-            component: pod
-            severity: warning
-          annotations:
-            summary: "Deployment pod in non-ready state for more than 1 hour. Check on it next buisness day."
-            description: {{ printf "%q" "{{ $labels.pod }} in namespace {{ $labels.namespace }} has been in a non-ready state for longer than an hour." }}
-
-        - alert: KubePodNotReadyInPlatform
-          expr: |
-            sum by (namespace, pod) (kube_pod_status_phase{namespace="{{ .Release.Name }}", job="kube-state", phase=~"Pending|Unknown"}) > 0
-          for: 1h
-          labels:
-            tier: platform
-            component: pod
-            severity: urgent
-          annotations:
-            summary: "Pod in non-ready state for more than 1 hour"
-            description: {{ printf "%q" "{{ $labels.pod }} has been in a non-ready state for longer than an hour." }}
 
         - alert: NginxIngressDown
           expr: |
@@ -347,5 +231,1062 @@ data:
           annotations:
             summary: "Half or more of schedulers do not have a heartbeat"
             description: "Half or more of schedulers do not have a heartbeat in the last five minutes"
+
+
+        ## JPW added
+      - name: node-exporter.rules ## Recording rules
+        rules:
+        - expr: |
+            count without (cpu) (
+              count without (mode) (
+                node_cpu_seconds_total{job="node-exporter"}
+              )
+            )
+          record: instance:node_num_cpu:sum
+        - expr: |
+            1 - avg without (cpu, mode) (
+              rate(node_cpu_seconds_total{job="node-exporter", mode="idle"}[1m])
+            )
+          record: instance:node_cpu_utilisation:rate1m
+        - expr: |
+            (
+              node_load1{job="node-exporter"}
+            /
+              instance:node_num_cpu:sum{job="node-exporter"}
+            )
+          record: instance:node_load1_per_cpu:ratio
+        - expr: |
+            1 - (
+              node_memory_MemAvailable_bytes{job="node-exporter"}
+            /
+              node_memory_MemTotal_bytes{job="node-exporter"}
+            )
+          record: instance:node_memory_utilisation:ratio
+        - expr: |
+            rate(node_vmstat_pgmajfault{job="node-exporter"}[1m])
+          record: instance:node_vmstat_pgmajfault:rate1m
+        - expr: |
+            rate(node_disk_io_time_seconds_total{job="node-exporter", device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
+          record: instance_device:node_disk_io_time_seconds:rate1m
+        - expr: |
+            rate(node_disk_io_time_weighted_seconds_total{job="node-exporter", device=~"nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+"}[1m])
+          record: instance_device:node_disk_io_time_weighted_seconds:rate1m
+        - expr: |
+            sum without (device) (
+              rate(node_network_receive_bytes_total{job="node-exporter", device!="lo"}[1m])
+            )
+          record: instance:node_network_receive_bytes_excluding_lo:rate1m
+        - expr: |
+            sum without (device) (
+              rate(node_network_transmit_bytes_total{job="node-exporter", device!="lo"}[1m])
+            )
+          record: instance:node_network_transmit_bytes_excluding_lo:rate1m
+        - expr: |
+            sum without (device) (
+              rate(node_network_receive_drop_total{job="node-exporter", device!="lo"}[1m])
+            )
+          record: instance:node_network_receive_drop_excluding_lo:rate1m
+        - expr: |
+            sum without (device) (
+              rate(node_network_transmit_drop_total{job="node-exporter", device!="lo"}[1m])
+            )
+          record: instance:node_network_transmit_drop_excluding_lo:rate1m
+
+      - name: k8s.rules ## Recording rules
+        rules:
+        - expr: |
+            sum(rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}[5m])) by (namespace)
+          record: namespace:container_cpu_usage_seconds_total:sum_rate
+        - expr: |
+            sum by (cluster, namespace, pod, container) (
+              rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}[5m])
+            ) * on (cluster, namespace, pod) group_left(node) max by(cluster, namespace, pod, node) (kube_pod_info)
+          record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
+        - expr: |
+            container_memory_working_set_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+          record: node_namespace_pod_container:container_memory_working_set_bytes
+        - expr: |
+            container_memory_rss{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+          record: node_namespace_pod_container:container_memory_rss
+        - expr: |
+            container_memory_cache{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+          record: node_namespace_pod_container:container_memory_cache
+        - expr: |
+            container_memory_swap{job="kubelet", metrics_path="/metrics/cadvisor", image!=""}
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+          record: node_namespace_pod_container:container_memory_swap
+        - expr: |
+            sum(container_memory_usage_bytes{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}) by (namespace)
+          record: namespace:container_memory_usage_bytes:sum
+        - expr: |
+            sum by (namespace) (
+                sum by (namespace, pod) (
+                    max by (namespace, pod, container) (
+                        kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
+                    ) * on(namespace, pod) group_left() max by (namespace, pod) (
+                        kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                    )
+                )
+            )
+          record: namespace:kube_pod_container_resource_requests_memory_bytes:sum
+        - expr: |
+            sum by (namespace) (
+                sum by (namespace, pod) (
+                    max by (namespace, pod, container) (
+                        kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
+                    ) * on(namespace, pod) group_left() max by (namespace, pod) (
+                      kube_pod_status_phase{phase=~"Pending|Running"} == 1
+                    )
+                )
+            )
+          record: namespace:kube_pod_container_resource_requests_cpu_cores:sum
+        - expr: |
+            sum(
+              label_replace(
+                label_replace(
+                  kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+                  "replicaset", "$1", "owner_name", "(.*)"
+                ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{job="kube-state-metrics"},
+                "workload", "$1", "owner_name", "(.*)"
+              )
+            ) by (cluster, namespace, workload, pod)
+          labels:
+            workload_type: deployment
+          record: mixin_pod_workload
+        - expr: |
+            sum(
+              label_replace(
+                kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+                "workload", "$1", "owner_name", "(.*)"
+              )
+            ) by (cluster, namespace, workload, pod)
+          labels:
+            workload_type: daemonset
+          record: mixin_pod_workload
+        - expr: |
+            sum(
+              label_replace(
+                kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+                "workload", "$1", "owner_name", "(.*)"
+              )
+            ) by (cluster, namespace, workload, pod)
+          labels:
+            workload_type: statefulset
+          record: mixin_pod_workload
+      - name: kube-scheduler.rules ## Recording Rules
+        rules:
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.99, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.99"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.9, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.9"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_e2e_scheduling_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_scheduling_algorithm_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_scheduling_algorithm_duration_seconds:histogram_quantile
+        - expr: |
+            histogram_quantile(0.5, sum(rate(scheduler_binding_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
+          labels:
+            quantile: "0.5"
+          record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
+      - name: node.rules ## Recording Rules
+        rules:
+        - expr: |
+            sum(min(kube_pod_info) by (cluster, node))
+          record: ':kube_pod_info_node_count:'
+        - expr: |
+            max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+          record: 'node_namespace_pod:kube_pod_info:'
+        - expr: |
+            count by (cluster, node) (sum by (node, cpu) (
+              node_cpu_seconds_total{job="node-exporter"}
+            * on (namespace, pod) group_left(node)
+              node_namespace_pod:kube_pod_info:
+            ))
+          record: node:node_num_cpu:sum
+        - expr: |
+            sum(
+              node_memory_MemAvailable_bytes{job="node-exporter"} or
+              (
+                node_memory_Buffers_bytes{job="node-exporter"} +
+                node_memory_Cached_bytes{job="node-exporter"} +
+                node_memory_MemFree_bytes{job="node-exporter"} +
+                node_memory_Slab_bytes{job="node-exporter"}
+              )
+            ) by (cluster)
+          record: :node_memory_MemAvailable_bytes:sum
+      - name: kube-prometheus-node-recording.rules ## Recording Rules
+        rules:
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[3m])) BY
+            (instance)
+          record: instance:node_cpu:rate:sum
+        - expr: sum((node_filesystem_size_bytes{mountpoint="/"} - node_filesystem_free_bytes{mountpoint="/"}))
+            BY (instance)
+          record: instance:node_filesystem_usage:sum
+        - expr: sum(rate(node_network_receive_bytes_total[3m])) BY (instance)
+          record: instance:node_network_receive_bytes:rate:sum
+        - expr: sum(rate(node_network_transmit_bytes_total[3m])) BY (instance)
+          record: instance:node_network_transmit_bytes:rate:sum
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[5m])) WITHOUT
+            (cpu, mode) / ON(instance) GROUP_LEFT() count(sum(node_cpu_seconds_total)
+            BY (instance, cpu)) BY (instance)
+          record: instance:node_cpu:ratio
+        - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[5m]))
+          record: cluster:node_cpu:sum_rate5m
+        - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
+            BY (instance, cpu))
+          record: cluster:node_cpu:ratio
+      - name: kube-prometheus-general.rules ## Recording Rules
+        rules:
+        - expr: count without(instance, pod, node) (up == 1)
+          record: count:up1
+        - expr: count without(instance, pod, node) (up == 0)
+          record: count:up0
+      - name: kube-state-metrics
+        rules:
+        - alert: KubeStateMetricsListErrors
+          annotations:
+            message: kube-state-metrics is experiencing errors at an elevated rate in
+              list operations. This is likely causing it to not be able to expose metrics
+              about Kubernetes objects correctly or at all.
+            runbook_url: 
+          expr: |
+            (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+              /
+            sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+            > 0.01
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStateMetricsWatchErrors
+          annotations:
+            message: kube-state-metrics is experiencing errors at an elevated rate in
+              watch operations. This is likely causing it to not be able to expose metrics
+              about Kubernetes objects correctly or at all.
+            runbook_url: 
+          expr: |
+            (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+              /
+            sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+            > 0.01
+          for: 15m
+          labels:
+            severity: critical
+      - name: node-exporter
+        rules:
+        - alert: NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available space left and is filling
+              up.
+            runbook_url: 
+            summary: Filesystem is predicted to run out of space within the next 24 hours.
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 40
+            and
+              predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemSpaceFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available space left and is filling
+              up fast.
+            runbook_url: 
+            summary: Filesystem is predicted to run out of space within the next 4 hours.
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 20
+            and
+              predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: 
+            summary: Filesystem has less than 5% space left.
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 5
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemAlmostOutOfSpace
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available space left.
+            runbook_url: 
+            summary: Filesystem has less than 3% space left.
+          expr: |
+            (
+              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 3
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available inodes left and is filling
+              up.
+            runbook_url: 
+            summary: Filesystem is predicted to run out of inodes within the next 24 hours.
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 40
+            and
+              predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemFilesFillingUp
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available inodes left and is filling
+              up fast.
+            runbook_url: 
+            summary: Filesystem is predicted to run out of inodes within the next 4 hours.
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 20
+            and
+              predict_linear(node_filesystem_files_free{job="node-exporter",fstype!=""}[6h], 4*60*60) < 0
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: 
+            summary: Filesystem has less than 5% inodes left.
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 5
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeFilesystemAlmostOutOfFiles
+          annotations:
+            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
+              has only {{ printf "%.2f" $value }}% available inodes left.
+            runbook_url: 
+            summary: Filesystem has less than 3% inodes left.
+          expr: |
+            (
+              node_filesystem_files_free{job="node-exporter",fstype!=""} / node_filesystem_files{job="node-exporter",fstype!=""} * 100 < 3
+            and
+              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
+            )
+          for: 1h
+          labels:
+            severity: critical
+        - alert: NodeNetworkReceiveErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
+              {{ printf "%.0f" $value }} receive errors in the last two minutes.'
+            runbook_url: 
+            summary: Network interface is reporting many receive errors.
+          expr: |
+            increase(node_network_receive_errs_total[2m]) > 10
+          for: 1h
+          labels:
+            severity: warning
+        - alert: NodeNetworkTransmitErrs
+          annotations:
+            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
+              {{ printf "%.0f" $value }} transmit errors in the last two minutes.'
+            runbook_url: 
+            summary: Network interface is reporting many transmit errors.
+          expr: |
+            increase(node_network_transmit_errs_total[2m]) > 10
+          for: 1h
+          labels:
+            severity: warning
+      - name: kubernetes-apps
+        rules:
+        - alert: KubePodCrashLooping
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
+              }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+            runbook_url: 
+          expr: |
+            rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubePodNotReady
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+              state for longer than 15 minutes.
+            runbook_url: 
+          expr: |
+            sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDeploymentGenerationMismatch
+          annotations:
+            message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
+              }} does not match, this indicates that the Deployment has failed but has
+              not been rolled back.
+            runbook_url:
+          expr: |
+            kube_deployment_status_observed_generation{job="kube-state-metrics"}
+              !=
+            kube_deployment_metadata_generation{job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDeploymentReplicasMismatch
+          annotations:
+            message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+              matched the expected number of replicas for longer than 15 minutes.
+            runbook_url: 
+          expr: |
+            kube_deployment_spec_replicas{job="kube-state-metrics"}
+              !=
+            kube_deployment_status_replicas_available{job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetReplicasMismatch
+          annotations:
+            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+              not matched the expected number of replicas for longer than 15 minutes.
+            runbook_url: 
+          expr: |
+            kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+              !=
+            kube_statefulset_status_replicas{job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetGenerationMismatch
+          annotations:
+            message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
+              }} does not match, this indicates that the StatefulSet has failed but has
+              not been rolled back.
+            runbook_url:
+          expr: |
+            kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+              !=
+            kube_statefulset_metadata_generation{job="kube-state-metrics"}
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeStatefulSetUpdateNotRolledOut
+          annotations:
+            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+              has not been rolled out.
+            runbook_url:
+          expr: |
+            max without (revision) (
+              kube_statefulset_status_current_revision{job="kube-state-metrics"}
+                unless
+              kube_statefulset_status_update_revision{job="kube-state-metrics"}
+            )
+              *
+            (
+              kube_statefulset_replicas{job="kube-state-metrics"}
+                !=
+              kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+            )
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeDaemonSetRolloutStuck
+          annotations:
+            message: Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet
+              {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
+            runbook_url: 
+          expr: |
+            kube_daemonset_status_number_ready{job="kube-state-metrics"}
+              /
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} < 1.00
+          for: 15m
+          labels:
+            severity: critical
+        - alert: KubeContainerWaiting
+          annotations:
+            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
+              has been in waiting state for longer than 1 hour.
+            runbook_url: 
+          expr: |
+            sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"}) > 0
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetNotScheduled
+          annotations:
+            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+              }} are not scheduled.'
+            runbook_url: 
+          expr: |
+            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+              -
+            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeDaemonSetMisScheduled
+          annotations:
+            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
+              }} are running where they are not supposed to run.'
+            runbook_url: 
+          expr: |
+            kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: KubeCronJobRunning
+          annotations:
+            message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+              than 1h to complete.
+            runbook_url: 
+          expr: |
+            time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeJobCompletion
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+              than one hour to complete.
+            runbook_url: 
+          expr: |
+            kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
+          for: 1h
+          labels:
+            severity: warning
+        - alert: KubeJobFailed
+          annotations:
+            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+            runbook_url: 
+          expr: |
+            kube_job_failed{job="kube-state-metrics"}  > 0
+          for: 15m
+          labels:
+            severity: warning
+      - name: kubernetes-resources
+        rules:
+        - alert: KubeCPUOvercommit
+          annotations:
+            message: Cluster has overcommitted CPU resource requests for Pods and cannot
+              tolerate node failure.
+            runbook_url:
+          expr: |
+            sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum)
+              /
+            sum(kube_node_status_allocatable_cpu_cores)
+              >
+            (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeMemOvercommit
+          annotations:
+            message: Cluster has overcommitted memory resource requests for Pods and cannot
+              tolerate node failure.
+            runbook_url:
+          expr: |
+            sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum)
+              /
+            sum(kube_node_status_allocatable_memory_bytes)
+              >
+            (count(kube_node_status_allocatable_memory_bytes)-1)
+              /
+            count(kube_node_status_allocatable_memory_bytes)
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeCPUOvercommit
+          annotations:
+            message: Cluster has overcommitted CPU resource requests for Namespaces.
+            runbook_url:
+          expr: |
+            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="cpu"})
+              /
+            sum(kube_node_status_allocatable_cpu_cores)
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeMemOvercommit
+          annotations:
+            message: Cluster has overcommitted memory resource requests for Namespaces.
+            runbook_url:
+          expr: |
+            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="memory"})
+              /
+            sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
+              > 1.5
+          for: 5m
+          labels:
+            severity: warning
+        - alert: KubeQuotaExceeded
+          annotations:
+            message: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
+              }} of its {{ $labels.resource }} quota.
+            runbook_url: 
+          expr: |
+            kube_resourcequota{job="kube-state-metrics", type="used"}
+              / ignoring(instance, job, type)
+            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+              > 0.90
+          for: 15m
+          labels:
+            severity: warning
+        - alert: CPUThrottlingHigh
+          annotations:
+            message: '{{ $value | humanizePercentage }} throttling of CPU in namespace
+              {{ $labels.namespace }} for container {{ $labels.container }} in pod {{
+              $labels.pod }}.'
+            runbook_url: 
+          expr: |
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
+              /
+            sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
+              > ( 25 / 100 )
+          for: 15m
+          labels:
+            severity: warning
+      - name: kubernetes-storage
+        rules:
+        - alert: KubePersistentVolumeUsageCritical
+          annotations:
+            message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
+              }} free.
+            runbook_url:
+          expr: |
+            kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+              /
+            kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+              < 0.03
+          for: 1m
+          labels:
+            severity: critical
+        - alert: KubePersistentVolumeFullInFourDays
+          annotations:
+            message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim
+              }} in Namespace {{ $labels.namespace }} is expected to fill up within four
+              days. Currently {{ $value | humanizePercentage }} is available.
+            runbook_url:
+          expr: |
+            (
+              kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
+                /
+              kubelet_volume_stats_capacity_bytes{job="kubelet", metrics_path="/metrics"}
+            ) < 0.15
+            and
+            predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
+          for: 1h
+          labels:
+            severity: critical
+        - alert: KubePersistentVolumeErrors
+          annotations:
+            message: The persistent volume {{ $labels.persistentvolume }} has status {{
+              $labels.phase }}.
+            runbook_url:
+          expr: |
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+          for: 5m
+          labels:
+            severity: critical
+      - name: kubernetes-system
+        rules:
+        - alert: KubeVersionMismatch
+          annotations:
+            message: There are {{ $value }} different semantic versions of Kubernetes
+              components running.
+            runbook_url: 
+          expr: |
+            count(count by (gitVersion) (label_replace(kubernetes_build_info{job!~"kube-dns|coredns"},"gitVersion","$1","gitVersion","(v[0-9]*.[0-9]*.[0-9]*).*"))) > 1
+          for: 15m
+          labels:
+            severity: warning
+      
+
+      - name: kubernetes-system-kubelet
+        rules:
+        - alert: KubeNodeNotReady
+          annotations:
+            message: '{{ $labels.node }} has been unready for more than 15 minutes.'
+            runbook_url: 
+          expr: |
+            kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeNodeUnreachable
+          annotations:
+            message: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
+            runbook_url: 
+          expr: |
+            kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+          for: 2m
+          labels:
+            severity: warning
+        - alert: KubeletTooManyPods
+          annotations:
+            message: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
+              }} of its Pod capacity.
+            runbook_url: 
+          expr: |
+            max(max(kubelet_running_pod_count{job="kubelet", metrics_path="/metrics"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"}) by(node) / max(kube_node_status_capacity_pods{job="kube-state-metrics"}) by(node) > 0.95
+          for: 15m
+          labels:
+            severity: warning
+        - alert: KubeletDown
+          annotations:
+            message: Kubelet has disappeared from Prometheus target discovery.
+            runbook_url: 
+          expr: |
+            absent(up{job="kubelet", metrics_path="/metrics"} == 1)
+          for: 15m
+          labels:
+            severity: critical
+
+            severity: critical
+
+      - name: prometheus
+        rules:
+        - alert: PrometheusBadConfig
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to
+              reload its configuration.
+            summary: Failed Prometheus configuration reload.
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(prometheus_config_last_reload_successful{job="prometheus-k8s",namespace="monitoring"}[5m]) == 0
+          for: 10m
+          labels:
+            severity: critical
+        - alert: PrometheusNotificationQueueRunningFull
+          annotations:
+            description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+              is running full.
+            summary: Prometheus alert notification queue predicted to run full in less
+              than 30m.
+          expr: |
+            # Without min_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              predict_linear(prometheus_notifications_queue_length{job="prometheus-k8s",namespace="monitoring"}[5m], 60 * 30)
+            >
+              min_over_time(prometheus_notifications_queue_capacity{job="prometheus-k8s",namespace="monitoring"}[5m])
+            )
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
+          annotations:
+            description: '{{ printf "%.1f" $value }}% errors while sending alerts from
+              Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.alertmanager}}.'
+            summary: Prometheus has encountered more than 1% errors sending alerts to
+              a specific Alertmanager.
+          expr: |
+            (
+              rate(prometheus_notifications_errors_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+            /
+              rate(prometheus_notifications_sent_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+            )
+            * 100
+            > 1
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
+          annotations:
+            description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts
+              from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.'
+            summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
+          expr: |
+            min without(alertmanager) (
+              rate(prometheus_notifications_errors_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+            /
+              rate(prometheus_notifications_sent_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+            )
+            * 100
+            > 3
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusNotConnectedToAlertmanagers
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
+              to any Alertmanagers.
+            summary: Prometheus is not connected to any Alertmanagers.
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            max_over_time(prometheus_notifications_alertmanagers_discovered{job="prometheus-k8s",namespace="monitoring"}[5m]) < 1
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusTSDBReloadsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} reload failures over the last 3h.
+            summary: Prometheus has issues reloading blocks from disk.
+          expr: |
+            increase(prometheus_tsdb_reloads_failures_total{job="prometheus-k8s",namespace="monitoring"}[3h]) > 0
+          for: 4h
+          labels:
+            severity: warning
+        - alert: PrometheusTSDBCompactionsFailing
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
+              {{$value | humanize}} compaction failures over the last 3h.
+            summary: Prometheus has issues compacting blocks.
+          expr: |
+            increase(prometheus_tsdb_compactions_failed_total{job="prometheus-k8s",namespace="monitoring"}[3h]) > 0
+          for: 4h
+          labels:
+            severity: warning
+        - alert: PrometheusNotIngestingSamples
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
+              samples.
+            summary: Prometheus is not ingesting samples.
+          expr: |
+            rate(prometheus_tsdb_head_samples_appended_total{job="prometheus-k8s",namespace="monitoring"}[5m]) <= 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusDuplicateTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with different values but duplicated
+              timestamp.
+            summary: Prometheus is dropping samples with duplicate timestamps.
+          expr: |
+            rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusOutOfOrderTimestamps
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
+              {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of order.
+            summary: Prometheus drops samples with out-of-order timestamps.
+          expr: |
+            rate(prometheus_target_scrapes_sample_out_of_order_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: PrometheusRemoteStorageFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send
+              {{ printf "%.1f" $value }}% of the samples to queue {{$labels.queue}}.
+            summary: Prometheus fails to send samples to remote storage.
+          expr: |
+            (
+              rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+            /
+              (
+                rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+              +
+                rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
+              )
+            )
+            * 100
+            > 1
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusRemoteWriteBehind
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              is {{ printf "%.1f" $value }}s behind for queue {{$labels.queue}}.
+            summary: Prometheus remote write is behind.
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
+            - on(job, instance) group_right
+              max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
+            )
+            > 120
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusRemoteWriteDesiredShards
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
+              desired shards calculation wants to run {{ $value }} shards, which is more
+              than the max of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job="prometheus-k8s",namespace="monitoring"}`
+              $labels.instance | query | first | value }}.
+            summary: Prometheus remote write desired shards calculation wants to run more
+              than configured max shards.
+          expr: |
+            # Without max_over_time, failed scrapes could create false negatives, see
+            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
+            (
+              max_over_time(prometheus_remote_storage_shards_desired{job="prometheus-k8s",namespace="monitoring"}[5m])
+            >
+              max_over_time(prometheus_remote_storage_shards_max{job="prometheus-k8s",namespace="monitoring"}[5m])
+            )
+          for: 15m
+          labels:
+            severity: warning
+        - alert: PrometheusRuleFailures
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to
+              evaluate {{ printf "%.0f" $value }} rules in the last 5m.
+            summary: Prometheus is failing rule evaluations.
+          expr: |
+            increase(prometheus_rule_evaluation_failures_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: critical
+        - alert: PrometheusMissingRuleEvaluations
+          annotations:
+            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{
+              printf "%.0f" $value }} rule group evaluations in the last 5m.
+            summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
+          expr: |
+            increase(prometheus_rule_group_iterations_missed_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
+          for: 15m
+          labels:
+            severity: warning
+      - name: alertmanager.rules
+        rules:
+        - alert: AlertmanagerConfigInconsistent
+          annotations:
+            message: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}`
+              are out of sync.
+          expr: |
+            count_values("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{job="prometheus-operator",namespace="monitoring",controller="alertmanager"}) by (name, job, namespace, controller), "service", "alertmanager-$1", "name", "(.*)") != 1
+          for: 5m
+          labels:
+            severity: critical
+        - alert: AlertmanagerFailedReload
+          annotations:
+            message: Reloading Alertmanager's configuration has failed for {{ $labels.namespace
+              }}/{{ $labels.pod}}.
+          expr: |
+            alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"} == 0
+          for: 10m
+          labels:
+            severity: warning
+        - alert: AlertmanagerMembersInconsistent
+          annotations:
+            message: Alertmanager has not found all other members of the cluster.
+          expr: |
+            alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"}
+              != on (service) GROUP_LEFT()
+            count by (service) (alertmanager_cluster_members{job="alertmanager-main",namespace="monitoring"})
+          for: 5m
+          labels:
+            severity: critical
+      - name: general.rules
+        rules:
+        - alert: TargetDown
+          annotations:
+            message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service
+              }} targets in {{ $labels.namespace }} namespace are down.'
+          expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
+            namespace, service)) > 10
+          for: 10m
+          labels:
+            severity: warning
+        - alert: Watchdog
+          annotations:
+            message: |
+              This is an alert meant to ensure that the entire alerting pipeline is functional.
+              This alert is always firing, therefore it should always be firing in Alertmanager
+              and always fire against a receiver. There are integrations with various notification
+              mechanisms that send a notification when this alert is not firing. For example the
+              "DeadMansSnitch" integration in PagerDuty.
+          expr: vector(1)
+          labels:
+            severity: none
+      - name: node-time
+        rules:
+        - alert: ClockSkewDetected
+          annotations:
+            message: Clock skew detected on node-exporter {{ $labels.namespace }}/{{ $labels.pod
+              }}. Ensure NTP is configured correctly on this host.
+          expr: |
+            abs(node_timex_offset_seconds{job="node-exporter"}) > 0.05
+          for: 2m
+          labels:
+            severity: warning
+      - name: node-network
+        rules:
+        - alert: NodeNetworkInterfaceFlapping
+          annotations:
+            message: Network interface "{{ $labels.device }}" changing it's up status
+              often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"
+          expr: |
+            changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
+          for: 2m
+          labels:
+            severity: warning
+
+
 
         {{- end }}

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -232,9 +232,8 @@ data:
             summary: "Half or more of schedulers do not have a heartbeat"
             description: "Half or more of schedulers do not have a heartbeat in the last five minutes"
 
-
         ## JPW added
-      - name: node-exporter.rules ## Recording rules
+      - name: node-exporter-recording.rules 
         rules:
         - expr: |
             count without (cpu) (
@@ -292,7 +291,7 @@ data:
             )
           record: instance:node_network_transmit_drop_excluding_lo:rate1m
 
-      - name: k8s.rules ## Recording rules
+      - name: k8s-recording.rules 
         rules:
         - expr: |
             sum(rate(container_cpu_usage_seconds_total{job="kubelet", metrics_path="/metrics/cadvisor", image!="", container!="POD"}[5m])) by (namespace)
@@ -376,7 +375,7 @@ data:
           labels:
             workload_type: statefulset
           record: mixin_pod_workload
-      - name: kube-scheduler.rules ## Recording Rules
+      - name: kube-scheduler-recording.rules 
         rules:
         - expr: |
             histogram_quantile(0.99, sum(rate(scheduler_e2e_scheduling_duration_seconds_bucket{job="kube-scheduler"}[5m])) without(instance, pod))
@@ -423,7 +422,7 @@ data:
           labels:
             quantile: "0.5"
           record: cluster_quantile:scheduler_binding_duration_seconds:histogram_quantile
-      - name: node.rules ## Recording Rules
+      - name: node-recording.rules 
         rules:
         - expr: |
             sum(min(kube_pod_info) by (cluster, node))
@@ -449,7 +448,7 @@ data:
               )
             ) by (cluster)
           record: :node_memory_MemAvailable_bytes:sum
-      - name: kube-prometheus-node-recording.rules ## Recording Rules
+      - name: kube-prometheus-node-recording.rules 
         rules:
         - expr: sum(rate(node_cpu_seconds_total{mode!="idle",mode!="iowait"}[3m])) BY
             (instance)
@@ -470,7 +469,7 @@ data:
         - expr: cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
             BY (instance, cpu))
           record: cluster:node_cpu:ratio
-      - name: kube-prometheus-general.rules ## Recording Rules
+      - name: kube-prometheus-general-recording.rules 
         rules:
         - expr: count without(instance, pod, node) (up == 1)
           record: count:up1
@@ -1286,7 +1285,6 @@ data:
           for: 2m
           labels:
             severity: warning
-
 
 
         {{- end }}

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -112,7 +112,7 @@ data:
           for: 5m
           labels:
             tier: platform
-            severity: urgent
+            severity: critical
           annotations:
             summary: {{ printf "%q" "{{ $value }} airflow schedulers are not heartbeating" }}
             description: "If more than 5 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires."
@@ -123,7 +123,7 @@ data:
           labels:
             tier: platform
             component: fluentd
-            severity: urgent
+            severity: critical
           annotations:
             summary: {{ printf "%q" "Average Fluentd buffer queue length is {{ $value }}" }}
             description: "Check on Elastic Search client and try restarting Fluentd pods"
@@ -166,18 +166,6 @@ data:
           annotations:
             summary: "A container in the platform namespace uses more than 80% of the memory limit"
             description: {{ printf "%q" "{{ $labels.container }} in {{ $labels.pod }} is using {{ printf \"%.2f\" $value }}% of available memory." }}
-
-        - alert: NginxIngressDown
-          expr: |
-            absent(up{job="nginx"} == 1)
-          for: 15m
-          labels:
-            tier: platform
-            component: nginx
-          annotations:
-            summary: "Nginx Ingress Controller has disappeared from Prometheus target discovery"
-            description: "This alert fires if Prometheus target discovery was not able to
-              reach ingress-nginx-metrics in the last 15 minutes."
 
         {{- if .Values.global.veleroEnabled }}
         - alert: VeleroMetricsAbsent
@@ -228,7 +216,7 @@ data:
           labels:
             tier: platform
             component: airflow
-            severity: urgent
+            severity: critical
           annotations:
             summary: "Half or more of schedulers do not have a heartbeat"
             description: "Half or more of schedulers do not have a heartbeat in the last five minutes"

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1007,8 +1007,6 @@ data:
           labels:
             severity: critical
 
-            severity: critical
-
       - name: prometheus
         rules:
         - alert: PrometheusBadConfig

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -105,13 +105,12 @@ data:
 
       - name: platform
         rules:
-
         - alert: AirflowOperatorFailureRate
           expr: 100 * (sum by (operator) (increase(airflow_operator_failures{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])) / (sum by (operator) (increase(airflow_operator_successes{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])) + sum by (operator) (increase(airflow_operator_failures{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])))) > 50
           for: 2h
           labels:
             tier: platform
-            severity: info
+            severity: warn
             operator: {{ printf "%q" "{{ $labels.operator }}" }}
           annotations:
             summary: {{ printf "%q" "Across all deployments, {{ $labels.operator }} is failing {{ $value }}% of the time" }}
@@ -126,99 +125,6 @@ data:
           annotations:
             summary: {{ printf "%q" "{{ $value }} airflow schedulers are not heartbeating" }}
             description: "If more than 5 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires."
-
-        - alert: FluentdQueueLarge
-          expr: avg(fluentd_status_buffer_queue_length) > 2
-          for: 15m
-          labels:
-            tier: platform
-            component: fluentd
-            severity: critical
-          annotations:
-            summary: {{ printf "%q" "Average Fluentd buffer queue length is {{ $value }}" }}
-            description: "Check on Elastic Search client and try restarting Fluentd pods"
-
-        - alert: NginxIngressHighFailureRate
-          expr: |
-            (sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!="", status=~"[4-5][0-9][0-9]"}[2m]))
-              /
-            sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m]))) * 100 > 10
-          for: 10m
-          labels:
-            tier: platform
-            component: nginx
-          annotations:
-            summary: {{ printf "%q" "NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf \"%.2f\" $value }}%." }}
-            description: "This alert fires if the failure rate (the rate of 4xx or 5xx reponses)
-              measured on a time window of 2 minutes was higher than 10% in the last
-              10 minutes."
-
-        - alert: KubeNamespaceStuckAtTerminating
-          expr: |
-            kube_namespace_status_phase{namespace=~".*-.*-.*-[0-9]{4}", phase="Terminating"} == 1
-          for: 1h
-          labels:
-            tier: platform
-            component: namespace
-          annotations:
-            summary: "Namespace in TERMINATING state for more than 1 hour"
-            description: {{ printf "%q" "Namespace {{ $labels.namespace }} has been in a TERMINATING state for longer than an hour." }}
-
-        - alert: ContainerMemoryNearTheLimitPlatform
-          expr: |
-            (container_memory_working_set_bytes{namespace="{{ .Release.Name }}", container_name!="POD"} /
-            container_spec_memory_limit_bytes{namespace="{{ .Release.Name }}", container_name!="POD"}) * 100 > 80 < +Inf
-          for: 1h
-          labels:
-            tier: platform
-            component: container
-            severity: warning
-          annotations:
-            summary: "A container in the platform namespace uses more than 80% of the memory limit"
-            description: {{ printf "%q" "{{ $labels.container }} in {{ $labels.pod }} is using {{ printf \"%.2f\" $value }}% of available memory." }}
-
-        {{- if .Values.global.veleroEnabled }}
-        - alert: VeleroMetricsAbsent
-          expr: absent(up{job="velero"} == 1)
-          for: 15m
-          labels:
-            tier: platform
-            component: velero
-          annotations:
-            summary: "Velero has disappeared from Prometheus target discovery"
-            description: "This alert fires if Prometheus target discovery was not able to
-              scrape Velero metrics in the last 15 minutes."
-
-        - alert: FailedVeleroBackup
-          expr: increase(velero_backup_failure_total{job="velero"}[1d]) > 0
-          for: 5m
-          labels:
-            tier: platform
-            component: velero
-          annotations:
-            summary: "Velero failed to backup"
-            description: {{ printf "%q" "Backup attempt failed in Velero past 1 day \n LABELS - {{ $labels }}." }}
-
-        - alert: PartialFailedVeleroBackup
-          expr: increase(velero_backup_partial_failure_total{job="velero"}[1d]) > 0
-          for: 5m
-          labels:
-            tier: platform
-            component: velero
-          annotations:
-            summary: "Velero partially failed to backup"
-            description: {{ printf "%q" "Backup attempt partially failed in Velero past 1 day \n LABELS - {{ $labels }}." }}
-
-        - alert: VeleroNoBackupForLong
-          expr: time() - velero_backup_last_successful_timestamp > 172800
-          for: 5m
-          labels:
-            tier: platform
-            component: velero
-          annotations:
-            summary: "2 days since last successful Backup for a Velero Schedule"
-            description: {{ printf "%q" "Time since last successful backup for {{ $labels.schedule }} :\n  VALUE = {{ $value }}\n  LABELS - {{ $labels }}" }}
-        {{- end }}
 
         - alert: SchedulersNotHealthy
           expr: (count(rate(airflow_scheduler_heartbeat{}[1m]) > 0) / count(rate(airflow_scheduler_heartbeat{}[1m]))) < 0.5
@@ -503,6 +409,7 @@ data:
           for: 15m
           labels:
             severity: critical
+
       - name: node-exporter
         rules:
         - alert: NodeFilesystemSpaceFillingUp
@@ -908,6 +815,20 @@ data:
           for: 15m
           labels:
             severity: warning
+
+        - alert: ContainerMemoryNearTheLimitPlatform
+          expr: |
+            (container_memory_working_set_bytes{namespace="{{ .Release.Name }}", container_name!="POD"} /
+            container_spec_memory_limit_bytes{namespace="{{ .Release.Name }}", container_name!="POD"}) * 100 > 80 < +Inf
+          for: 1h
+          labels:
+            tier: platform
+            component: container
+            severity: warning
+          annotations:
+            summary: "A container in the platform namespace uses more than 80% of the memory limit"
+            description: {{ printf "%q" "{{ $labels.container }} in {{ $labels.pod }} is using {{ printf \"%.2f\" $value }}% of available memory." }}
+
       - name: kubernetes-storage
         rules:
         - alert: KubePersistentVolumeUsageCritical
@@ -963,6 +884,17 @@ data:
           for: 15m
           labels:
             severity: warning
+
+        - alert: KubeNamespaceStuckAtTerminating
+          expr: |
+            kube_namespace_status_phase{namespace=~".*-.*-.*-[0-9]{4}", phase="Terminating"} == 1
+          for: 1h
+          labels:
+            tier: platform
+            component: namespace
+          annotations:
+            summary: "Namespace in TERMINATING state for more than 1 hour"
+            description: {{ printf "%q" "Namespace {{ $labels.namespace }} has been in a TERMINATING state for longer than an hour." }}
   
       - name: kubernetes-system-kubelet
         rules:
@@ -1226,5 +1158,97 @@ data:
           labels:
             severity: warning
 
+ 
+      {{- if .Values.global.veleroEnabled }}
+      - name: velero
+        rules: 
+        - alert: VeleroMetricsAbsent
+          expr: absent(up{job="velero"} == 1)
+          for: 15m
+          labels:
+            tier: platform
+            component: velero
+          annotations:
+            summary: "Velero has disappeared from Prometheus target discovery"
+            description: "This alert fires if Prometheus target discovery was not able to
+              scrape Velero metrics in the last 15 minutes."
 
+        - alert: FailedVeleroBackup
+          expr: increase(velero_backup_failure_total{job="velero"}[1d]) > 0
+          for: 5m
+          labels:
+            tier: platform
+            component: velero
+          annotations:
+            summary: "Velero failed to backup"
+            description: {{ printf "%q" "Backup attempt failed in Velero past 1 day \n LABELS - {{ $labels }}." }}
 
+        - alert: PartialFailedVeleroBackup
+          expr: increase(velero_backup_partial_failure_total{job="velero"}[1d]) > 0
+          for: 5m
+          labels:
+            tier: platform
+            component: velero
+          annotations:
+            summary: "Velero partially failed to backup"
+            description: {{ printf "%q" "Backup attempt partially failed in Velero past 1 day \n LABELS - {{ $labels }}." }}
+
+        - alert: VeleroNoBackupForLong
+          expr: time() - velero_backup_last_successful_timestamp > 172800
+          for: 5m
+          labels:
+            tier: platform
+            component: velero
+          annotations:
+            summary: "2 days since last successful Backup for a Velero Schedule"
+            description: {{ printf "%q" "Time since last successful backup for {{ $labels.schedule }} :\n  VALUE = {{ $value }}\n  LABELS - {{ $labels }}" }}
+        {{- end }}
+
+      - name: Ingress
+        rules:
+        - alert: NginxIngressHigh4XXRate
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4.."}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 5
+          for: 10m
+          labels:
+            tier: platform
+            component: nginx
+          annotations:
+            summary: {{ printf "%q" "NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf \"%.2f\" $value }}%." }}
+            description: "This alert fires if the failure rate (the rate of 4xx)
+              measured on a time window of 2 minutes was higher than 5% in the last
+              10 minutes."
+
+        - alert: NginxIngressHigh5XXRate
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4.."}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 1
+          for: 5m
+          labels:
+            tier: platform
+            component: nginx
+          annotations:
+            summary: {{ printf "%q" "NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf \"%.2f\" $value }}%." }}
+            description: "This alert fires if the failure rate (the rate of 5xx reponses)
+              measured on a time window of 2 minutes was higher than 1% in the last
+              5 minutes."
+
+      - name: logging
+        rules: 
+        - alert: FluentdQueueLarge
+          expr: sum by (host)( fluentd_status_buffer_queue_length) > 2
+          for: 15m
+          labels:
+            tier: platform
+            component: fluentd
+            severity: critical
+          annotations:
+            summary: {{ printf "%q" "Fluentd buffer queue length is {{ $value }} For {{ $labels.host }} " }}
+            description: "Check on Elastic Search client and try restarting Fluentd pods"
+
+        - alert: ElasticSeachUnassignedShards
+          expr: elasticsearch_cluster_health_unassigned_shards > 0
+          for: 10m
+          labels:
+            severity: High
+          annotations:
+            summary: {{ printf "%q" "Elastic Search has {{ $value }} unassigned shards" }}
+            description: "Unassigned shards in Elastic Search cluster"
+    

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -220,6 +220,7 @@ data:
           annotations:
             summary: "2 days since last successful Backup for a Velero Schedule"
             description: {{ printf "%q" "Time since last successful backup for {{ $labels.schedule }} :\n  VALUE = {{ $value }}\n  LABELS - {{ $labels }}" }}
+        {{- end }}
 
         - alert: SchedulersNotHealthy
           expr: (count(rate(airflow_scheduler_heartbeat{}[1m]) > 0) / count(rate(airflow_scheduler_heartbeat{}[1m]))) < 0.5
@@ -232,7 +233,6 @@ data:
             summary: "Half or more of schedulers do not have a heartbeat"
             description: "Half or more of schedulers do not have a heartbeat in the last five minutes"
 
-        ## JPW added
       - name: node-exporter-recording.rules 
         rules:
         - expr: |
@@ -509,8 +509,8 @@ data:
         rules:
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available space left and is filling
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available space left and is filling
               up.
             runbook_url: 
             summary: Filesystem is predicted to run out of space within the next 24 hours.
@@ -527,8 +527,8 @@ data:
             severity: warning
         - alert: NodeFilesystemSpaceFillingUp
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available space left and is filling
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available space left and is filling
               up fast.
             runbook_url: 
             summary: Filesystem is predicted to run out of space within the next 4 hours.
@@ -545,8 +545,8 @@ data:
             severity: critical
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available space left.
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available space left.
             runbook_url: 
             summary: Filesystem has less than 5% space left.
           expr: |
@@ -560,8 +560,8 @@ data:
             severity: warning
         - alert: NodeFilesystemAlmostOutOfSpace
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available space left.
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available space left.
             runbook_url: 
             summary: Filesystem has less than 3% space left.
           expr: |
@@ -575,8 +575,8 @@ data:
             severity: critical
         - alert: NodeFilesystemFilesFillingUp
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available inodes left and is filling
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available inodes left and is filling
               up.
             runbook_url: 
             summary: Filesystem is predicted to run out of inodes within the next 24 hours.
@@ -593,8 +593,8 @@ data:
             severity: warning
         - alert: NodeFilesystemFilesFillingUp
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available inodes left and is filling
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available inodes left and is filling
               up fast.
             runbook_url: 
             summary: Filesystem is predicted to run out of inodes within the next 4 hours.
@@ -611,8 +611,8 @@ data:
             severity: critical
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available inodes left.
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available inodes left.
             runbook_url: 
             summary: Filesystem has less than 5% inodes left.
           expr: |
@@ -626,8 +626,8 @@ data:
             severity: warning
         - alert: NodeFilesystemAlmostOutOfFiles
           annotations:
-            description: Filesystem on {{ $labels.device }} at {{ $labels.instance }}
-              has only {{ printf "%.2f" $value }}% available inodes left.
+            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
+              has only {{`{{ printf "%.2f" $value }}`}}% available inodes left.
             runbook_url: 
             summary: Filesystem has less than 3% inodes left.
           expr: |
@@ -641,8 +641,8 @@ data:
             severity: critical
         - alert: NodeNetworkReceiveErrs
           annotations:
-            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
-              {{ printf "%.0f" $value }} receive errors in the last two minutes.'
+            description: '{{`{{ $labels.instance }}`}} interface {{`{{ $labels.device }}`}} has encountered
+              {{`{{ printf "%.0f" $value }}`}} receive errors in the last two minutes.'
             runbook_url: 
             summary: Network interface is reporting many receive errors.
           expr: |
@@ -652,8 +652,8 @@ data:
             severity: warning
         - alert: NodeNetworkTransmitErrs
           annotations:
-            description: '{{ $labels.instance }} interface {{ $labels.device }} has encountered
-              {{ printf "%.0f" $value }} transmit errors in the last two minutes.'
+            description: '{{`{{ $labels.instance }}`}} interface {{`{{ $labels.device }}`}} has encountered
+              {{`{{ printf "%.0f" $value }}`}} transmit errors in the last two minutes.'
             runbook_url: 
             summary: Network interface is reporting many transmit errors.
           expr: |
@@ -661,12 +661,13 @@ data:
           for: 1h
           labels:
             severity: warning
+     
       - name: kubernetes-apps
         rules:
         - alert: KubePodCrashLooping
           annotations:
-            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container
-              }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.
+            message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} ({{`{{ $labels.container
+              }}`}}) is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
             runbook_url: 
           expr: |
             rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
@@ -675,7 +676,7 @@ data:
             severity: critical
         - alert: KubePodNotReady
           annotations:
-            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready
+            message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready
               state for longer than 15 minutes.
             runbook_url: 
           expr: |
@@ -685,8 +686,8 @@ data:
             severity: critical
         - alert: KubeDeploymentGenerationMismatch
           annotations:
-            message: Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment
-              }} does not match, this indicates that the Deployment has failed but has
+            message: Deployment generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment
+              }}`}} does not match, this indicates that the Deployment has failed but has
               not been rolled back.
             runbook_url:
           expr: |
@@ -698,7 +699,7 @@ data:
             severity: critical
         - alert: KubeDeploymentReplicasMismatch
           annotations:
-            message: Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not
+            message: Deployment {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}} has not
               matched the expected number of replicas for longer than 15 minutes.
             runbook_url: 
           expr: |
@@ -710,7 +711,7 @@ data:
             severity: critical
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
-            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has
+            message: StatefulSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset }}`}} has
               not matched the expected number of replicas for longer than 15 minutes.
             runbook_url: 
           expr: |
@@ -722,8 +723,8 @@ data:
             severity: critical
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
-            message: StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset
-              }} does not match, this indicates that the StatefulSet has failed but has
+            message: StatefulSet generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset
+              }}`}} does not match, this indicates that the StatefulSet has failed but has
               not been rolled back.
             runbook_url:
           expr: |
@@ -735,7 +736,7 @@ data:
             severity: critical
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
-            message: StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update
+            message: StatefulSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset }}`}} update
               has not been rolled out.
             runbook_url:
           expr: |
@@ -755,8 +756,8 @@ data:
             severity: critical
         - alert: KubeDaemonSetRolloutStuck
           annotations:
-            message: Only {{ $value | humanizePercentage }} of the desired Pods of DaemonSet
-              {{ $labels.namespace }}/{{ $labels.daemonset }} are scheduled and ready.
+            message: Only {{`{{ $value | humanizePercentage }}`}} of the desired Pods of DaemonSet
+              {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset }}`}} are scheduled and ready.
             runbook_url: 
           expr: |
             kube_daemonset_status_number_ready{job="kube-state-metrics"}
@@ -767,7 +768,7 @@ data:
             severity: critical
         - alert: KubeContainerWaiting
           annotations:
-            message: Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}}
+            message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} container {{`{{ $labels.container}}`}}
               has been in waiting state for longer than 1 hour.
             runbook_url: 
           expr: |
@@ -777,8 +778,8 @@ data:
             severity: warning
         - alert: KubeDaemonSetNotScheduled
           annotations:
-            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-              }} are not scheduled.'
+            message: '{{`{{ $value }}`}} Pods of DaemonSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset
+              }}`}} are not scheduled.'
             runbook_url: 
           expr: |
             kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
@@ -789,8 +790,8 @@ data:
             severity: warning
         - alert: KubeDaemonSetMisScheduled
           annotations:
-            message: '{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset
-              }} are running where they are not supposed to run.'
+            message: '{{`{{ $value }}`}} Pods of DaemonSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset
+              }}`}} are running where they are not supposed to run.'
             runbook_url: 
           expr: |
             kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
@@ -799,7 +800,7 @@ data:
             severity: warning
         - alert: KubeCronJobRunning
           annotations:
-            message: CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} is taking more
+            message: CronJob {{`{{ $labels.namespace }}`}}/{{`{{ $labels.cronjob }}`}} is taking more
               than 1h to complete.
             runbook_url: 
           expr: |
@@ -809,7 +810,7 @@ data:
             severity: warning
         - alert: KubeJobCompletion
           annotations:
-            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more
+            message: Job {{`{{ $labels.namespace }}`}}/{{`{{ $labels.job_name }}`}} is taking more
               than one hour to complete.
             runbook_url: 
           expr: |
@@ -819,7 +820,7 @@ data:
             severity: warning
         - alert: KubeJobFailed
           annotations:
-            message: Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.
+            message: Job {{`{{ $labels.namespace }}`}}/{{`{{ $labels.job_name }}`}} failed to complete.
             runbook_url: 
           expr: |
             kube_job_failed{job="kube-state-metrics"}  > 0
@@ -884,8 +885,8 @@ data:
             severity: warning
         - alert: KubeQuotaExceeded
           annotations:
-            message: Namespace {{ $labels.namespace }} is using {{ $value | humanizePercentage
-              }} of its {{ $labels.resource }} quota.
+            message: Namespace {{`{{ $labels.namespace }}`}} is using {{`{{ $value | humanizePercentage
+              }}`}} of its {{`{{ $labels.resource }}`}} quota.
             runbook_url: 
           expr: |
             kube_resourcequota{job="kube-state-metrics", type="used"}
@@ -897,9 +898,9 @@ data:
             severity: warning
         - alert: CPUThrottlingHigh
           annotations:
-            message: '{{ $value | humanizePercentage }} throttling of CPU in namespace
-              {{ $labels.namespace }} for container {{ $labels.container }} in pod {{
-              $labels.pod }}.'
+            message: '{{`{{ $value | humanizePercentage }}`}} throttling of CPU in namespace
+              {{`{{ $labels.namespace }}`}} for container {{`{{ $labels.container }}`}} in pod {{`{{
+              $labels.pod }}`}}.'
             runbook_url: 
           expr: |
             sum(increase(container_cpu_cfs_throttled_periods_total{container!="", }[5m])) by (container, pod, namespace)
@@ -913,9 +914,9 @@ data:
         rules:
         - alert: KubePersistentVolumeUsageCritical
           annotations:
-            message: The PersistentVolume claimed by {{ $labels.persistentvolumeclaim
-              }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage
-              }} free.
+            message: The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim
+              }}`}} in Namespace {{`{{ $labels.namespace }}`}} is only {{`{{ $value | humanizePercentage
+              }}`}} free.
             runbook_url:
           expr: |
             kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}
@@ -927,9 +928,9 @@ data:
             severity: critical
         - alert: KubePersistentVolumeFullInFourDays
           annotations:
-            message: Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim
-              }} in Namespace {{ $labels.namespace }} is expected to fill up within four
-              days. Currently {{ $value | humanizePercentage }} is available.
+            message: Based on recent sampling, the PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim
+              }}`}} in Namespace {{`{{ $labels.namespace }}`}} is expected to fill up within four
+              days. Currently {{`{{ $value | humanizePercentage }}`}} is available.
             runbook_url:
           expr: |
             (
@@ -944,8 +945,8 @@ data:
             severity: critical
         - alert: KubePersistentVolumeErrors
           annotations:
-            message: The persistent volume {{ $labels.persistentvolume }} has status {{
-              $labels.phase }}.
+            message: The persistent volume {{`{{ $labels.persistentvolume }}`}} has status {{`{{
+              $labels.phase }}`}}.
             runbook_url:
           expr: |
             kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
@@ -956,7 +957,7 @@ data:
         rules:
         - alert: KubeVersionMismatch
           annotations:
-            message: There are {{ $value }} different semantic versions of Kubernetes
+            message: There are {{`{{ $value }}`}} different semantic versions of Kubernetes
               components running.
             runbook_url: 
           expr: |
@@ -970,7 +971,7 @@ data:
         rules:
         - alert: KubeNodeNotReady
           annotations:
-            message: '{{ $labels.node }} has been unready for more than 15 minutes.'
+            message: '{{`{{ $labels.node }}`}} has been unready for more than 15 minutes.'
             runbook_url: 
           expr: |
             kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
@@ -979,7 +980,7 @@ data:
             severity: warning
         - alert: KubeNodeUnreachable
           annotations:
-            message: '{{ $labels.node }} is unreachable and some workloads may be rescheduled.'
+            message: '{{`{{ $labels.node }}`}} is unreachable and some workloads may be rescheduled.'
             runbook_url: 
           expr: |
             kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
@@ -988,8 +989,8 @@ data:
             severity: warning
         - alert: KubeletTooManyPods
           annotations:
-            message: Kubelet '{{ $labels.node }}' is running at {{ $value | humanizePercentage
-              }} of its Pod capacity.
+            message: Kubelet '{{`{{ $labels.node }}`}}' is running at {{`{{ $value | humanizePercentage
+              }}`}} of its Pod capacity.
             runbook_url: 
           expr: |
             max(max(kubelet_running_pod_count{job="kubelet", metrics_path="/metrics"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"}) by(node) / max(kube_node_status_capacity_pods{job="kube-state-metrics"}) by(node) > 0.95
@@ -1012,7 +1013,7 @@ data:
         rules:
         - alert: PrometheusBadConfig
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has failed to
               reload its configuration.
             summary: Failed Prometheus configuration reload.
           expr: |
@@ -1024,7 +1025,7 @@ data:
             severity: critical
         - alert: PrometheusNotificationQueueRunningFull
           annotations:
-            description: Alert notification queue of Prometheus {{$labels.namespace}}/{{$labels.pod}}
+            description: Alert notification queue of Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}}
               is running full.
             summary: Prometheus alert notification queue predicted to run full in less
               than 30m.
@@ -1041,8 +1042,8 @@ data:
             severity: warning
         - alert: PrometheusErrorSendingAlertsToSomeAlertmanagers
           annotations:
-            description: '{{ printf "%.1f" $value }}% errors while sending alerts from
-              Prometheus {{$labels.namespace}}/{{$labels.pod}} to Alertmanager {{$labels.alertmanager}}.'
+            description: '{{`{{ printf "%.1f" $value }}`}}% errors while sending alerts from
+              Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} to Alertmanager {{`{{$labels.alertmanager}}`}}.'
             summary: Prometheus has encountered more than 1% errors sending alerts to
               a specific Alertmanager.
           expr: |
@@ -1058,8 +1059,8 @@ data:
             severity: warning
         - alert: PrometheusErrorSendingAlertsToAnyAlertmanager
           annotations:
-            description: '{{ printf "%.1f" $value }}% minimum errors while sending alerts
-              from Prometheus {{$labels.namespace}}/{{$labels.pod}} to any Alertmanager.'
+            description: '{{`{{ printf "%.1f" $value }}`}}% minimum errors while sending alerts
+              from Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} to any Alertmanager.'
             summary: Prometheus encounters more than 3% errors sending alerts to any Alertmanager.
           expr: |
             min without(alertmanager) (
@@ -1074,7 +1075,7 @@ data:
             severity: critical
         - alert: PrometheusNotConnectedToAlertmanagers
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not connected
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is not connected
               to any Alertmanagers.
             summary: Prometheus is not connected to any Alertmanagers.
           expr: |
@@ -1086,8 +1087,8 @@ data:
             severity: warning
         - alert: PrometheusTSDBReloadsFailing
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
-              {{$value | humanize}} reload failures over the last 3h.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected
+              {{`{{$value | humanize}}`}} reload failures over the last 3h.
             summary: Prometheus has issues reloading blocks from disk.
           expr: |
             increase(prometheus_tsdb_reloads_failures_total{job="prometheus-k8s",namespace="monitoring"}[3h]) > 0
@@ -1096,8 +1097,8 @@ data:
             severity: warning
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has detected
-              {{$value | humanize}} compaction failures over the last 3h.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected
+              {{`{{$value | humanize}}`}} compaction failures over the last 3h.
             summary: Prometheus has issues compacting blocks.
           expr: |
             increase(prometheus_tsdb_compactions_failed_total{job="prometheus-k8s",namespace="monitoring"}[3h]) > 0
@@ -1106,7 +1107,7 @@ data:
             severity: warning
         - alert: PrometheusNotIngestingSamples
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is not ingesting
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is not ingesting
               samples.
             summary: Prometheus is not ingesting samples.
           expr: |
@@ -1116,8 +1117,8 @@ data:
             severity: warning
         - alert: PrometheusDuplicateTimestamps
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
-              {{ printf "%.4g" $value  }} samples/s with different values but duplicated
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is dropping
+              {{`{{ printf "%.4g" $value  }}`}} samples/s with different values but duplicated
               timestamp.
             summary: Prometheus is dropping samples with duplicate timestamps.
           expr: |
@@ -1127,8 +1128,8 @@ data:
             severity: warning
         - alert: PrometheusOutOfOrderTimestamps
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} is dropping
-              {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of order.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is dropping
+              {{`{{ printf "%.4g" $value  }}`}} samples/s with timestamps arriving out of order.
             summary: Prometheus drops samples with out-of-order timestamps.
           expr: |
             rate(prometheus_target_scrapes_sample_out_of_order_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
@@ -1137,8 +1138,8 @@ data:
             severity: warning
         - alert: PrometheusRemoteStorageFailures
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} failed to send
-              {{ printf "%.1f" $value }}% of the samples to queue {{$labels.queue}}.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} failed to send
+              {{`{{ printf "%.1f" $value }}`}}% of the samples to queue {{`{{$labels.queue}}`}}.
             summary: Prometheus fails to send samples to remote storage.
           expr: |
             (
@@ -1157,8 +1158,8 @@ data:
             severity: critical
         - alert: PrometheusRemoteWriteBehind
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
-              is {{ printf "%.1f" $value }}s behind for queue {{$labels.queue}}.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} remote write
+              is {{`{{ printf "%.1f" $value }}`}}s behind for queue {{`{{$labels.queue}}`}}.
             summary: Prometheus remote write is behind.
           expr: |
             # Without max_over_time, failed scrapes could create false negatives, see
@@ -1172,29 +1173,10 @@ data:
           for: 15m
           labels:
             severity: critical
-        - alert: PrometheusRemoteWriteDesiredShards
-          annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} remote write
-              desired shards calculation wants to run {{ $value }} shards, which is more
-              than the max of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job="prometheus-k8s",namespace="monitoring"}`
-              $labels.instance | query | first | value }}.
-            summary: Prometheus remote write desired shards calculation wants to run more
-              than configured max shards.
-          expr: |
-            # Without max_over_time, failed scrapes could create false negatives, see
-            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-            (
-              max_over_time(prometheus_remote_storage_shards_desired{job="prometheus-k8s",namespace="monitoring"}[5m])
-            >
-              max_over_time(prometheus_remote_storage_shards_max{job="prometheus-k8s",namespace="monitoring"}[5m])
-            )
-          for: 15m
-          labels:
-            severity: warning
         - alert: PrometheusRuleFailures
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has failed to
-              evaluate {{ printf "%.0f" $value }} rules in the last 5m.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has failed to
+              evaluate {{`{{ printf "%.0f" $value }}`}} rules in the last 5m.
             summary: Prometheus is failing rule evaluations.
           expr: |
             increase(prometheus_rule_evaluation_failures_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
@@ -1203,8 +1185,8 @@ data:
             severity: critical
         - alert: PrometheusMissingRuleEvaluations
           annotations:
-            description: Prometheus {{$labels.namespace}}/{{$labels.pod}} has missed {{
-              printf "%.0f" $value }} rule group evaluations in the last 5m.
+            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has missed {{`{{
+              printf "%.0f" $value }}`}} rule group evaluations in the last 5m.
             summary: Prometheus is missing rule evaluations due to slow rule group evaluation.
           expr: |
             increase(prometheus_rule_group_iterations_missed_total{job="prometheus-k8s",namespace="monitoring"}[5m]) > 0
@@ -1215,7 +1197,7 @@ data:
         rules:
         - alert: AlertmanagerConfigInconsistent
           annotations:
-            message: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}`
+            message: The configuration of the instances of the Alertmanager cluster {{`{{$labels.service}}`}}
               are out of sync.
           expr: |
             count_values("config_hash", alertmanager_config_hash{job="alertmanager-main",namespace="monitoring"}) BY (service) / ON(service) GROUP_LEFT() label_replace(max(prometheus_operator_spec_replicas{job="prometheus-operator",namespace="monitoring",controller="alertmanager"}) by (name, job, namespace, controller), "service", "alertmanager-$1", "name", "(.*)") != 1
@@ -1224,8 +1206,8 @@ data:
             severity: critical
         - alert: AlertmanagerFailedReload
           annotations:
-            message: Reloading Alertmanager's configuration has failed for {{ $labels.namespace
-              }}/{{ $labels.pod}}.
+            message: Reloading Alertmanager's configuration has failed for {{`{{ $labels.namespace
+              }}`}}/{{`{{ $labels.pod}}`}}.
           expr: |
             alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"} == 0
           for: 10m
@@ -1245,8 +1227,8 @@ data:
         rules:
         - alert: TargetDown
           annotations:
-            message: '{{ printf "%.4g" $value }}% of the {{ $labels.job }}/{{ $labels.service
-              }} targets in {{ $labels.namespace }} namespace are down.'
+            message: '{{`{{ printf "%.4g" $value }}`}} % of the {{`{{ $labels.job }}`}}/{{`{{ $labels.service
+              }}`}} targets in {{`{{ $labels.namespace }}`}} namespace are down.'
           expr: 100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job,
             namespace, service)) > 10
           for: 10m
@@ -1267,8 +1249,8 @@ data:
         rules:
         - alert: ClockSkewDetected
           annotations:
-            message: Clock skew detected on node-exporter {{ $labels.namespace }}/{{ $labels.pod
-              }}. Ensure NTP is configured correctly on this host.
+            message: Clock skew detected on node-exporter {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod
+              }}`}}`. Ensure NTP is configured correctly on this host.
           expr: |
             abs(node_timex_offset_seconds{job="node-exporter"}) > 0.05
           for: 2m
@@ -1278,8 +1260,8 @@ data:
         rules:
         - alert: NodeNetworkInterfaceFlapping
           annotations:
-            message: Network interface "{{ $labels.device }}" changing it's up status
-              often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"
+            message: Network interface "{{`{{ $labels.device }}`}}" changing it's up status
+              often on node-exporter {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}}"
           expr: |
             changes(node_network_up{job="node-exporter",device!~"veth.+"}[2m]) > 2
           for: 2m
@@ -1287,4 +1269,4 @@ data:
             severity: warning
 
 
-        {{- end }}
+

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -324,7 +324,7 @@ data:
             sum by (namespace) (
                 sum by (namespace, pod) (
                     max by (namespace, pod, container) (
-                        kube_pod_container_resource_requests_memory_bytes{job="kube-state-metrics"}
+                        kube_pod_container_resource_requests_memory_bytes{job="kube-state"}
                     ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                     )
@@ -335,7 +335,7 @@ data:
             sum by (namespace) (
                 sum by (namespace, pod) (
                     max by (namespace, pod, container) (
-                        kube_pod_container_resource_requests_cpu_cores{job="kube-state-metrics"}
+                        kube_pod_container_resource_requests_cpu_cores{job="kube-state"}
                     ) * on(namespace, pod) group_left() max by (namespace, pod) (
                       kube_pod_status_phase{phase=~"Pending|Running"} == 1
                     )
@@ -346,9 +346,9 @@ data:
             sum(
               label_replace(
                 label_replace(
-                  kube_pod_owner{job="kube-state-metrics", owner_kind="ReplicaSet"},
+                  kube_pod_owner{job="kube-state", owner_kind="ReplicaSet"},
                   "replicaset", "$1", "owner_name", "(.*)"
-                ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{job="kube-state-metrics"},
+                ) * on(replicaset, namespace) group_left(owner_name) kube_replicaset_owner{job="kube-state"},
                 "workload", "$1", "owner_name", "(.*)"
               )
             ) by (cluster, namespace, workload, pod)
@@ -358,7 +358,7 @@ data:
         - expr: |
             sum(
               label_replace(
-                kube_pod_owner{job="kube-state-metrics", owner_kind="DaemonSet"},
+                kube_pod_owner{job="kube-state", owner_kind="DaemonSet"},
                 "workload", "$1", "owner_name", "(.*)"
               )
             ) by (cluster, namespace, workload, pod)
@@ -368,7 +368,7 @@ data:
         - expr: |
             sum(
               label_replace(
-                kube_pod_owner{job="kube-state-metrics", owner_kind="StatefulSet"},
+                kube_pod_owner{job="kube-state", owner_kind="StatefulSet"},
                 "workload", "$1", "owner_name", "(.*)"
               )
             ) by (cluster, namespace, workload, pod)
@@ -428,7 +428,7 @@ data:
             sum(min(kube_pod_info) by (cluster, node))
           record: ':kube_pod_info_node_count:'
         - expr: |
-            max(label_replace(kube_pod_info{job="kube-state-metrics"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
+            max(label_replace(kube_pod_info{job="kube-state"}, "pod", "$1", "pod", "(.*)")) by (node, namespace, pod)
           record: 'node_namespace_pod:kube_pod_info:'
         - expr: |
             count by (cluster, node) (sum by (node, cpu) (
@@ -484,9 +484,9 @@ data:
               about Kubernetes objects correctly or at all.
             runbook_url: 
           expr: |
-            (sum(rate(kube_state_metrics_list_total{job="kube-state-metrics",result="error"}[5m]))
+            (sum(rate(kube_state_metrics_list_total{job="kube-state",result="error"}[5m]))
               /
-            sum(rate(kube_state_metrics_list_total{job="kube-state-metrics"}[5m])))
+            sum(rate(kube_state_metrics_list_total{job="kube-state"}[5m])))
             > 0.01
           for: 15m
           labels:
@@ -498,9 +498,9 @@ data:
               about Kubernetes objects correctly or at all.
             runbook_url: 
           expr: |
-            (sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics",result="error"}[5m]))
+            (sum(rate(kube_state_metrics_watch_total{job="kube-state",result="error"}[5m]))
               /
-            sum(rate(kube_state_metrics_watch_total{job="kube-state-metrics"}[5m])))
+            sum(rate(kube_state_metrics_watch_total{job="kube-state"}[5m])))
             > 0.01
           for: 15m
           labels:
@@ -670,7 +670,7 @@ data:
               }}`}}) is restarting {{`{{ printf "%.2f" $value }}`}} times / 5 minutes.
             runbook_url: 
           expr: |
-            rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * 60 * 5 > 0
+            rate(kube_pod_container_status_restarts_total{job="kube-state"}[15m]) * 60 * 5 > 0
           for: 15m
           labels:
             severity: critical
@@ -680,7 +680,7 @@ data:
               state for longer than 15 minutes.
             runbook_url: 
           expr: |
-            sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
+            sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
           for: 15m
           labels:
             severity: critical
@@ -691,9 +691,9 @@ data:
               not been rolled back.
             runbook_url:
           expr: |
-            kube_deployment_status_observed_generation{job="kube-state-metrics"}
+            kube_deployment_status_observed_generation{job="kube-state"}
               !=
-            kube_deployment_metadata_generation{job="kube-state-metrics"}
+            kube_deployment_metadata_generation{job="kube-state"}
           for: 15m
           labels:
             severity: critical
@@ -703,9 +703,9 @@ data:
               matched the expected number of replicas for longer than 15 minutes.
             runbook_url: 
           expr: |
-            kube_deployment_spec_replicas{job="kube-state-metrics"}
+            kube_deployment_spec_replicas{job="kube-state"}
               !=
-            kube_deployment_status_replicas_available{job="kube-state-metrics"}
+            kube_deployment_status_replicas_available{job="kube-state"}
           for: 15m
           labels:
             severity: critical
@@ -715,9 +715,9 @@ data:
               not matched the expected number of replicas for longer than 15 minutes.
             runbook_url: 
           expr: |
-            kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
+            kube_statefulset_status_replicas_ready{job="kube-state"}
               !=
-            kube_statefulset_status_replicas{job="kube-state-metrics"}
+            kube_statefulset_status_replicas{job="kube-state"}
           for: 15m
           labels:
             severity: critical
@@ -728,9 +728,9 @@ data:
               not been rolled back.
             runbook_url:
           expr: |
-            kube_statefulset_status_observed_generation{job="kube-state-metrics"}
+            kube_statefulset_status_observed_generation{job="kube-state"}
               !=
-            kube_statefulset_metadata_generation{job="kube-state-metrics"}
+            kube_statefulset_metadata_generation{job="kube-state"}
           for: 15m
           labels:
             severity: critical
@@ -741,15 +741,15 @@ data:
             runbook_url:
           expr: |
             max without (revision) (
-              kube_statefulset_status_current_revision{job="kube-state-metrics"}
+              kube_statefulset_status_current_revision{job="kube-state"}
                 unless
-              kube_statefulset_status_update_revision{job="kube-state-metrics"}
+              kube_statefulset_status_update_revision{job="kube-state"}
             )
               *
             (
-              kube_statefulset_replicas{job="kube-state-metrics"}
+              kube_statefulset_replicas{job="kube-state"}
                 !=
-              kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
+              kube_statefulset_status_replicas_updated{job="kube-state"}
             )
           for: 15m
           labels:
@@ -760,9 +760,9 @@ data:
               {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset }}`}} are scheduled and ready.
             runbook_url: 
           expr: |
-            kube_daemonset_status_number_ready{job="kube-state-metrics"}
+            kube_daemonset_status_number_ready{job="kube-state"}
               /
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} < 1.00
+            kube_daemonset_status_desired_number_scheduled{job="kube-state"} < 1.00
           for: 15m
           labels:
             severity: critical
@@ -772,7 +772,7 @@ data:
               has been in waiting state for longer than 1 hour.
             runbook_url: 
           expr: |
-            sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state-metrics"}) > 0
+            sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state"}) > 0
           for: 1h
           labels:
             severity: warning
@@ -782,9 +782,9 @@ data:
               }}`}} are not scheduled.'
             runbook_url: 
           expr: |
-            kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}
+            kube_daemonset_status_desired_number_scheduled{job="kube-state"}
               -
-            kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0
+            kube_daemonset_status_current_number_scheduled{job="kube-state"} > 0
           for: 10m
           labels:
             severity: warning
@@ -794,7 +794,7 @@ data:
               }}`}} are running where they are not supposed to run.'
             runbook_url: 
           expr: |
-            kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} > 0
+            kube_daemonset_status_number_misscheduled{job="kube-state"} > 0
           for: 10m
           labels:
             severity: warning
@@ -804,7 +804,7 @@ data:
               than 1h to complete.
             runbook_url: 
           expr: |
-            time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} > 3600
+            time() - kube_cronjob_next_schedule_time{job="kube-state"} > 3600
           for: 1h
           labels:
             severity: warning
@@ -814,7 +814,7 @@ data:
               than one hour to complete.
             runbook_url: 
           expr: |
-            kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"}  > 0
+            kube_job_spec_completions{job="kube-state"} - kube_job_status_succeeded{job="kube-state"}  > 0
           for: 1h
           labels:
             severity: warning
@@ -823,7 +823,7 @@ data:
             message: Job {{`{{ $labels.namespace }}`}}/{{`{{ $labels.job_name }}`}} failed to complete.
             runbook_url: 
           expr: |
-            kube_job_failed{job="kube-state-metrics"}  > 0
+            kube_job_failed{job="kube-state"}  > 0
           for: 15m
           labels:
             severity: warning
@@ -864,7 +864,7 @@ data:
             message: Cluster has overcommitted CPU resource requests for Namespaces.
             runbook_url:
           expr: |
-            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="cpu"})
+            sum(kube_resourcequota{job="kube-state", type="hard", resource="cpu"})
               /
             sum(kube_node_status_allocatable_cpu_cores)
               > 1.5
@@ -876,7 +876,7 @@ data:
             message: Cluster has overcommitted memory resource requests for Namespaces.
             runbook_url:
           expr: |
-            sum(kube_resourcequota{job="kube-state-metrics", type="hard", resource="memory"})
+            sum(kube_resourcequota{job="kube-state", type="hard", resource="memory"})
               /
             sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
               > 1.5
@@ -889,9 +889,9 @@ data:
               }}`}} of its {{`{{ $labels.resource }}`}} quota.
             runbook_url: 
           expr: |
-            kube_resourcequota{job="kube-state-metrics", type="used"}
+            kube_resourcequota{job="kube-state", type="used"}
               / ignoring(instance, job, type)
-            (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
+            (kube_resourcequota{job="kube-state", type="hard"} > 0)
               > 0.90
           for: 15m
           labels:
@@ -949,7 +949,7 @@ data:
               $labels.phase }}`}}.
             runbook_url:
           expr: |
-            kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state-metrics"} > 0
+            kube_persistentvolume_status_phase{phase=~"Failed|Pending",job="kube-state"} > 0
           for: 5m
           labels:
             severity: critical
@@ -974,7 +974,7 @@ data:
             message: '{{`{{ $labels.node }}`}} has been unready for more than 15 minutes.'
             runbook_url: 
           expr: |
-            kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
+            kube_node_status_condition{job="kube-state",condition="Ready",status="true"} == 0
           for: 15m
           labels:
             severity: warning
@@ -983,7 +983,7 @@ data:
             message: '{{`{{ $labels.node }}`}} is unreachable and some workloads may be rescheduled.'
             runbook_url: 
           expr: |
-            kube_node_spec_taint{job="kube-state-metrics",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
+            kube_node_spec_taint{job="kube-state",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
           for: 2m
           labels:
             severity: warning
@@ -993,7 +993,7 @@ data:
               }}`}} of its Pod capacity.
             runbook_url: 
           expr: |
-            max(max(kubelet_running_pod_count{job="kubelet", metrics_path="/metrics"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"}) by(node) / max(kube_node_status_capacity_pods{job="kube-state-metrics"}) by(node) > 0.95
+            max(max(kubelet_running_pod_count{job="kubelet", metrics_path="/metrics"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubelet", metrics_path="/metrics"}) by(node) / max(kube_node_status_capacity_pods{job="kube-state"}) by(node) > 0.95
           for: 15m
           labels:
             severity: warning

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1,6 +1,16 @@
 ################################
 ## Prometheus Alerts ConfigMap
 #################################
+
+## Severity Definitions
+# Info - goes to an info channel specific to the group that is interested. This should be very little
+# Warning - goes to warning channel
+#   things we want to know about but are not always actionable. Get a pulse of potential future issues
+# High - Goes to slack prod alerts channel
+#   Things that are actionable and should be taken care of but do not need to wake someone up 
+# Critical - goes to slack prod alerts channel and pager duty
+#	   Things that would impact uptime or customer experience and are worth waking up in the middle of the night
+    
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -661,7 +661,7 @@ data:
             rate(kube_pod_container_status_restarts_total{job="kube-state"}[15m]) * 60 * 5 > 0
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubePodNotReady
           annotations:
             message: Pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been in a non-ready
@@ -671,7 +671,7 @@ data:
             sum by (namespace, pod) (max by(namespace, pod) (kube_pod_status_phase{job="kube-state", phase=~"Pending|Unknown"}) * on(namespace, pod) group_left(owner_kind) max by(namespace, pod, owner_kind) (kube_pod_owner{owner_kind!="Job"})) > 0
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeDeploymentGenerationMismatch
           annotations:
             message: Deployment generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment
@@ -684,7 +684,7 @@ data:
             kube_deployment_metadata_generation{job="kube-state"}
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeDeploymentReplicasMismatch
           annotations:
             message: Deployment {{`{{ $labels.namespace }}`}}/{{`{{ $labels.deployment }}`}} has not
@@ -696,7 +696,7 @@ data:
             kube_deployment_status_replicas_available{job="kube-state"}
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeStatefulSetReplicasMismatch
           annotations:
             message: StatefulSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset }}`}} has
@@ -708,7 +708,7 @@ data:
             kube_statefulset_status_replicas{job="kube-state"}
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeStatefulSetGenerationMismatch
           annotations:
             message: StatefulSet generation for {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset
@@ -721,7 +721,7 @@ data:
             kube_statefulset_metadata_generation{job="kube-state"}
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeStatefulSetUpdateNotRolledOut
           annotations:
             message: StatefulSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.statefulset }}`}} update
@@ -741,7 +741,7 @@ data:
             )
           for: 15m
           labels:
-            severity: critical
+            severity: high
         - alert: KubeDaemonSetRolloutStuck
           annotations:
             message: Only {{`{{ $value | humanizePercentage }}`}} of the desired Pods of DaemonSet
@@ -763,7 +763,7 @@ data:
             sum by (namespace, pod, container) (kube_pod_container_status_waiting_reason{job="kube-state"}) > 0
           for: 1h
           labels:
-            severity: warning
+            severity: high
         - alert: KubeDaemonSetNotScheduled
           annotations:
             message: '{{`{{ $value }}`}} Pods of DaemonSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset
@@ -775,7 +775,7 @@ data:
             kube_daemonset_status_current_number_scheduled{job="kube-state"} > 0
           for: 10m
           labels:
-            severity: warning
+            severity: critical
         - alert: KubeDaemonSetMisScheduled
           annotations:
             message: '{{`{{ $value }}`}} Pods of DaemonSet {{`{{ $labels.namespace }}`}}/{{`{{ $labels.daemonset
@@ -930,7 +930,7 @@ data:
             predict_linear(kubelet_volume_stats_available_bytes{job="kubelet", metrics_path="/metrics"}[6h], 4 * 24 * 3600) < 0
           for: 1h
           labels:
-            severity: critical
+            severity: high
         - alert: KubePersistentVolumeErrors
           annotations:
             message: The persistent volume {{`{{ $labels.persistentvolume }}`}} has status {{`{{
@@ -953,8 +953,7 @@ data:
           for: 15m
           labels:
             severity: warning
-      
-
+  
       - name: kubernetes-system-kubelet
         rules:
         - alert: KubeNodeNotReady
@@ -965,7 +964,7 @@ data:
             kube_node_status_condition{job="kube-state",condition="Ready",status="true"} == 0
           for: 15m
           labels:
-            severity: warning
+            severity: high
         - alert: KubeNodeUnreachable
           annotations:
             message: '{{`{{ $labels.node }}`}} is unreachable and some workloads may be rescheduled.'
@@ -974,7 +973,7 @@ data:
             kube_node_spec_taint{job="kube-state",key="node.kubernetes.io/unreachable",effect="NoSchedule"} == 1
           for: 2m
           labels:
-            severity: warning
+            severity: high
         - alert: KubeletTooManyPods
           annotations:
             message: Kubelet '{{`{{ $labels.node }}`}}' is running at {{`{{ $value | humanizePercentage
@@ -993,7 +992,7 @@ data:
             absent(up{job="kubelet", metrics_path="/metrics"} == 1)
           for: 15m
           labels:
-            severity: critical
+            severity: high
 
       - name: prometheus
         rules:
@@ -1070,7 +1069,7 @@ data:
             max_over_time(prometheus_notifications_alertmanagers_discovered{job="prometheus-k8s",namespace="monitoring"}[5m]) < 1
           for: 10m
           labels:
-            severity: warning
+            severity: high
         - alert: PrometheusTSDBReloadsFailing
           annotations:
             description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected
@@ -1080,7 +1079,7 @@ data:
             increase(prometheus_tsdb_reloads_failures_total{job="prometheus-k8s",namespace="monitoring"}[3h]) > 0
           for: 4h
           labels:
-            severity: warning
+            severity: high
         - alert: PrometheusTSDBCompactionsFailing
           annotations:
             description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has detected
@@ -1100,7 +1099,7 @@ data:
             rate(prometheus_tsdb_head_samples_appended_total{job="prometheus-k8s",namespace="monitoring"}[5m]) <= 0
           for: 10m
           labels:
-            severity: warning
+            severity: hight
         - alert: PrometheusDuplicateTimestamps
           annotations:
             description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} is dropping
@@ -1122,43 +1121,6 @@ data:
           for: 10m
           labels:
             severity: warning
-        - alert: PrometheusRemoteStorageFailures
-          annotations:
-            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} failed to send
-              {{`{{ printf "%.1f" $value }}`}}% of the samples to queue {{`{{$labels.queue}}`}}.
-            summary: Prometheus fails to send samples to remote storage.
-          expr: |
-            (
-              rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
-            /
-              (
-                rate(prometheus_remote_storage_failed_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
-              +
-                rate(prometheus_remote_storage_succeeded_samples_total{job="prometheus-k8s",namespace="monitoring"}[5m])
-              )
-            )
-            * 100
-            > 1
-          for: 15m
-          labels:
-            severity: critical
-        - alert: PrometheusRemoteWriteBehind
-          annotations:
-            description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} remote write
-              is {{`{{ printf "%.1f" $value }}`}}s behind for queue {{`{{$labels.queue}}`}}.
-            summary: Prometheus remote write is behind.
-          expr: |
-            # Without max_over_time, failed scrapes could create false negatives, see
-            # https://www.robustperception.io/alerting-on-gauges-in-prometheus-2-0 for details.
-            (
-              max_over_time(prometheus_remote_storage_highest_timestamp_in_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
-            - on(job, instance) group_right
-              max_over_time(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{job="prometheus-k8s",namespace="monitoring"}[5m])
-            )
-            > 120
-          for: 15m
-          labels:
-            severity: critical
         - alert: PrometheusRuleFailures
           annotations:
             description: Prometheus {{`{{$labels.namespace}}`}}/{{`{{$labels.pod}}`}} has failed to
@@ -1198,7 +1160,7 @@ data:
             alertmanager_config_last_reload_successful{job="alertmanager-main",namespace="monitoring"} == 0
           for: 10m
           labels:
-            severity: warning
+            severity: high
         - alert: AlertmanagerMembersInconsistent
           annotations:
             message: Alertmanager has not found all other members of the cluster.
@@ -1219,7 +1181,7 @@ data:
             namespace, service)) > 10
           for: 10m
           labels:
-            severity: warning
+            severity: critical
         - alert: Watchdog
           annotations:
             message: |
@@ -1241,7 +1203,7 @@ data:
             abs(node_timex_offset_seconds{job="node-exporter"}) > 0.05
           for: 2m
           labels:
-            severity: warning
+            severity: high
       - name: node-network
         rules:
         - alert: NodeNetworkInterfaceFlapping

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -45,6 +45,7 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.fullname" . }}
+      {{- if .Values.persistence.enabled }}
       initContainers:
         - name: init
           image: {{ include "prometheus.init.image" . }}
@@ -53,6 +54,7 @@ spec:
           volumeMounts:
             - name: data
               mountPath: "{{ .Values.dataDir }}"
+      {{- end }}
       containers:
         - name: prometheus
           image: {{ include "prometheus.image" . }}
@@ -68,8 +70,10 @@ spec:
               mountPath: /etc/prometheus/config
             - name: alert-volume
               mountPath: /etc/prometheus/alerts.d
+            {{- if .Values.persistence.enabled }}
             - name: data
               mountPath: {{ .Values.dataDir }}
+            {{- end }}
           ports:
             - name: prometheus-data
               containerPort: {{ .Values.ports.http }}


### PR DESCRIPTION
General theme is adding a bunch of alert rules to increase coverage. Sub theme is some reorganization of the groups.

* Lots of new rules to watch Kubernetes specific things as well a some more generic rules that cover all workloads and allow for the removal of workload specific rules. 
* Moved the rules from the platform group that were more infra specific out of the platform group and into groups where they were a better fit. Platform group is now solely astronomer platform workloads and not any infra stuff. 
* Changed `severity: urgent` to `severity: critical` 
* I did not add `tier: platform` labels to any of the new alerts, because I’m trying to separate infra platform (k8s, nodes etc) from astronomer platform (workloads that run on the infra). This goes along with proposed changes for how we handle alert routing see issue #861 