### PR TITLE
Added scrape job for kube-apiservers.

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -48,6 +48,18 @@ data:
       - job_name: prometheus
         static_configs:
           - targets: ["localhost:9090"]
+      
+      - job_name: 'kubernetes-apiservers'
+        kubernetes_sd_configs:
+          - role: endpoints
+        scheme: https 
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
+            action: keep
+            regex: default;kubernetes;https
 
       - job_name: nginx
         kubernetes_sd_configs:


### PR DESCRIPTION
Allows us to gather metrics from the kube-apiserver itself.

This was put in live on prod last week to get info about the API Server with suspected rate limiting. Following up to get this committed so it doesn't get reverted. 