### PR TITLE
Add missing commits from 0 13

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.1-alpha.3
-appVersion: 0.13.1-alpha.3
+version: 0.13.1-alpha.2
+appVersion: 0.13.1-alpha.2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-alpha.2
-appVersion: 0.13.0-alpha.2
+version: 0.13.0-alpha.3
+appVersion: 0.13.0-alpha.3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.1-alpha.1
-appVersion: 0.13.1-alpha.1
+version: 0.13.1-alpha.3
+appVersion: 0.13.1-alpha.3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0
-appVersion: 0.13.0
+version: 0.13.1-alpha.1
+appVersion: 0.13.1-alpha.1
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-rc.1
-appVersion: 0.13.0-rc.1
+version: 0.13.0
+appVersion: 0.13.0
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-alpha.3
-appVersion: 0.13.0-alpha.3
+version: 0.13.0-alpha.4
+appVersion: 0.13.0-alpha.4
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-alpha.4
-appVersion: 0.13.0-alpha.4
+version: 0.13.0-alpha.2
+appVersion: 0.13.0-alpha.2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-alpha.3
-appVersion: 0.13.0-alpha.3
+version: 0.13.0-rc.1
+appVersion: 0.13.0-rc.1
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/bin/release
+++ b/bin/release
@@ -54,7 +54,7 @@ wget https://helm.astronomer.io/index.yaml -O /tmp/index.yaml.current
 helm repo index . --url https://helm.astronomer.io --merge /tmp/index.yaml.current
 
 gsutil cp -a public-read $HELM_CHART_PATH gs://helm.astronomer.io
-gsutil cp -a public-read -h "Cache-Control:no-cache,max-age=0" ./index.yaml gs://helm.astronomer.io
+gsutil cp -a public-read ./index.yaml gs://helm.astronomer.io
 
 set +x
 echo ""

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: astronomerinc/ap-alertmanager
-    tag: 0.11.0
+    tag: 0.20.0
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0
+version: 0.13.1
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: astronomerinc/ap-registry
-    tag: 0.11.0
+    tag: 2.7.1
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
@@ -34,7 +34,7 @@ images:
     pullPolicy: IfNotPresent
   prisma:
     repository: astronomerinc/ap-prisma
-    tag: 0.11.1
+    tag: 1.34.8
     pullPolicy: IfNotPresent
   e2eTest:
     repository: astronomerinc/ap-e2e-test

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.13.3
+    tag: 0.13.4
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper
-    tag: 0.13.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
   cliInstall:
     repository: astronomerinc/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.13.1
+    tag: 0.13.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: astronomerinc/ap-registry
-    tag: 2.7.1
+    tag: 3.11.5-4
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
@@ -30,7 +30,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: astronomerinc/ap-cli-install
-    tag: 0.13.0
+    tag: 0.13.1
     pullPolicy: IfNotPresent
   prisma:
     repository: astronomerinc/ap-prisma

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -26,11 +26,11 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper
-    tag: 0.11.0
+    tag: 0.13.0
     pullPolicy: IfNotPresent
   cliInstall:
     repository: astronomerinc/ap-cli-install
-    tag: 0.11.0
+    tag: 0.13.0
     pullPolicy: IfNotPresent
   prisma:
     repository: astronomerinc/ap-prisma

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.13.4
+    tag: 0.13.1
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -56,12 +56,12 @@ spec:
           image: {{ template "exporter.image" . }}
           imagePullPolicy: {{ .Values.images.exporter.pullPolicy }}
           command: ["elasticsearch_exporter",
-                    "-es.uri=http://{{ .Release.Name }}-elasticsearch:{{ .Values.common.ports.http }}",
-                    "-es.all={{ .Values.exporter.es.all }}",
-                    "-es.indices={{ .Values.exporter.es.indices }}",
-                    "-es.timeout={{ .Values.exporter.es.timeout }}",
-                    "-web.listen-address=:{{ .Values.exporter.service.httpPort }}",
-                    "-web.telemetry-path={{ .Values.exporter.web.path }}"]
+                    "--es.uri=http://{{ .Release.Name }}-elasticsearch:{{ .Values.common.ports.http }}",
+                    "--es.all",
+                    "--es.indices",
+                    "--es.timeout={{ .Values.exporter.es.timeout }}",
+                    "--web.listen-address=:{{ .Values.exporter.service.httpPort }}",
+                    "--web.telemetry-path={{ .Values.exporter.web.path }}"]
           securityContext:
             capabilities:
               drop:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -193,13 +193,6 @@ exporter:
     # Address (host and port) of the Elasticsearch node we should connect to.
     # uri: localhost:9200
 
-    # If true, query stats for all nodes in the cluster, rather than just the
-    # node we connect to.
-    all: true
-
-    # If true, query stats for all indices in the cluster.
-    indices: true
-
     # Timeout for trying to get stats from Elasticsearch. (ex: 20s)
     timeout: 30s
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   es:
     repository: astronomerinc/ap-elasticsearch
-    tag: 0.11.2
+    tag: 7.6.1
     pullPolicy: IfNotPresent
   init:
     repository: astronomerinc/ap-base
@@ -13,15 +13,15 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: astronomerinc/ap-curator
-    tag: 0.11.0
+    tag: 5.8.1
     pullPolicy: IfNotPresent
   exporter:
     repository: astronomerinc/ap-elasticsearch-exporter
-    tag: 0.11.0
+    tag: 1.1.0
     pullPolicy: IfNotPresent
   nginx:
     repository: astronomerinc/ap-nginx-es
-    tag: 0.11.0
+    tag: 3.11.3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   es:
     repository: astronomerinc/ap-elasticsearch
-    tag: 7.6.1
+    tag: 7.6.2
     pullPolicy: IfNotPresent
   init:
     repository: astronomerinc/ap-base
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: astronomerinc/ap-curator
-    tag: 5.8.1
+    tag: 3.11.5-4
     pullPolicy: IfNotPresent
   exporter:
     repository: astronomerinc/ap-elasticsearch-exporter
@@ -21,7 +21,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: astronomerinc/ap-nginx-es
-    tag: 3.11.3
+    tag: 3.11.5-3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -36,7 +36,6 @@ data:
         </pattern>
       </parse>
       tag raw.kubernetes.*
-      format json
       read_from_head true
     </source>
     # Detect exceptions in the log output and forward them as one log entry.
@@ -124,8 +123,6 @@ data:
       key_name message
       replace_invalid_sequence true
       emit_invalid_record_to_error false
-      suppress_parse_error_log true
-      ignore_key_not_exist true
       reserve_data true
     </filter>
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: 0.11.1
+    tag: 6.6.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: 6.6.2
+    tag: 6.7.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: 6.7.2
+    tag: 6.7.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper
-    tag: 0.12.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/keda/values.yaml
+++ b/charts/keda/values.yaml
@@ -3,8 +3,8 @@ enabled: true
 keda:
   image:
     # Enable KEDA POC in cloud
