### PR TITLE
Improve Astronomer 0.16 upgrade script

### DIFF
--- a/bin/migration-scripts/upgrade-to-lts.sh
+++ b/bin/migration-scripts/upgrade-to-lts.sh
@@ -396,7 +396,7 @@ function main {
 
   git_clone_if_necessary
 
-  kubectl delete sts --cascade=false --namespace $NAMESPACE $RELEASE-es-master $RELEASE-es-data || true
+  kubectl delete sts --cascade=false --namespace "$NAMESPACE" "${RELEASE}-es-master" "${RELEASE}-es-data" || true
   sleep 5
   echo "Upgrading Astronomer... (1/4) converge Helm 3 labels"
   helm3 upgrade --namespace "$NAMESPACE" \

--- a/bin/migration-scripts/upgrade-to-lts.sh
+++ b/bin/migration-scripts/upgrade-to-lts.sh
@@ -396,6 +396,8 @@ function main {
 
   git_clone_if_necessary
 
+  kubectl delete sts --cascade=false --namespace $NAMESPACE $RELEASE-es-master $RELEASE-es-data || true
+  sleep 5
   echo "Upgrading Astronomer... (1/4) converge Helm 3 labels"
   helm3 upgrade --namespace "$NAMESPACE" \
                --reset-values \


### PR DESCRIPTION
There is a situation with some users who have upgraded a few times where a historically present config is carrying through upgrades such that it is causing a collision in a yaml merge of two lists. This is solved by deleting elasticsearch statefulset but not the persistent volumes behind.