### PR TITLE
Remove --force-namespace-isolation

### DIFF
--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -52,9 +52,6 @@ spec:
             - --configmap={{ .Release.Namespace }}/{{ template "nginx.fullname" . }}-ingress-controller
             - --ingress-class={{ template "nginx.ingress.class" . }}
             - --default-ssl-certificate={{ .Release.Namespace }}/{{ .Values.global.tlsSecret }}
-            {{- if .Values.forceNamespaceIsolation }}
-            - --force-namespace-isolation
-            {{- end }}
             {{- if .Values.global.singleNamespace }}
             - --watch-namespace={{ .Release.Namespace }}
             {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -16,7 +16,6 @@ images:
     tag: 0.16.1
     pullPolicy: IfNotPresent
 
-forceNamespaceIsolation: true
 ingressClass: ~
 
 replicas: 2

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: astronomerinc/ap-nginx
-    tag: 0.33.0
+    tag: 0.30.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: astronomerinc/ap-nginx
-    tag: 0.30.0
+    tag: 0.33.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: astronomerinc/ap-default-backend


### PR DESCRIPTION
## Description

The nginx ingress controller has deprecated the --force-namespace-isolation flag, which apparently was not even doing anything.

## Additional context

- Removal of feature from ingress-nginx: https://github.com/kubernetes/ingress-nginx/pull/3887
- Where this feature shows up in our chart:
  - https://github.com/astronomer/astronomer/blob/master/charts/nginx/templates/nginx-deployment.yaml#L55-L57
  - https://github.com/astronomer/astronomer/blob/master/charts/nginx/values.yaml#L19

## PR Title

Remove deprecated nginx ingress flag `--force-namespace-isolation`

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/1911

## 🧪  Testing

- Verified that this fix works in kind
- Reviewed upstream code to verify that the flag removal was in fact not doing anything