### PR TITLE
Add support for AWS S3 registry backend

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -170,6 +170,17 @@ azure:
   realm: {{ .Values.registry.azure.realm }}
 {{- end }}
 
+{{- define "registry.s3Config" }}
+s3:
+  accesskey: {{ .Values.registry.s3.accesskey }}
+  secretkey: {{ .Values.registry.s3.secretkey }}
+  region: {{ .Values.registry.s3.region }}
+  bucket: {{ .Values.registry.s3.bucket }}
+  encrypt: {{ .Values.registry.s3.encrypt }}
+  keyid: {{ .Values.registry.s3.keyid }}
+  rootdirectory: {{ .Values.registry.s3.rootdirectory }}
+{{- end }}
+
 {{- define "houston_environment" }}
 {{- /* Dynamically created envs */ -}}
 {{- range $i, $config := .Values.houston.env }}

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -25,6 +25,8 @@ data:
     {{- include "registry.gcsConfig" . | indent 6 }}
     {{- else if .Values.registry.azure.enabled }}
     {{- include "registry.azureConfig" . | indent 6 }}
+    {{- else if .Values.registry.s3.enabled }}
+    {{- include "registry.s3Config" . | indent 6 }}
     {{- else }}
       filesystem:
         rootdirectory: /var/lib/registry

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry StatefulSet
 #################################
 {{- if .Values.global.baseDomain }}
-{{- if or .Values.registry.gcs.enabled .Values.registry.azure.enabled }}
+{{- if or .Values.registry.gcs.enabled .Values.registry.azure.enabled .Values.registry.s3.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 {{- else }}
@@ -28,7 +28,7 @@ spec:
       component: registry
       tier: astronomer
       release: {{ .Release.Name }}
-{{- if and (not .Values.registry.gcs.enabled) (not .Values.registry.azure.enabled) }}
+{{- if and (not .Values.registry.gcs.enabled) (not .Values.registry.azure.enabled) (not .Values.registry.s3.enabled)}}
   serviceName: {{ .Release.Name }}-registry
 {{- end }}
   template:
@@ -95,7 +95,7 @@ spec:
         {{- if .Values.registry.gcs.enabled }}
         {{- include "registry.gcsVolume" . | indent 8 }}
         {{- end }}
-  {{- if or (not .Values.registry.persistence.enabled) (.Values.registry.gcs.enabled) (.Values.registry.azure.enabled) }}
+  {{- if or (not .Values.registry.persistence.enabled) (.Values.registry.gcs.enabled) (.Values.registry.azure.enabled) (.Values.registry.s3.enabled)}}
         - name: data
           emptyDir: {}
   {{- else }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -235,6 +235,16 @@ registry:
     container: ~
     realm: ~
 
+  s3:
+    enabled: false
+    accesskey: ~
+    secretkey: ~
+    region: ~
+    bucket: ~
+    encrypt: false
+    keyid: ~
+    rootdirectory: ~
+
 install:
   resources: {}
   #  limits:


### PR DESCRIPTION
- Add ability to use AWS S3 bucket as registry storage backend
- Example config:
```
astronomer:
  registry:
    s3:
      enabled: true
      accesskey: my-access-key
      secretkey: my-secret-key
      region: us-east-1
      bucket: astro-registry
```
- Driver documentation:
  - https://docs.docker.com/registry/configuration/
  - https://github.com/docker/docker.github.io/blob/master/registry/storage-drivers/s3.md
- Related to astronomer/issues#93