### PR TITLE
Change houston charts from npm to yarn

### DIFF
--- a/charts/astronomer/templates/houston/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/houston-check-updates-cronjob.yaml
@@ -42,7 +42,7 @@ spec:
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-              args: ["npm", "run", "check-platfrom-updates", "--", " --url={{ .Values.houston.updateCheck.url }}"]
+              args: ["yarn", "check-platfrom-updates", "--", " --url={{ .Values.houston.updateCheck.url }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}
               env:

--- a/charts/astronomer/templates/houston/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/houston-cleanup-deployments-cronjob.yaml
@@ -42,7 +42,7 @@ spec:
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-              args: ["npm", "run", "cleanup-deployments", "--", "--older-than={{ .Values.houston.cleanupDeployments.olderThan }}", "--dry-run={{ .Values.houston.cleanupDeployments.dryRun }}", "--canary={{ .Values.houston.cleanupDeployments.canary }}"]
+              args: ["yarn", "cleanup-deployments", "--", "--older-than={{ .Values.houston.cleanupDeployments.olderThan }}", "--dry-run={{ .Values.houston.cleanupDeployments.dryRun }}", "--canary={{ .Values.houston.cleanupDeployments.canary }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}
               env:

--- a/charts/astronomer/templates/houston/houston-expire-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/houston-expire-deployments-cronjob.yaml
@@ -39,7 +39,7 @@ spec:
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-              args: ["npm", "run", "expire-deployments", "--", "--dry-run={{ .Values.houston.expireDeployments.dryRun }}", "--canary={{ .Values.houston.expireDeployments.canary }}"]
+              args: ["yarn", "expire-deployments", "--", "--dry-run={{ .Values.houston.expireDeployments.dryRun }}", "--canary={{ .Values.houston.expireDeployments.canary }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}
               env:

--- a/charts/astronomer/templates/houston/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/houston-upgrade-deployments-job.yaml
@@ -45,7 +45,7 @@ spec:
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-          args: ["npm", "run", "upgrade-deployments", "--", "--canary={{ .Values.houston.upgradeDeployments.canary }}"]
+          args: ["yarn", "upgrade-deployments", "--", "--canary={{ .Values.houston.upgradeDeployments.canary }}"]
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}
           env:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.15.5
+    tag: master
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui


### PR DESCRIPTION
This feature is linked to the houston-api PR located here: https://github.com/astronomer/houston-api/pull/334

I confirmed this fix by testing the following:

1. Build a docker image locally
2. Push the docker image to my personal docker hub registry
3. Change the `houston-api` image in the `charts/astronomer/values.yaml` to the newly created docker image
4. Run `./bin/reset-local-dev`
5. Check the k8s pods and logs to make sure everything is working correctly
6. Launch the `astro-ui`, log in and click test to make sure `houston-api` is responding correctly