### PR TITLE
Corrected labeling in airflow alerts

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -33,10 +33,10 @@ data:
             tier: airflow
             component: deployment
             workspace: {{ printf "%q" "{{ $labels.workspace }}" }}
-            deployment: {{ printf "%q" "{{ $labels.release }}" }}
+            deployment: {{ printf "%q" "{{ $labels.deployment }}" }}
           annotations:
-            summary: {{ printf "%q" "{{ $labels.release }} deployment is unhealthy" }}
-            description: {{ printf "%q" "The {{ $labels.release }} deployment is not completely available." }}
+            summary: {{ printf "%q" "{{ $labels.deployment }} deployment is unhealthy" }}
+            description: {{ printf "%q" "The {{ $labels.deployment }} deployment is not completely available." }}
 
 
         # This alert depends on the scheduler_heartbeat metric being a counter.
@@ -61,10 +61,10 @@ data:
             tier: airflow
             component: deployment
             workspace: {{ printf "%q" "{{ $labels.workspace }}" }}
-            deployment: {{ printf "%q" "{{ $labels.release }}" }}
+            deployment: {{ printf "%q" "{{ $labels.deployment }}" }}
           annotations:
-            summary: {{ printf "%q" "{{ $labels.release }} is near its pod quota" }}
-            description: {{ printf "%q" "{{ $labels.release }} has been using over 95% of its pod quota for over 10 minutes." }}
+            summary: {{ printf "%q" "{{ $labels.deployment }} is near its pod quota" }}
+            description: {{ printf "%q" "{{ $labels.deployment }} has been using over 95% of its pod quota for over 10 minutes." }}
 
         - alert: AirflowEphemeralStorageLimit
           expr: (container_fs_usage_bytes{pod_name=~".*(scheduler|webserver|worker).*"}) >= 1800000000


### PR DESCRIPTION

Resolution for issue https://github.com/astronomer/issues/issues/1214
related to https://github.com/astronomer/issues/issues/1189

change labels in airflow alerts from $labels.release to $labels.deployment. I think the ones with release were there in error as we do not have `release` available as a usable label. 

