### PR TITLE
Increase registry timeout to 30s

### DIFF
--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -55,7 +55,7 @@ data:
       endpoints:
         - name: "houston"
           url: "http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events"
-          timeout: 3s
+          timeout: 30s
           threshold: 10
           backoff: 1s
           ignoredmediatypes:


### PR DESCRIPTION
- Increase registry timeout to 30s
- Previous default value can cause houston to loop on upgrade deployment when user pushes to registry
- Related to astronomer/issues#1194