### PR TITLE
Adding prometheus label drop for a duplicate label

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -210,6 +210,8 @@ data:
           # Pods have this label twice
           - regex: 'label_kubernetes_executor'
             action: labeldrop
+          - regex: 'label_kubernetes_pod_operator'
+            action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
             regex: "^{{ .Release.Namespace }}-(.*-.*-[0-9]{4})$"


### PR DESCRIPTION
We started seeing duplicates for the label `label_kubernetes_pod_operator` that was causing kube-state-metrics  ingestion issues. A label drop was added for this label to get through the issue