### PR TITLE
Optionally copy a private certificate to all nodes

### DIFF
--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -1,0 +1,62 @@
+################################
+## DaemonSet to mount the private root CA
+##
+## This can be used by enterprise with private
+## CAs that do not already install their root
+## certificate on the kubernetes nodes.
+#################################
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-private-ca
+  labels:
+    tier: platform
+    component: private-ca
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      tier: platform
+      component: private-ca
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        tier: platform
+        component: private-ca
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-private-ca
+      containers:
+      - name: sleeper
+        image: alpine:latest
+        command:
+          - "/bin/bash"
+          - "-c"
+        args:
+          - "cp /private-ca-certs/* /host-trust-store/ && sleep infinity"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: hostcerts
+          mountPath: /host-trust-store
+        {{ range $secret_name := (.Values.global.privateCaCerts) }}
+        - name: {{ $secret_name }}
+          mountPath: /private-ca-certs/{{ $secret_name }}.pem
+          subPath: cert.pem
+        {{- end }}
+        resources:
+          requests:
+            cpu: 1m
+            memory: "1Mi"
+          limits:
+            cpu: 10m
+            memory: "1Mi"
+      volumes:
+      - name: hostcerts
+        hostPath:
+          path: {{ .Values.global.privateCaCertsAddToHost.hostDirectory }}
+      {{ range $secret_name := (.Values.global.privateCaCerts) }}
+      - name: {{ $secret_name }}
+        secret:
+          secretName: {{ $secret_name }}
+      {{- end }}

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.privateCaCertsAddToHost.enabled }}
 ################################
 ## DaemonSet to mount the private root CA
 ##
@@ -68,3 +69,4 @@ spec:
         secret:
           secretName: {{ $secret_name }}
       {{- end }}
+{{- end }}

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -34,20 +34,20 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:
-      - name: sleeper
-        image: ubuntu:20.04
+      - name: cert-copy
+        image: alpine
         command:
-          - "/bin/bash"
+          - "sh"
           - "-c"
         args:
-          - "ls -ltrah /private-ca-certs/* && cp -v /private-ca-certs/* /host-trust-store/ && sleep infinity"
+          - "while true; do date; cp -v /private-ca-certs/* /host-trust-store/; sleep 10; done"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: hostcerts
           mountPath: /host-trust-store
         {{ range $secret_name := (.Values.global.privateCaCerts) }}
         - name: {{ $secret_name }}
-          # mush be named as *.crt to be noticed by Docker
+          # must be named as *.crt to be noticed by Docker
           # after this is copied to docker trust store
           mountPath: /private-ca-certs/{{ $secret_name }}.crt
           subPath: cert.pem

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -14,6 +14,11 @@ metadata:
     component: private-ca
     release: {{ .Release.Name }}
 spec:
+  # allow update to occur all at once
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "100%"
   selector:
     matchLabels:
       tier: platform
@@ -29,32 +34,35 @@ spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:
       - name: sleeper
-        image: alpine:latest
+        image: ubuntu:20.04
         command:
           - "/bin/bash"
           - "-c"
         args:
-          - "cp /private-ca-certs/* /host-trust-store/ && sleep infinity"
+          - "ls -ltrah /private-ca-certs/* && cp -v /private-ca-certs/* /host-trust-store/ && sleep infinity"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: hostcerts
           mountPath: /host-trust-store
         {{ range $secret_name := (.Values.global.privateCaCerts) }}
         - name: {{ $secret_name }}
-          mountPath: /private-ca-certs/{{ $secret_name }}.pem
+          # mush be named as *.crt to be noticed by Docker
+          # after this is copied to docker trust store
+          mountPath: /private-ca-certs/{{ $secret_name }}.crt
           subPath: cert.pem
         {{- end }}
         resources:
           requests:
             cpu: 1m
-            memory: "1Mi"
+            memory: "25Mi"
           limits:
-            cpu: 10m
-            memory: "1Mi"
+            cpu: 50m
+            memory: "50Mi"
+      terminationGracePeriodSeconds: 1
       volumes:
       - name: hostcerts
         hostPath:
-          path: {{ .Values.global.privateCaCertsAddToHost.hostDirectory }}
+          path: {{ .Values.global.privateCaCertsAddToHost.hostDirectory }}/registry.{{ .Values.global.baseDomain }}/
       {{ range $secret_name := (.Values.global.privateCaCerts) }}
       - name: {{ $secret_name }}
         secret:

