### PR TITLE
Add AC 1.10.7-15 to supported images

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -139,6 +139,12 @@ data:
         - version: 1.10.7
           channel: stable
           tag: 1.10.7-14-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-15-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-15-buster-onbuild
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-alpine3.10-onbuild


### PR DESCRIPTION
- https://github.com/astronomer/ap-airflow/pull/135
- https://hub.docker.com/r/astronomerinc/ap-airflow/tags?page=1&ordering=last_updated&name=1.10.7-15