### PR TITLE
Update Grafana to 7.0.1-r1

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: 6.7.3
+    tag: "7.0.1+astro1"
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: astronomerinc/ap-grafana
-    tag: "7.0.1+astro1"
+    tag: "7.0.1-r1"
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
Security Update and Dashboard update. 
Security update pushes us up to the 7.0 release of Grafana


https://grafana.com/docs/grafana/latest/guides/whats-new-in-v7-0/