### PR TITLE
Fix/nats houston connection

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -110,6 +110,10 @@ spec:
             failureThreshold: {{ .Values.houston.readinessProbe.failureThreshold }}
           env:
             {{- include "houston_environment" . | indent 12 }}
+            - name: NATS__URL
+              value: nats://{{ .Release.Name }}-nats:4222
+            - name: NATS__CLUSTER_ID
+              value: {{ .Release.Name }}-stan
             - name: APOLLO_SERVER_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Add env vars for NATS Cluster ID and NATS URL to use for Houston (similar to the Houston Worker).

Related https://github.com/astronomer/houston-api/pull/391