### PR TITLE
Fix/disable commander houston worker

### DIFF
--- a/charts/astronomer/templates/houston/worker/houston-worker-configmap.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-configmap.yaml
@@ -1,0 +1,18 @@
+######################################
+## Astronomer Houston Worker ConfigMap
+######################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-houston-worker-config
+  labels:
+    component: houston-worker
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+data:
+  # These are system-specified config overrides.
+  production.yaml: |
+    commander:
+      enabled: false

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -98,6 +98,8 @@ spec:
               value: nats://{{ .Release.Name }}-nats:4222
             - name: NATS__CLUSTER_ID
               value: {{ .Release.Name }}-stan
+            - name: COMMANDER__ENABLED
+              value: "false"
             - name: APOLLO_SERVER_ID
               valueFrom:
                 fieldRef:

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -26,7 +26,7 @@ spec:
         component: houston-worker
         release: {{ .Release.Name }}
       annotations:
-        checksum/houston-config: {{ include (print $.Template.BasePath "/houston/api/houston-configmap.yaml") . | sha256sum }}
+        checksum/houston-config: {{ include (print $.Template.BasePath "/houston/worker/houston-worker-configmap.yaml") . | sha256sum }}
     spec:
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -126,7 +126,7 @@ houston:
 
   # Worker to connect to NATS
   worker:
-    enabled: false
+    enabled: true
     replicas: 2
 
   # Automatically upgrade Airflow deployments to the latest


### PR DESCRIPTION
Disables Commander for Houston Workers.

Fixes https://github.com/astronomer/issues/issues/1620

**Verification steps:**
1. Pull the latest `houston-api` main branch
2. Build your local image and tag `kind load docker-image {IMAGE_NAME}:{IMAGE_TAG}`
3. `./bin/reset-local-dev` to deploy updates to kind
4. Once the control plane comes up you can: `kind load docker-image  {IMAGE_NAME}:{IMAGE_TAG}`
5. Wait for the pods to come up and then log into Astro UI
6. Open up the worker logs `k logs {HOUSTON_WORKER_POD} -n astronomer -f`
7. Create a new deployment 
8. View the logs from the Houston Worker (using kind locally). You should see something similar to:

```
2020-08-04T16:56:12 INFO NATS publishing message houston.deployment.created.started for ckdg6pb39004d0l87qz6vfywo.
2020-08-04T16:56:13 INFO Creating database extraterrestrial_fission_3877_airflow
2020-08-04T16:56:13 INFO Created airflow schema for extraterrestrial_fission_3877_airflow
2020-08-04T16:56:13 INFO Created celery schema for extraterrestrial_fission_3877_celery
2020-08-04T16:56:13 INFO Created database extraterrestrial_fission_3877_airflow
2020-08-04T16:56:13 INFO Commander disabled, skipping call to #createDeployment
2020-08-04T16:56:13 INFO Created Deployment extraterrestrial-fission-3877
```