### PR TITLE
Fixed Houston upgrade deployments job has an invalid job spec

### DIFF
--- a/charts/astronomer/templates/houston/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/houston-upgrade-deployments-job.yaml
@@ -19,8 +19,8 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn’t finished yet, the cron job skips the new job run
-  concurrencyPolicy: Forbid
+  completions: 1
+  parallelism: 1
   backoffLimit: 1
   template:
     metadata:


### PR DESCRIPTION
removed the invalid spec fields and added in the appropriate fields to accomplish the same goal for `kind: Job` rather than what it had which is for `kind: CronJob`

resolves https://github.com/astronomer/issues/issues/1079