### PR TITLE
Add labels for later versions of cAdvisor

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -449,6 +449,19 @@ data:
             replacement: $1
             action: drop
 
+            # For versions of cAdvisor that no longer include label pod_name
+          - source_labels: [pod]
+            regex: (.*)
+            target_label: pod_name
+            replacement: $1
+            action: replace
+
+            # For versions of cAdvisor that no longer include label container_name
+          - source_labels: [container]
+            regex: "^(.*)$"
+            replacement: "$1"
+            target_label: container_name
+            action: replace
 
           - action: replace
             source_labels: [id]


### PR DESCRIPTION
- Add support for later versions of cAdvisor that use slightly different labels
- This resolves missing CPU / Mem / Networking metrics in EE environments
- Related to astronomer/issues#1458