### PR TITLE
Improve Houston API Startup by Performing Houston migrations via Init Container

### DIFF
--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -33,7 +33,7 @@ while getopts ':hHkK:Mx' option ; do
     h) usage ; exit 0 ;;
     H) USE_HA=1 ;;
     k) get_kube_versions ; exit 0 ;;
-    K) export KUBE_VERSION="${OPTARG/v/}" ;;
+    K) export KUBE_VERSION="${OPTARG}" ;;
     M) MULTI_NODE=1 ;;
     x) set -x ;;
     *) echo "ERROR: Unknown option: -${OPTARG}" ; usage ; exit 1 ;;

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -28,12 +28,13 @@ get_kube_versions() {
     sort
 }
 
-while getopts ':hHkK:x' option ; do
+while getopts ':hHkK:Mx' option ; do
   case "${option}" in
     h) usage ; exit 0 ;;
     H) USE_HA=1 ;;
     k) get_kube_versions ; exit 0 ;;
     K) export KUBE_VERSION="${OPTARG/v/}" ;;
+    M) MULTI_NODE=1 ;;
     x) set -x ;;
     *) echo "ERROR: Unknown option: -${OPTARG}" ; usage ; exit 1 ;;
   esac

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -66,6 +66,13 @@ spec:
               value: {{ .Release.Namespace }}
             - name: IN_CLUSTER
               value: "true"
+        - name: init-migrations
+          image: {{ template "houston.image" . }}
+          imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+          command: ['yarn', 'migrate']
+          env:
+            {{- include "houston_environment" . | indent 12 }}
+
       {{- end }}
       containers:
         - name: houston


### PR DESCRIPTION
## Description
Currently Houston performs database migrations as part of the API container startup. These happen before the serving portion of the application has started. If those migrations take a long time, it will cause the container to fail its liveness probe and will get restarted. This change moves that work to an init container to be performed before the start up of the primary container. This takes the migration time out of the application startup time as far as the liveness and readiness probes are concerned. 

There are two minor changes that fix bugs in the kind startup script for local dev that I fixed as well. 

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1658
Related PR to houston https://github.com/astronomer/houston-api/pull/442

## 🧪  Testing

If the init container didn't run or migrations failed, Houston would (in the future) not be able to startup correctly. There is a corresponding change to the houston codebase to remove migrate from it's `serve` subcommand, which is the command it starts with today. 

