### PR TITLE
Prometheus global scrape interval less frequent

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -14,7 +14,7 @@ metadata:
 data:
   prometheus.yaml: |-
     global:
-      scrape_interval: 10s
+      scrape_interval: 30s
       evaluation_interval: 30s
 
     # Configure Alertmanager
@@ -126,7 +126,7 @@ data:
       {{- end }}
 
       - job_name: kube-state
-        scrape_interval: 5s # Faster scrape to power dashboards
+        scrape_interval: 10s # Faster scrape to power dashboards
         kubernetes_sd_configs:
           - role: service
             namespaces:
@@ -276,7 +276,7 @@ data:
       {{- end }}
 
       - job_name: airflow
-        scrape_interval: 5s # Faster scrape to power dashboards
+        scrape_interval: 10s # Faster scrape to power dashboards
         kubernetes_sd_configs:
           - role: service
           {{- if .Values.global.singleNamespace }}


### PR DESCRIPTION
raised the global default and also the kube-state-metrics, airflow scrape jobs. 

For the high frequency ones for dashboards. Starting with small step to 10 seconds. We can revisit if we are still collecting too much. 