### PR TITLE
Set StatefulSet to apps/v1 for k8s before 1.16 where it was removed. 

### DIFF
--- a/templates/_apivers.tpl
+++ b/templates/_apivers.tpl
@@ -45,7 +45,7 @@ scheduling.k8s.io/v1beta1
 {{- end -}}
 
 {{- define "apiVersion.StatefulSet" -}}
-{{- if semverCompare "^1.16-0" .Capabilities.KubeVersion.Version -}}
+{{- if semverCompare "^1.15-0" .Capabilities.KubeVersion.Version -}}
 apps/v1
 {{- else -}}
 apps/v1beta2


### PR DESCRIPTION
It is available to use before that though.

https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#statefulset-v1-apps

Otherwise you can't update it to v1 before upgrading k8s itself, which is not compatible with the old apiVersion.

## Description

Set StatefulSet to apps/v1 before kubernetes 1.16. apps/v1beta2 was removed in 1.16, so you need to set it to apps/v1 before upgrading to 1.16.

## PR Title

Set StatefulSet to apps/v1 for k8s before 1.16 where it was removed. 

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

It is applied as apps/v1beta2 and could then stop working when you upgrade to Kubernetes 1.16.

## 📸 Screenshots

```
$ helm get all astronomer | egrep -A1 'kind: StatefulSet'
kind: StatefulSet
apiVersion: apps/v1beta2
$ helm list
NAME      	NAMESPACE 	REVISION	UPDATED                                	STATUS  	CHART            	APP VERSION
astronomer	astronomer	28      	2020-09-08 14:19:02.93415208 +0200 CEST	deployed	astronomer-0.16.4	0.16.4
```

https://github.com/FairwindsOps/pluto
```
$ pluto detect-helm --helm-version 3 -owide
NAME                                                 NAMESPACE      KIND                           VERSION                                REPLACEMENT                       DEPRECATED   DEPRECATED IN   REMOVED   REMOVED IN
astronomer/astronomer-registry                       astronomer     StatefulSet                    apps/v1beta2                           apps/v1                           true         v1.9.0          true      v1.16.0
```

This is checking helm data, as I did above it manually, to see what was actually applied. Using AWS EKS you can't actually query etcd directly to see what is stored there.

```
$ kubectl proxy --port 8080 &
$ curl -s http://127.0.0.1:8080/apis/apps/v1beta2/namespaces/astronomer/statefulsets/astronomer-registry | grep apiVersion
  "apiVersion": "apps/v1beta2",
$ !!:s/v1beta2/v1
curl -s http://127.0.0.1:8080/apis/apps/v1/namespaces/astronomer/statefulsets/astronomer-registry | grep apiVersion
  "apiVersion": "apps/v1",
```

And kube will respond to all supported apiVersions to make it even more confusing.

## 📋 Checklist

- [X] The PR title is informative to the user experience
