### PR TITLE
Enable Commander for Houston API Workers

### DIFF
--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -98,8 +98,6 @@ spec:
               value: nats://{{ .Release.Name }}-nats:4222
             - name: NATS__CLUSTER_ID
               value: {{ .Release.Name }}-stan
-            - name: COMMANDER__ENABLED
-              value: "false"
             - name: APOLLO_SERVER_ID
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Description

In support of fully enabling both create and and delete deployment workers to publish to commander.

## 🎟 Issue(s)

Resolves astronomer/issues#1619

## 🧪 Functional Testing

See Houston API Pull Request for all of the testing steps: https://github.com/astronomer/houston-api/pull/417

## 📋 Checklist

- [x] Rebased from the main (or release if patching) branch
- [ ] Added/updated applicable tests
- [ ] Communicated to/tagged owners of respective clients potentially impacted by these changes.
- [ ] Updated any related [documentation](https://github.com/astronomer/astro-docs/)
