### PR TITLE
Ingress for monitoring

### DIFF
--- a/bin/run-ci
+++ b/bin/run-ci
@@ -35,8 +35,10 @@ sleep 10
 # kill $FORWARD_PID
 
 # Test monitoring/alerting ingress - This is a stopgap until it can move in to full testing suite
-curl -f -s -o /dev/null -H "Host: alertmanager.local.astronomer-development.com"  http://172.17.0.1/
-curl -f -s -o /dev/null -H "Host: prometheus.local.astronomer-development.com"  http://172.17.0.1/
+echo "Testing alertmanager ingress"
+curl -f -s -o /dev/null -H "Host: alertmanager.local.astronomer-development.com"  http://127.0.0.1/
+echo "Testing prometheus ingress"
+curl -f -s -o /dev/null -H "Host: prometheus.local.astronomer-development.com"  http://127.0.0.1/
 
 
 # Run tests

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -34,6 +34,11 @@ sleep 10
 ./bin/create-initial-user "tester@astronomer.io" "password"
 # kill $FORWARD_PID
 
+# Test monitoring/alerting ingress - This is a stopgap until it can move in to full testing suite
+curl -f -s -o /dev/null -H "Host: alertmanager.local.astronomer-development.com"  http://172.17.0.1/
+curl -f -s -o /dev/null -H "Host: prometheus.local.astronomer-development.com"  http://172.17.0.1/
+
+
 # Run tests
 set +e
 helm test astronomer

--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -41,3 +41,7 @@ Image name.
 {{ .Values.images.alertmanager.repository }}:{{ .Values.images.alertmanager.tag }}
 {{- end -}}
 {{- end -}}
+
+{{ define "alertmanager.url" -}}
+alertmanager.{{ .Values.global.baseDomain }}
+{{- end }}

--- a/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
+++ b/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
@@ -26,6 +26,11 @@ spec:
           tier: monitoring
           component: prometheus
           release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: nginx
+          component: ingress-controller
+          release: {{ .Release.Name }}
     ports:
     - protocol: TCP
       port: {{ .Values.ports.http }}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -1,0 +1,41 @@
+################################
+## alertmanager Ingress
+#################################
+{{- if .Values.global.baseDomain }}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "alertmanager.fullname" . }}-ingress
+  labels:
+    tier: alertmanager-networking
+    component: alertmanager-ingress
+    chart: {{ template "alertmanager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
+    nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+spec:
+  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  tls:
+  {{- if .Values.global.acme }}
+    - secretName: alertmanager-tls
+  {{- end }}
+  {{- if .Values.global.tlsSecret }}
+    - secretName: {{ .Values.global.tlsSecret }}
+  {{- end }}
+      hosts:
+        - {{ template "alertmanager.url" . }}
+  {{- end }}
+  rules:
+    - host: {{ template "alertmanager.url" . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "alertmanager.fullname" . }}
+              servicePort: http
+{{- end }}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -37,3 +37,7 @@ Create chart name and version as used by the chart label.
 {{ .Values.images.init.repository }}:{{ .Values.images.init.tag }}
 {{- end }}
 {{- end }}
+
+{{ define "prometheus.url" -}}
+prometheus.{{ .Values.global.baseDomain }}
+{{- end }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -1,0 +1,41 @@
+################################
+## Prometheus Ingress
+#################################
+{{- if .Values.global.baseDomain }}
+kind: Ingress
+apiVersion: extensions/v1beta1
+metadata:
+  name: {{ template "prometheus.fullname" . }}-ingress
+  labels:
+    tier: prometheus-networking
+    component: prometheus-ingress
+    chart: {{ template "prometheus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
+    nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+spec:
+  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  tls:
+  {{- if .Values.global.acme }}
+    - secretName: prometheus-tls
+  {{- end }}
+  {{- if .Values.global.tlsSecret }}
+    - secretName: {{ .Values.global.tlsSecret }}
+  {{- end }}
+      hosts:
+        - {{ template "prometheus.url" . }}
+  {{- end }}
+  rules:
+    - host: {{ template "prometheus.url" . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "prometheus.fullname" . }}
+              servicePort: prometheus-data
+{{- end }}

--- a/charts/prometheus/templates/prometheus-networkpolicy.yaml
+++ b/charts/prometheus/templates/prometheus-networkpolicy.yaml
@@ -31,6 +31,11 @@ spec:
           tier: monitoring
           component: grafana
           release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: nginx
+          component: ingress-controller
+          release: {{ .Release.Name }}
     # It is sometimes useful to whitelist other pods,
     # for example admin Airflow tasks.
     {{- range .Values.ingressNetworkPolicyExtraSelectors }}


### PR DESCRIPTION
This PR creates ingress sources and modified network policies for prometheus and Alertmanager 
So they can be exposed (behind Houston auth) over the internet. 

Today in order to access these things in prod you must port forward with `kubectl`. Having this ability will enable the ability to add helpful links/buttons to our alert messages to silence alerts, go go straight to prometheus to see the raw data that triggered the alert etc. 