### PR TITLE
Resolve extra messages sent to NATS Workers

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.19.5
+    tag: 0.19.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui


### PR DESCRIPTION
## Description

Update Houston so that the workers do not receive extra messages from NATS

## PR Title

> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

## 🎟 Issue(s)

Resolves astronomer/issues#1619

## 🧪  Testing

Check the k8s logs for the worker pods in dev after creating, deleting or updating deployments and make sure that the messages only come through once.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable
