### PR TITLE
Changed default airflow chart version to 0.18.0

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 0.17.1
+airflowChartVersion: 0.18.0
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description
Updated the default airflow version used with the astronomer chart to be 0.18.0



