### PR TITLE
Cherrypicked changes from release 0.13.1-alpha2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.13.0-alpha.3
-appVersion: 0.13.0-alpha.3
+version: 0.13.1-alpha.2
+appVersion: 0.13.1-alpha.2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -10,27 +10,27 @@ tolerations: []
 images:
   commander:
     repository: astronomerinc/ap-commander
-    tag: 0.14.0
+    tag: 0.13.1
     pullPolicy: IfNotPresent
   registry:
     repository: astronomerinc/ap-registry
-    tag: 0.11.0
+    tag: 3.11.5-4
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.13.4
+    tag: 0.13.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: 0.13.3
+    tag: 0.13.4
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper
-    tag: 0.11.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
   cliInstall:
     repository: astronomerinc/ap-cli-install
-    tag: 0.11.0
+    tag: 0.13.1
     pullPolicy: IfNotPresent
   prisma:
     repository: astronomerinc/ap-prisma

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -5,15 +5,15 @@ tolerations: []
 images:
   es:
     repository: astronomerinc/ap-elasticsearch
-    tag: 0.11.2
+    tag: 7.6.2
     pullPolicy: IfNotPresent
   init:
     repository: astronomerinc/ap-base
-    tag: 0.11.0
+    tag: 3.11.5-3
     pullPolicy: IfNotPresent
   curator:
     repository: astronomerinc/ap-curator
-    tag: 0.11.0
+    tag: 3.11.5-3
     pullPolicy: IfNotPresent
   exporter:
     repository: astronomerinc/ap-elasticsearch-exporter
@@ -21,7 +21,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: astronomerinc/ap-nginx-es
-    tag: 0.11.0
+    tag: 3.11.5-3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: 0.11.1
+    tag: 6.7.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper
-    tag: 0.12.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: astronomerinc/ap-kibana
-    tag: 0.11.2
+    tag: 7.6.2
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend
-    tag: 0.11.0
+    tag: 0.13.0
     pullPolicy: IfNotPresent
 
 forceNamespaceIsolation: true

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -17,7 +17,7 @@ replicas: 1
 images:
   init:
     repository: astronomerinc/ap-base
-    tag: 0.11.0
+    tag: 3.11.5-3
     pullPolicy: IfNotPresent
   prometheus:
     repository: astronomerinc/ap-prometheus


### PR DESCRIPTION
There were container image versions that were changed on the release-0.13 branch for the .1-alpha2 release. This is bring those changes over to master.