### PR TITLE
add missing step to migrate alertEmails

### DIFF
--- a/bin/migration-scripts/prisma1_to_prisma2.sql
+++ b/bin/migration-scripts/prisma1_to_prisma2.sql
@@ -42,3 +42,11 @@ ALTER TABLE "houston$default"."Deployment" ALTER COLUMN "workspaceId" SET DATA T
 ALTER TABLE "houston$default"."DockerImage" ALTER COLUMN "id" SET DATA TYPE varchar(30);
 ALTER TABLE "houston$default"."DockerImage" ALTER COLUMN "deploymentId" SET DATA TYPE varchar(30);
 ALTER TABLE "houston$default"."PlatformRelease" ALTER COLUMN "id" SET DATA TYPE varchar(30);
+
+-- migrate Deployment_alertEmails"
+ALTER TABLE "houston$default"."Deployment" ADD COLUMN "alertEmails" text[];
+UPDATE "houston$default"."Deployment" AS v
+SET "alertEmails" = s.alert_emails
+FROM (select string_to_array(string_agg(value, ',' order by position),',') as alert_emails, "nodeId" from "houston$default"."Deployment_alertEmails" group by "nodeId") AS s
+WHERE v.id = s."nodeId";
+DROP table if exists "houston$default"."Deployment_alertEmails";


### PR DESCRIPTION
## Description

Add missing step to migrate `Deployment_alertEmails` to prevent during prisma1 -> to prisma2 rollout.

And prevent interactive message:
```
⚠️  There will be data loss:

  • You are about to drop the `Deployment_alertEmails` table, which is not empty (1 rows).

```

practically tested using release-016/ and than main.