### PR TITLE
Corrected typo in severity label

### DIFF
--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -24,7 +24,7 @@ data:
       - receiver: platform-critical-receiver
         continue: true  # allows alert to continue down the tree matching any additional child routes
         match:
-          serverity: critical
+          severity: critical
           tier: platform
       {{ end }}
       - receiver: {{ if .Values.receivers.platform }} platform-receiver {{ else }} blackhole-receiver {{ end }}


### PR DESCRIPTION
fixing a dumb typo mistake in the alert manager config. 