### PR TITLE
Add support for Pod Security Policies

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -73,6 +73,7 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:
           privileged: true
+      serviceAccountName: {{ template "elasticsearch.fullname" . }}          
       containers:
       - name: es-client
         securityContext:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -101,6 +101,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+      serviceAccountName: {{ template "elasticsearch.fullname" . }}
       containers:
       - name: es-data
         securityContext:

--- a/charts/elasticsearch/templates/es-psp-clusterrole.yaml
+++ b/charts/elasticsearch/templates/es-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP ClusterRole
 #################################

--- a/charts/elasticsearch/templates/es-psp-clusterrole.yaml
+++ b/charts/elasticsearch/templates/es-psp-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Elasticsearch PSP ClusterRole
+#################################
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-elasticsearch
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Release.Name }}-elasticsearch
+  verbs:
+  - use
+{{- end -}}

--- a/charts/elasticsearch/templates/es-psp-rolebinding.yaml
+++ b/charts/elasticsearch/templates/es-psp-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP Rolebinding
 #################################

--- a/charts/elasticsearch/templates/es-psp-rolebinding.yaml
+++ b/charts/elasticsearch/templates/es-psp-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Elasticsearch PSP Rolebinding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp-elasticsearch
+  namespace: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-elasticsearch
+subjects:
+- kind: ServiceAccount
+  name: {{ template "elasticsearch.fullname" . }}
+  namespace: {{ .Release.Name }}
+{{- end -}}

--- a/charts/elasticsearch/templates/es-psp.yaml
+++ b/charts/elasticsearch/templates/es-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP
 #################################
@@ -36,3 +37,4 @@ spec:
       - min: 1
         max: 65535
   readOnlyRootFilesystem: false
+{{- end -}}

--- a/charts/elasticsearch/templates/es-psp.yaml
+++ b/charts/elasticsearch/templates/es-psp.yaml
@@ -1,0 +1,38 @@
+################################
+## Elasticsearch PSP
+#################################
+apiVersion: policy/v1beta1 
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-elasticsearch
+spec:
+  privileged: true
+  #requiredDropCapabilities:
+  allowedCapabilities:
+    - IPC_LOCK
+    - SYS_RESOURCE
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'persistentVolumeClaim'
+  hostNetwork: false
+  hostIPC: true
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false

--- a/charts/elasticsearch/templates/es-serviceaccount.yaml
+++ b/charts/elasticsearch/templates/es-serviceaccount.yaml
@@ -1,0 +1,15 @@
+################################
+## elasticsearch ServiceAccount
+#################################
+{{- if .Values.global.rbacEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "elasticsearch.fullname" . }}
+  labels:
+    tier: logging
+    component: {{ template "elasticsearch.name" . }}
+    chart: {{ template "elasticsearch.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -56,12 +56,12 @@ spec:
           image: {{ template "exporter.image" . }}
           imagePullPolicy: {{ .Values.images.exporter.pullPolicy }}
           command: ["elasticsearch_exporter",
-                    "-es.uri=http://{{ .Release.Name }}-elasticsearch:{{ .Values.common.ports.http }}",
-                    "-es.all={{ .Values.exporter.es.all }}",
-                    "-es.indices={{ .Values.exporter.es.indices }}",
-                    "-es.timeout={{ .Values.exporter.es.timeout }}",
-                    "-web.listen-address=:{{ .Values.exporter.service.httpPort }}",
-                    "-web.telemetry-path={{ .Values.exporter.web.path }}"]
+                    "--es.uri=http://{{ .Release.Name }}-elasticsearch:{{ .Values.common.ports.http }}",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.timeout={{ .Values.exporter.es.timeout }}",
+                    "--web.listen-address=:{{ .Values.exporter.service.httpPort }}",
+                    "--web.telemetry-path={{ .Values.exporter.web.path }}"]
           securityContext:
             capabilities:
               drop:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -100,6 +100,7 @@ spec:
         volumeMounts:
         - mountPath: /usr/share/elasticsearch/data
           name: data
+      serviceAccountName: {{ template "elasticsearch.fullname" . }}
       containers:
       - name: es-master
         securityContext:

--- a/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
+++ b/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP ClusterRole
 #################################

--- a/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
+++ b/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Fluentd PSP ClusterRole
+#################################
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-fluentd
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Release.Name }}-fluentd
+  verbs:
+  - use
+{{- end -}}

--- a/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
+++ b/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Fluentd PSP RoleBinding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp-fluentd
+  namespace: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-fluentd
+subjects:
+- kind: ServiceAccount
+  name: {{ template "fluentd.fullname" . }}
+  namespace: {{ .Release.Name }}
+{{- end -}}

--- a/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
+++ b/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP RoleBinding
 #################################

--- a/charts/fluentd/templates/fluentd-psp.yaml
+++ b/charts/fluentd/templates/fluentd-psp.yaml
@@ -1,0 +1,31 @@
+################################
+## Fluentd PSP
+#################################
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-fluentd
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'configMap'
+  - 'hostPath'
+  - 'secret'
+  - 'projected'
+  allowedHostPaths:
+    - pathPrefix: /var/log
+    - pathPrefix: /var/lib/docker/containers
+    - pathPrefix: /usr/lib64
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false

--- a/charts/fluentd/templates/fluentd-psp.yaml
+++ b/charts/fluentd/templates/fluentd-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP
 #################################
@@ -29,3 +30,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end -}}

