### PR TITLE
Update install script to get latest minor version

### DIFF
--- a/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
+++ b/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
@@ -15,54 +15,12 @@ data:
   install.sh: |-
     #! /usr/bin/env bash
 
-    TAG=${1:-v{{ .Chart.Version }}}
-        
+    TAG=${1:-v{{ .Values.Install.CliVersion }}}
+
     if (( EUID != 0 )); then
         echo "Please run command as root."
         exit
     fi
 
     DOWNLOADER="https://raw.githubusercontent.com/astronomerio/astro-cli/master/godownloader.sh"
-    MAX_ATTEMPT=2
-    ATTEMPT=0
-    HTTP_STATUS=500
-
-    # If we haven't retried more than once then curl to see if the particular tag exists before trying to download 
-    check_version_exists() {
-      if [[ $ATTEMPT < $MAX_ATTEMPT ]] ; then
-        HTTP_STATUS=$(curl --head --write-out %{http_code} --silent --output /dev/null https://github.com/astronomer/astro-cli/releases/tag/$TAG)
-        download_version $HTTP_STATUS
-      else
-        echo "We couldn't download astro-cli version $TAG. Please check https://github.com/astronomer/astro-cli/releases/ for more information on to resolve this issue."
-        exit 0
-      fi
-    }
-
-    # If the HTTP_STATUS from checking the version tag return a 200 then try to download it, otherwise try to parse the next previous minor version 
-    download_version() {
-      if [[ "$HTTP_STATUS" == 200 ]] ; then
-        echo "Installing version $TAG. Please wait..."
-        curl -sL -o- "${DOWNLOADER}" | bash -s -- -b /usr/local/bin "$TAG"
-      else
-        ((ATTEMPT+=1))
-        release=$(get_latest_minor_release)
-        TAG=$(echo $release)
-
-        check_version_exists
-      fi
-    }
-
-    # Remove the patch number from $TAG to locate the most recent minor version from Github Releases
-    # i.e. $TAG=v0.16.1 => $VER=v0.16 then grab the tags from Github
-    get_latest_minor_release() {
-      VER=$(echo $TAG | rev | cut -d"." -f2-  | rev)
-      query=$(echo '/.*'${VER}'.*/!d')
-      curl --silent "https://api.github.com/repos/astronomer/astro-cli/releases" | # Get 30 most recent releases from GitHub API
-        grep '"tag_name":' | # Locate the tag_name key for each release
-        sed -E $query | # Only look at releases that match the minor version provided
-        sed -E 's/.*"([^"]+)".*/\1/' | # Parse out only the version from the key, value pair
-        awk 'NR==1' # Return the first (most recent) minor version from the list
-    }
-
-    # Check the initial version provided by $TAG
-    check_version_exists
+    curl -sL -o- "${DOWNLOADER}" | bash -s -- -b /usr/local/bin "$TAG"

--- a/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
+++ b/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
@@ -16,11 +16,53 @@ data:
     #! /usr/bin/env bash
 
     TAG=${1:-v{{ .Chart.Version }}}
-
+        
     if (( EUID != 0 )); then
         echo "Please run command as root."
         exit
     fi
 
     DOWNLOADER="https://raw.githubusercontent.com/astronomerio/astro-cli/master/godownloader.sh"
-    curl -sL -o- "${DOWNLOADER}" | bash -s -- -b /usr/local/bin "$TAG"
+    MAX_ATTEMPT=2
+    ATTEMPT=0
+    HTTP_STATUS=500
+
+    # If we haven't retried more than once then curl to see if the particular tag exists before trying to download 
+    check_version_exists() {
+      if [[ $ATTEMPT < $MAX_ATTEMPT ]] ; then
+        HTTP_STATUS=$(curl --head --write-out %{http_code} --silent --output /dev/null https://github.com/astronomer/astro-cli/releases/tag/$TAG)
+        download_version $HTTP_STATUS
+      else
+        echo "We couldn't download astro-cli version $TAG. Please check https://github.com/astronomer/astro-cli/releases/ for more information on to resolve this issue."
+        exit 0
+      fi
+    }
+
+    # If the HTTP_STATUS from checking the version tag return a 200 then try to download it, otherwise try to parse the next previous minor version 
+    download_version() {
+      if [[ "$HTTP_STATUS" == 200 ]] ; then
+        echo "Installing version $TAG. Please wait..."
+        curl -sL -o- "${DOWNLOADER}" | bash -s -- -b /usr/local/bin "$TAG"
+      else
+        ((ATTEMPT+=1))
+        release=$(get_latest_minor_release)
+        TAG=$(echo $release)
+
+        check_version_exists
+      fi
+    }
+
+    # Remove the patch number from $TAG to locate the most recent minor version from Github Releases
+    # i.e. $TAG=v0.16.1 => $VER=v0.16 then grab the tags from Github
+    get_latest_minor_release() {
+      VER=$(echo $TAG | rev | cut -d"." -f2-  | rev)
+      query=$(echo '/.*'${VER}'.*/!d')
+      curl --silent "https://api.github.com/repos/astronomer/astro-cli/releases" | # Get 30 most recent releases from GitHub API
+        grep '"tag_name":' | # Locate the tag_name key for each release
+        sed -E $query | # Only look at releases that match the minor version provided
+        sed -E 's/.*"([^"]+)".*/\1/' | # Parse out only the version from the key, value pair
+        awk 'NR==1' # Return the first (most recent) minor version from the list
+    }
+
+    # Check the initial version provided by $TAG
+    check_version_exists

--- a/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
+++ b/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
@@ -15,7 +15,7 @@ data:
   install.sh: |-
     #! /usr/bin/env bash
 
-    TAG=${1:-v{{ .Values.Install.CliVersion }}}
+    TAG=${1:-v{{ .Values.Install.cliVersion }}}
 
     if (( EUID != 0 )); then
         echo "Please run command as root."

--- a/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
+++ b/charts/astronomer/templates/cli-install/cli-install-configmap.yaml
@@ -15,7 +15,7 @@ data:
   install.sh: |-
     #! /usr/bin/env bash
 
-    TAG=${1:-v{{ .Values.Install.cliVersion }}}
+    TAG=${1:-v{{ .Values.install.cliVersion }}}
 
     if (( EUID != 0 )); then
         echo "Please run command as root."

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -252,6 +252,7 @@ registry:
 
 install:
   resources: {}
+  cliVersion: 0.15.0
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
Update install script to use GitHub API to get the latest minor version is there is a patch version mismatch between the platform and the CLI.

Fixes https://github.com/astronomer/issues/issues/1116

**Testing**
The best way to test is this to copy the script into a .sh file and try running it.  You'll need to modify `TAG` at the top of the script because when you're running in the shell you won't have access to `{{ .Chart.Version }}` like you would from the final version from helm.  The script will fallback to the `{{ .Chart.Version }}` when a version isn't provided by the user.

The script (copy lines 18-EOF from the proposed config-map.yml) can be run with the following test cases:

Update the `TAG=${1:-v{{ .Chart.Version }}}` line with test input like `TAG=${1:-v0.13.2}`.  Keep in mind that v0.13.2 does not exist.  This script should install the next available version that does exist `v0.13.1`.

Default script:
`./your-test-script.sh`

Any test version
`./your-test-script.sh 0.15.X`

**Additional Feedback**

1. Should we notify the user that we are attempting to download a different version than what's in the script?  i.e. `TAG=${1:-v{{ .Chart.Version }}}` when `.Chart.Version` is `0.13.2` (which doesn't exist at the moment for astro-cli), but the script downloads the previous existing patch version `0.13.1` without notifying the user this fallback download is occurring.  The current script does not notify the user this is happening, but it will automatically download version `0.13.1`.
2. Should we skip the recheck if the user supplies an invalid version as a argument?  Currently this script still tries to get the fallback version is the user supplied version doesn't exist.
