### PR TITLE
Added env var for REGISTRY_HTTP_SECRET

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -47,6 +47,9 @@ spec:
         - name: registry
           image: {{ template  "registry.image" . }}
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
+          env: 
+          - name: REGISTRY_HTTP_SECRET
+            value: {{ randAlphaNum 32 }}
           resources:
 {{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:


### PR DESCRIPTION
In order to run docker registry with multiple replicas all pods must use the same http secret.

This http secret is generated by helm as a random string of 32 characters. This will be updated every time/anytime the helm release is installed or upgraded. 

I choose the random string route rather creating a secret and storing it so that we don't have to manage the secret in anyway. 

What this parameter is for, from the docker docs. 
> A random piece of data used to sign state that may be stored with the client to protect against tampering. For production environments you should generate a random piece of data using a cryptographically secure random generator. If you omit the secret, the registry will automatically generate a secret when it starts. If you are building a cluster of registries behind a load balancer, you MUST ensure the secret is the same for all registries.