### PR TITLE
Disable e2e testing until working

### DIFF
--- a/bin/run-ci
+++ b/bin/run-ci
@@ -23,6 +23,8 @@ sleep 5
 
 $DIR/waitfor-platform
 
+exit 0
+
 ### Test Prep
 echo "172.17.0.1 local.astronomer-development.com" | sudo tee -a /etc/hosts
 sudo /tmp/bin/kubectl port-forward -n astronomer svc/astronomer-nginx 80 443 &


### PR DESCRIPTION
This will save a lot of Circle CI credits, and when Tony's PR is done we can turn it back on