### PR TITLE
Add network policy rules

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -40,6 +40,11 @@ spec:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
+          component: houston-expire-deployments
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
           component: houston
     - podSelector:
         matchLabels:

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -26,37 +26,26 @@ spec:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-db-migrations
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.commanderGRPC }}
-  - from:
     - podSelector:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-upgrader
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.commanderGRPC }}
-  - from:
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-update-check
     - podSelector:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.commanderGRPC }}
-  - from:
     - podSelector:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-worker
-    ports:
-    - protocol: TCP
-      port: {{ .Values.ports.commanderGRPC }}
-  - from:
     - podSelector:
         matchLabels:
           tier: astronomer

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -24,6 +24,16 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
+          component: houston-update-check
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          component: houston-expire-deployments
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: astronomer
           component: houston-db-migrations
           release: {{ .Release.Name }}
     - podSelector:


### PR DESCRIPTION
## Description

add ingress rules to commander and registry from houston job pods

## 🎟 Issue(s)

no issue associated

## 🧪  Testing

we detected this issue during 0.20 release process. For other network policies, I usually add a function test. But these are jobs, so the pods aren't around all the time, so they aren't available for the functional test. I will add some helm chart unit tests.

## 📸 Screenshots

> Add screenshots to illustrate the changes, if applicable.

## 📋 Checklist

- [x] The PR title is informative to the user experience
