### PR TITLE
Fix Houston Knex Migration Error

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.21.0
+    tag: 0.21.1
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui


### PR DESCRIPTION
## Description

Fix the migration script for Houston API.  Prevent the `workspaceId` null error database constraint error from throwing errors during our migration.


## 🎟 Issue(s)

Resolves astronomer/issues#1926

## 🧪  Testing

The migrations should successfully run when there are `InviteToken.workspaceId` null values in the database (you'll need to seed your DB with invites and then make the workspaceIds null manually).


## 📋 Checklist

- [x] The PR title is informative to the user experience