## 📸 Screenshots
Houston up and running after init container ran migrations
![Screen Shot 2020-08-31 at 4 23 40 PM](https://user-images.githubusercontent.com/942071/91765080-646a2d80-eba6-11ea-8ddd-396fae8dbcc8.png)

Too big for a screenshot but here is the log output from the init container
```
klogs -n astronomer astronomer-houston-5f69fb554-m48gh -c init-migrations -f                                                    [default]
yarn run v1.22.4
$ yarn knex-migrate && yarn prisma-deploy
$ yarn knex migrate:latest
$ babel-node node_modules/.bin/knex migrate:latest
WARNING: NODE_ENV value of 'production' did not match any deployment config file names.
WARNING: See https://github.com/lorenwest/node-config/wiki/Strict-Mode
FS-related option specified for migration configuration. This resets migrationSource to default FsMigrations
FS-related option specified for migration configuration. This resets migrationSource to default FsMigrations
2020-08-31T20:20:05 DEBUG Skipping fix_relationships data migration
2020-08-31T20:20:05 DEBUG Running prisma-deploy

Creating stage default for service houston... ✔

Deploying service `houston` to stage `default` to server `default`... 3.4s

Changes:

  User (Type)
  + Created type `User`
  + Created field `id` of type `ID!`
  + Created field `username` of type `String`
  + Created field `status` of type `String`
  + Created field `fullName` of type `String`
  + Created field `avatarUrl` of type `String`
  + Created field `emails` of type `[Email!]!`
  + Created field `roleBindings` of type `[RoleBinding!]!`
  + Created field `localCredential` of type `LocalCredential`
  + Created field `oauthCredentials` of type `[OAuthCredential!]!`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  RoleBinding (Type)
  + Created type `RoleBinding`
  + Created field `id` of type `ID!`
  + Created field `role` of type `Enum`
  + Created field `user` of type `User`
  + Created field `serviceAccount` of type `ServiceAccount`
  + Created field `workspace` of type `Workspace`
  + Created field `deployment` of type `Deployment`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  Email (Type)
  + Created type `Email`
  + Created field `id` of type `ID!`
  + Created field `address` of type `String`
  + Created field `primary` of type `Boolean`
  + Created field `token` of type `String`
  + Created field `user` of type `User`
  + Created field `verified` of type `Boolean`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  LocalCredential (Type)
  + Created type `LocalCredential`
  + Created field `id` of type `ID!`
  + Created field `user` of type `User`
  + Created field `password` of type `String`
  + Created field `resetToken` of type `String`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  OAuthCredential (Type)
  + Created type `OAuthCredential`
  + Created field `id` of type `ID!`
  + Created field `expiresAt` of type `DateTime`
  + Created field `oauthProvider` of type `String!`
  + Created field `oauthUserId` of type `String!`
  + Created field `user` of type `User`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  InviteToken (Type)
  + Created type `InviteToken`
  + Created field `id` of type `ID!`
  + Created field `email` of type `String!`
  + Created field `token` of type `String!`
  + Created field `source` of type `Enum!`
  + Created field `workspace` of type `Workspace`
  + Created field `role` of type `Enum`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  ServiceAccount (Type)
  + Created type `ServiceAccount`
  + Created field `id` of type `ID!`
  + Created field `apiKey` of type `String`
  + Created field `label` of type `String`
  + Created field `category` of type `String`
  + Created field `active` of type `Boolean`
  + Created field `roleBinding` of type `RoleBinding`
  + Created field `lastUsedAt` of type `DateTime`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  Workspace (Type)
  + Created type `Workspace`
  + Created field `id` of type `ID!`
  + Created field `deployments` of type `[Deployment!]!`
  + Created field `description` of type `String`
  + Created field `invites` of type `[InviteToken!]!`
  + Created field `label` of type `String`
  + Created field `roleBindings` of type `[RoleBinding!]!`
  + Created field `stripeCustomerId` of type `String`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`
  + Created field `isSuspended` of type `Boolean`
  + Created field `trialEndsAt` of type `DateTime`

  Deployment (Type)
  + Created type `Deployment`
  + Created field `id` of type `ID!`
  + Created field `config` of type `Json`
  + Created field `description` of type `String`
  + Created field `label` of type `String`
  + Created field `registryPassword` of type `String`
  + Created field `elasticsearchPassword` of type `String`
  + Created field `releaseName` of type `String`
  + Created field `version` of type `String`
  + Created field `extraAu` of type `Int`
  + Created field `airflowVersion` of type `String`
  + Created field `alertEmails` of type `[String!]!`
  + Created field `roleBindings` of type `[RoleBinding!]!`
  + Created field `workspace` of type `Workspace`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`
  + Created field `deletedAt` of type `DateTime`
  + Created field `images` of type `[DockerImage!]!`
  + Created field `canary` of type `Boolean`

  DockerImage (Type)
  + Created type `DockerImage`
  + Created field `id` of type `ID!`
  + Created field `name` of type `String`
  + Created field `labels` of type `Json!`
  + Created field `env` of type `Json!`
  + Created field `tag` of type `String!`
  + Created field `digest` of type `String!`
  + Created field `deployment` of type `Deployment!`
  + Created field `createdAt` of type `DateTime!`

  PlatformRelease (Type)
  + Created type `PlatformRelease`
  + Created field `id` of type `ID!`
  + Created field `version` of type `String`
  + Created field `url` of type `String`
  + Created field `description` of type `String`
  + Created field `level` of type `String`
  + Created field `releaseDate` of type `DateTime!`
  + Created field `createdAt` of type `DateTime!`
  + Created field `updatedAt` of type `DateTime!`

  Role (Enum)
  + Created enum Role with values `SYSTEM_ADMIN`, `SYSTEM_EDITOR`, `SYSTEM_VIEWER`, `WORKSPACE_ADMIN`, `WORKSPACE_EDITOR`, `WORKSPACE_VIEWER`, `DEPLOYMENT_ADMIN`, `DEPLOYMENT_EDITOR`, `DEPLOYMENT_VIEWER`, `USER`

  InviteSource (Enum)
  + Created enum InviteSource with values `SYSTEM`, `WORKSPACE`

  DeploymentToWorkspace (Relation)
  + Created an inline relation between `Deployment` and `Workspace` in the column `workspace` of table `Deployment`

  RoleBindingToServiceAccount (Relation)
  + Created an inline relation between `RoleBinding` and `ServiceAccount` in the column `serviceAccount` of table `RoleBinding`

  DeploymentDockerImages (Relation)
  + Created an inline relation between `Deployment` and `DockerImage` in the column `deployment` of table `DockerImage`

  EmailToUser (Relation)
  + Created an inline relation between `Email` and `User` in the column `user` of table `Email`

  RoleBindingToWorkspace (Relation)
  + Created an inline relation between `RoleBinding` and `Workspace` in the column `workspace` of table `RoleBinding`

  OAuthCredentialToUser (Relation)
  + Created an inline relation between `OAuthCredential` and `User` in the column `user` of table `OAuthCredential`

  RoleBindingToUser (Relation)
  + Created an inline relation between `RoleBinding` and `User` in the column `user` of table `RoleBinding`

  InviteTokenToWorkspace (Relation)
  + Created an inline relation between `InviteToken` and `Workspace` in the column `workspace` of table `InviteToken`

  LocalCredentialToUser (Relation)
  + Created an inline relation between `LocalCredential` and `User` in the column `localCredential` of table `User`

  DeploymentRoleBindings (Relation)
  + Created an inline relation between `Deployment` and `RoleBinding` in the column `deployment` of table `RoleBinding`


Applying changes... (0/125)
Applying changes... (18/125)
Applying changes... (39/125)
Applying changes... (58/125)
Applying changes... (82/125)
Applying changes... (115/125)
Applying changes... (125/125)
Applying changes... 5.1s

Generating schema... 153ms
Saving Prisma GraphQL schema (SDL) at /houston/src/lib/generated/schema/prisma.graphql
Saving Prisma Client (JavaScript) at /houston/src/lib/generated/client

Your Prisma endpoint is live:

  HTTP:  http://astronomer-prisma:4466/houston
  WS:    ws://astronomer-prisma:4466/houston

You can view & edit your data here:

  Prisma Admin: http://astronomer-prisma:4466/houston/_admin

2020-08-31T20:20:30 DEBUG Updating new columns in RoleBinding
2020-08-31T20:20:30 DEBUG Updating new columns in Deployment
2020-08-31T20:20:30 DEBUG Updating new columns in Email
2020-08-31T20:20:30 DEBUG Updating new columns in RoleBinding
2020-08-31T20:20:30 DEBUG Updating new columns in RoleBinding
2020-08-31T20:20:30 DEBUG Updating new columns in User
2020-08-31T20:20:30 DEBUG Updating new columns in InviteToken
2020-08-31T20:20:30 DEBUG Updating new columns in OAuthCredential
2020-08-31T20:20:30 DEBUG Updating new columns in RoleBinding
Batch 1 run: 1 migrations
$ prisma deploy --force

Deploying service `houston` to stage `default` to server `default`... 1.5s
Service is already up to date.
Done in 34.88s.
```

## 📋 Checklist

- [ ] The PR title is informative to the user experience
