### PR TITLE
Add Prometheus monitoring for kube-dns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: alpine/helm:3.2.3
+      - image: astronomerio/ap-build:0.1.3
     steps:
       - checkout
       - run:
           name: unittest the Astronomer chart
-          command: apk add make git bash && make unittest-charts
+          command: make unittest-charts
 
   build-artifact:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,12 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: alpine/helm:3.2.3
     steps:
       - checkout
       - run:
           name: unittest the Astronomer chart
-          command: make unittest-charts
+          command: apk add make git bash && make unittest-charts
 
   build-artifact:
     docker:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,10 +13,12 @@ Resolves astronomer/issues#XXXX
 
 ## 🧪  Testing
 
-> Please add helm unit testing if possible
+> What are the main risks associated with this change, and how are they addressed by tests added in this PR?
 
-> You also have the option to add system / config testing [here](../bin/functional-tests)
+> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.
+
+> Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
 
 ## 📸 Screenshots
 
-> Add screenshots to illustrate the changes, if applicable
+> Add screenshots to illustrate the changes, if applicable.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@ Resolves astronomer/issues#XXXX
 
 > Please add helm unit testing if possible
 
+> You also have the option to add system / config testing [here](../bin/functional-tests)
+
 ## 📸 Screenshots
 
 > Add screenshots to illustrate the changes, if applicable

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ dev-config.yaml
 **kubeconfig**
 certs
 /secrets
-test-*
 
 # IDEs
 .idea/
@@ -25,3 +24,4 @@ dev-account.json
 temp.sh
 
 /venv/
+**pycache**

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint-astro:
 
 .PHONY: unittest-charts
 unittest-charts:
-	helm plugin install https://github.com/quintush/helm-unittest >/dev/null || true
+	helm plugin install https://github.com/astronomer/helm-unittest >/dev/null || true
 	helm unittest -3 .
 
 .PHONY: lint-charts

--- a/bin/functional-tests/requirements.txt
+++ b/bin/functional-tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest==6.0.1
+testinfra==5.2.2
+docker==4.3.1

--- a/bin/functional-tests/test_astronomer.py
+++ b/bin/functional-tests/test_astronomer.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+This file is for system testing the Astronomer Helm chart.
+
+Testinfra is used to create test fixures.
+
+testinfra simplifies and provides syntactic sugar for doing
+execs into a running pods.
+"""
+
+import json
+import os
+import pytest
+import testinfra
+import docker
+
+def test_prometheus_user(prometheus):
+    """ Ensure Airflow is in PATH
+    """
+    user = prometheus.check_output('whoami')
+    assert user == "nobody", \
+        f"Expected prometheus to be running as 'nobody', not '{user}'"
+
+def test_prometheus_targets(prometheus):
+    """ Ensure Airflow is in PATH
+    """
+    data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/targets")
+    targets = json.loads(data)['data']['activeTargets']
+    for target in targets:
+        assert target['health'] == 'up', \
+            'Expected all prometheus targets to be up. ' + \
+            'Please check the "targets" view in the Prometheus UI'
+
+# Create a test fixture for the promtheus pod
+@pytest.fixture(scope='session')
+def prometheus(request):
+    """ This is the host fixture for testinfra. To read more, please see
+    the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
+    namespace = os.environ.get('NAMESPACE')
+    release_name = os.environ.get('RELEASE_NAME')
+    if not namespace:
+        print("NAMESPACE env var is not present, using 'default' namespace")
+        namespace = 'default'
+    if not release_name:
+        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
+        release_name = 'astronomer'
+    pod = f'{release_name}-prometheus-0'
+    yield testinfra.get_host(f'kubectl://{pod}?container=prometheus&namespace={namespace}')
+
+
+@pytest.fixture(scope='session')
+def docker_client(request):
+    """ This is a text fixture for the docker client,
+    should it be needed in a test
+    """
+    client = docker.from_env()
+    yield client
+    client.close()

--- a/bin/functional-tests/test_astronomer.py
+++ b/bin/functional-tests/test_astronomer.py
@@ -15,14 +15,14 @@ import testinfra
 import docker
 
 def test_prometheus_user(prometheus):
-    """ Ensure Airflow is in PATH
+    """ Ensure user is 'nobody'
     """
     user = prometheus.check_output('whoami')
     assert user == "nobody", \
         f"Expected prometheus to be running as 'nobody', not '{user}'"
 
 def test_prometheus_targets(prometheus):
-    """ Ensure Airflow is in PATH
+    """ Ensure all Prometheus targets are healthy
     """
     data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/targets")
     targets = json.loads(data)['data']['activeTargets']
@@ -31,7 +31,7 @@ def test_prometheus_targets(prometheus):
             'Expected all prometheus targets to be up. ' + \
             'Please check the "targets" view in the Prometheus UI'
 
-# Create a test fixture for the promtheus pod
+# Create a test fixture for the prometheus pod
 @pytest.fixture(scope='session')
 def prometheus(request):
     """ This is the host fixture for testinfra. To read more, please see

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -10,6 +10,8 @@ pip3 install virtualenv
 virtualenv --python=python3 /tmp/venv
 source /tmp/venv/bin/activate
 pip install -r $REPO_DIR/bin/functional-tests/requirements.txt
+export NAMESPACE=astronomer
+export RELEASE_NAME=astronomer
 pytest $REPO_DIR/bin/functional-tests/
 deactivate
 

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -6,9 +6,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # The path to the working directory - the root of the repo
 REPO_DIR=$DIR/../
 
+pip3 install virtualenv
+virtualenv --python=python3 /tmp/venv
+source /tmp/venv/bin/activate
 pip install -r $REPO_DIR/bin/functional-tests/requirements.txt
 pytest $REPO_DIR/bin/functional-tests/
-
+deactivate
 
 # TODO: below this is legacy e2e tests that will be replaced
 

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -6,6 +6,12 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # The path to the working directory - the root of the repo
 REPO_DIR=$DIR/../
 
+pip install -r $REPO_DIR/bin/functional-tests/requirements.txt
+pytest $REPO_DIR/bin/functional-tests/
+
+
+# TODO: below this is legacy e2e tests that will be replaced
+
 TESTING_VERSION="v0.0.1"
 
 # get testing repo

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -61,6 +61,20 @@ data:
             action: keep
             regex: default;kubernetes;https
 
+      - job_name: kube-dns
+        kubernetes_sd_configs:
+          - role: pod
+            namespaces:
+              names:
+                - kube-system
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: keep
+            regex: "^kubedns"
+          - source_labels: [__meta_kubernetes_pod_container_port_number]
+            action: keep
+            regex: "^10055"
+
       - job_name: nginx
         kubernetes_sd_configs:
           - role: service


### PR DESCRIPTION
## Description

- Add a scrape configuration to prometheus to monitor kube-dns
- Add to PR template
- Add a place to do system testing

## 🎟 Issue(s)

Closes: https://github.com/astronomer/issues/issues/1717

## 🧪  Testing

I added a very simple, functional testing set up.

## 📸 Screenshots

This is what it looks like when the cluster is using kube dns:
![image](https://user-images.githubusercontent.com/7516283/91060737-4e35fd80-e5f9-11ea-97ce-ed6e15047545.png)


This is what is looks like when the cluster is not using kube dns, e.g. core dns:
![image](https://user-images.githubusercontent.com/7516283/91060779-5b52ec80-e5f9-11ea-9218-dad15ff2377e.png)

