### PR TITLE
Dropping things that start with id was causing duplicate records

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -426,8 +426,8 @@ data:
             target_label: systemd_service_name
             replacement: '${1}'
 
-            # Drop some unnecessary labels
-          - regex: "^(id|name)"
+            # Drop some unnecessary labels.
+          - regex: "^name"
             action: labeldrop
 
             # Add deployment name via container_name


### PR DESCRIPTION
With removing the restriction of astronomer namespace only it allows us to get node specific container metrics. the id label is part of this information, by dropping that label these were causing non-unique metrics because that id label was needed to keep them unique.

These needs to go in before we push 0.12.1 to prod


solves https://github.com/astronomer/issues/issues/1005