### PR TITLE
Fix Astro UI Billing Permissions Bug

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -27,7 +27,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: astronomerinc/ap-astro-ui
-    tag: 0.21.1
+    tag: 0.21.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: astronomerinc/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Fix the Astro UI billing details bug.


## 🎟 Issue(s)

Resolves astronomer/issues#1900

## 🧪  Testing

1. Log into Astro UI
2. Go to the billing page as a `WORKSPACE_ADMIN` **not** a `SYS_ADMIN` and try to view the billing details
3. You should be able to see the billing details and the update the billing information

## 📸 Screenshots

https://github.com/astronomer/astro-ui/pull/855

## 📋 Checklist

- [ ] The PR title is informative to the user experience
