### PR TITLE
Increase default proxy timeouts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: astronomer
-version: 0.15.0
-appVersion: 0.15.0
+version: 0.15.5
+appVersion: 0.15.5
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.15.1
+version: 0.15.5
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -13,6 +13,7 @@ metadata:
 data:
   add-headers: {{ .Release.Namespace }}/{{ template "nginx.fullname" . }}-ingress-controller-headers
   proxy-add-original-uri-header: "true"
+  send-timeout: {{ .Values.sendTimeout | quote }}
   proxy-connect-timeout: {{ .Values.proxyConnectTimeout | quote }}
   proxy-read-timeout: {{ .Values.proxyReadTimeout | quote }}
   proxy-send-timeout: {{ .Values.proxySendTimeout | quote }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -49,7 +49,7 @@ privateLoadBalancer: false
 preserveSourceIP: false
 
 sendTimeout: 600
-proxyConnectTimeout: 600
+proxyConnectTimeout: 15
 proxyReadTimeout: 600
 proxySendTimeout: 600
 proxyBodySize: "512m"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -48,7 +48,8 @@ privateLoadBalancer: false
 # Dependent on cloud provider
 preserveSourceIP: false
 
-proxyConnectTimeout: 15
+sendTimeout: 600
+proxyConnectTimeout: 600
 proxyReadTimeout: 600
 proxySendTimeout: 600
 proxyBodySize: "512m"


### PR DESCRIPTION
This helps avoid 504 for customers with a more significant latency between nodes (specifically between nginx ingress pods and the backend services)