### PR TITLE
Update to new helm stable repo

### DIFF
--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -46,7 +46,7 @@ else
 fi
 
 # Add stable helm repo
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 
 if [[ $FORCE -eq 0 && -f /tmp/bin/kubectl ]]; then
   echo "kubectl is already installed."


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>