### PR TITLE
Add additional domain to policy for Segment API

### DIFF
--- a/charts/nginx/templates/nginx-headers-configmap.yaml
+++ b/charts/nginx/templates/nginx-headers-configmap.yaml
@@ -12,7 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   # Policy was generated using https://report-uri.com/home/generate
-  Content-Security-Policy: "default-src 'self' *.{{ .Values.global.baseDomain }}; script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net cdn.astronomer.io cdn.metarouter.io cdn.segment.com www.google-analytics.com js.stripe.com widget.intercom.io js.intercomcdn.com cdn.lr-ingest.io; img-src 'self' data: *; connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} e.metarouter.io api.segment.com api-iam.intercom.io wss://nexus-websocket-a.intercom.io; style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net fonts.googleapis.com; frame-src js.stripe.com; font-src *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.gstatic.com js.intercomcdn.com data:; worker-src blob:"
+  Content-Security-Policy: "default-src 'self' *.{{ .Values.global.baseDomain }}; script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net cdn.astronomer.io cdn.metarouter.io cdn.segment.com www.google-analytics.com js.stripe.com widget.intercom.io js.intercomcdn.com cdn.lr-ingest.io; img-src 'self' data: *; connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} e.metarouter.io api.segment.com api.segment.io api-iam.intercom.io wss://nexus-websocket-a.intercom.io; style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net fonts.googleapis.com; frame-src js.stripe.com; font-src *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.gstatic.com js.intercomcdn.com data:; worker-src blob:"
   Referrer-Policy: "no-referrer"
   X-Frame-Options: "deny"
   X-XSS-Protection: "1; mode=block"


### PR DESCRIPTION
Another!

Adds `api.segment.io` to `connect-src` within `Content-Security-Policy`.

Resolves astronomer/issues#990.