### PR TITLE
remove env vars that are duplicated in cloud config

### DIFF
--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -64,9 +64,3 @@ spec:
             - name: APP_API_LOC_WSS
               value: "wss://houston.{{ .Values.global.baseDomain }}/ws"
             {{- end }}
-            - name: APP_ENABLE_ERROR_REPORTING
-              value: "false"
-            - name: APP_SENTRY_DSN
-              value: "https://5c7da1dadf834cd9b8d212b20cd53d47@sentry.io/1773523"
-            - name: APP_LOGROCKET
-              value: "1hv1sf/orbit"


### PR DESCRIPTION
The env vars here causes problems with deployment. These env var name and values should go in `.Values.astroUI.env`. The template is already setup to loop through that and add env vars.