### PR TITLE
Slack alert improvment

### DIFF
--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -16,6 +16,7 @@ data:
     route:
       group_wait: 30s
       group_interval: 5m
+      group_by: [alertname]
       repeat_interval: 3h
       receiver: default-receiver
       routes:

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -51,8 +51,8 @@ spec:
           args:
             - --config.file=/etc/config/alertmanager.yaml
             - --storage.path={{ .Values.dataDir }}
-          {{- if .Values.baseURL }}
-            - --web.external-url={{ .Values.baseURL }}
+          {{- if .Values.global.baseDomain }}
+            - --web.external-url=https://alertmanager.{{ .Values.global.baseDomain }}
           {{- end }}
           ports:
             - containerPort: {{ .Values.ports.http }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -66,6 +66,9 @@ spec:
             {{- if .Values.enableLifecycle }}
             - "--web.enable-lifecycle"
             {{- end }}
+            {{- if .Values.global.baseDomain }}
+            - "--web.external-url=https://prometheus.{{ .Values.global.baseDomain }}"
+            {{- end }}
           volumeMounts:
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/config


### PR DESCRIPTION

Adds external URL setting so that alerts can have links back to alert manager and prometheus. 
Groups platform alerts by alter name to help organize things better. 