### PR TITLE
Enable json logging for nginx ingress

### DIFF
--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -21,3 +21,11 @@ data:
   server-name-hash-bucket-size: {{ .Values.serverNameHashBucketSize | quote }}
   enable-vts-status: "true"
   server-tokens: "false"
+  log-format-escape-json: "true"
+  log-format-upstream: '{"timestamp": "$time_iso8601", "requestID": "$req_id", "proxyUpstreamName":
+    "$proxy_upstream_name", "proxyAlternativeUpstreamName": "$proxy_alternative_upstream_name","upstreamStatus":
+    "$upstream_status", "upstreamAddr": "$upstream_addr","httpRequest":{"requestMethod":
+    "$request_method", "requestUrl": "$host$request_uri", "status": $status,"requestSize":
+    "$request_length", "responseSize": "$upstream_response_length", "userAgent": "$http_user_agent",
+    "remoteIp": "$remote_addr", "referer": "$http_referer", "latency": "$upstream_response_time
+    s", "protocol":"$server_protocol"}}'


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

This enables outputting nginx logs as json structured data rather than plain text to make parsing and querying easier for things such as GCP Stackdriver. For example we can query on status codes, or request ids or IPs etc. With the current textPayload that is unsctructured we do not have this capability with Stackdriver.

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots
Example of capabilities we get in stack driver with json logging from nginx
![Screen Shot 2020-10-26 at 11 48 15 PM](https://user-images.githubusercontent.com/942071/97254887-c7162900-17e5-11eb-8211-05672cf685f9.png)


## 📋 Checklist

- [x] The PR title is informative to the user experience
