### PR TITLE
Only auto test latest k8s version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,46 +131,45 @@ workflows:
       - build-artifact:
           requires:
             - lint
+            - unittest-charts
+
+      - test-all-platforms:
+          type: approval
+          requires:
+            - build-artifact
 
       - platform-1-14-10:
           requires:
-            - build-artifact
-            - unittest-charts
+            - test-all-platforms
 
       - platform-1-15-11:
           requires:
-            - build-artifact
-            - unittest-charts
+            - test-all-platforms
 
       - platform-1-16-9:
           requires:
-            - build-artifact
-            - unittest-charts
+            - test-all-platforms
 
       - platform-1-17-5:
           requires:
-            - build-artifact
-            - unittest-charts
+            - test-all-platforms
 
       - platform-1-18-2:
           requires:
             - build-artifact
-            - unittest-charts
 
       - approve-internal-release:
           type: approval
           requires:
-
             - platform-1-14-10
             - platform-1-15-11
             - platform-1-16-9
             - platform-1-17-5
             - platform-1-18-2
-
-          filters:
-            branches:
-              only:
-                - '/release-0\.\d+/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,10 +168,10 @@ workflows:
             - platform-1-16-15
             - platform-1-17-11
             - platform-1-18-8
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.\d+/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -181,18 +181,19 @@ workflows:
           type: approval
           requires:
             - release-to-internal
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.(12|13|14|15|16)/'
+
+          filters:
+            branches:
+              only:
+                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
             - approve-public-release
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.(12|13|14|15|16)/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,10 +166,10 @@ workflows:
             - platform-1-16-9
             - platform-1-17-5
             - platform-1-18-2
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.\d+/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,10 +168,10 @@ workflows:
             - platform-1-16-15
             - platform-1-17-11
             - platform-1-18-8
-          filters:
-            branches:
-              only:
-                - '/release-0\.\d+/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -181,19 +181,18 @@ workflows:
           type: approval
           requires:
             - release-to-internal
-
-          filters:
-            branches:
-              only:
-                - '/release-0\.(12|13|14|15|16)/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
             - approve-public-release
-          filters:
-            branches:
-              only:
-                - '/release-0\.(12|13|14|15|16)/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,24 +135,26 @@ workflows:
 
       - test-all-platforms:
           type: approval
-          requires:
-            - build-artifact
 
       - platform-1-14-10:
           requires:
             - test-all-platforms
+            - build-artifact
 
       - platform-1-15-12:
           requires:
             - test-all-platforms
+            - build-artifact
 
       - platform-1-16-15:
           requires:
             - test-all-platforms
+            - build-artifact
 
       - platform-1-17-11:
           requires:
             - test-all-platforms
+            - build-artifact
 
       - platform-1-18-8:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,42 +81,42 @@ jobs:
       - helm-install:
           astronomer-tags: "platform postgresql monitoring logging kubed keda"
 
-  platform-1-15-11:
+  platform-1-15-12:
     machine:
       image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
-      KUBE_VERSION: v1.15.11
+      KUBE_VERSION: v1.15.12
     steps:
       - helm-install:
           astronomer-tags: "platform postgresql monitoring logging kubed keda"
 
-  platform-1-16-9:
+  platform-1-16-15:
     machine:
       image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
-      KUBE_VERSION: v1.16.9
+      KUBE_VERSION: v1.16.15
     steps:
       - helm-install:
           astronomer-tags: "platform postgresql monitoring logging kubed keda"
 
-  platform-1-17-5:
+  platform-1-17-11:
     machine:
       image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
-      KUBE_VERSION: v1.17.5
+      KUBE_VERSION: v1.17.11
     steps:
       - helm-install:
           astronomer-tags: "platform postgresql monitoring logging kubed keda"
 
-  platform-1-18-2:
+  platform-1-18-8:
     machine:
       image: ubuntu-2004:202008-01
       resource_class: xlarge
     environment:
-      KUBE_VERSION: v1.18.2
+      KUBE_VERSION: v1.18.8
     steps:
       - helm-install:
           astronomer-tags: "platform postgresql monitoring logging kubed keda"
@@ -142,19 +142,19 @@ workflows:
           requires:
             - test-all-platforms
 
-      - platform-1-15-11:
+      - platform-1-15-12:
           requires:
             - test-all-platforms
 
-      - platform-1-16-9:
+      - platform-1-16-15:
           requires:
             - test-all-platforms
 
-      - platform-1-17-5:
+      - platform-1-17-11:
           requires:
             - test-all-platforms
 
-      - platform-1-18-2:
+      - platform-1-18-8:
           requires:
             - build-artifact
 
@@ -162,10 +162,10 @@ workflows:
           type: approval
           requires:
             - platform-1-14-10
-            - platform-1-15-11
-            - platform-1-16-9
-            - platform-1-17-5
-            - platform-1-18-2
+            - platform-1-15-12
+            - platform-1-16-15
+            - platform-1-17-11
+            - platform-1-18-8
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -110,10 +110,10 @@ workflows:
           requires:
 {%- for version in kube_versions %}
             - platform-{{ version | replace(".", "-") }}{% endfor %}
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.\d+/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -109,10 +109,10 @@ workflows:
           requires:
 {%- for version in kube_versions %}
             - platform-{{ version | replace(".", "-") }}{% endfor %}
-          filters:
-            branches:
-              only:
-                - '/release-0\.\d+/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -122,19 +122,18 @@ workflows:
           type: approval
           requires:
             - release-to-internal
-
-          filters:
-            branches:
-              only:
-                - '/release-0\.(12|13|14|15|16)/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
             - approve-public-release
-          filters:
-            branches:
-              only:
-                - '/release-0\.(12|13|14|15|16)/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -93,8 +93,6 @@ workflows:
 
       - test-all-platforms:
           type: approval
