### PR TITLE
Reduce cache time for index file

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -55,7 +55,7 @@ wget https://helm.astronomer.io/index.yaml -O /tmp/index.yaml.current
 helm repo index . --url https://helm.astronomer.io --merge /tmp/index.yaml.current
 
 gsutil cp -a public-read $HELM_CHART_PATH gs://helm.astronomer.io
-gsutil cp -a public-read -h 'Content-Type: text/html' -h "Cache-Control:no-cache,max-age=0" ./index.yaml gs://helm.astronomer.io
+gsutil cp -a public-read -h "Cache-Control:no-cache,max-age=0" ./index.yaml gs://helm.astronomer.io
 
 set +x
 echo ""

--- a/bin/release
+++ b/bin/release
@@ -55,7 +55,7 @@ wget https://helm.astronomer.io/index.yaml -O /tmp/index.yaml.current
 helm repo index . --url https://helm.astronomer.io --merge /tmp/index.yaml.current
 
 gsutil cp -a public-read $HELM_CHART_PATH gs://helm.astronomer.io
-gsutil cp -a public-read ./index.yaml gs://helm.astronomer.io
+gsutil cp -a public-read -h 'Content-Type: text/html' -h "Cache-Control:no-cache,max-age=0" ./index.yaml gs://helm.astronomer.io
 
 set +x
 echo ""


### PR DESCRIPTION
Thanks Ash and Tony for this fix suggestion!

This is to help with CDN propagation for new helm chart versions. I'm only doing it on the index file, because other files (artifacts, i.e. versioned helm tarballs) are intended immutable.