-    keda: "astronomerinc/ap-keda:0.11.1"
-    metricsAdapter: "astronomerinc/ap-keda-metrics-adapter:0.11.1"
+    keda: "astronomerinc/ap-keda:1.3.0"
+    metricsAdapter: "astronomerinc/ap-keda-metrics-adapter:1.3.0"
   nodeSelector: {}
   tolerations: {}
   affinity: {}

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: astronomerinc/ap-kibana
-    tag: 0.11.2
+    tag: 7.6.1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: astronomerinc/ap-kibana
-    tag: 7.6.1
+    tag: 7.6.2
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: astronomerinc/ap-kube-state
-    tag: 0.11.0
+    tag: 1.7.2
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -12,6 +12,7 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   add-headers: {{ .Release.Namespace }}/{{ template "nginx.fullname" . }}-ingress-controller-headers
+  proxy-add-original-uri-header: "true"
   proxy-connect-timeout: {{ .Values.proxyConnectTimeout | quote }}
   proxy-read-timeout: {{ .Values.proxyReadTimeout | quote }}
   proxy-send-timeout: {{ .Values.proxySendTimeout | quote }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: astronomerinc/ap-nginx
-    tag: 0.11.1
+    tag: 0.27.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: astronomerinc/ap-nginx
-    tag: 0.27.1
+    tag: 0.30.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend

--- a/charts/node-exporter/values.yaml
+++ b/charts/node-exporter/values.yaml
@@ -12,4 +12,4 @@ prometheus-node-exporter:
     prometheus.io/port: "9100"
   image:
     repository: astronomerinc/ap-node-exporter
-    tag: 0.0.1
+    tag: 0.18.1

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -79,7 +79,7 @@ resources:
     cpu: "5m"
     memory: "75Mi"
   limits:
-    cpu: "150m"
+    cpu: "15m"
     memory: "100Mi"
 
 priorityClassName: ""

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -21,7 +21,7 @@ images:
     pullPolicy: IfNotPresent
   prometheus:
     repository: astronomerinc/ap-prometheus
-    tag: 0.12.0
+    tag: 2.15.2
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -21,7 +21,7 @@ images:
     pullPolicy: IfNotPresent
   prometheus:
     repository: astronomerinc/ap-prometheus
-    tag: 2.15.2
+    tag: 2.17.1
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
git cherry -v release-0.13 | grep +
+ e9b3271b040e816ef1366341ee9cda6cd2c4df70 Add configuration to re-generate CA on each upgrade (#627)
+ f890251efd8de84e2e9f3e863393e7f90636ce66 Add upgrade script (#630)
+ 863f1c2da29f3fed839b3d2d0a3a903c2a7de211 Add example IKS fluentd config (#632)
+ 6cbd67854c176c80d550565135bd9ac4c90e5b65 Make the probes more configurable (#636)
+ dc5cef1f3fd6a1475b8c0a1899aa2d30f03047fc Made scrape intervals less frequent (#628)
+ 2c3aafd94a5e9dd7cedff70771fc8b13844ff507 Add namespace var to upgrade_version_in_astro_db (#637)
+ 81fe3031d6c1cecb0a0ff444de93fd6cd630b1a0 Add list of other supported images (#640)
+ 2423fe547e01ec1827a1f168d1e30cf3fa5a42a3 Houston 0.13.3 and reconfigure resources on blackbox exporter (#646)
+ 7b4dd139998d7d4e96bc2c281b7aa71b4190e016 Add secret block back into Houston environment (#644)
+ a7ebb2773141945feaec9fc85a9d20e8930789f0 Add secret block back into Houston environment (#644)
+ 8de66e3bc88a73ef45b3bc2af0ec6563279ec134 Houston 0.13.4
+ 1eca1f0e06976821c91d026ee9b607070c82ccf7 Astro UI 0.13.1
+ 7be22490f6dcf47ec8a61232333d7b70bf1e68c6 Specify new name for signing cert in upgrade script (#645)
+ 3f38773a5baf6666d9db8be30d20ec30f2925cf6 Astro UI 0.13.2
+ f94bbba807f87c9c1c94c86d16a4ea973a18a8c8 Raised the default cpu limit of blackbox exporter (#651)
+ 2228fd7d01c3bc5378381d986308d44fd57dfd09 Added scrape job for kube-apiservers. (#653)
+ 9ffcb4c4f214b324d900ef018e7ad03065f93cc3 Add SECURITY.md for security notes
+ 5550941cf638d3582922438351f8f4d88b12aa0b Revise note
+ 2ea21c2ed605d892f8c47254cb3ac19a835cb715 Update README.md
+ 8bed4a7c887470d4681656844f535f1441bee85f Add ap-airflow 1.10.10 Images to Supported list (#655)
+ 96032eed839a962d9461d795058cf10c055ac5d1 Updates to CPUThrottlingHigh and Nginx 5xx and 4xx alerts (#652)
+ 66c63c55d85d3d426549fba5ccadb19e3faed652 Reformat so item can be linked
+ 6c977a3abe15945022fb7f1d6a6b272b7cf1ccad Changed $labels.release to $labels.deployment (#658)
+ 722f7f547f7ceba570da6e2cb8361faad17281d3 add tolerations to KEDA helm chart (#660)
+ a8ea42682b93fc6cf61522decd62f98830fce514 sadly appears you can't template a values.yaml (#662)
+ a3c5482a74098ca4a299dbd537ad06145baf8976 Helm 3
+ d7610a5d018a82e7943900b4c80c3914391f03ee Updated fluentd to use image with bugfux (#663)