### PR TITLE
Hotfix/ingress after upgrading

### DIFF
--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   add-headers: {{ .Release.Namespace }}/{{ template "nginx.fullname" . }}-ingress-controller-headers
+  proxy-add-original-uri-header: "true"
   proxy-connect-timeout: {{ .Values.proxyConnectTimeout | quote }}
   proxy-read-timeout: {{ .Values.proxyReadTimeout | quote }}
   proxy-send-timeout: {{ .Values.proxySendTimeout | quote }}


### PR DESCRIPTION
**before this change:**
```
The push refers to repository [registry.local.astronomer-development.com/devoid-impact-7504/airflow]
00e769a38cde: Preparing
d9057861c537: Preparing
a89b2583c5dc: Preparing
2e109a197324: Preparing
6d8912a2c90e: Preparing
a4aa0bd7845a: Waiting
14901f6d2e0f: Waiting
8a1fd2fc9c08: Waiting
d33adb97c43b: Waiting
73bade508418: Waiting
de8894de8605: Waiting
3c1aa9d08181: Waiting
605c75ea035e: Waiting
a1d98aefe07e: Waiting
531743b7098c: Waiting
Error: command 'docker push registry.local.astronomer-development.com/devoid-impact-7504/airflow:deploy-1' failed: name unknown: Unknown registry service request
(
```

**after this change (tested in KinD):**
```
Sending build context to Docker daemon  11.26kB
Step 1/1 : FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild
# Executing 5 build triggers
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> Using cache
 ---> cb33acba63ef
Successfully built cb33acba63ef
Successfully tagged devoid-impact-7504/airflow:latest
Pushing image to Astronomer registry
The push refers to repository [registry.local.astronomer-development.com/devoid-impact-7504/airflow]
00e769a38cde: Pushed
d9057861c537: Pushed
a89b2583c5dc: Pushed
2e109a197324: Pushed
6d8912a2c90e: Pushed
a4aa0bd7845a: Pushed
14901f6d2e0f: Pushed
8a1fd2fc9c08: Pushed
d33adb97c43b: Pushed
73bade508418: Pushing [===========>                                       ]  134.9MB/595.8MB
de8894de8605: Pushed
3c1aa9d08181: Pushed
605c75ea035e: Pushed
a1d98aefe07e: Pushed
531743b7098c: Pushed
```