### PR TITLE
Remove apiVersion.StatefulSet, always use apps/v1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
       - id: check-xml
       - id: check-yaml
         args: ['--allow-multiple-documents']
+        exclude: charts
       - id: debug-statements
       - id: detect-private-key
       - id: end-of-file-fixer

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Alertmanager StatefulSet
 #################################
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: {{ template "alertmanager.fullname" . }}
   labels:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -7,7 +7,7 @@ kind: Deployment
 apiVersion: apps/v1
 {{- else }}
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 {{- end }}
 metadata:
   name: {{ .Release.Name }}-registry
@@ -50,7 +50,7 @@ spec:
         - name: registry
           image: {{ template  "registry.image" . }}
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
-          env: 
+          env:
           - name: REGISTRY_HTTP_SECRET
             value: {{ randAlphaNum 32 }}
           resources:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Data StatefulSet
 #################################
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: {{ template "elasticsearch.fullname" . }}-data
   labels:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Master StatefulSet
 #################################
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: {{ template "elasticsearch.fullname" . }}-master
   labels:

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.replication.enabled }}
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: "{{ template "postgresql.fullname" . }}-slave"
   labels:

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -1,5 +1,5 @@
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: {{ template "postgresql.master.fullname" . }}
   labels:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Prometheus StatefulSet
 #################################
 kind: StatefulSet
-apiVersion: {{ template "apiVersion.StatefulSet" . }}
+apiVersion: apps/v1
 metadata:
   name: {{ template "prometheus.fullname" . }}
   labels:

--- a/templates/_apivers.tpl
+++ b/templates/_apivers.tpl
@@ -44,15 +44,6 @@ scheduling.k8s.io/v1beta1
 {{- end -}}
 {{- end -}}
 
-{{- define "apiVersion.StatefulSet" -}}
-{{- if semverCompare "^1.16-0" .Capabilities.KubeVersion.Version -}}
-apps/v1
-{{- else -}}
-apps/v1beta2
-{{- end -}}
-{{- end -}}
-
-
 {{- define "apiVersion.rbac.v1beta2" -}}
 {{- if semverCompare "^1.16-0" .Capabilities.KubeVersion.Version -}}
 rbac.authorization.k8s.io/v1


### PR DESCRIPTION
## Description

Remove helm template for apiVersion.StatefulSet which sometimes selected `apps/v1beta2` when `apps/v1` was available. This template was also only one of three places that should have had such a mechanic if it were useful (daemonset, statefulset, deployment).

This will be a no-op to the user, it merely takes out an unneeded conditional.

## PR Title

Remove apiVersion.StatefulSet, always use apps/v1

## 🎟 Issue(s)

Resolves astronomer/astronomer/pull/838 discussion points, and supersedes that PR.

## 🧪  Testing

There should be no risks associated with this change. the `apps/v1` endpoint has existed since way before any currently supported version.