### PR TITLE
Moves default configuration out of Airflow chart to Houston default

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -103,6 +103,15 @@ data:
 
       # These values get passed directly into the airflow helm deployments
       helm:
+        env:
+          - name: ASTRONOMER__AIRFLOW__WORKER_LOG_RETENTION
+            value: "3"
+          - name: ASTRONOMER__JWT_SIGNING_CERT
+            value: "/etc/airflow/tls/tls.crt"
+          - name: ASTRONOMER__JWT_AUDIENCE
+            value: "deployments.baseDomain"
+            value: {{ printf "deployments.%s" .Values.global.baseDomain }}
+
         # Webserver configuration.
         webserver:
           # This is the name of the secret that gets copied from the platform namespace
@@ -120,6 +129,54 @@ data:
           # Disable creation of initial user.
           defaultUser:
             enabled: false
+
+          extraNetworkPolicies:
+          - namespaceSelector: {}
+            podSelector:
+              matchLabels:
+                tier: nginx
+                component: ingress-controller
+                release: {{ .Release.Name }}
+
+          webserverConfig: |
+            import os
+            from airflow import configuration as conf
+            from flask_appbuilder.security.manager import AUTH_REMOTE_USER
+            basedir = os.path.abspath(os.path.dirname(__file__))
+
+            # The SQLAlchemy connection string.
+            SQLALCHEMY_DATABASE_URI = conf.get('core', 'SQL_ALCHEMY_CONN')
+
+            # Flask-WTF flag for CSRF
+            CSRF_ENABLED = True
+
+            # ----------------------------------------------------
+            # AUTHENTICATION CONFIG
+            # ----------------------------------------------------
+            AUTH_TYPE = AUTH_REMOTE_USER
+
+            from astronomer.flask_appbuilder.security import AirflowAstroSecurityManager
+            SECURITY_MANAGER_CLASS = AirflowAstroSecurityManager
+
+          extraVolumes:
+          - name: signing-certificate
+            secret:
+              secretName: "jwtSigningCertificateSecretName"
+
+          extraVolumeMounts:
+          - name: signing-certificate
+            mountPath: "/etc/airflow/tls"
+            readOnly: true
+
+        # Flower configuration
+        flower:
+          extraNetworkPolicies:
+          - namespaceSelector: {}
+            podSelector:
+              matchLabels:
+                tier: nginx
+                component: ingress-controller
+                release: {{ .Release.Name }}
 
         # Worker configuration (applies to Celery and Kubernetes task pods).
         workers:
@@ -199,6 +256,20 @@ data:
           # This is here for upgrading to 0.11.2+ of Airflow.
           safeToEvict: true
 
+        # Statsd settings
+        statsd:
+          service:
+            extraAnnotations:
+              astronomer.io/platform-release: {{ .Release.Name }}
+
+          extraNetworkPolicies:
+          - namespaceSelector: {}
+            podSelector:
+              matchLabels:
+                tier: monitoring
+                component: prometheus
+                release: {{ .Release.Name }}
+
         # Pgbouncer settings
         pgbouncer:
           # Pgbouner pod disruption budget
@@ -208,6 +279,18 @@ data:
             # PDB configuration
             config:
               maxUnavailable: 1
+
+          service:
+            extraAnnotations:
+              astronomer.io/platform-release: {{ .Release.Name }}
+
+          extraNetworkPolicies:
+          - namespaceSelector: {}
+            podSelector:
+              matchLabels:
+                tier: monitoring
+                component: prometheus
+                release: {{ .Release.Name }}
 
         # Default quotas for airflow deployments.
         quotas:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -109,7 +109,6 @@ data:
           - name: ASTRONOMER__JWT_SIGNING_CERT
             value: "/etc/airflow/tls/tls.crt"
           - name: ASTRONOMER__JWT_AUDIENCE
-            value: "deployments.baseDomain"
             value: {{ printf "deployments.%s" .Values.global.baseDomain }}
 
         # Webserver configuration.


### PR DESCRIPTION
This PR is the Astronomer side of this PR to remove the platform refs from Airflow chart here: https://github.com/astronomer/airflow-chart/pull/66.

This essentially takes the old values that were hard-coded into the Airflow chart templates and uses the new helm variables to add them back in via the platform level.