### PR TITLE
Allowing houston-workers through network policies.

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -34,6 +34,15 @@ spec:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
+          component: houston-worker
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.commanderGRPC }}      
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
           component: houston-cleanup
     ports:
     - protocol: TCP

--- a/charts/astronomer/templates/prisma/prisma-networkpolicy.yaml
+++ b/charts/astronomer/templates/prisma/prisma-networkpolicy.yaml
@@ -33,6 +33,15 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
+          component: houston-worker
+          release: {{ .Release.Name }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.prismaHTTP }}      
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: astronomer
           component: houston-cleanup
           release: {{ .Release.Name }}
     ports:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -33,6 +33,11 @@ spec:
           release: {{ .Release.Name }}
     - podSelector:
         matchLabels:
+          tier: astronomer
+          component: houston-worker
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
           tier: nginx
           component: ingress-controller
           release: {{ .Release.Name }}


### PR DESCRIPTION
Prevously this allowed things with component label houston. Needs to allow component label houston-worker as well.