### PR TITLE
Add support for AC 1.10.5 & 1.10.10 Docker images

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -60,42 +60,6 @@ data:
       # Airflow image settings
       # This is a list of supported airflow versions and corresponding docker tag
       images:
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-7-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-8-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-10-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-11-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-12-alpine3.10-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-buster-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-7-buster-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-8-buster-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-10-buster-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-11-buster-onbuild
-        - version: 1.10.7
-          channel: stable
-          tag: 1.10.7-12-buster-onbuild
 
         - version: 1.10.5
           channel: stable
@@ -116,18 +80,62 @@ data:
           channel: stable
           tag: 1.10.5-8-buster-onbuild
 
-        - version: 1.10.10
+        - version: 1.10.7
           channel: stable
-          tag: 1.10.10-buster-onbuild
+          tag: 1.10.7-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-7-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-7-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-8-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-8-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-10-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-10-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-11-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-11-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-12-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-12-buster-onbuild
+
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-alpine3.10-onbuild
         - version: 1.10.10
           channel: stable
-          tag: 1.10.10-1-buster-onbuild
+          tag: 1.10.10-buster-onbuild
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-1-alpine3.10-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-1-buster-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-2-alpine3.10-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-2-buster-onbuild
+
         # - version: 1.10.6
         #   channel: edge
         #   tag: 1.10.6-alpine3.10-onbuild

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -96,6 +96,26 @@ data:
         - version: 1.10.7
           channel: stable
           tag: 1.10.7-12-buster-onbuild
+
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-alpine3.10-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-buster-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-7-alpine3.10-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-7-buster-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-8-alpine3.10-onbuild
+        - version: 1.10.5
+          channel: stable
+          tag: 1.10.5-8-buster-onbuild
+
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-buster-onbuild


### PR DESCRIPTION
Depends on https://github.com/astronomer/astronomer/pull/702

Based on the conversation in https://github.com/astronomer/astronomer/pull/659


**Note**: Only review last commit: https://github.com/astronomer/astronomer/pull/703/commits/c19043c68a07dee5028d2a439da5435dbc4cc731