### PR TITLE
Use ubuntu 20.04 machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -57,7 +57,7 @@ jobs:
 
   release-to-public:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -73,7 +73,7 @@ jobs:
 
   platform-1-14-10:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.14.10
@@ -83,7 +83,7 @@ jobs:
 
   platform-1-15-11:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.15.11
@@ -93,7 +93,7 @@ jobs:
 
   platform-1-16-9:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.16.9
@@ -103,7 +103,7 @@ jobs:
 
   platform-1-17-5:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.17.5
@@ -113,7 +113,7 @@ jobs:
 
   platform-1-18-2:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.18.2

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -40,7 +40,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -55,7 +55,7 @@ jobs:
 
   release-to-public:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -71,7 +71,7 @@ jobs:
 {% for version in kube_versions %}
   platform-{{ version | replace(".", "-") }}:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}


### PR DESCRIPTION
## Description

CI changes only. Use ubuntu 20.04 as machine image.

## 🧪  Testing

These changes are all related to CI, so the customer impact is zero as long as tests are passing.

## Related links

- <https://discuss.circleci.com/t/early-preview-new-ubuntu-20-04-linux-machine-executor-image/37140>