### PR TITLE
Fix conditionally disabling subcharts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install ci tools
-          command: ./bin/install-ci-tools 1
-      - run:
           name: Package the Astronomer chart
-          command: make build
+          command: |
+            source ./bin/install-ci-tools 1
+            make build
       - persist_to_workspace:
           root: '.'
           paths:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -28,11 +28,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Install ci tools
-          command: ./bin/install-ci-tools 1
-      - run:
           name: Package the Astronomer chart
-          command: make build
+          command: |
+            source ./bin/install-ci-tools 1
+            make build
       - persist_to_workspace:
           root: '.'
           paths:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,10 +4,8 @@ version: 0.21.2
 appVersion: 0.21.2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
-
 keywords:
   - astronomer
-
 dependencies:
   # Platform components
   - name: astronomer
@@ -18,7 +16,6 @@ dependencies:
     condition: global.nginxEnabled
     tags:
       - platform
-
   # Monitoring stack
   - name: grafana
     condition: global.grafanaEnabled
@@ -48,7 +45,6 @@ dependencies:
     condition: global.blackboxExporterEnabled
     tags:
       - monitoring
-
   # Logging stack
   - name: elasticsearch
     condition: global.elasticsearchEnabled
@@ -62,32 +58,27 @@ dependencies:
     condition: global.fluentdEnabled
     tags:
       - logging
-
   # KubeD
   - name: kubed
     condition: global.kubedEnabled
     tags:
       - kubed
-
   # In-cluster DB, not recommended
   # for production
   - name: postgresql
     condition: global.postgresqlEnabled
     tags:
       - postgresql
-
   # Used to enable Celery autoscaling
   - name: keda
     condition: global.kedaEnabled
     tags:
       - keda
-
   # Nats-server
   - name: nats
     condition: global.nats.enabled
     tags:
       - nats
-
   # Nats-streaming
   - name: stan
     condition: global.stan.enabled

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -17,6 +17,15 @@ from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
 
+def test_default_disabled(kube_client):
+    pods = kube_client.list_namespaced_pod('astronomer')
+    default_disabled = ['keda', 'prometheus-postgres-exporter']
+    for pod in pods.items:
+        for feature in default_disabled:
+            if feature in pod.metadata.name:
+                raise Exception(f"Expected '{feature}' to be disabled")
+
+
 def test_prometheus_user(prometheus):
     """Ensure user is 'nobody'"""
     user = prometheus.check_output("whoami")


### PR DESCRIPTION

## Description

The build in CI was being performed with Helm 2, and that broke the Helm 3 conditional subchart logic. Instead, all subcharts were unconditionally enabled.

## 🧪  Testing

I added a functional test to protect against regression

- [x] The PR title is informative to the user experience
