### PR TITLE
Use on-demand instances for sensitive workloads

### DIFF
--- a/charts/astronomer/templates/prisma/prisma-deployment.yaml
+++ b/charts/astronomer/templates/prisma/prisma-deployment.yaml
@@ -21,6 +21,9 @@ spec:
   template:
     metadata:
       labels:
+        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
+        # Prisma to run on on-demand nodes instead of pre-emptible VMs
+        spotinst.io/node-lifecycle: od
         component: prisma
         tier: astronomer
         release: {{ .Release.Name }}

--- a/charts/astronomer/templates/prisma/prisma-deployment.yaml
+++ b/charts/astronomer/templates/prisma/prisma-deployment.yaml
@@ -21,9 +21,9 @@ spec:
   template:
     metadata:
       labels:
-        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
-        # Prisma to run on on-demand nodes instead of pre-emptible VMs
-        spotinst.io/node-lifecycle: od
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         component: prisma
         tier: astronomer
         release: {{ .Release.Name }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -30,9 +30,9 @@ spec:
   template:
     metadata:
       labels:
-        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
-        # Registry to run on on-demand nodes instead of pre-emptible VMs
-        spotinst.io/node-lifecycle: od
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         component: registry
         tier: astronomer
         release: {{ .Release.Name }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -30,6 +30,9 @@ spec:
   template:
     metadata:
       labels:
+        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
+        # Registry to run on on-demand nodes instead of pre-emptible VMs
+        spotinst.io/node-lifecycle: od
         component: registry
         tier: astronomer
         release: {{ .Release.Name }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -180,6 +180,7 @@ houston:
     schedule: "0 0 * * *"
 
 prisma:
+  podLabels: {}
   env: []
   resources: {}
   #  limits:
@@ -204,6 +205,7 @@ commander:
    #  memory: 128Mi
 
 registry:
+  podLabels: {}
   resources: {}
   #  limits:
   #   cpu: 100m

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -22,9 +22,9 @@ spec:
   template:
     metadata:
       labels:
-        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
-        # Prometheus to run on on-demand nodes instead of pre-emptible VMs
-        spotinst.io/node-lifecycle: od
+{{- with .Values.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
         tier: monitoring
         component: {{ template "prometheus.name" . }}
         release: {{ .Release.Name }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -22,6 +22,9 @@ spec:
   template:
     metadata:
       labels:
+        # https://help.spot.io/container-management/kubernetes/kubernetes-concepts/spotinst-labels/
+        # Prometheus to run on on-demand nodes instead of pre-emptible VMs
+        spotinst.io/node-lifecycle: od
         tier: monitoring
         component: {{ template "prometheus.name" . }}
         release: {{ .Release.Name }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -5,6 +5,7 @@
 nodeSelector: {}
 affinity: {}
 tolerations: []
+podLabels: {}
 
 # Prometheus is not designed to be horizontally scalable behind a single load
 # balancer. This configuration will increase the replicas in the Prometheus

--- a/values.yaml
+++ b/values.yaml
@@ -189,6 +189,7 @@ grafana:
 ## Prometheus configuration
 #################################
 prometheus:
+  podLabels: {}
   # Data retention
   retention: 15d
 


### PR DESCRIPTION
I figure just add the label no matter what because it's just one less thing to worry about configuring.