### PR TITLE
Optimize DNS query volume with regard to pgbouncer lookups

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 0.15.4
+airflowChartVersion: 0.15.5
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

> Describe the purpose of this pull request.

Increment the Airflow chart version. This change is to optimize DNS queries with regard to pgbouncer lookups. This is PR'ed into the 0.16 release branch because it is only intended for the LTS version.

## PR Title

> Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

> If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.

## 🎟 Issue(s)

Resolves astronomer/issues#XXXX

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

I think the main risk is that the upgrade would not work. I added this test in commander, which is not the ideal location for such a test, but I know there is a test scaffolding available there that is prepared to test airflow chart version upgrades. https://github.com/astronomer/commander/pull/38

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
