### PR TITLE
Add configuration to re-generate CA on each upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ config.yml
 !.circleci/config.yml
 certs
 /secrets
+**kubeconfig**
 
 # IDEs
 .idea/

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.12.4
-appVersion: 0.12.4
+version: 0.12.5
+appVersion: 0.12.5
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/templates/houston/houston-jwt-certificate-secret.yaml
+++ b/charts/astronomer/templates/houston/houston-jwt-certificate-secret.yaml
@@ -17,7 +17,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
   annotations:
+    {{- if .Values.houston.regenerateCaEachUpgrade }}
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    {{- else }}
     "helm.sh/hook": "pre-install"
+    {{- end }}
+    # before-hook-creation	Delete the previous resource before a new hook is launched (default)
+    # This ensures that 'pre-upgrade' hook will not collide with existing secret, the previous
+    # secret should be cleaned up before running the next pre-upgrade hook.
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
 type: Opaque
@@ -40,7 +47,14 @@ metadata:
   annotations:
     # Indicate that we want to sync this to airflow namespaces
     "kubed.appscode.com/sync": {{ (printf "platform-release=%s" .Release.Name) | quote }}
+    {{- if .Values.houston.regenerateCaEachUpgrade }}
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    {{- else }}
     "helm.sh/hook": "pre-install"
+    {{- end }}
+    # before-hook-creation	Delete the previous resource before a new hook is launched (default)
+    # This ensures that 'pre-upgrade' hook will not collide with existing secret, the previous
+    # secret should be cleaned up before running the next pre-upgrade hook.
     "helm.sh/hook-delete-policy": "before-hook-creation"
     "helm.sh/hook-weight": "0"
 type: Opaque

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -48,6 +48,12 @@ astroUI:
   #   memory: 128Mi
 
 houston:
+  # Houston can regenerate its certificate authority on each 'helm upgrade'
+  # or leave it alone. If this is set to 'true', then all users are logged
+  # out on each helm upgrade. This is usually preferred 'true' for the case of
+  # enterprise, and 'false' for the case of SaaS, where upgrades should be
+  # without user interruption.
+  regenerateCaEachUpgrade: false
   replicas: 1
   # Houston datastore
   backendSecretName: ~


### PR DESCRIPTION
This patch, in the form of an optional configuration to 0.12, allows upgrades from before 0.10 to work without first delete --purge of the whole platform. The reason the --purge was required before is that since 0.10, there is a new secret installed by the helm hook. Since the helm hook runs by default only on installation, then delete --purge + install is performed to get the jwt token resource to create.

The solution proposed by this change request is to provide an optional configuration that configures this helm hook to run on each upgrade, in addition to installation. Since the helm template generates a self-signed certificate on each application, it will replace Houston's certificate authority on each helm upgrade.

One example for why this is valuable is that it eliminates the requirement for users to update their DNS records after upgrading Astronomer. This is often a challenge in the corporate environment.