-          requires:
-            - build-artifact
 {% for version in kube_versions %}{% if version == kube_versions[-1:][0] %}
       - platform-{{ version | replace(".", "-") }}:
           requires:
@@ -103,6 +101,7 @@ workflows:
       - platform-{{ version | replace(".", "-") }}:
           requires:
             - test-all-platforms
+            - build-artifact
 {% endif %}{% endfor %}
 
       - approve-internal-release:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -109,10 +109,10 @@ workflows:
           requires:
 {%- for version in kube_versions %}
             - platform-{{ version | replace(".", "-") }}{% endfor %}
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.\d+/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:
@@ -122,18 +122,19 @@ workflows:
           type: approval
           requires:
             - release-to-internal
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.(12|13|14|15|16)/'
+
+          filters:
+            branches:
+              only:
+                - '/release-0\.(12|13|14|15|16)/'
 
       - release-to-public:
           requires:
             - approve-public-release
-#          filters:
-#            branches:
-#              only:
-#                - '/release-0\.(12|13|14|15|16)/'
+          filters:
+            branches:
+              only:
+                - '/release-0\.(12|13|14|15|16)/'
 
 commands:
   helm-install:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -89,22 +89,31 @@ workflows:
       - build-artifact:
           requires:
             - lint
-{% for version in kube_versions %}
+            - unittest-charts
+
+      - test-all-platforms:
+          type: approval
+          requires:
+            - build-artifact
+{% for version in kube_versions %}{% if version == kube_versions[-1:][0] %}
       - platform-{{ version | replace(".", "-") }}:
           requires:
             - build-artifact
-            - unittest-charts
-{% endfor %}
+{%- else %}
+      - platform-{{ version | replace(".", "-") }}:
+          requires:
+            - test-all-platforms
+{% endif %}{% endfor %}
+
       - approve-internal-release:
           type: approval
           requires:
-{% for version in kube_versions %}
+{%- for version in kube_versions %}
             - platform-{{ version | replace(".", "-") }}{% endfor %}
-
-          filters:
-            branches:
-              only:
-                - '/release-0\.\d+/'
+#          filters:
+#            branches:
+#              only:
+#                - '/release-0\.\d+/'
 
       - release-to-internal:
           requires:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,6 +9,7 @@ from jinja2 import Template
 
 # When adding a new version, look up the most
 # recent patch version on Dockerhub
+# https://hub.docker.com/r/kindest/node/tags
 KUBE_VERSIONS = ["1.14.10", "1.15.12", "1.16.15", "1.17.11", "1.18.8"]
 
 

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,15 +9,11 @@ from jinja2 import Template
 
 # When adding a new version, look up the most
 # recent patch version on Dockerhub
-KUBE_VERSIONS = ['1.14.10',
-        '1.15.11',
-        '1.16.9',
-        '1.17.5',
-        '1.18.2']
+KUBE_VERSIONS = ["1.14.10", "1.15.11", "1.16.9", "1.17.5", "1.18.2"]
+
 
 def main():
-    """ Render the Jinja2 template file
-    """
+    """Render the Jinja2 template file"""
     circle_directory = os.path.dirname(os.path.realpath(__file__))
     config_template_path = os.path.join(circle_directory, "config.yml.j2")
     config_path = os.path.join(circle_directory, "config.yml")
@@ -25,14 +21,15 @@ def main():
     with open(config_template_path, "r") as circle_ci_config_template:
         templated_file_content = circle_ci_config_template.read()
     template = Template(templated_file_content)
-    config = template.render(
-            kube_versions=KUBE_VERSIONS
-            )
-    warning_header = "# Warning: automatically generated file\n" + \
-            "# Please edit config.yml.j2, and use the script generate_circleci_config.py\n"
+    config = template.render(kube_versions=KUBE_VERSIONS)
+    warning_header = (
+        "# Warning: automatically generated file\n"
+        + "# Please edit config.yml.j2, and use the script generate_circleci_config.py\n"
+    )
     with open(config_path, "w") as circle_ci_config_file:
         circle_ci_config_file.write(warning_header)
         circle_ci_config_file.write(config)
+        circle_ci_config_file.write("\n")
 
 
 if __name__ == "__main__":

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,7 +9,7 @@ from jinja2 import Template
 
 # When adding a new version, look up the most
 # recent patch version on Dockerhub
-KUBE_VERSIONS = ["1.14.10", "1.15.11", "1.16.9", "1.17.5", "1.18.2"]
+KUBE_VERSIONS = ["1.14.10", "1.15.12", "1.16.15", "1.17.11", "1.18.8"]
 
 
 def main():


### PR DESCRIPTION

## Description

Automatically test only the latest k8s version on each run. Testing all runs is now a manual step that must be run before releasing to internal.

Update kind versions to latest available in https://hub.docker.com/r/kindest/node/tags

Added a final newline to the rendering. Ran `black` on generate_circleci_config.py via pre-commit hooks.

This should be cherry-picked to all branches.

## PR Title

CI changes only. No-op for all installations.

## 🎟 Issue(s)

Related to astronomer/issues#1932

## 🧪  Testing

[Iterated on several configs](https://app.circleci.com/pipelines/github/astronomer/astronomer?branch=1932-reduce-ci-resource-usage) before arriving at the final config. "Test all platforms" is a manual step that can be approved immediately at the start of the run, essentially giving pre-approval to test all versions without needing to wait for early steps to succeed.

## 📸 Screenshots

<img width="2467" alt="Screen Shot 2020-10-14 at 6 56 47 PM" src="https://user-images.githubusercontent.com/1323808/96067679-29b70e80-0e4f-11eb-9572-50b63b19877c.png">
