### PR TITLE
Do not set ACLs since we now use uniform bucket perms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,13 +94,13 @@ push: build
 .PHONY: push-repo
 push-repo:
 	for chart in ${CHARTS} ; do \
-		gsutil cp -a public-read ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz ${BUCKET} || exit 1; \
+		gsutil cp ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz ${BUCKET} || exit 1; \
 	done; \
 	$(MAKE) push-index
 
 .PHONY: push-index
 push-index: build-index
-	gsutil cp -a public-read ${OUTPUT}/index.yaml ${BUCKET}
+	gsutil cp ${OUTPUT}/index.yaml ${BUCKET}
 
 .PHONY: clean
 clean:

--- a/bin/release-helm-chart
+++ b/bin/release-helm-chart
@@ -103,8 +103,8 @@ process_and_release_chart_file() {
   wget "https://${target_repo}/index.yaml" -O /tmp/index.yaml.current
   helm repo index . --url "https://${target_repo}" --merge /tmp/index.yaml.current
 
-  gsutil cp -a public-read "$helm_chart_path" "gs://${target_repo}"
-  gsutil cp -a public-read ./index.yaml "gs://${target_repo}"
+  gsutil cp "$helm_chart_path" "gs://${target_repo}"
+  gsutil cp ./index.yaml "gs://${target_repo}"
 
   set +x
   hr


### PR DESCRIPTION
We are now using uniform bucket permissions for helm repo, so we need to stop attempting to set an ACL because it now triggers an error.