### PR TITLE
Astro UI revert build dependencies to previous versions

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -27,7 +27,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: 0.19.1
+    tag: 0.19.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Resolve dependency issues in the minified version of `astro-ui` in `0.19.1` (https://github.com/astronomer/astro-ui/commit/95bff83ec735519023abe8c1e2bccb113259256b)
This issue is only occurring on the minified, production ran version. Was not reproducible in the `localhost` environment where the code is not compiled and minified.

## 🎟 Issue(s)

No ticket created. Issue was found during `0.19` internal testing by @shmanu017 

Should resolve: 
![image](https://user-images.githubusercontent.com/6862485/91209950-8103f280-e6da-11ea-8a80-0aa1342ee211.png)

## 🧪  Testing

This error was seen across the app on different pages such as workspace user, billing, and service account. 

The easiest way to test would be to:
1) Makes sure trials are turned on and login
2) Create a new workspace
3) Add workspace billing 

If the page does not flash to replicate the screenshot above, then issue is resolved.
