### PR TITLE
Update default tags for new repo defaults

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: master
+    tag: main
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
@@ -121,7 +121,7 @@ houston:
   #   memory: 128Mi
 
   # Any Houston configuration. Reference here:
-  # https://github.com/astronomer/houston-api/blob/master/config/default.yaml
+  # https://github.com/astronomer/houston-api/blob/main/config/default.yaml
   config: {}
 
   # Automatically upgrade Airflow deployments to the latest

--- a/configs/master.yaml
+++ b/configs/master.yaml
@@ -16,11 +16,11 @@ astronomer:
       pullPolicy: Always
     houston:
       repository: astronomerinc/ap-houston-api
-      tag: master
+      tag: main
       pullPolicy: Always
     astroUI:
       repository: astronomerinc/ap-astro-ui
-      tag: master
+      tag: main
       pullPolicy: Always
     dbBootstrapper:
       repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
These two repos now use `main` as their default branch (and build images with that name).