### PR TITLE
Update curator image tag for bug fix.

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: astronomerinc/ap-curator
-    tag: 3.11.5-3
+    tag: 3.11.5-4
     pullPolicy: IfNotPresent
   exporter:
     repository: astronomerinc/ap-elasticsearch-exporter


### PR DESCRIPTION
Curator image had a bug after CVE updates where it was missing a python module. The image has been updated and this update is to have helm use the new image tag.