### PR TITLE
Allow registry template to specify replica count via values.

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -18,7 +18,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.registry.replicas }}
   selector:
     matchLabels:
       component: registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -205,6 +205,7 @@ commander:
    #  memory: 128Mi
 
 registry:
+  replicas: 1
   podLabels: {}
   resources: {}
   #  limits:


### PR DESCRIPTION
Previously the registry was hardcoded at number of replicase == 1. Now that we are setting up for HA registry with multiple replicas the template needs to be variable so it can populate the template from a values file. This PR does that, with a default value of 1 for non HA deployments. 