### PR TITLE
Disallow publishing of future releases to public helm repository

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
             pyenv global 2.7.17
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
-  release-to-prod:
+  release-to-public:
     machine:
       image: ubuntu-1604:202004-01
     steps:
@@ -166,13 +166,13 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.\d+'
 
       - release-to-internal:
           requires:
             - approve-internal-release
 
-      - approve-prod-release:
+      - approve-public-release:
           type: approval
           requires:
             - release-to-internal
@@ -180,15 +180,15 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.(12|13|14|15|16)'
 
-      - release-to-prod:
+      - release-to-public:
           requires:
-            - approve-prod-release
+            - approve-public-release
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.(12|13|14|15|16)'
 
 commands:
   helm-install:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -104,7 +104,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.\d+'
 
       - release-to-internal:
           requires:
@@ -118,7 +118,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.(12|13|14|15|16)'
 
       - release-to-prod:
           requires:
@@ -126,7 +126,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-.*/'
+                - '/release-0\.(12|13|14|15|16)'
 
 commands:
   helm-install:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -53,7 +53,7 @@ jobs:
             pyenv global 2.7.17
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
-  release-to-prod:
+  release-to-public:
     machine:
       image: ubuntu-1604:202004-01
     steps:
@@ -110,7 +110,7 @@ workflows:
           requires:
             - approve-internal-release
 
-      - approve-prod-release:
+      - approve-public-release:
           type: approval
           requires:
             - release-to-internal
@@ -120,9 +120,9 @@ workflows:
               only:
                 - '/release-0\.(12|13|14|15|16)'
 
-      - release-to-prod:
+      - release-to-public:
           requires:
-            - approve-prod-release
+            - approve-public-release
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description

Disallow publishing of future releases to public helm repository, github tag, and github release.

## 🎟 Issue(s)

Resolves astronomer/issues#1771

## 🧪  Testing

AFAIK it's not possible to test this without committing to at least two release branch (eg: release-0.16 and release-0.19). It's possible the regular expressions do not match due to the regex dialect used by CircleCI, but I have made an effort to reference other people's regex examples and think that this is correct.