### PR TITLE
Astro UI fix Oops! on workspace billing page

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -27,7 +27,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: 0.19.2
+    tag: 0.19.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Continued effort to fix https://github.com/astronomer/astronomer/pull/822.
Reoccuring hooks error on the Workspace billing page after submitting billing info.

## 🎟 Issue(s)

No ticket created. Issue was found during 0.19 internal testing by @shmanu017
![image](https://user-images.githubusercontent.com/6862485/91367716-32874e80-e7d5-11ea-8891-fdf037c2972e.png)

## 🧪  Testing

1. Makes sure trials are turned on and login
2. Create a new workspace
3. Add workspace billing and submit form
4. Expect page to reload then show billing info and edit button.