### PR TITLE
Prevent duplicate labels of kubernetes_executor

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -195,6 +195,9 @@ data:
             action: labeldrop            
             # end jpw new
         metric_relabel_configs:
+          # Pods have this label twice
+          - regex: 'label_kubernetes_executor'
+            action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
             regex: "^{{ .Release.Namespace }}-(.*-.*-[0-9]{4})$"


### PR DESCRIPTION
pods have the labels `kubernetes-executor` and `kubernetes_exector` when those get turned in to metric labels the dash becomes and underscore which causes duplicated labels. Prometheus must have unique labels per metric. 