### PR TITLE
1771 add missing slash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.\d+'
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -180,7 +180,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)'
+                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
@@ -188,7 +188,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)'
+                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -104,7 +104,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.\d+'
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -118,7 +118,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)'
+                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
@@ -126,7 +126,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)'
+                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:


### PR DESCRIPTION
This is a quick follow up to #843 which left out a trailing slash at the end of the regex. I also found a way to test this, by pushing it as a future release branch. This was done so [here](https://app.circleci.com/pipelines/github/astronomer/astronomer?branch=release-0.999). The failing tests are due to me deleting the branch before they could run. The important details is that there are "approve-internal-release" and "release-to-internal" steps.