### PR TITLE
Fix Houston API pod disruption budget to not match Houston cron jobs

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -23,7 +23,7 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston
+            component: houston-update-check
             release: {{ .Release.Name }}
           {{- if .Values.global.istio.enabled }}
           annotations:

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Release.Name }}-houston-update-check
   labels:
     tier: astronomer
-    component: houston
+    component: houston-update-check
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-expire-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-expire-deployments-cronjob.yaml
@@ -20,7 +20,7 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston
+            component: houston-expire-deployments
             release: {{ .Release.Name }}
           {{- if .Values.global.istio.enabled }}
           annotations:

--- a/charts/astronomer/templates/houston/cronjobs/houston-expire-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-expire-deployments-cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Release.Name }}-houston-expire-deployments
   labels:
     tier: astronomer
-    component: houston
+    component: houston-expire-deployments
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ .Release.Name }}-houston-upgrade-deployments
   labels:
     tier: astronomer
-    component: houston
+    component: houston-upgrader
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
@@ -26,7 +26,7 @@ spec:
     metadata:
       labels:
         tier: astronomer
-        component: houston
+        component: houston-upgrader
         release: {{ .Release.Name }}
       {{- if .Values.global.istio.enabled }}
       annotations:

--- a/charts/astronomer/tests/houston_pdb_test.yaml
+++ b/charts/astronomer/tests/houston_pdb_test.yaml
@@ -1,0 +1,46 @@
+suite: Test houston pod disruption budget
+# if omitted, all templates are rendered
+# templates:
+tests:
+- it: should have the PDB labels on the API deployment
+  asserts:
+    - equal:
+        path: spec.template.metadata.labels.tier
+        value: astronomer
+      template: houston/api/houston-deployment.yaml
+    - equal:
+        path: spec.template.metadata.labels.component
+        value: houston
+      template: houston/api/houston-deployment.yaml
+- it: PDB labels match the deployment
+  asserts:
+    - equal:
+        path: spec.selector.matchLabels.tier
+        value: astronomer
+      template: houston/api/houston-pod-disruption-budget.yaml
+    - equal:
+        path: spec.selector.matchLabels.component
+        value: houston
+      template: houston/api/houston-pod-disruption-budget.yaml
+- it: does not match cronjobs or workers
+  asserts:
+    - notEqual:
+        path: spec.jobTemplate.spec.template.metadata.labels.component
+        value: houston
+      template: houston/cronjobs/houston-expire-deployments-cronjob.yaml
+    - notEqual:
+        path: spec.jobTemplate.spec.template.metadata.labels.component
+        value: houston
+      template: houston/cronjobs/houston-check-updates-cronjob.yaml
+    - notEqual:
+        path: spec.jobTemplate.spec.template.metadata.labels.component
+        value: houston
+      template: houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+    - notEqual:
+        path: spec.jobTemplate.spec.template.metadata.labels.component
+        value: houston
+      template: houston/cronjobs/houston-check-updates-cronjob.yaml
+    - notEqual:
+        path: spec.selector.matchLabels.component
+        value: houston
+      template: houston/worker/houston-worker-deployment.yaml


### PR DESCRIPTION
closes: https://github.com/astronomer/issues/issues/1229

houston PDB is accidentally patching the labels on the these jobs, this makes the houston rollout get 'stuck' for users with low replica count. For example if PDB says maxUnavailable: 1, then it will remain stuck as long as any of these jobs are in a non-ready state, including "completed"

I'm going to leave this in draft, I want to see if I can use the new unit testing framework to capture the logic 'no pods match these labels except the ones we want'

This is optionally in 0.18 and ought to be backported to 0.16, since it is a bug fix.