--- a/templates/trust-private-ca-on-all-nodes/psp-clusterrole.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.privateCaCertsAddToHost.enabled }}
 {{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,4 +13,5 @@ rules:
   - {{ .Release.Name }}-private-ca
   verbs:
   - use
+{{- end -}}
 {{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp-clusterrole.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp-clusterrole.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.global.pspEnabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-psp-private-ca
+rules:
+- apiGroups:
+  - policy
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - {{ .Release.Name }}-private-ca
+  verbs:
+  - use
+{{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp-rolebinding.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp-rolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.global.pspEnabled }}
+################################
+## PSP RoleBinding
+#################################
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-psp-private-ca
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-psp-private-ca
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-private-ca
+{{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp-rolebinding.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.privateCaCertsAddToHost.enabled }}
 {{- if .Values.global.pspEnabled }}
 ################################
 ## PSP RoleBinding
@@ -13,4 +14,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-private-ca
+{{- end -}}
 {{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.global.pspEnabled }}
+{{- if .Values.global.privateCaCertsAddToHost.enabled }}
 ################################
 ## Private CA PSP
 #################################
@@ -26,4 +27,5 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end -}}
 {{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.global.pspEnabled }}
+################################
+## Private CA PSP
+#################################
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ .Release.Name }}-private-ca
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  volumes:
+  - 'secret'
+  - 'emptyDir'
+  allowedHostPaths:
+    - pathPrefix: /etc/docker/certs.d
+  hostNetwork: true
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/psp.yaml
+++ b/templates/trust-private-ca-on-all-nodes/psp.yaml
@@ -14,8 +14,8 @@ spec:
   - 'secret'
   - 'emptyDir'
   allowedHostPaths:
-    - pathPrefix: /etc/docker/certs.d
-  hostNetwork: true
+    - pathPrefix: {{ .Vales.global.privateCaCertsAddToHost.hostDirectory }}
+  hostNetwork: false
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/templates/trust-private-ca-on-all-nodes/serviceaccount.yaml
+++ b/templates/trust-private-ca-on-all-nodes/serviceaccount.yaml
@@ -1,0 +1,13 @@
+################################
+## ServiceAccount
+#################################
+{{- if .Values.global.rbacEnabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-private-ca
+  labels:
+    tier: platform
+    component: private-ca
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/serviceaccount.yaml
+++ b/templates/trust-private-ca-on-all-nodes/serviceaccount.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.global.privateCaCertsAddToHost.enabled }}
+{{- if .Values.global.rbacEnabled }}
 ################################
 ## ServiceAccount
 #################################
-{{- if .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     tier: platform
     component: private-ca
     release: {{ .Release.Name }}
+{{- end -}}
 {{- end -}}

--- a/tests/private-ca-ds.yaml
+++ b/tests/private-ca-ds.yaml
@@ -1,0 +1,22 @@
+---
+suite: Test fluentd-daemonset
+templates:
+  - trust-private-ca-on-all-nodes/daemonset.yaml
+tests:
+  - it: should exist
+    set:
+      global:
+        privateCaCertsAddToHost:
+          enabled: True
+    asserts:
+      - isKind:
+          of: DaemonSet
+  - it: should not exist
+    set:
+      global:
+        privateCaCertsAddToHost:
+          enabled: False
+    asserts:
+      - not: true
+        isKind:
+          of: DaemonSet

--- a/tests/private-ca-ds.yaml
+++ b/tests/private-ca-ds.yaml
@@ -1,5 +1,5 @@
 ---
-suite: Test fluentd-daemonset
+suite: Test private-ca-daemonset
 templates:
   - trust-private-ca-on-all-nodes/daemonset.yaml
 tests:

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,15 @@ global:
 
   # List of secrets containing private CA certificates
   privateCaCerts: []
+  # Most users with private CA will already have their node
+  # images created including the cert to trust in the appropriate
+  # location. If not, it is necessary to configure Docker (or containerd)
+  # on all nodes to trust the private root CA. This will allow
+  # kubelet to pull from the Astronomer registry that has been signed
+  # by the same private CA.
+  privateCaCertsAddToHost:
+    enabled: false
+    hostDirectory: /etc/docker/certs.d
 
   # Use kube-lego
   acme: false


### PR DESCRIPTION
## Description

Private certificate authorities are used by enterprises to authenticate services and for TLS encryption in their networks. In addition, maintaining control of a root certificate authority trusted by all clients in an enterprise network allows enterprises to decrypt and inspect TLS traffic.

In most cases, enterprises will install this certificate into all their nodes. However, in other cases they may use default images for their kubernetes nodes. In this case, the Docker (or containerd) daemon must be configured to accept this certificate, such that image pulls from the Astronomer registry will work.

## 🧪  Testing

I have tested manually on AKS to make sure image pull works after "astro deploy" with a private cert. Complete manual steps are documented here: https://github.com/astronomer/labs/tree/master/astronomer-with-private-ca (work in progress on this doc, but mostly done - just need to update how to set the config newly defined in this PR).

Also, I have added a unit test that asserts this feature is conditionally enabled as expected.

## 📋 Checklist

- [x] The PR title is informative to the user experience
