### PR TITLE
Set max-age of index.yaml files to 5 minutes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ push-repo:
 
 .PHONY: push-index
 push-index: build-index
-	gsutil cp ${OUTPUT}/index.yaml ${BUCKET}
+	gsutil -h "Cache-Control: public, max-age=300" cp ${OUTPUT}/index.yaml ${BUCKET}
 
 .PHONY: clean
 clean:

--- a/bin/release-helm-chart
+++ b/bin/release-helm-chart
@@ -104,7 +104,7 @@ process_and_release_chart_file() {
   helm repo index . --url "https://${target_repo}" --merge /tmp/index.yaml.current
 
   gsutil cp "$helm_chart_path" "gs://${target_repo}"
-  gsutil cp ./index.yaml "gs://${target_repo}"
+  gsutil -h "Cache-Control: public, max-age=300" cp ./index.yaml "gs://${target_repo}"
 
   set +x
   hr


### PR DESCRIPTION
This sets the max-age of the index.yaml to 5 minutes, which allows us a shorter window until we get consistent results after releasing a new helm chart.