### PR TITLE
Add ability to adjust replica count for kube-state-metrics

### DIFF
--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -13,7 +13,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       tier: {{ template "kube-state.name" . }}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -24,3 +24,5 @@ resources: {}
 ports:
   scrape: 8080
   telemetry: 8081
+
+replicas: 1


### PR DESCRIPTION
This is cleanup work reflecting state change live in prod. We upped the replicas count to 2. The chart currently did not allow us to modify the chart through a vairable. This PR allows it. 