### PR TITLE
Update NGINX policy

### DIFF
--- a/charts/nginx/templates/nginx-headers-configmap.yaml
+++ b/charts/nginx/templates/nginx-headers-configmap.yaml
@@ -17,4 +17,4 @@ data:
   X-Frame-Options: "deny"
   X-XSS-Protection: "1; mode=block"
   X-Content-Type-Options: "nosniff"
-  Feature-Policy: "autoplay 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; microphone 'none'; midi 'none'; payment 'none'; vr 'none'"
+  Feature-Policy: "autoplay 'none'; camera 'none'; encrypted-media 'none'; fullscreen 'none'; geolocation 'none'; microphone 'none'; midi 'none'; payment 'none'; xr-spatial-tracking 'none'"


### PR DESCRIPTION
From [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy/vr):

> The WebVR API has been replaced with the WebXR Device API and is currently being removed from the web platform. Use the feature identifier xr-spatial-tracking for WebXR Device API instead.

This is why this error is being shown in Chrome:

![image](https://user-images.githubusercontent.com/3267/89794946-c2e74300-daf5-11ea-873c-b4c2b82850b1.png)
