### PR TITLE
Fix registry configuration

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -28,7 +28,7 @@ spec:
       component: registry
       tier: astronomer
       release: {{ .Release.Name }}
-{{- if or (not .Values.registry.gcs.enabled) (not .Values.registry.azure.enabled) }}
+{{- if and (not .Values.registry.gcs.enabled) (not .Values.registry.azure.enabled) }}
   serviceName: {{ .Release.Name }}-registry
 {{- end }}
   template:


### PR DESCRIPTION
'serviceName' should only exist when it's a stateful set. The conditional was not the negation of the conditional for the 'kind', which is:
```
{{- if or .Values.registry.gcs.enabled .Values.registry.azure.enabled }}
```