### PR TITLE
Fix fluentd scrape config bug

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -178,7 +178,7 @@ data:
           - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
             action: keep
             regex: true
-          - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+          - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             action: replace
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2


### PR DESCRIPTION
prometheus was trying to scrape ports on the fluentd pods that it shouldn’t be and caused false reporting of it being a down target. 

see https://github.com/astronomer/issues/issues/880