### PR TITLE
Added Annotation for IBM IKS Private Load Balancer

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -19,6 +19,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-internal: "true"
     cloud.google.com/load-balancer-type: "Internal"
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
     {{- end }}
 
     # Metrics annotations


### PR DESCRIPTION
This pull request adds support for IBM Cloud Private Load Balancers to Astronomer's NGINX Ingress Controller. This change is being actively used by an IBM/Astronomer client so has been thoroughly tested.

For reference, IBM Cloud Documentation for this feature can be found here: https://cloud.ibm.com/docs/containers?topic=containers-vpc-lbaas