### PR TITLE
Bump helm to newest versions (security)

### DIFF
--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -3,7 +3,7 @@ set -xeuo pipefail
 
 KIND_VERSION="0.9.0"
 HELM2_VERSION="2.16.8"
-HELM3_VERSION="3.2.3"
+HELM3_VERSION="3.3.4"
 GCLOUD_VERSION="292.0.0"
 MKCERT_VERSION="1.4.1"
 
@@ -80,7 +80,7 @@ fi
 
 echo "--------- versions -------------"
 
-# kind 
+# kind
 set +e
 kind version
 helm2 version --client

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -28,8 +28,8 @@ If you are in one of these categories, please contact Astronomer support to help
 Install some command line tools:
 
 - kubectl (version appropriate for your cluster's version or newer)
-- [helm (version 2.16.1)](https://github.com/helm/helm/releases/tag/v2.16.1), please install into PATH as "helm"
-- [helm 3 (version 3.2.3)](https://github.com/helm/helm/releases/tag/v3.2.3), please install into PATH as "helm3"
+- [helm (version 2.16.12)](https://github.com/helm/helm/releases/tag/v2.16.12), please install into PATH as "helm"
+- [helm 3 (version 3.3.4)](https://github.com/helm/helm/releases/tag/v3.3.4), please install into PATH as "helm3"
 - [jq](https://stedolan.github.io/jq/download/)
 
 On Mac, if you have brew, you can install 'jq' with:

--- a/bin/migration-scripts/upgrade-to-lts.sh
+++ b/bin/migration-scripts/upgrade-to-lts.sh
@@ -381,8 +381,8 @@ function main {
   export UPGRADE_TO_VERSION_AIRFLOW=0.15.2
 
   # Pre-flight checks
-  check_helm_version_client '2.16.1'
-  check_helm3_version_client '3.2.3'
+  check_helm_version_client '2.16.12'
+  check_helm3_version_client '3.3.4'
   check_cli_tools_installed helm kubectl jq head tail grep awk base64 cut wc git
 
   determine_helm_version


### PR DESCRIPTION
## Description

[Helm 3.3.2](https://github.com/helm/helm/releases/tag/v3.3.2) was a security patch.

> Helm v3.3.2 is a security (patch) release. Users are strongly recommended to update to this release. It fixes a variety of minor security issues, as well as four notable security issues for which we have opened security advisories. More information on the security advisory can be found [on the security advisory page](https://github.com/helm/helm/security/advisories).

[Helm 2.16.11](https://github.com/helm/helm/releases/tag/v2.16.11) was also a security patch.

> Helm v2.16.11 is a security (patch) release. Users are strongly recommended to update to this release. It fixes four notable security issues for which we have opened security advisories. More information on the security advisory can be found [on the security advisory page](https://github.com/helm/helm/security/advisories).

These were both them bumped again due to hotfixes for the security patch versions.