### PR TITLE
Prometheus lifecycle api

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 0.12.0
+version: 0.12.1-alpha.1
 description: Helm chart to deploy the Astronomer Platform Prometheus module
 keywords:
   - astronomer

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 0.12.1-alpha.1
+version: 0.12.0
 description: Helm chart to deploy the Astronomer Platform Prometheus module
 keywords:
   - astronomer

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -63,6 +63,9 @@ spec:
             - "--config.file=/etc/prometheus/config/prometheus.yaml"
             - "--storage.tsdb.path={{ .Values.dataDir }}"
             - "--storage.tsdb.retention={{ .Values.retention }}"
+            {{- if .Values.enableLifecycle }}
+            - "--web.enable-lifecycle"
+            {{- end }}
           volumeMounts:
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/config

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -48,3 +48,6 @@ ports:
   http: 9090
 
 ingressNetworkPolicyExtraSelectors: []
+
+# Enable prometheus lifecycle api
+enableLifecycle: true


### PR DESCRIPTION
<!--
Thank you for contributing to Astronomer!
-->

This PR adds the ability to enable/disable the prometheus lifecycle api endpoint. The big reason for this to be added is so we can live reload configMap changes without having to restart the prometheus pod 

Related Prometheus docs
https://prometheus.io/docs/prometheus/latest/configuration/configuration/

**Checklist**

Go to Github and look at the releases for this project. Consider "VERSION" as the most recent version, with the patch number incremented by one.

- [ ]  Chart.yaml version and appVersion updated to match VERSION
- [x]  For each modified subchart, charts/subchart/Chart.yaml version updated to VERSION
