### PR TITLE
Move helm-chart-released-already check into release script.

### DIFF
--- a/bin/functional-tests/README.md
+++ b/bin/functional-tests/README.md
@@ -69,6 +69,5 @@ This test file makes assertions about the configuration of the platform by live-
 ### test_versioning.py
 
 This test file makes assertions about versioning:
-  - This version should not already by published
   - Patch versions support downgrade and upgrade
   - Versioning is in a valid configuration

--- a/bin/functional-tests/test_versioning.py
+++ b/bin/functional-tests/test_versioning.py
@@ -11,6 +11,7 @@ git_root_dir = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     "..","..")
 
+
 def test_astro_sub_chart_version_match():
     """
     Tests that Chart.yaml and charts/astronomer/Chart.yaml
@@ -29,28 +30,6 @@ def test_astro_sub_chart_version_match():
         "Please ensure that 'version' in Chart.yaml and " + \
         "charts/astronomer/Chart.yaml exactly match."
 
-def test_chart_version_is_not_already_published():
-    """
-    Tests that Chart.yaml has been incremented
-    """
-    with open(os.path.join(git_root_dir,
-                           "Chart.yaml"), "r") as f:
-        astro_chart_dot_yaml = yaml.safe_load(f.read())
-    major, minor, patch = semver(astro_chart_dot_yaml['version']).release
-    if patch == 0:
-      print("This test does not apply to patch version zero")
-      return
-    repo_result = check_output(
-        f"helm3 search repo --output=json --version=^{major}.{minor} astronomer-internal/astronomer",
-        shell=True)
-    # Example result:
-    # [{"name":"astronomer-internal/astronomer","version":"0.19.3","app_version":"0.19.3","description":"Helm chart to deploy the Astronomer Platform"}]
-    repo_result = json.loads(repo_result)
-    for line in repo_result:
-        assert line['version'] != astro_chart_dot_yaml['version'], \
-            f"Version {astro_chart_dot_yaml['version']} is already released " + \
-            "to https://internal-helm.astronomer.io/, please increment 'version' " + \
-            "in both Chart.yaml and charts/astronomer/Chart.yaml"
 
 def test_downgrade_then_upgrade():
     """

--- a/bin/release-helm-chart
+++ b/bin/release-helm-chart
@@ -53,6 +53,14 @@ else
   target_env="helm-dev"
 fi
 
+echo "${GCP_TOKEN}" > /tmp/gcs_token.json
+gcloud auth activate-service-account --key-file=/tmp/gcs_token.json
+
+if gsutil -q stat "gs://${target_repo}/${helm_chart_path##*/}" ; then
+  echo "ABORT: destination file ${helm_chart_path##*/} already exists. Did you forget to bump the chart version number in both Chart.yaml and charts/astronomer/Chart.yaml?"
+  exit 1
+fi
+
 pre-flight-setup() {
   # Set script_path to the path of this script
   script_path="${0%/*}"
@@ -78,10 +86,6 @@ pre-flight-setup() {
 
   # This is needed to avoid using the CI's built-in gcloud configurations.
   export BOTO_CONFIG=/dev/null
-
-  set +x
-  echo "${GCP_TOKEN}" > /tmp/gcs_token.json
-  gcloud auth activate-service-account --key-file=/tmp/gcs_token.json
 }
 
 process_and_release_chart_file() {


### PR DESCRIPTION
## Description

Move the check for an already published helm chart farther down the line so chart version mismatches don't block code testing.

## 🧪  Testing

Manually tested the release process on my laptop with an already published version.