### PR TITLE
Add AC 1.10.10-5 to supported images

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -169,6 +169,12 @@ data:
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-4-buster-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-5-alpine3.10-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-5-buster-onbuild
 
       # Kubernetes labels to add on each airflow deployment namespace
       namespaceLabels:


### PR DESCRIPTION
astronomer/ap-airflow@74fd8a6

1.10.10-5 Tag: https://github.com/astronomer/airflow/releases/tag/v1.10.10%2Bastro.5

