### PR TITLE
Adding configmap-reloader sidecar to prometheus

### DIFF
--- a/bin/functional-tests/README.md
+++ b/bin/functional-tests/README.md
@@ -9,7 +9,7 @@
 - pytest https://docs.pytest.org/en/stable/getting-started.html
 - testinfra https://testinfra.readthedocs.io/en/latest/
 
-## How does it work
+## How it works
 
 This is a pytest suite that assumes the current shell is authenticated to a kubernetes cluster running Astronomer. It is not safe to run against a production system and does perform mutations on the system. This is designed to work running locally using Kind (kubernetes in docker).
 

--- a/bin/functional-tests/README.md
+++ b/bin/functional-tests/README.md
@@ -60,7 +60,7 @@ Long story short, testinfra allows for connections to various places (in this ca
 
 pytest fixtures can also be used to provide connections to kubernetes, for example a kubernetes client.
 
-## What does it do
+## What it does
 
 ### test_config.py
 

--- a/bin/functional-tests/README.md
+++ b/bin/functional-tests/README.md
@@ -6,8 +6,10 @@
 - Astronomer-internal is added to Helm 3 repositories and up-to-date
 - Kubernetes cluster, with Astronomer already installed from this chart in test
 - HELM_CHART_PATH environment variable is set to a path to the chart in test
+- pytest https://docs.pytest.org/en/stable/getting-started.html
+- testinfra https://testinfra.readthedocs.io/en/latest/
 
-## How does it work?
+## How does it work
 
 This is a pytest suite that assumes the current shell is authenticated to a kubernetes cluster running Astronomer. It is not safe to run against a production system and does perform mutations on the system. This is designed to work running locally using Kind (kubernetes in docker).
 
@@ -58,7 +60,7 @@ Long story short, testinfra allows for connections to various places (in this ca
 
 pytest fixtures can also be used to provide connections to kubernetes, for example a kubernetes client.
 
-## What does it do?
+## What does it do
 
 ### test_config.py
 

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -15,6 +15,65 @@ import time
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
+# This test should remain first because this sleep is required to allow for other tests
+# to have enough time for metrics to be collected.
+def test_prometheus_config_reloader_works(prometheus, kube_client):
+    """ Ensure that Prometheus reloads it's config when the cofigMap is updated
+    and the reloader sidecar triggers the reload
+    """
+
+    # get the current configmap
+    orig_cm = kube_client.read_namespaced_config_map("astronomer-prometheus-config", "astronomer")
+
+    # define the test configmap
+    test_cm = {
+        "data": {
+            "config": """global:
+    scrape_interval: 30s
+    evaluation_interval: 30s"""
+        }
+    }
+
+    # check the checksum of the currenty configuration file
+    pre_md5sum = prometheus.check_output("md5sum /etc/prometheus/config/prometheus.yaml")
+
+    # update the configmap
+    kube_client.patch_namespaced_config_map(
+        name="astronomer-prometheus-config",
+        namespace="astronomer",
+        body=test_cm
+    )
+
+    # hackup original
+    orig_cm.metadata.resource_version = ""
+
+    # wait here, it can take up to a minute or more sometimes for change to be picked up and reloaded.
+    time.sleep(70)
+
+    # # check the md5sum again of the configuration file
+    post_md5sum = prometheus.check_output("md5sum /etc/prometheus/config/prometheus.yaml")
+
+    # put the old configmap back
+    try:
+        kube_client.delete_namespaced_config_map(
+            name="astronomer-prometheus-config",
+            namespace="astronomer"
+        )
+    except ApiException as e:
+        print("Exception when calling CoreV1Api->delete_namespaced_config_map: %s\n" % e)
+    try:
+        kube_client.create_namespaced_config_map(
+            namespace="astronomer",
+            body=orig_cm
+        )
+    except ApiException as e:
+        print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
+
+
+    assert pre_md5sum != post_md5sum, \
+        f"Expected the md5 checksum of the prometheus config file to change"
+
+
 def test_prometheus_user(prometheus):
     """ Ensure user is 'nobody'
     """
@@ -70,60 +129,3 @@ def test_houston_metrics_are_collected(prometheus):
     parsed = json.loads(data)
     assert len(parsed['data']['result']) > 0, \
         f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
-
-
-def test_prometheus_config_reloader_works(prometheus, kube_client):
-    """ Ensure that Prometheus reloads it's config when the cofigMap is updated
-    and the reloader sidecar triggers the reload
-    """
-    
-    # get the current configmap
-    orig_cm = kube_client.read_namespaced_config_map("astronomer-prometheus-config", "astronomer")
-
-    # define the test configmap
-    test_cm = {
-        "data": {
-            "config": """global:
-    scrape_interval: 30s
-    evaluation_interval: 30s"""
-        }
-    }
-
-    # check the checksum of the currenty configuration file
-    pre_md5sum = prometheus.check_output("md5sum /etc/prometheus/config/prometheus.yaml")
-
-    # update the configmap
-    kube_client.patch_namespaced_config_map(
-        name="astronomer-prometheus-config",
-        namespace="astronomer",
-        body=test_cm
-    )
-
-    # hackup original 
-    orig_cm.metadata.resource_version = ""
-
-    # wait here, it can take up to a minute or more sometimes for change to be picked up and reloaded.
-    time.sleep(70)
-
-    # # check the md5sum again of the configuration file
-    post_md5sum = prometheus.check_output("md5sum /etc/prometheus/config/prometheus.yaml")
-
-    # put the old configmap back
-    try:
-        kube_client.delete_namespaced_config_map(
-            name="astronomer-prometheus-config",
-            namespace="astronomer"
-        )
-    except ApiException as e:
-        print("Exception when calling CoreV1Api->delete_namespaced_config_map: %s\n" % e)
-    try: 
-        kube_client.create_namespaced_config_map(
-            namespace="astronomer",
-            body=orig_cm
-        )
-    except ApiException as e:
-        print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
-
-
-    assert pre_md5sum != post_md5sum, \
-        f"Expected the md5 checksum of the prometheus config file to change"

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -75,7 +75,7 @@ def test_houston_metrics_are_collected(prometheus):
 
 def test_prometheus_config_reloader_works(prometheus, kube_client):
     """ 
-    Ensure that Prometheus reloads it's config when the cofigMap is updated
+    Ensure that Prometheus reloads its config when the cofigMap is updated
     and the reloader sidecar triggers the reload
     """
     # define new value we'll use for the config change

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -16,65 +16,84 @@ import yaml
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
+
 def test_prometheus_user(prometheus):
-    """ Ensure user is 'nobody'
-    """
-    user = prometheus.check_output('whoami')
-    assert user == "nobody", \
-        f"Expected prometheus to be running as 'nobody', not '{user}'"
+    """Ensure user is 'nobody'"""
+    user = prometheus.check_output("whoami")
+    assert (
+        user == "nobody"
+    ), f"Expected prometheus to be running as 'nobody', not '{user}'"
+
 
 def test_houston_config(houston_api):
-    """ Make assertions about Houston's configuration
-    """
-    data = houston_api.check_output("echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -")
+    """Make assertions about Houston's configuration"""
+    data = houston_api.check_output(
+        "echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -"
+    )
     houston_config = json.loads(data)
-    assert 'url' not in houston_config['nats'].keys(), \
-        f"Did not expect to find 'url' configured for 'nats'. Found:\n\n{houston_config['nats']}"
-    assert len(houston_config['nats']['servers']), \
-        f"Expected to find 'servers' configured for 'nats'. Found:\n\n{houston_config['nats']}"
-    for server in houston_config['nats']:
-        assert 'localhost' not in server, \
-            f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
+    assert (
+        "url" not in houston_config["nats"].keys()
+    ), f"Did not expect to find 'url' configured for 'nats'. Found:\n\n{houston_config['nats']}"
+    assert len(
+        houston_config["nats"]["servers"]
+    ), f"Expected to find 'servers' configured for 'nats'. Found:\n\n{houston_config['nats']}"
+    for server in houston_config["nats"]:
+        assert (
+            "localhost" not in server
+        ), f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
+
 
 def test_houston_can_reach_prometheus(houston_api):
-    houston_api.check_output("wget -qO- --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
+    houston_api.check_output(
+        "wget -qO- --timeout=1 http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets"
+    )
+
 
 def test_nginx_can_reach_default_backend(nginx):
-    nginx.check_output("curl -s --max-time 1 http://astronomer-nginx-default-backend:8080")
+    nginx.check_output(
+        "curl -s --max-time 1 http://astronomer-nginx-default-backend:8080"
+    )
+
 
 def test_prometheus_targets(prometheus):
-    """ Ensure all Prometheus targets are healthy
-    """
+    """Ensure all Prometheus targets are healthy"""
     data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/targets")
-    targets = json.loads(data)['data']['activeTargets']
+    targets = json.loads(data)["data"]["activeTargets"]
     for target in targets:
-        assert target['health'] == 'up', \
-            'Expected all prometheus targets to be up. ' + \
-            'Please check the "targets" view in the Prometheus UI' + \
-            f" Target data from the one that is not up:\n\n{target}"
+        assert target["health"] == "up", (
+            "Expected all prometheus targets to be up. "
+            + 'Please check the "targets" view in the Prometheus UI'
+            + f" Target data from the one that is not up:\n\n{target}"
+        )
 
 
 def test_core_dns_metrics_are_collected(prometheus):
-    """ Ensure CoreDNS metrics are collected.
+    """Ensure CoreDNS metrics are collected.
 
     This test should work in CI and locally because Kind uses CoreDNS
     """
-    data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/query?query=coredns_dns_request_count_total")
+    data = prometheus.check_output(
+        "wget -qO- http://localhost:9090/api/v1/query?query=coredns_dns_request_count_total"
+    )
     parsed = json.loads(data)
-    assert len(parsed['data']['result']) > 0, \
-        f"Expected to find a metric coredns_dns_request_count_total, but we got this response:\n\n{parsed}"
+    assert (
+        len(parsed["data"]["result"]) > 0
+    ), f"Expected to find a metric coredns_dns_request_count_total, but we got this response:\n\n{parsed}"
+
 
 def test_houston_metrics_are_collected(prometheus):
-    """ Ensure Houston metrics are collected and prefixed with 'houston_'
-    """
-    data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/query?query=houston_up")
+    """Ensure Houston metrics are collected and prefixed with 'houston_'"""
+    data = prometheus.check_output(
+        "wget -qO- http://localhost:9090/api/v1/query?query=houston_up"
+    )
     parsed = json.loads(data)
-    assert len(parsed['data']['result']) > 0, \
-        f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
+    assert (
+        len(parsed["data"]["result"]) > 0
+    ), f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
 
 
 def test_prometheus_config_reloader_works(prometheus, kube_client):
-    """ 
+    """
     Ensure that Prometheus reloads its config when the cofigMap is updated
     and the reloader sidecar triggers the reload
     """
@@ -82,64 +101,59 @@ def test_prometheus_config_reloader_works(prometheus, kube_client):
     new_scrape_interval = "31s"
 
     # get the current configmap
-    orig_cm = kube_client.read_namespaced_config_map("astronomer-prometheus-config", "astronomer")
+    orig_cm = kube_client.read_namespaced_config_map(
+        "astronomer-prometheus-config", "astronomer"
+    )
 
-    prom_config = yaml.safe_load(orig_cm.data['config'])
+    prom_config = yaml.safe_load(orig_cm.data["config"])
     # modify the configmap
-    prom_config['global']['scrape_interval'] = new_scrape_interval
+    prom_config["global"]["scrape_interval"] = new_scrape_interval
     new_body = {
         "apiversion": "v1",
         "kind": "ConfigMap",
-        "data": {
-            "config": yaml.dump(prom_config)
-        }
+        "data": {"config": yaml.dump(prom_config)},
     }
 
     try:
         # update the configmap
         kube_client.patch_namespaced_config_map(
-            name="astronomer-prometheus-config",
-            namespace="astronomer",
-            body=new_body
+            name="astronomer-prometheus-config", namespace="astronomer", body=new_body
         )
     except ApiException as e:
         print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
-    
+
     # This can take more than a minute.
-    i = 0 
-    while i < 12: 
-        data = prometheus.check_output("wget -qO- http://localhost:9090/api/v1/status/config")
+    i = 0
+    while i < 12:
+        data = prometheus.check_output(
+            "wget -qO- http://localhost:9090/api/v1/status/config"
+        )
         j_parsed = json.loads(data)
         # print(parsed['data']['yaml']['config']['global'])
-        y_parsed = yaml.safe_load(j_parsed['data']['yaml'])
-        if y_parsed['global']['scrape_interval'] != "30s":
-            print(y_parsed['global']['scrape_interval'])
+        y_parsed = yaml.safe_load(j_parsed["data"]["yaml"])
+        if y_parsed["global"]["scrape_interval"] != "30s":
+            print(y_parsed["global"]["scrape_interval"])
             break
         else:
             time.sleep(10)
-        i+=1
-        
+        i += 1
 
     # set the config back to it's original settings
-    prom_config['global']['scrape_interval'] = "30s"
+    prom_config["global"]["scrape_interval"] = "30s"
     new_body = {
         "apiversion": "v1",
         "kind": "ConfigMap",
-        "data": {
-            "config": yaml.dump(prom_config)
-        }
+        "data": {"config": yaml.dump(prom_config)},
     }
 
     try:
         # update the configmap
         kube_client.patch_namespaced_config_map(
-            name="astronomer-prometheus-config",
-            namespace="astronomer",
-            body=new_body
+            name="astronomer-prometheus-config", namespace="astronomer", body=new_body
         )
     except ApiException as e:
         print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
 
-
-    assert y_parsed['global']['scrape_interval'] != "30s", \
-        f"Expected the prometheus config file to change"
+    assert (
+        y_parsed["global"]["scrape_interval"] != "30s"
+    ), f"Expected the prometheus config file to change"

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -16,5 +16,10 @@ pip install -r $REPO_DIR/bin/functional-tests/requirements.txt
 export NAMESPACE=astronomer
 export RELEASE_NAME=astronomer
 
+# Sleep twice the prometheus scrape period
+# plus five seconds to allow for metrics to be
+# collected, which the functional tests need.
+sleep 65
+
 pytest -s $REPO_DIR/bin/functional-tests/
 deactivate

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -16,9 +16,5 @@ pip install -r $REPO_DIR/bin/functional-tests/requirements.txt
 export NAMESPACE=astronomer
 export RELEASE_NAME=astronomer
 
-# Sleep twice the prometheus scrape period
-# plus five seconds to allow for metrics to be
-# collected, which the functional tests need.
-sleep 65
 pytest -s $REPO_DIR/bin/functional-tests/
 deactivate

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -30,6 +30,15 @@ Create chart name and version as used by the chart label.
 {{- end }}
 {{- end }}
 
+
+{{ define "configReloader.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-config-reloader:{{ .Values.images.configReloader.tag }}
+{{- else -}}
+{{ .Values.images.configReloader.repository }}:{{ .Values.images.configReloader.tag }}
+{{- end }}
+{{- end }}
+
 {{ define "prometheus.init.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.images.init.tag }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -43,25 +43,21 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.fullname" . }}
       containers:
-        - args:
-          - --webhook-url=http://localhost:9090/-/reload
-          - --volume-dir=/etc/prometheus/alerts.d
-          - --volume-dir=/etc/prometheus/config
-          image: jimmidyson/configmap-reload:v0.4.0
-          imagePullPolicy: IfNotPresent
-          name: configmap-reloader
+        - name: configmap-reloader
+          args:
+            - --webhook-url=http://localhost:9090/-/reload
+            - --volume-dir=/etc/prometheus/alerts.d
+            - --volume-dir=/etc/prometheus/config
+          image: {{ include "configReloader.image" . }}
+          imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}
           resources:
-            limits:
-              cpu: 100m
-              memory: 25Mi
-            requests:
-              cpu: 100m
-              memory: 25Mi
+{{ toYaml .Values.configMapReloader.resources | indent 12 }}
           volumeMounts:
           - name: alert-volume
             mountPath: /etc/prometheus/alerts.d
           - name: prometheus-config-volume
             mountPath: /etc/prometheus/config
+
         - name: prometheus
           image: {{ include "prometheus.image" . }}
           imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -44,14 +44,6 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.fullname" . }}
-      initContainers:
-        - name: init
-          image: {{ include "prometheus.init.image" . }}
-          imagePullPolicy: {{ .Values.images.init.pullPolicy }}
-          command: ["chown", "-R", "65534:65534", "{{ .Values.dataDir }}"]
-          volumeMounts:
-            - name: data
-              mountPath: "{{ .Values.dataDir }}"
       containers:
         - name: prometheus
           image: {{ include "prometheus.image" . }}
@@ -90,6 +82,10 @@ spec:
               port: {{ .Values.ports.http }}
             initialDelaySeconds: 10
             periodSeconds: 5
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
       volumes:
         - name: prometheus-config-volume
           configMap:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
           args:
             - "--config.file=/etc/prometheus/config/prometheus.yaml"
             - "--storage.tsdb.path={{ .Values.dataDir }}"
-            - "--storage.tsdb.retention={{ .Values.retention }}"
+            - "--storage.tsdb.retention.time={{ .Values.retention }}"
             {{- if .Values.enableLifecycle }}
             - "--web.enable-lifecycle"
             {{- end }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -29,8 +29,6 @@ spec:
         component: {{ template "prometheus.name" . }}
         release: {{ .Release.Name }}
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/prometheus-config-configmap.yaml") . | sha256sum }}
-        checksum/alerts: {{ include (print $.Template.BasePath "/prometheus-alerts-configmap.yaml") . | sha256sum }}
 {{- if .Values.global.istio.enabled }}
         sidecar.istio.io/proxyCPU: "500m"
         sidecar.istio.io/proxyMemory: "400Mi"
@@ -45,6 +43,25 @@ spec:
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.fullname" . }}
       containers:
+        - args:
+          - --webhook-url=http://localhost:9090/-/reload
+          - --volume-dir=/etc/prometheus/alerts.d
+          - --volume-dir=/etc/prometheus/config
+          image: jimmidyson/configmap-reload:v0.4.0
+          imagePullPolicy: IfNotPresent
+          name: configmap-reloader
+          resources:
+            limits:
+              cpu: 100m
+              memory: 25Mi
+            requests:
+              cpu: 100m
+              memory: 25Mi
+          volumeMounts:
+          - name: alert-volume
+            mountPath: /etc/prometheus/alerts.d
+          - name: prometheus-config-volume
+            mountPath: /etc/prometheus/config
         - name: prometheus
           image: {{ include "prometheus.image" . }}
           imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}

--- a/charts/prometheus/tests/prometheus-statefulset_test.yaml
+++ b/charts/prometheus/tests/prometheus-statefulset_test.yaml
@@ -18,3 +18,10 @@ tests:
       - equal: 
           path: spec.template.spec.securityContext.runAsNonRoot
           value: true
+
+  - it: Should have configmap-reloader sidecar container
+    asserts:
+    - equal:
+        path: spec.template.spec.containers[0].name
+        value: configmap-reloader
+    

--- a/charts/prometheus/tests/prometheus-statefulset_test.yaml
+++ b/charts/prometheus/tests/prometheus-statefulset_test.yaml
@@ -7,3 +7,14 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
+  - it: Security context should have user and fsgroup set correctly
+    asserts:
+      - equal: 
+          path: spec.template.spec.securityContext.fsGroup
+          value: 65534
+      - equal: 
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal: 
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -16,13 +16,9 @@ podLabels: {}
 replicas: 1
 
 images:
-  init:
-    repository: astronomerinc/ap-base
-    tag: 3.11.5-3
-    pullPolicy: IfNotPresent
   prometheus:
     repository: astronomerinc/ap-prometheus
-    tag: 2.17.1
+    tag: 2.21.0
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -20,6 +20,12 @@ images:
     repository: astronomerinc/ap-prometheus
     tag: 2.21.0
     pullPolicy: IfNotPresent
+  configReloader:
+    # repository: astronomerinc/ap-config-reloader
+    repository: quay.io/astronomer/ap-configmap-reloader
+    tag: 0.4.0
+    pullPolicy: IfNotPresent
+
 
 resources: {}
 #  limits:
@@ -28,6 +34,15 @@ resources: {}
 #  requests:
 #   cpu: 100m
 #   memory: 128Mi
+
+configMapReloader:
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 25Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 25Mi
 
 # Which directory prometheus data should be stored
 dataDir: "/prometheus"


### PR DESCRIPTION
## Description

This PR adds a sidecar to prometheus to allow reloading the config of prometheus when the configmap for the configuration or alert rules is modified. 

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1832

## 🧪  Testing

There is risk of the configmap-reloader not triggering, or not communicating correctly with prometheus. A unit test has been added to test for the presence of the sidecar. A functional test has been added that modifies the configmap and looks for those changes to be reflected in the container. 

- [x] The PR title is informative to the user experience
