### PR TITLE
livenessProbe and readinessProbe added to Stan server.

### DIFF
--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -106,6 +106,18 @@ spec:
           - name: NATS_URL
             value: nats://$(NATS_OPERATOR_SERVICE_ACCOUNT):$(NATS_OPERATOR_BOUND_TOKEN)@$(NATS_SERVICE)
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /streaming/serverz
+              port: monitor
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /streaming/serverz
+              port: monitor
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
           ports:
           - containerPort: 8222
             name: monitor

--- a/charts/stan/tests/statefulset_test.yaml
+++ b/charts/stan/tests/statefulset_test.yaml
@@ -13,3 +13,15 @@ tests:
           path: spec.template.spec.containers[0].livenessProbe
       - isNotEmpty:
           path: spec.template.spec.containers[0].readinessProbe
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: "/streaming/serverz"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: "/streaming/serverz"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: "monitor"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: "monitor"

--- a/charts/stan/tests/statefulset_test.yaml
+++ b/charts/stan/tests/statefulset_test.yaml
@@ -7,3 +7,9 @@ tests:
     asserts:
       - isKind:
           of: StatefulSet
+  - it: STAN Server Should Have Readiness and LivenessProbes
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].livenessProbe
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].readinessProbe


### PR DESCRIPTION
## Description

The nats Stan component did not previously have liveness or readiness probes. These are being added here. 

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1672

## 🧪  Testing

If the probe was misconfigured it could either never pass the probe checks or would pass incorrectly, false positive. 

helm-unittest tests have been added to check for the existence of livenessProbe and readinessProbe
and that the path/port are correct

