### PR TITLE
Updates to CPUThrottlingHigh and Nginx 5xx and 4xx alerts

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1299,7 +1299,7 @@ data:
               10 minutes."
 
         - alert: NginxIngressHigh5XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..",  namespace="{{.Release.Name}}" }[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 1
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..",  namespace="{{.Release.Namespace}}" }[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 1
           for: 5m
           labels:
             tier: platform

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1287,7 +1287,7 @@ data:
       - name: Ingress
         rules:
         - alert: NginxIngressHigh4XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="{{.Release.Name}}"}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 5
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="{{.Release.Namespace}}"}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 5
           for: 10m
           labels:
             tier: platform

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -861,7 +861,7 @@ data:
           expr: |
             sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"^astronomer-.*-[0-9]{4}$", namespace != "kube-system"}[5m])) by (container, pod, namespace)
               /
-            sum(increase(container_cpu_cfs_periods_total{container!="", namespace!~"^astronomer-.*-[0-9]{4}$", namespace != "kube-system"}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_periods_total{container!="", namespace!~"^{{ .Release.Namespace }}-.*-[0-9]{4}$", namespace != "kube-system"}[5m])) by (container, pod, namespace)
               > ( 51 / 100 )
           for: 15m
           labels:

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -859,10 +859,10 @@ data:
             summary: 'CPU Throttling high in pod {{`{{$labels.pod }}`}}'
             runbook_url: 
           expr: |
-            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"^astronomer-.*-[0-9]{4}$"}[5m])) by (container, pod, namespace)
+            sum(increase(container_cpu_cfs_throttled_periods_total{container!="", namespace!~"^astronomer-.*-[0-9]{4}$", namespace != "kube-system"}[5m])) by (container, pod, namespace)
               /
-            sum(increase(container_cpu_cfs_periods_total{}[5m])) by (container, pod, namespace)
-              > ( 25 / 100 )
+            sum(increase(container_cpu_cfs_periods_total{container!="", namespace!~"^astronomer-.*-[0-9]{4}$", namespace != "kube-system"}[5m])) by (container, pod, namespace)
+              > ( 51 / 100 )
           for: 15m
           labels:
             severity: warning
@@ -1287,7 +1287,7 @@ data:
       - name: Ingress
         rules:
         - alert: NginxIngressHigh4XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4.."}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 5
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="{{.Release.Name}}"}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 5
           for: 10m
           labels:
             tier: platform
@@ -1299,7 +1299,7 @@ data:
               10 minutes."
 
         - alert: NginxIngressHigh5XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5.."}[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 1
+          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..",  namespace="{{.Release.Name}}" }[2m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[2m])) * 100 > 1
           for: 5m
           labels:
             tier: platform


### PR DESCRIPTION
Chagned CPUThrottling alert to have higher threshold and exlucde pods from kube-system namespace. In managed cloud environments there is rarely anything that can be actionable if this alert fires for things in kube-system. For other environments the cluster operators should have alerting in place for this already and our alerts are only around the astronomer platform.

Changed nginx 5xx/4xx errors to only report on the astronomer deployment namespace.
Airflow deployments produce 5XX errors when airflow is starting up and is expected behavior, people see the airflow loading page. We really want to target the astronomer platform here with these alerts not all the individual airflows. 