### PR TITLE
UI package updates, variable RBAC updates, deployment removal enhancements

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -27,7 +27,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: 0.18.0
+    tag: 0.19.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
`astronomerinc/ap-astro-ui:0.19.0`

Commits: 

> 98702fa Build(deps-dev): Bump eslint from 7.6.0 to 7.7.0 (https://github.com/astronomer/astro-ui/pull/751)
> bafae21 Build(deps): Bump lodash from 4.17.19 to 4.17.20 (https://github.com/astronomer/astro-ui/pull/750)
> 5e8ad7b Build(deps): Bump logrocket from 1.0.10 to 1.0.11 (https://github.com/astronomer/astro-ui/pull/747)
> 6b5f3e1 Build(deps-dev): Bump jest from 26.3.0 to 26.4.0 (https://github.com/astronomer/astro-ui/pull/749)
> 90d3fe3 Delete deployment error messaging (https://github.com/astronomer/astro-ui/pull/745)
> b86b0eb Build(deps): Bump @testing-library/jest-dom from 5.11.2 to 5.11.3 (https://github.com/astronomer/astro-ui/pull/744)
> f35f85c Displays toast message after successful deployment deletion (https://github.com/astronomer/astro-ui/pull/743)
> c1e3c3d Move testing packages to devDependencies (https://github.com/astronomer/astro-ui/pull/742)
> 8a6d8dc Build(deps): Bump enzyme-adapter-react-16 from 1.15.2 to 1.15.3 (https://github.com/astronomer/astro-ui/pull/741)
> 1b54a1e Build(deps-dev): Bump jest from 26.2.2 to 26.3.0 (https://github.com/astronomer/astro-ui/pull/740)
> 5d1645b Build(deps): Bump dayjs from 1.8.32 to 1.8.33 (https://github.com/astronomer/astro-ui/pull/739)
> 1e3a2a9 Build(deps-dev): Bump concurrently from 5.2.0 to 5.3.0 (https://github.com/astronomer/astro-ui/pull/737)
> 798d17f Deployment variables schema update (https://github.com/astronomer/astro-ui/pull/719)
> b9bbd41 Build(deps): Bump @testing-library/react from 10.4.7 to 10.4.8 (https://github.com/astronomer/astro-ui/pull/736)
> 4f58f75 Build(deps-dev): Bump cypress from 4.12.0 to 4.12.1 (https://github.com/astronomer/astro-ui/pull/735)
> 75f3cd1 Build(deps): Bump dayjs from 1.8.31 to 1.8.32 (https://github.com/astronomer/astro-ui/pull/733)
> d53cafd Build(deps-dev): Bump @babel/core from 7.11.0 to 7.11.1 (https://github.com/astronomer/astro-ui/pull/734)
