### PR TITLE
Add a test for an internal component called Houston Upgrader

### DIFF
--- a/bin/install-platform
+++ b/bin/install-platform
@@ -89,6 +89,7 @@ helm ${ACTION} \
   --set global.postgresqlEnabled=${postgresql} \
   --set tags.keda=${keda} \
   --set astronomer.houston.upgradeDeployments.enabled=true \
+  --set astronomer.houston.upgradeDeployments.sleepForeverNoUpgrade=true \
   $HELM_CHART_PATH
 
 if [ ! $? -eq 0 ]; then

--- a/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-upgrade-deployments-job.yaml
@@ -12,12 +12,16 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if not .Values.houston.upgradeDeployments.sleepForeverNoUpgrade }}
+  # In the case of test mode, we do not want to wait on this as a hook,
+  # but just create it and move on.
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": post-upgrade,post-install
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 spec:
   completions: 1
   parallelism: 1
@@ -45,7 +49,11 @@ spec:
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
+          {{- if .Values.houston.upgradeDeployments.sleepForeverNoUpgrade }}
+          args: ["sleep", "infinity"]
+          {{- else }}
           args: ["yarn", "upgrade-deployments", "--", "--canary={{ .Values.houston.upgradeDeployments.canary }}"]
+          {{- end }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -139,6 +139,14 @@ houston:
     # Only run on deployments marked as canary
     canary: false
 
+    # This configuration is available to set the entrypoint
+    # in the upgrader to 'sleep infinity', such that the pod
+    # will hang around during integration testing instead of
+    # finishing and cleaning itself up. This will help out
+    # in testing so we can connect into the pod and make
+    # various assertions about the environment.
+    sleepForeverNoUpgrade: false
+
   # Expire deployments that have gone past trial date in Houston
   # This runs as a CronJob
   expireDeployments:


### PR DESCRIPTION
## Description

Houston upgrader is not working on stage cloud, and I was creating test to try to figure out why. I'm still not sure yet, but here is a new way to test houston upgrader.

## 🎟 Issue(s)

no issue associated, done for 0.19 release process

## 🧪  Testing

This change is mostly adding testing

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
