### PR TITLE
Add support for adding additional custom routes to alertmanager

### DIFF
--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -20,6 +20,9 @@ data:
       repeat_interval: 3h
       receiver: default-receiver
       routes:
+{{ if .Values.customRoutes }}
+{{ toYaml .Values.customRoutes | trim | indent 6 }}
+{{ end }}
       {{ if .Values.receivers.platformCritical }}
       - receiver: platform-critical-receiver
         continue: true  # allows alert to continue down the tree matching any additional child routes

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -47,3 +47,10 @@ receivers:
 
   # Configs for airflow alerts
   airflow: {}
+
+customRoutes: {}
+# Example
+# - receiver: blackhole-receiver
+#   match_re:
+#     tier: platform
+#     namespace: ^(test-ns.*)


### PR DESCRIPTION

<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

This PR adds the ability to augment alert manager routing rules with custom routes. Currently we only have predefined routes that we can enable or disable. This change opens up at the ability for us, or a customer to inject whatever extra routing rules they with to implement. 


## 🎟 Issue(s)

does not resolve the following issue. But is in support of completing that issue
https://github.com/astronomer/issues/issues/1934

## 🧪  Testing

Tested with `amtool` with a goal to black hole a specific set of alerts


## 📸 Screenshots
```
amtool config routes test --config.file test_routing.yaml tier=platform namespace=test-ns-2 --tree
Matching routes:
.
└── default-route
    └── {namespace=~"^(?:^(test-ns.*))$",tier=~"^(?:platform)$"}  receiver: blackhole-receiver


blackhole-receiver
```
## 📋 Checklist

- [ ] The PR title is informative to the user experience
