### PR TITLE
Remove .ONESHELL, rework logic to enable this.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build:
 	rm -rf ${TEMP}/astronomer || true
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
-	find ${TEMP}/astronomer/charts -name requirements.yaml -type f -printf '%h\n' | xargs -r -n1 helm dep update
+	find "${TEMP}/astronomer/charts" -name requirements.yaml -type f -printf '%h\0' | xargs -0 -r -n1 helm dep update
 	helm package ${TEMP}/astronomer
 
 .PHONY: build-index

--- a/Makefile
+++ b/Makefile
@@ -18,41 +18,28 @@ lint: lint-prep lint-astro lint-charts
 #lint-prom (omitted)
 
 .PHONY: lint-venv
-.ONESHELL:
 lint-venv:
-	set -eu
 	python3 -m venv venv
-	. venv/bin/activate
-	pip install pyyaml
+	. venv/bin/activate && pip install pyyaml
 
 .PHONY: lint-prep
-.ONESHELL:
 lint-prep:
-	set -eu
 	rm -rf ${TEMP}/astronomer || true
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
 
 .PHONY: lint-astro
-.ONESHELL:
 lint-astro:
-	set -eu
 	helm lint ${TEMP}/astronomer
 
 .PHONY: lint-charts
-.ONESHELL:
 lint-charts:
-	set -eu
 	# get a copy of the global values for helm lint'n the dependent charts
 	python3 -c "import yaml; from pathlib import Path; globals = {'global': yaml.safe_load(Path('${TEMP}/astronomer/values.yaml').read_text())['global']}; Path('${TEMP}/globals.yaml').write_text(yaml.dump(globals))"
-	for chart in $$(ls ${TEMP}/astronomer/charts); do
-	helm lint -f ${TEMP}/globals.yaml ${TEMP}/astronomer/charts/$$chart
-	done
+	find "${TEMP}/astronomer/charts" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n1 helm lint -f ${TEMP}/globals.yaml
 
 .PHONY: lint-prom
-.ONESHELL:
 lint-prom:
-	set -eu
 	# Lint the Prometheus alerts configuration
 	helm template -s ${TEMP}/astronomer/charts/prometheus/templates/prometheus-alerts-configmap.yaml ${TEMP}/astronomer > ${TEMP}/prometheus_alerts.yaml
 	# Parse the alerts.yaml data from the config map resource
@@ -60,25 +47,16 @@ lint-prom:
 	promtool check rules  ${TEMP}/prometheus_alerts.yaml
 
 .PHONY: lint-clean
-.ONESHELL:
 lint-clean:
 	rm -rf ${TEMP}
 
-
 .PHONY: build
-.ONESHELL:
 build:
-	set -xe
 	helm repo add kedacore https://kedacore.github.io/charts
 	rm -rf ${TEMP}/astronomer || true
 	mkdir -p ${TEMP}
 	cp -R ../astronomer ${TEMP}/astronomer || cp -R ../project ${TEMP}/astronomer
-	# Install external charts
-	for chart in $$(ls ${TEMP}/astronomer/charts); do
-	if test -f ${TEMP}/astronomer/charts/$$chart/requirements.yaml; then
-	helm dep update ${TEMP}/astronomer/charts/$$chart
-	fi
-	done
+	find ${TEMP}/astronomer/charts -name requirements.yaml -type f -printf '%h\n' | xargs -r -n1 helm dep update
 	helm package ${TEMP}/astronomer
 
 .PHONY: build-index


### PR DESCRIPTION
Using `.ONESHELL` changes the behavior of every target in the entire Makefile. Looking at how how it was being used, I found that we didn't really need it, and removing it would make our Makefile a bit simpler, more compatible and more in line with common Makefile behaviors.

One consideration here is that some of the logic I added requires GNU find, so it will not work on vanilla macOS. I assume this isn't a problem though since the Makefile is meant to be run on linux.