### PR TITLE
Add Pod Disruption Budget for NATS and STAN

### DIFF
--- a/charts/astronomer/templates/houston/worker/houston-worker-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-pod-disruption-budget.yaml
@@ -1,0 +1,18 @@
+###################################################
+## Astronomer Houston Worker Pod Disruption Budget
+###################################################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-houston-worker-pdb
+spec:
+  {{- if lt ( .Values.houston.worker.replicas | int ) 4 }}
+  maxUnavailable: 1
+  {{- else }}
+  maxUnavailable: {{ .Values.houston.worker.replicas.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      tier: astronomer
+      component: houston-worker
+      release: {{ .Release.Name }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-pod-disruption-budget.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-pod-disruption-budget.yaml
@@ -6,10 +6,12 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ .Release.Name }}-houston-worker-pdb
 spec:
-  {{- if lt ( .Values.houston.worker.replicas | int ) 4 }}
-  maxUnavailable: 1
+  {{- if lt ( .Values.houston.worker.replicas | int ) 2 }}
+  minAvailable: 0
+  {{- else if lt ( .Values.houston.worker.replicas | int ) 4 }}
+  minAvailable: 1
   {{- else }}
-  maxUnavailable: {{ .Values.houston.worker.replicas.maxUnavailable }}
+  minAvailable: "25%"
   {{- end }}
   selector:
     matchLabels:

--- a/charts/nats/templates/pod-disruption-budget.yaml
+++ b/charts/nats/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: astronomer
+      tier: nats
       component: {{ template "nats.name" . }}
       release: {{ .Release.Name }}

--- a/charts/nats/templates/pod-disruption-budget.yaml
+++ b/charts/nats/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: logging
+      tier: astronomer
       component: {{ template "nats.name" . }}
       release: {{ .Release.Name }}

--- a/charts/nats/templates/pod-disruption-budget.yaml
+++ b/charts/nats/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: nats
-      component: {{ template "nats.name" . }}
+      tier: astronomer
+      app: {{ template "nats.name" . }}
       release: {{ .Release.Name }}

--- a/charts/nats/templates/pod-disruption-budget.yaml
+++ b/charts/nats/templates/pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+##############################
+## NATS Pod Disruption Budget
+##############################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-nats-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      tier: logging
+      component: {{ template "nats.name" . }}
+      release: {{ .Release.Name }}

--- a/charts/nats/templates/service.yaml
+++ b/charts/nats/templates/service.yaml
@@ -14,7 +14,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   selector:
+    tier: astronomer
     app: {{ template "nats.name" . }}
+    release: {{ .Release.Name }}
   clusterIP: None
   ports:
   - name: client

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -30,7 +30,9 @@ spec:
       {{- end }}
       {{- end }}
       labels:
+        tier: astronomer
         app: {{ template "nats.name" . }}
+        release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
 {{- with .Values.imagePullSecrets }}

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: astronomer
+      tier: nats
       component: {{ template "stan.name" . }}
       release: {{ .Release.Name }}

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: nats
-      component: {{ template "stan.name" . }}
+      tier: astronomer
+      app: {{ template "stan.name" . }}
       release: {{ .Release.Name }}

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -1,0 +1,14 @@
+##############################
+## STAN Pod Disruption Budget
+##############################
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-stan-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      tier: logging
+      component: {{ template "stan.name" . }}
+      release: {{ .Release.Name }}

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -9,6 +9,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      tier: logging
+      tier: astronomer
       component: {{ template "stan.name" . }}
       release: {{ .Release.Name }}

--- a/charts/stan/templates/service.yaml
+++ b/charts/stan/templates/service.yaml
@@ -14,7 +14,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 spec:
   selector:
+    tier: astronomer
     app: {{ template "stan.name" . }}
+    release: {{ .Release.Name }}
   clusterIP: None
   ports:
   - name: metrics

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -30,7 +30,9 @@ spec:
       {{- end }}
       {{- end }}
       labels:
+        tier: astronomer
         app: {{ template "stan.name" . }}
+        release: {{ .Release.Name }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
       {{- if .Values.stan.nats.serviceRoleAuth.enabled }}


### PR DESCRIPTION
**Context**
Astro CLI is occasionally reporting `Error: connection closed` on `create` and `delete` deployment commands.  This most likely affects Astro UI as well, but errors there haven't been reported yet. 

**Propsed Solution**
Currently NATS and STAN can be down for a short amount of time and our system will continue to report that it's healthy.  We need NATS and STAN to have `maxUnavailable: 1` to function similarly to Commander.