### PR TITLE
airflowChartVersion from 0.17.0 to 0.17.1

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 0.17.0
+airflowChartVersion: 0.17.1
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

Bump airflowChartVersion from 0.17.0 to 0.17.1

## PR Title

Optimize FQDN DNS lookups.

## 🧪  Testing

This patch has been live in many environments running Airflow 0.15.