### PR TITLE
Add support for 1.10.6-3 and 1.10.5-7

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -63,6 +63,30 @@ data:
       # Airflow image settings
       # This is a list of supported airflow versions and corresponding docker tag
       images:
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-alpine3.10-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-buster-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-7-alpine3.10-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-7-buster-onbuild
+        - version: 1.10.6
+          channel: stable
+          tag: 1.10.6-alpine3.10-onbuild
+        - version: 1.10.6
+          channel: stable
+          tag: 1.10.6-buster-onbuild
+        - version: 1.10.6
+          channel: stable
+          tag: 1.10.6-3-alpine3.10-onbuild
+        - version: 1.10.6
+          channel: stable
+          tag: 1.10.6-3-buster-onbuild
         - version: 1.10.7
           channel: stable
           tag: 1.10.7-alpine3.10-onbuild


### PR DESCRIPTION
Based on https://github.com/astronomer/ap-airflow/pull/71

One thing I am not sure is: Were the users getting some kind of warning when using 1.10.5 or 1.10.6 images as they are not on the list ??