### PR TITLE
Updated fluentd to use image with bugfix

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: astronomerinc/ap-fluentd
-    tag: 0.11.1
+    tag: 1.9.2-r1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
updating the image tag to use the most recent build of fluentd that contains a fix for the plugin that was causing issues. 