### PR TITLE
Fix createToken Houston API Bug

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: astronomerinc/ap-houston-api
-    tag: 0.21.3
+    tag: 0.21.4
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui


### PR DESCRIPTION
## Description

Fix the createToken Houston API Bug
Fix a bug with the `trialEndsAt` date being in an invalid format

## 🎟 Issue(s)

Resolves astronomer/issues#1933
Resolves astronomer/issues#1935

## 🧪  Testing

1. Log in as an admin
2. Invite a user your-email+{SOME_INT}@astronomer.io
3. Check your email and accept the invite (make sure you use a different browser or are logged out of your admin account)
4. Use the basic auth option to login with the new invite
5. After signing in, log out
6. Log in again with the newly created account (at this point you should be able to get back in without any errors)


## 📋 Checklist

- [ ] The PR title is informative to the user experience
