### PR TITLE
Wait for nats

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -49,6 +49,21 @@ spec:
 {{ toYaml .Values.houston.resources | indent 12 }}
           env:
             {{- include "houston_environment" . | indent 12 }}
+        - name: wait-for-nats-server
+          command:
+            - "dockerize"
+          args:
+            - "-wait"
+            - "tcp://{{ .Release.Name }}-nats:4222"
+            - "-timeout"
+            - "1m"
+          image: astronomerinc/ap-base:3.12-1
+          imagePullPolicy: IfNotPresent
+          resources:
+{{ toYaml .Values.houston.resources | indent 12 }}
+          env:
+            - name: NATS__URL
+              value: nats://{{ .Release.Name }}-nats:4222
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}


### PR DESCRIPTION
Adding wait for NATS so Houston will correctly connect to NATS and avoid reconnect failures.

Related https://github.com/astronomer/issues/issues/1534