### PR TITLE
Parse timestamps from non UTC times

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -39,7 +39,7 @@ data:
          <pattern>
            format /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
            # https://docs.ruby-lang.org/en/2.4.0/Time.html#method-c-strptime
-           time_format %Y-%m-%dT%H:%M:%S.%N+%z
+           time_format %Y-%m-%dT%H:%M:%S.%N%z
          </pattern>
       </parse>
       tag raw.kubernetes.*


### PR DESCRIPTION
## Description

I should not have included the plus sign in the recent change

```
2020-11-12T03:15:23.657380000++0530 Asia/Kolkata
2020-11-11T23:45:23.661661000++0200 Europe/Kiev
2020-11-11T21:45:23.666075000++0000 Europe/London
2020-11-11T16:45:23.670673000+-0500 US/Eastern
2020-11-11T15:45:23.675109000+-0600 US/Central
2020-11-11T13:45:23.678963000+-0800 US/Pacific
```
