### PR TITLE
Remove duplicate env var

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -32,7 +32,7 @@ common:
     CLUSTER_NAME: "astronomer"
     HTTP_CORS_ENABLE: "true"
     HTTP_CORS_ALLOW_ORIGIN: "*"
-    NUMBER_OF_MASTERS: "1"
+    NUMBER_OF_MASTERS: "2"
     MAX_LOCAL_STORAGE_NODES: "1"
     SHARD_ALLOCATION_AWARENESS: ""
     SHARD_ALLOCATION_AWARENESS_ATTR: ""
@@ -141,11 +141,6 @@ master:
     NODE_MASTER: "true"
     NODE_INGEST: "false"
     HTTP_ENABLE: "false"
-
-    # The default value for this environment variable is 2, meaning a cluster
-    # will need a minimum of 2 master nodes to operate. If you have 3 masters
-    # and one dies, the cluster still works.
-    NUMBER_OF_MASTERS: "2"
 
   # Determines the properties of the persistent volume claim associated with a
   # data node StatefulSet that is created when the common.stateful.enabled


### PR DESCRIPTION
This was causing a helm 3 upgrade error: https://app.circleci.com/pipelines/github/astronomer/google-environments/27/workflows/862bed6c-2ba2-4b7c-8410-f4f080dc0869/jobs/119/parallel-runs/0/steps/0-103

we can see in the dry run it's duplicated https://app.circleci.com/pipelines/github/astronomer/google-environments/27/workflows/862bed6c-2ba2-4b7c-8410-f4f080dc0869/jobs/117/parallel-runs/0/steps/0-103