--- a/charts/fluentd/templates/fluentd-psp.yaml
+++ b/charts/fluentd/templates/fluentd-psp.yaml
@@ -14,6 +14,7 @@ spec:
   - 'hostPath'
   - 'secret'
   - 'projected'
+  - 'emptyDir'
   allowedHostPaths:
     - pathPrefix: /var/log
     - pathPrefix: /var/lib/docker/containers

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -35,6 +35,14 @@ spec:
       serviceAccountName: {{ template "nginx.fullname" . }}
       containers:
         - name: nginx
+          securityContext:
+            allowPrivilegeEscalation: true
+            capabilities:
+              add:
+                - NET_BIND_SERVICE
+              drop:
+                - ALL
+            runAsUser: 101
           image: {{ template "nginx.image" . }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/charts/nginx/templates/nginx-psp-clusterrole.yaml
+++ b/charts/nginx/templates/nginx-psp-clusterrole.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Nginx PSP ClusterRole
+#################################
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-ingress-nginx
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies  
+  resourceNames:
+  - {{ .Release.Name }}-ingress-nginx
+  verbs:
+  - use
+  {{- end -}}

--- a/charts/nginx/templates/nginx-psp-clusterrole.yaml
+++ b/charts/nginx/templates/nginx-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Nginx PSP ClusterRole
 #################################

--- a/charts/nginx/templates/nginx-psp-rolebinding.yaml
+++ b/charts/nginx/templates/nginx-psp-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.global.rbacEnabled }}
+################################
+## Nginx PSP RoleBinding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp-ingress-nginx
+  namespace: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-ingress-nginx
+subjects:
+- kind: ServiceAccount
+  name: {{ template "nginx.fullname" . }}
+  namespace: {{ .Release.Name }}
+{{- end -}}

--- a/charts/nginx/templates/nginx-psp-rolebinding.yaml
+++ b/charts/nginx/templates/nginx-psp-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Nginx PSP RoleBinding
 #################################

--- a/charts/nginx/templates/nginx-psp.yaml
+++ b/charts/nginx/templates/nginx-psp.yaml
@@ -1,0 +1,43 @@
+################################
+## Nginx PSP
+#################################
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-ingress-nginx
+spec:
+  allowedCapabilities:
+  - NET_BIND_SERVICE
+  allowPrivilegeEscalation: true
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1
+      max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  hostPorts:
+  - min: 80
+    max: 65535
+  privileged: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+    ranges:
+    - min: 101
+      max: 65535
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    # Forbid adding the root group.
+    - min: 1
+      max: 65535
+  volumes:
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'projected'
+  - 'secret'

--- a/charts/nginx/templates/nginx-psp.yaml
+++ b/charts/nginx/templates/nginx-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.pspEnabled }}
 ################################
 ## Nginx PSP
 #################################
@@ -41,3 +42,4 @@ spec:
   - 'emptyDir'
   - 'projected'
   - 'secret'
+{{- end -}}

--- a/templates/psp/permissive-clusterrole.yaml
+++ b/templates/psp/permissive-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-permissive
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Release.Name }}-permissive
+  verbs:
+  - use
+{{- end -}}

--- a/templates/psp/permissive-clusterrolebinding.yaml
+++ b/templates/psp/permissive-clusterrolebinding.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.pspEnabled }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp-permissive
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-permissive
+subjects:
+- kind: ServiceAccount
+  name: daemon-set-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: replicaset-controller
+  namespace: kube-system
+- kind: ServiceAccount
+  name: job-controller
+  namespace: kube-system
+{{- end -}}

--- a/templates/psp/permissive-psp.yaml
+++ b/templates/psp/permissive-psp.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.global.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-permissive
+spec:
+  privileged: true
+  hostNetwork: true
+  hostIPC: true
+  hostPID: true
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  hostPorts:
+  - min: 0
+    max: 65535
+  volumes:
+  - '*'
+{{- end -}}

--- a/templates/psp/restrictive-cluserrolebinding.yaml
+++ b/templates/psp/restrictive-cluserrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.pspEnabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-restrictive
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-restrictive
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/templates/psp/restrictive-clusterrole.yaml
+++ b/templates/psp/restrictive-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-restrictive
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Release.Name }}-restrictive
+  verbs:
+  - use
+{{- end -}}

--- a/templates/psp/restrictive-psp.yaml
+++ b/templates/psp/restrictive-psp.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.global.pspEnabled }}
+# All purpose catch all restrictive policy
+# If a specific policy is not applied this one will be
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-restrictive
+spec:
+  privileged: false
+  hostNetwork: false
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
+  hostPID: false
+  hostIPC: false
+  runAsUser:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - 'configMap'
+  - 'downwardAPI'
+  - 'emptyDir'
+  - 'persistentVolumeClaim'
+  - 'secret'
+  - 'projected'
+  allowedCapabilities:
+  - '*'
+{{- end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -44,6 +44,9 @@ global:
   # Used to enable Celery autoscaling
   kedaEnabled: false
 
+  # If PodSecurityPolicies (PSP) should be enabled
+  pspEnabled: false
+
   # Set nodeSelector, affinity, and tolerations values for platform and deployment related pods.
   # This allows for separation of platform and airflow pods between kubernetes node pools.
   # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui, prisma,


### PR DESCRIPTION
added policies, clusterroles and role bindings for
- nginx
- fluentd
- elasticsearch

added service account for elastic search (fluentd and Nginx already had them)
Everything else gets covered by a general restrictive and permissive policies. This will also need good testing before we can merge in to any release branch

**special attention**
Review the Policies themselves to see if we want to tighten up or change them in anyway. 

