### PR TITLE
Fix network policy to allow houston upgrader to connect to DB

### DIFF
--- a/bin/install-platform
+++ b/bin/install-platform
@@ -88,8 +88,8 @@ helm ${ACTION} \
   --set tags.kubed=${kubed} \
   --set global.postgresqlEnabled=${postgresql} \
   --set tags.keda=${keda} \
+  --set astronomer.houston.upgradeDeployments.enabled=true \
   $HELM_CHART_PATH
-
 
 if [ ! $? -eq 0 ]; then
   set +x

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -25,6 +25,15 @@ spec:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
+          component: houston-upgrader
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.commanderGRPC }}
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
           component: houston
     ports:
     - protocol: TCP
@@ -37,7 +46,7 @@ spec:
           component: houston-worker
     ports:
     - protocol: TCP
-      port: {{ .Values.ports.commanderGRPC }}      
+      port: {{ .Values.ports.commanderGRPC }}
   - from:
     - podSelector:
         matchLabels:

--- a/charts/astronomer/templates/prisma/prisma-networkpolicy.yaml
+++ b/charts/astronomer/templates/prisma/prisma-networkpolicy.yaml
@@ -33,6 +33,15 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
+          component: houston-upgrader
+          release: {{ .Release.Name }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.prismaHTTP }}
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: astronomer
           component: houston-worker
           release: {{ .Release.Name }}
     ports:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -24,6 +24,11 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
+          component: houston-upgrader
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: astronomer
           component: houston
           release: {{ .Release.Name }}
     - podSelector:


### PR DESCRIPTION
## Description

The houston upgrader pod needs network policy to allow connection. This bug is caused by my other PR that adjusted the labels on the houston upgrader pod to not match the houston pod disruption budget.

## 🎟 Issue(s)

hot fix before release, no associated issue

## 🧪  Testing

I turned this part on by default in CI runs.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.
