### PR TITLE
Add pod disruption budgets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 config.yaml
 config.yml
+dev-config.yaml
 !.circleci/config.yml
 certs
 /secrets

--- a/README.md
+++ b/README.md
@@ -90,6 +90,34 @@ export KUBE_VERSION='v1.16.3'
 bin/reset-local-dev
 ```
 
+#### Locally test HA configurations:
+
+You need a powerful computer to run the HA testing locally. 28 GB or more of memory should be available to Docker.
+
+Environment variables:
+
+- USE_HA: when set, will deploy using HA configurations
+- CORDON_NODE: when set, will cordon this node after kind create cluster
+- MULTI_NODE: when set, will deploy kind with two worker nodes
+
+Scripts:
+
+- Use bin/run-ci to start the cluster
+- Modify / use bin/drain.sh to test draining
+
+Example:
+
+```
+export USE_HA=1
+export CORDON_NODE=kind-worker
+export MULTI_NODE=1
+bin/run-ci
+```
+
+After the platform is up, then do
+```
+bin/drain.sh
+```
 
 ## Releasing
 

--- a/bin/drain.sh
+++ b/bin/drain.sh
@@ -1,0 +1,4 @@
+set -xe
+kubectl uncordon kind-worker
+kubectl cordon kind-worker2
+kubectl drain --force --delete-local-data --ignore-daemonsets kind-worker2

--- a/bin/install-platform
+++ b/bin/install-platform
@@ -39,12 +39,18 @@ set +ex
 
 HELM_TIMEOUT=${HELM_TIMEOUT:-800}
 
+if [[ -z "${USE_HA+x}" ]]; then
+  CONFIG_FILE=$REPO_DIR/configs/local-dev.yaml
+else
+  CONFIG_FILE=$REPO_DIR/configs/local-dev-ha.yaml
+fi
+
 set -x
 helm install \
   --namespace astronomer \
   --name astronomer \
   --timeout $HELM_TIMEOUT \
-  -f configs/local-dev.yaml \
+  -f $CONFIG_FILE \
   --set tags.platform=${platform} \
   --set tags.logging=${logging} \
   --set tags.monitoring=${monitoring} \

--- a/bin/kind/multi-node.yaml
+++ b/bin/kind/multi-node.yaml
@@ -1,0 +1,7 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -6,13 +6,19 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # The path to the working directory - the root of the repo
 REPO_DIR=$DIR/../
 
+if [[ -z "${USE_HA+x}" ]]; then
+  CONFIG_FILE=$REPO_DIR/configs/local-dev.yaml
+else
+  CONFIG_FILE=$REPO_DIR/configs/local-dev-ha.yaml
+fi
+
 # Fail fast for helm syntax errors
-helm template -f $REPO_DIR/configs/local-dev.yaml $REPO_DIR
+helm template -f $CONFIG_FILE $REPO_DIR
 
 source $REPO_DIR/bin/setup-kind
 
 echo "Deploying Astronomer..."
-helm install -f configs/local-dev.yaml \
+helm install -f $CONFIG_FILE \
   --namespace astronomer -n astronomer \
   --set global.postgresqlEnabled=true \
   $REPO_DIR

--- a/bin/setup-kind
+++ b/bin/setup-kind
@@ -39,9 +39,15 @@ set -xe
 # Delete the old cluster, if it exists
 kind delete cluster || true
 
+if [[ -z "${MULTI_NODE+x}" ]]; then
+  CONFIG_OPTION=""
+else
+  CONFIG_OPTION="--config $REPO_DIR/bin/kind/multi-node.yaml"
+fi
+
 # Start a cluster
 set +e
-kind create cluster --image kindest/node:${KUBE_VERSION}
+kind create cluster $CONFIG_OPTION --image kindest/node:${KUBE_VERSION}
 # I have found kind create cluster
 # fails rarely, but since we are running
 # so many in parallel, that it happens
@@ -50,11 +56,15 @@ if ! [[ $? -eq 0 ]]; then
   set -e
   echo "Failed to create Kind cluster, trying one more time"
   kind delete cluster || true
-  kind create cluster --image kindest/node:${KUBE_VERSION}
+  kind create cluster $CONFIG_OPTION --image kindest/node:${KUBE_VERSION}
 fi
 
 set -e
 set +x
+
+if ! [[ -z "${CORDON_NODE+x}" ]]; then
+  kubectl cordon $CORDON_NODE
+fi
 
 kubectl get nodes
 

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.astroUI.replicas }}
   selector:
     matchLabels:
       component: astro-ui

--- a/charts/astronomer/templates/astro-ui/astro-ui-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+################################
+## Astronomer UI Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-astro-ui-pdb
+spec:
+  {{- if lt ( .Values.astroUI.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: astronomer
+      component: astro-ui
+      release: {{ .Release.Name }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.astroUI.replicas | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.astroUI.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/astronomer/templates/commander/commander-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/commander/commander-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.commander.replicas | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.commander.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/astronomer/templates/commander/commander-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/commander/commander-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+################################
+## Astronomer Commander Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-commander-pdb
+spec:
+  {{- if lt ( .Values.commander.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      component: commander
+      tier: astronomer
+      release: {{ .Release.Name }}

--- a/charts/astronomer/templates/houston/houston-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/houston/houston-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.houston.replicas | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.houston.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/astronomer/templates/houston/houston-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/houston/houston-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+################################
+## Astronomer Houston Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-houston-pdb
+spec:
+  {{- if lt ( .Values.houston.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: astronomer
+      component: houston
+      release: {{ .Release.Name }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -44,6 +44,8 @@ images:
 astroUI:
   replicas: 2
   env: []
+  # This only applies when replicas > 3
+  maxUnavailable: 25%
   resources: {}
   #  limits:
   #   cpu: 100m
@@ -54,6 +56,8 @@ astroUI:
 
 houston:
   replicas: 2
+  # This only applies when replicas > 3
+  maxUnavailable: 25%
   # Houston datastore
   backendSecretName: ~
   backendConnection: {}
@@ -169,6 +173,8 @@ prisma:
 commander:
   replicas: 2
   env: []
+  # This only applies when replicas > 3
+  maxUnavailable: 25%
   resources: {}
    # limits:
    #  cpu: 100m

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -42,6 +42,7 @@ images:
     pullPolicy: IfNotPresent
 
 astroUI:
+  replicas: 2
   env: []
   resources: {}
   #  limits:
@@ -52,7 +53,7 @@ astroUI:
   #   memory: 128Mi
 
 houston:
-  replicas: 1
+  replicas: 2
   # Houston datastore
   backendSecretName: ~
   backendConnection: {}
@@ -166,7 +167,7 @@ prisma:
 
 
 commander:
-  replicas: 1
+  replicas: 2
   env: []
   resources: {}
    # limits:

--- a/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.client.replicas | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.client.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
@@ -1,0 +1,19 @@
+################################
+## Astronomer Elasticsearch Client Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-es-client-pdb
+spec:
+  {{- if lt ( .Values.client.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: logging
+      component: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+      role: client

--- a/charts/elasticsearch/templates/data/es-data-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/data/es-data-pod-disruption-budget.yaml
@@ -1,0 +1,15 @@
+################################
+## Astronomer Elasticsearch Data Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-es-data-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      tier: logging
+      component: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+      role: data

--- a/charts/elasticsearch/templates/master/es-master-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/master/es-master-pod-disruption-budget.yaml
@@ -1,0 +1,15 @@
+################################
+## Astronomer Elasticsearch Master Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-es-master-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      tier: logging
+      component: {{ template "elasticsearch.name" . }}
+      release: {{ .Release.Name }}
+      role: master

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -62,6 +62,8 @@ client:
   podAnnotations: {}
   # It isn't common to need more than 2 client nodes.
   replicas: 2
+  # This only applies when replicas > 3
+  maxUnavailable: 25%
   antiAffinity: "soft"
 
   # The amount of RAM allocated to the JVM heap. This should be set to the

--- a/charts/nginx/templates/nginx-default-backend-pod-disruption-budget.yaml
+++ b/charts/nginx/templates/nginx-default-backend-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+################################
+## Astronomer Nginx Default Backend Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-nginx-default-backend-pdb
+spec:
+  {{- if lt ( .Values.replicasDefaultBackend | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: {{ template "nginx.name" . }}
+      component: default-backend
+      release: {{ .Release.Name }}

--- a/charts/nginx/templates/nginx-default-backend-pod-disruption-budget.yaml
+++ b/charts/nginx/templates/nginx-default-backend-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.replicasDefaultBackend | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.maxUnavailableDefaultBackend }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicasDefaultBackend }}
   selector:
     matchLabels:
       tier: {{ template "nginx.name" . }}

--- a/charts/nginx/templates/nginx-pod-disruption-budget.yaml
+++ b/charts/nginx/templates/nginx-pod-disruption-budget.yaml
@@ -9,7 +9,7 @@ spec:
   {{- if lt ( .Values.replicas | int ) 4 }}
   maxUnavailable: 1
   {{- else }}
-  maxUnavailable: 25%
+  maxUnavailable: {{ .Values.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/nginx/templates/nginx-pod-disruption-budget.yaml
+++ b/charts/nginx/templates/nginx-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+################################
+## Astronomer Nginx Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-nginx-pdb
+spec:
+  {{- if lt ( .Values.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: 25%
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: {{ template "nginx.name" . }}
+      component: ingress-controller
+      release: {{ .Release.Name }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -21,6 +21,9 @@ ingressClass: ~
 
 replicas: 2
 replicasDefaultBackend: 2
+# These are only applicable when respective replicas > 3
+maxUnavailable: 25%
+maxUnavailableDefaultBackend: 25%
 
 resources: {}
 #  limits:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -19,7 +19,9 @@ images:
 forceNamespaceIsolation: true
 ingressClass: ~
 
-replicas: 1
+replicas: 2
+replicasDefaultBackend: 2
+
 resources: {}
 #  limits:
 #   cpu: 100m

--- a/charts/prometheus/templates/prometheus-pod-disruption-budget.yaml
+++ b/charts/prometheus/templates/prometheus-pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+################################
+## Astronomer Prometheus Pod Disruption Budget
+#################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-prometheus-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      tier: monitoring
+      component: {{ template "prometheus.name" . }}
+      release: {{ .Release.Name }}

--- a/configs/local-dev-ha.yaml
+++ b/configs/local-dev-ha.yaml
@@ -27,13 +27,13 @@ global:
 ############################
 astronomer:
   astroUI:
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: "0m"
         memory: "0Mi"
   houston:
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: "0m"
@@ -50,7 +50,7 @@ astronomer:
         cpu: "0m"
         memory: "0Mi"
   commander:
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: "0m"
@@ -71,8 +71,8 @@ astronomer:
 ## Nginx configuration
 #################################
 nginx:
-  replicas: 1
-  replicasDefaultBackend: 1
+  replicas: 2
+  replicasDefaultBackend: 2
   # Configure resources
   resources:
     requests:
@@ -96,7 +96,7 @@ grafana:
 ## Prometheus configuration
 #################################
 prometheus:
-  replicas: 1
+  replicas: 2
   # Configure resources
   resources:
     requests:
@@ -109,7 +109,7 @@ prometheus:
 elasticsearch:
   # Configure client nodes
   client:
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: "0"
@@ -117,7 +117,7 @@ elasticsearch:
 
   # Configure data nodes
   data:
-    replicas: 1
+    replicas: 2
     resources:
       requests:
         cpu: "0"
@@ -125,7 +125,7 @@ elasticsearch:
 
   # Configure master nodes
   master:
-    replicas: 1
+    replicas: 3
     resources:
       requests:
         cpu: "0"


### PR DESCRIPTION
The point of this PR is to make replicas configuration effective for HA during voluntary disruptions for the workloads that are already HA (or were very easy to make HA). There are other parts of the platform that are not HA yet and will take a bit more work (registry, prisma).

If workloads are tolerant to voluntary disruptions, taking less than 2 minutes to move, they are candidates to run on spot instances, and this can save 80% of compute cost.

Add HA for:
- astro-ui
- nginx-default-backend

Add PDB for:
- houston
- commander
- astro-ui
- es-client
- es-master
- es-data
- nginx
- nginx default backend
- prometheus

Default to HA configuration for:
- houston
- commander
- nginx

Add to script to enable local testing of cordon and drain

Video of testing: https://www.youtube.com/watch?v=BZPhy-PI4bw
- part 1: show cordon, drain with HA on
- part 2: show cordon, drain with HA off

A good chunk of the work for this issue: https://github.com/astronomer/issues/issues/1052