### PR TITLE
Use NLB as default AWS load balancer

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
     {{- if .Values.privateLoadBalancer }}
     # This annotation is detected by EKS to indicate that
     # it should provision a private ("internal") load balancer


### PR DESCRIPTION
## Description

- Use Network Load Balancer (NLB) as default AWS LB instead of Classic Load Balancer (default)
- AWS recommends migrating to the newer generation of load balancers

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1546

## 🧪  Testing

> What are the main risks associated with this change, and how are they addressed by tests added in this PR?

> Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

> Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [ ] The PR title is informative to the user experience
