### PR TITLE
Fix access to default backend for 404 pages

### DIFF
--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -69,3 +69,7 @@ def docker_client(request):
     client = docker.from_env()
     yield client
     client.close()
+
+@pytest.fixture(scope='session')
+def kube_client(request):
+    yield create_kube_client()

--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -36,7 +36,7 @@ def nginx(request):
         print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
         release_name = 'astronomer'
     kube = create_kube_client()
-    pods = kube.list_namespaced_pod(namespace, label_selector=f"component=ingress-controller")
+    pods = kube.list_namespaced_pod(namespace, label_selector="component=ingress-controller")
     pods = pods.items
     assert len(pods) > 0, "Expected to find at least one pod with label 'component: ingress-controller'"
     pod = pods[0]

--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -21,7 +21,27 @@ def create_kube_client(in_cluster=False):
         config.load_kube_config()
     return client.CoreV1Api()
 
-# Create a test fixture for the prometheus pod
+@pytest.fixture(scope='session')
+def nginx(request):
+    """ This is the host fixture for testinfra. To read more, please see
+    the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
+    namespace = os.environ.get('NAMESPACE')
+    release_name = os.environ.get('RELEASE_NAME')
+    if not namespace:
+        print("NAMESPACE env var is not present, using 'astronomer' namespace")
+        namespace = 'astronomer'
+    if not release_name:
+        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
+        release_name = 'astronomer'
+    kube = create_kube_client()
+    pods = kube.list_namespaced_pod(namespace, label_selector=f"component=ingress-controller")
+    pods = pods.items
+    assert len(pods) > 0, "Expected to find at least one pod with label 'component: ingress-controller'"
+    pod = pods[0]
+    yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=nginx&namespace={namespace}')
+
 @pytest.fixture(scope='session')
 def houston_api(request):
     """ This is the host fixture for testinfra. To read more, please see

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -36,7 +36,7 @@ def test_houston_can_reach_prometheus(houston_api):
     houston_api.check_output("wget -qO- --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
 
 def test_nginx_can_reach_default_backend(nginx):
-    nginx.check_output("curl --max-time 1 http://astronomer-nginx-default-backend:8080")
+    nginx.check_output("curl -s --max-time 1 http://astronomer-nginx-default-backend:8080")
 
 def test_prometheus_targets(prometheus):
     """ Ensure all Prometheus targets are healthy

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -33,7 +33,10 @@ def test_houston_config(houston_api):
             f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
 
 def test_houston_can_reach_prometheus(houston_api):
-    houston_api.check_output("wget --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
+    houston_api.check_output("wget -qO- --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
+
+def test_nginx_can_reach_default_backend(nginx):
+    nginx.check_output("curl --max-time 1 http://astronomer-nginx-default-backend:8080")
 
 def test_prometheus_targets(prometheus):
     """ Ensure all Prometheus targets are healthy

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -33,7 +33,7 @@ def test_houston_config(houston_api):
             f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
 
 def test_houston_can_reach_prometheus(houston_api):
-    houston_api.check_output("curl http://astronomer-prometheus.astronomer.svc.cluster.local/targets")
+    houston_api.check_output("wget --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
 
 def test_prometheus_targets(prometheus):
     """ Ensure all Prometheus targets are healthy

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -32,6 +32,8 @@ def test_houston_config(houston_api):
         assert 'localhost' not in server, \
             f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
 
+def test_houston_can_reach_prometheus(houston_api):
+    houston_api.check_output("curl http://astronomer-prometheus.astronomer.svc.cluster.local/targets")
 
 def test_prometheus_targets(prometheus):
     """ Ensure all Prometheus targets are healthy

--- a/bin/functional-tests/test_network_security.py
+++ b/bin/functional-tests/test_network_security.py
@@ -213,7 +213,14 @@ class KubernetesNetworkChecker():
         return result
 
 
-def test_network():
+def test_network(kube_client):
+    try:
+        kube_client.create_namespace(client.V1Namespace(
+            metadata=client.V1ObjectMeta(name='astronomer-scan-test')))
+    except Exception as e:
+        if not 'already exists' in str(e):
+            raise e
+        print("namespace astronomer-scan-test already exists, proceeding")
     network_assessment = KubernetesNetworkChecker()
     network_assessment.collect_scan_targets()
     logging.info(f"Collected {len(network_assessment.targets)} scan targets")
@@ -221,6 +228,8 @@ def test_network():
     allow_list = ["pod/coredns-",
                   "service/kube-dns",
                   "service/kubernetes",
+                  "service/astronomer-nginx",
+                  "pod/astronomer-nginx",
                   "service/astronomer-prometheus-node-exporter",
                   "pod/astronomer-prometheus-node-exporter"]
     for finding in scan_result.findings:

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -22,9 +22,3 @@ export RELEASE_NAME=astronomer
 sleep 65
 pytest -s $REPO_DIR/bin/functional-tests/
 deactivate
-
-pyenv global 3.8.2
-pip install --user pytest testinfra kubernetes
-export PATH=/home/circleci/.local/bin:$PATH
-kubectl create namespace astronomer-scan-test
-pytest $REPO_DIR/bin/network-security-test.py

--- a/charts/nginx/templates/nginx-default-backend-networkpolicy.yaml
+++ b/charts/nginx/templates/nginx-default-backend-networkpolicy.yaml
@@ -1,0 +1,31 @@
+################################
+## Nginx controller pods NetworkPolicy
+#################################
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ .Release.Name }}-nginx-default-backend-policy
+  labels:
+    tier: astronomer
+    component: nginx-default-backend-policy
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+spec:
+  podSelector:
+    matchLabels:
+      tier: {{ template "nginx.name" . }}
+      component: default-backend
+      release: {{ .Release.Name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          tier: {{ template "nginx.name" . }}
+          component: ingress-controller
+          release: {{ .Release.Name }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.ports.defaultBackendHTTP }}


### PR DESCRIPTION
## Description

Fix a test that is failing in CI and also fix network access from nginx ingress to default backend

## 🎟 Issue(s)

no issue associated, part of release 0.20 fixes

## 🧪  Testing

this change only adjusts tests or includes a functional test for the network policy change.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
