### PR TITLE
Collect metrics from Houston

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ temp.sh
 
 /venv/
 **pycache**
+server.key

--- a/bin/functional-tests/test_astronomer.py
+++ b/bin/functional-tests/test_astronomer.py
@@ -29,7 +29,16 @@ def test_prometheus_targets(prometheus):
     for target in targets:
         assert target['health'] == 'up', \
             'Expected all prometheus targets to be up. ' + \
-            'Please check the "targets" view in the Prometheus UI'
+            'Please check the "targets" view in the Prometheus UI' + \
+            f" Target data from the one that is not up:\n\n{target}"
+
+def test_houston_metrics_are_collected(prometheus):
+    """ Ensure Houston metrics are collected and prefixed with 'houston_'
+    """
+    data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/query?query=houston_up")
+    parsed = json.loads(data)
+    assert len(parsed['data']['result']) > 0, \
+        f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
 
 # Create a test fixture for the prometheus pod
 @pytest.fixture(scope='session')

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -71,6 +71,9 @@ data:
           - source_labels: [__meta_kubernetes_pod_container_name]
             action: keep
             regex: "^kubedns"
+          - source_labels: [__meta_kubernetes_endpoint_ready]
+            action: keep
+            regex: "^true"
           - source_labels: [__meta_kubernetes_pod_container_port_number]
             action: keep
             regex: "^10055"
@@ -623,6 +626,27 @@ data:
           - target_label: __address__
             replacement: {{.Release.Name}}-prometheus-blackbox-exporter.{{.Release.Namespace}}:9115
         {{- end }}
+
+      - job_name: houston-api
+        metrics_path: /v1/metrics
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - {{ .Release.Namespace }}
+        # Prefix all houston metrics with 'houston_'
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            target_label: __name__
+            replacement: "houston_${1}"
+        # Select only ready endpoints for collecting houston metrics
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            action: keep
+            regex: "^{{ .Release.Name }}-houston"
+          - source_labels: [__meta_kubernetes_endpoint_ready]
+            action: keep
+            regex: "^true"
 
       - job_name: nats_server
         kubernetes_sd_configs:

--- a/values.yaml
+++ b/values.yaml
@@ -268,11 +268,11 @@ prometheus-blackbox-exporter:
   # Configure resources
   resources:
     requests:
-      cpu: "5m"
-      memory: "7Mi"
+      cpu: "50m"
+      memory: "70Mi"
     limits:
-      cpu: "15m"
-      memory: "20Mi"
+      cpu: "100m"
+      memory: "200Mi"
 
 # define what astronomer platform services will be checked
 # for up/down status. Enable this will also include


### PR DESCRIPTION
## Description

Collect metrics from Houston's metrics endpoint

## 🎟 Issue(s)

Closes: https://github.com/astronomer/issues/issues/1727

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Prometheus misconfiguration is the biggest risk. Adding to the functional testing to check that the metrics are collected as intended.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
