### PR TITLE
privilege escalation needs to be allowed for now

### DIFF
--- a/templates/psp/restrictive-psp.yaml
+++ b/templates/psp/restrictive-psp.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   privileged: false
   hostNetwork: false
-  allowPrivilegeEscalation: false
-  defaultAllowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
+  defaultAllowPrivilegeEscalation: true
   hostPID: false
   hostIPC: false
   runAsUser:


### PR DESCRIPTION
the debian buster images make use of gosu in a way that requires us to allow privilege escalation. This will need to be changed back after the airflow AC images have been changed.

This change has already been made live in prod by editing the restrictive policy. 