### PR TITLE
Alert routing changes

### DIFF
--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -43,7 +43,7 @@ data:
         send_resolved: true
 {{- if .Values.receivers.platformCritical }}
     - name: platform-critical-receiver
-{{ toYaml .Values.receivers.platform | trim | indent 6 }}
+{{ toYaml .Values.receivers.platformCritical | trim | indent 6 }}
 {{- end }}
 {{- if .Values.receivers.platform }}
     - name: platform-receiver

--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -20,7 +20,7 @@ data:
       repeat_interval: 3h
       receiver: default-receiver
       routes:
-      {{ if .Values.receivers.platform-critical }}
+      {{ if .Values.receivers.platformCritical }}
       - receiver: platform-critical-receiver
         continue: true  # allows alert to continue down the tree matching any additional child routes
         match:
@@ -41,7 +41,7 @@ data:
       webhook_configs:
       - url: http://{{ .Release.Name }}-houston:8871/v1/alerts
         send_resolved: true
-{{- if .Values.receivers.platform }}
+{{- if .Values.receivers.platformCritical }}
     - name: platform-critical-receiver
 {{ toYaml .Values.receivers.platform | trim | indent 6 }}
 {{- end }}

--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -20,6 +20,13 @@ data:
       repeat_interval: 3h
       receiver: default-receiver
       routes:
+      {{ if .Values.receivers.platform-critical }}
+      - receiver: platform-critical-receiver
+        continue: true  # allows alert to continue down the tree matching any additional child routes
+        match:
+          serverity: critical
+          tier: platform
+      {{ end }}
       - receiver: {{ if .Values.receivers.platform }} platform-receiver {{ else }} blackhole-receiver {{ end }}
         match_re:
           tier: platform
@@ -34,6 +41,10 @@ data:
       webhook_configs:
       - url: http://{{ .Release.Name }}-houston:8871/v1/alerts
         send_resolved: true
+{{- if .Values.receivers.platform }}
+    - name: platform-critical-receiver
+{{ toYaml .Values.receivers.platform | trim | indent 6 }}
+{{- end }}
 {{- if .Values.receivers.platform }}
     - name: platform-receiver
 {{ toYaml .Values.receivers.platform | trim | indent 6 }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -40,5 +40,10 @@ receivers:
   # Configs for platform alerts
   platform: {}
 
+  platform-critical: {}
+  # example config for pager duty
+  # - routing_key: XXXXXXXXXX
+  #   send_resolved: true
+
   # Configs for airflow alerts
   airflow: {}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -40,7 +40,7 @@ receivers:
   # Configs for platform alerts
   platform: {}
 
-  platform-critical: {}
+  platformCritical: {}
   # example config for pager duty
   # - routing_key: XXXXXXXXXX
   #   send_resolved: true


### PR DESCRIPTION
If a `platformCritical` value is present, creates a route to match `critical` `platform` alerts and sends them to a critical alert receiver that only sends to pager duty. 

The route is configured such that an alert that matches the `platformCritical` receiver can continue matching other routes such as `platform`. This allows us keep the critical receiver scoped to just pager duty handling and not have to add any of the slack configs that we already have for platform alerts. 