### PR TITLE
Add secret block back into Houston environment

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -171,10 +171,19 @@ azure:
 {{- end }}
 
 {{- define "houston_environment" }}
+{{- /* Dynamically created envs */ -}}
 {{- range $i, $config := .Values.houston.env }}
 - name: {{ $config.name }}
   value: {{ $config.value | quote }}
-  {{- end }}
+{{- end }}
+{{- /* Dynamically created secret envs */ -}}
+{{- range $i, $config := .Values.houston.secret }}
+- name: {{ $config.envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $config.secretName }}
+      key: {{ default "value" $config.secretKey }}
+{{- end }}
 - name: NODE_ENV
   value: "production"
 - name: DATABASE__CONNECTION


### PR DESCRIPTION
@ashb added this block a while ago, but I think it was dropped during a refactor with the `houston_environment` helper.