### PR TITLE
bump houston-api image to 0.16.3

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.16.1
+    tag: 0.16.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui


### PR DESCRIPTION
fix https://github.com/astronomer/issues/issues/1490

**> Note: need cherry-pick to release branch too.!**

References:
[1] https://app.circleci.com/pipelines/github/astronomer/houston-api/1131/workflows/c8afacae-a596-42ad-9b83-1707443405a4/jobs/3378