### PR TITLE
Allow for user-supplied values in prometheus alerts configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lint-prom:
 	# Lint the Prometheus alerts configuration
 	helm template -s ${TEMP}/astronomer/charts/prometheus/templates/prometheus-alerts-configmap.yaml ${TEMP}/astronomer > ${TEMP}/prometheus_alerts.yaml
 	# Parse the alerts.yaml data from the config map resource
-	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMP}/prometheus_alerts.yaml').read_text())['data']['alerts.yaml']; Path('${TEMP}/prometheus_alerts.yaml').write_text(alerts)"
+	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMP}/prometheus_alerts.yaml').read_text())['data']['alerts']; Path('${TEMP}/prometheus_alerts.yaml').write_text(alerts)"
 	promtool check rules ${TEMP}/prometheus_alerts.yaml
 
 .PHONY: lint-clean

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -22,10 +22,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  alerts.yaml: |-
+  alerts: |-
     groups:
       - name: airflow
         rules:
+        {{- if .Values.additionalAlerts.airflow }}
+        {{- tpl .Values.additionalAlerts.airflow $ | nindent 8 }}
+        {{- end }}
         - alert: AirflowDeploymentUnhealthy
           expr: sum by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) - count by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) < 0
           for: 15m # Rough number but should be enough to clear deployments with a reasonable amount of workers
@@ -1456,7 +1459,7 @@ data:
         - alert: NumberOfNodesHigh
           expr: count(kube_node_info) >= 60
           for: 10m
-          labels: 
+          labels:
             severity: critical
             tier: platform
           annotations:

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -108,6 +108,9 @@ data:
 
       - name: platform
         rules:
+        {{- if .Values.additionalAlerts.platform }}
+        {{- tpl .Values.additionalAlerts.platform $ | nindent 8 }}
+        {{- end }}
         - alert: AirflowOperatorFailureRate
           expr: 100 * (sum by (operator) (increase(airflow_operator_failures{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])) / (sum by (operator) (increase(airflow_operator_successes{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])) + sum by (operator) (increase(airflow_operator_failures{operator=~"([A-Z][a-z0-9]+)(([0-9])|([A-Z0-9][a-z0-9]+))*([A-Z])?Operator"}[1h])))) > 50
           for: 2h

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -101,7 +101,7 @@ spec:
           configMap:
             name: {{ template "prometheus.fullname" . }}-alerts
             items:
-              - key: alerts.yaml
+              - key: alerts
                 path: alerts.yaml
   {{- if not .Values.persistence.enabled }}
         - name: data

--- a/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
+++ b/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
@@ -18,7 +18,7 @@ tests:
     set:
       additionalAlerts:
         airflow: |
-          - alert: MyExampleAlert
+          - alert: ExampleAirflowAlert
             # If greater than 10% task failure
             expr: 100 * sum(increase(airflow_ti_failures[30m])) /  (sum(increase(airflow_ti_failures[30m])) + sum(increase(airflow_ti_successes[30m]))) > 10
             for: 15m
@@ -27,7 +27,20 @@ tests:
             annotations:
               summary: The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf "%q" "{{ printf \"%.2f\" $value }}%" }} of the time over the past 30 minutes
               description: Task instances failing above threshold
+        platform: |
+          - alert: ExamplePlatformAlert
+            expr: count(rate(airflow_scheduler_heartbeat{}[1m]) <= 0) > 2
+            for: 5m
+            labels:
+              tier: platform
+              severity: critical
+            annotations:
+              summary: {{ printf "%q" "{{ $value }} airflow schedulers are not heartbeating" }}
+              description: "If more than 2 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires."
     asserts:
       - matchRegex:
           path: data.alerts
-          pattern: '.*The Astronomer Helm release my-release is failing task instances {{ printf "%.2f" $value }}% of the time over the past 30 minutes.*'
+          pattern: '.*The Astronomer Helm release my-release is failing task instances "{{ printf \\"%.2f\\" \$value }}\%" of the time over the past 30 minutes.*'
+      - matchRegex:
+          path: data.alerts
+          pattern: '.*If more than 2 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires..*'

--- a/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
+++ b/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
@@ -3,7 +3,31 @@ suite: Test prometheus-alerts-configmap
 templates:
   - prometheus-alerts-configmap.yaml
 tests:
-  - it: should work
+  - it: is the right type of resource
     asserts:
       - isKind:
           of: ConfigMap
+  - it: contains exactly one document
+    asserts:
+      - hasDocuments:
+          count: 1
+  - it: renders the additional alerts configuration correctly
+    release:
+      name: my-release
+      namespace: my-namespace
+    set:
+      additionalAlerts:
+        airflow: |
+          - alert: MyExampleAlert
+            # If greater than 10% task failure
+            expr: 100 * sum(increase(airflow_ti_failures[30m])) /  (sum(increase(airflow_ti_failures[30m])) + sum(increase(airflow_ti_successes[30m]))) > 10
+            for: 15m
+            labels:
+              tier: airflow
+            annotations:
+              summary: The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf "%q" "{{ printf \"%.2f\" $value }}%" }} of the time over the past 30 minutes
+              description: Task instances failing above threshold
+    asserts:
+      - matchRegex:
+          path: data.alerts
+          pattern: '.*The Astronomer Helm release my-release is failing task instances {{ printf "%.2f" $value }}% of the time over the past 30 minutes.*'

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -70,7 +70,7 @@ dnsTargets:
   - 10.98.0.10
 
 # Blackbox exporter tcp probe configuration
-# Currently is only configured to scape two targets 
+# Currently is only configured to scape two targets
 # listed below. To disable the probe and all of the targets
 # set tcpProbe.enabled to false.
 tcpProbe:
@@ -83,3 +83,21 @@ tcpProbe:
 # Enable prometheus lifecycle api
 enableLifecycle: true
 
+additionalAlerts:
+  # Additional rules for the 'platform' alert group
+  # Provide as a block string in yaml list form
+  platform: ~
+  # Additional rules for the 'airflow' alert group
+  # Provide as a block string in yaml list form
+  airflow: ~
+# Example:
+# airflow: |
+#   - alert: MyExampleAlert
+#     # If greater than 10% task failure
+#     expr: 100 * sum(increase(airflow_ti_failures[30m])) /  (sum(increase(airflow_ti_failures[30m])) + sum(increase(airflow_ti_successes[30m]))) > 10
+#     for: 15m
+#     labels:
+#       tier: airflow
+#     annotations:
+#       summary: "The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf \"%.2f\" $value }}% of the time over the past 30 minutes"
+#       description: Task instances failing above threshold


### PR DESCRIPTION
## Description

This allows for a user to pass custom alerts into prometheus alerts configmap via values in top-level `config.yaml`.

## PR Title

Allow for user-supplied values in prometheus alerts configmap

## 🎟 Issue(s)

Resolves astronomer/issues#1684

## 🧪  Testing

`/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml`

## 📸 Screenshots
- User supplied values in `config.yaml`
![image](https://user-images.githubusercontent.com/8935584/90926083-070cfa00-e3b8-11ea-9488-6a2ed5d4ddae.png)
- We can see the user supplied airflow alert passed through to `/charts/prometheus/templates/prometheus-alerts-configmap.yaml`
![image](https://user-images.githubusercontent.com/8935584/90926313-7a167080-e3b8-11ea-9253-bdfed8ec9587.png)
- We can see the user supplied platform alert passed through to `/charts/prometheus/templates/prometheus-alerts-configmap.yaml`
![image](https://user-images.githubusercontent.com/8935584/90926361-95817b80-e3b8-11ea-9287-0db26023b040.png)



