### PR TITLE
More compatibility for Astronomer logging

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -34,6 +34,13 @@ data:
           format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
           time_format %Y-%m-%dT%H:%M:%S.%NZ
         </pattern>
+         # Example log we are parsing
+         # 2020-11-11T19:22:45.526814634+00:00 stdout F 10.130.4.1 - - [11/Nov/2020:19:22:45 +0000] "GET /meteoroidal-kiloparsec-2912/airflow/health HTTP/1.1" 200 187 "-" "kube-probe/1.17+"
+         <pattern>
+           format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+           # https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime
+           time_format %Y-%m-%dT%H:%M:%S.%N+%z
+         </pattern>
       </parse>
       tag raw.kubernetes.*
       read_from_head true


### PR DESCRIPTION
## Description

I found that Airflow, when logging not in json mode, logs timestamps in a different format than is specified in our config file. We would not notice this error because most users (including our clouds) use json logging format for Airflow logs.

I think this pattern is not in the version of airflow I am using, 1.10.7:
```
%Y-%m-%dT%H:%M:%S.%NZ
```
This pattern is working:
```
%Y-%m-%dT%H:%M:%S.%N+%z
```
Example log line, copied from fluentd pod filesystem
```
 2020-11-11T19:22:45.526814634+00:00 stdout F 10.130.4.1 - - [11/Nov/2020:19:22:45 +0000] "GET /meteoroidal-kiloparsec-2912/airflow/health HTTP/1.1" 200 187 "-" "kube-probe/1.17+"
```

## 🎟 Issue(s)

Not related to any particular issue, but discovered during openshift work

## 🧪  Testing

This change adds an additional pattern match for fluentd parsing of logs, leaving all existing patterns in place. The risk is that it is a misconfiguration and logging will not work at all. I think our normal testing covers the risk of this change.

## 📋 Checklist

- [x] The PR title is informative to the user experience
