### PR TITLE
Allow commander to create and delete volumes

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -57,7 +57,7 @@ rules:
   verbs: ["get"]
 - apiGroups: [""]
   resources: ["persistentvolumes"]
-  verbs: ["list", "watch"]
+  verbs: ["create", "delete", "get", "list", "watch"]
 - apiGroups: [""]
   resources: ["replicationcontrollers"]
   verbs: ["list", "watch"]


### PR DESCRIPTION
- This allows commander to create / delete persistent volumes for airflow deployments
- Necessary for PR https://github.com/astronomer/airflow-chart/pull/127
- Related to issue https://github.com/astronomer/issues/issues/1954