### PR TITLE
Switch all docker images to point to quay in release-0.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:
@@ -17,7 +17,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:
@@ -26,7 +26,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:
@@ -24,7 +24,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: astronomerio/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.3
     steps:
       - checkout
       - run:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.16.12
-appVersion: 0.16.12
+version: 0.16.13
+appVersion: 0.16.13
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Astronomer is a commercial "Airflow as a Service" platform that runs on Kubernet
 ## Docker images
 
 Docker images for deploying and running Astronomer are currently available on
-[DockerHub](https://hub.docker.com/u/astronomerinc/).
+[Quay.io](https://quay.io/astronomer/)
 
 ## Documentation
 

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -4,7 +4,7 @@ This guide contains information about upgrading and downgrading between Astronom
 ## Astronomer v0.10.0
 With this release we modified how Houston's JWT signing certificate is generated and stored in Kubernetes secrets. A typical `helm upgrade` will lock Houston up, preventing the system from fully booting up. To avoid this, you can `helm delete --purge <relase-name>`, followed by a `helm install -n <release-name> -f my-config.yaml . --namespace <my-namespace>` The -n flag on the re-install, must match your old platform name. This ensures Houston re-associates with the correct database.
 
-Once the platform has been upgraded, the airflow webservers will become unavailable (although the scheduler and tasks are still running). To re-gain access, click the "Upgrade" button in the UI to upgrade the airflow deployment. Once the deployment has been upgraded, update the image name in your `Dockerfile` to be `FROM astronomerinc/ap-airflow:0.10.0-1.10.4` and deploy the update. You will need to do this for each airflow deployment.
+Once the platform has been upgraded, the airflow webservers will become unavailable (although the scheduler and tasks are still running). To re-gain access, click the "Upgrade" button in the UI to upgrade the airflow deployment. Once the deployment has been upgraded, update the image name in your `Dockerfile` to be `FROM quay.io/astronomer/ap-airflow:0.10.0-1.10.4` and deploy the update. You will need to do this for each airflow deployment.
 
 ## Astronomer v0.9.5
 With this release, we removed all individual oauth providers and replaced with a more generic OpenID Connect (OIDC) provider. As part of this upgrade the auth section of Houston's configuration has been slightly modified.

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -24,7 +24,7 @@ brew install jq
 
 Ensure that all your airflow deployments are running FROM this Docker image
 ```
-astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild
+quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild
 ```
 
 ## Kubernetes preparation
@@ -92,7 +92,7 @@ helm list | grep airflow
 - Note: above, the results that include "airflow" should all have the same version, and the version should be the [latest published airflow chart version](https://github.com/astronomer/airflow-chart/releases), not including alpha releases or release candidates (.alpha or .rc).
 - Check that all pods are running in the Airflow namespaces. If the scheduler is crashlooping with the liveness probe failing because 'airflow.jobs' module is missing, it's because you need to update Airflow Dockerfile to version
 ```
-FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild
+FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild
 ```
 - Tasks should resume normal success rate within a few minutes
 - Check that you can deploy changes to Airflow, and check that the chart version remains the same after deploying an update to an Airflow (helm list | grep airflow)

--- a/bin/migration-scripts/upgrade.sh
+++ b/bin/migration-scripts/upgrade.sh
@@ -271,7 +271,7 @@ function main {
   echo "curl -sSL https://install.astronomer.io | sudo bash -s -- v0.12.0"
   echo ""
   echo "Please Upgrade your Airflow version by changing your Dockerfile:"
-  echo "FROM astronomerinc/ap-airflow:1.10.7-alpine3.10-onbuild"
+  echo "FROM quay.io/astronomer/ap-airflow:1.10.7-alpine3.10-onbuild"
 }
 
 main $1 $2

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -8,7 +8,7 @@ tolerations: []
 
 images:
   alertmanager:
-    repository: astronomerinc/ap-alertmanager
+    repository: quay.io/astronomer/ap-alertmanager
     tag: 0.20.0
     pullPolicy: IfNotPresent
 

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.16.12
+version: 0.16.13
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -320,7 +320,7 @@ data:
           tolerations: []
 
         # This is here for upgrading to 0.11.0+ of Airflow.
-        defaultAirflowRepository: astronomerinc/ap-airflow
+        defaultAirflowRepository: quay.io/astronomer/ap-airflow
 
         # This is here for upgrading to 0.11.1+ of Airflow.
         data:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -14,35 +14,35 @@ tolerations: []
 # Images for Astronomer
 images:
   commander:
-    repository: astronomerinc/ap-commander
+    repository: quay.io/astronomer/ap-commander
     tag: 0.16.0
     pullPolicy: IfNotPresent
   registry:
-    repository: astronomerinc/ap-registry
+    repository: quay.io/astronomer/ap-registry
     tag: 3.11.5-4
     pullPolicy: IfNotPresent
   houston:
-    repository: astronomerinc/ap-houston-api
+    repository: quay.io/astronomer/ap-houston-api
     tag: 0.16.16
     pullPolicy: IfNotPresent
   astroUI:
-    repository: astronomerinc/ap-astro-ui
+    repository: quay.io/astronomer/ap-astro-ui
     tag: 0.16.8
     pullPolicy: IfNotPresent
   dbBootstrapper:
-    repository: astronomerinc/ap-db-bootstrapper
+    repository: quay.io/astronomer/ap-db-bootstrapper
     tag: 0.13.2
     pullPolicy: IfNotPresent
   cliInstall:
-    repository: astronomerinc/ap-cli-install
+    repository: quay.io/astronomer/ap-cli-install
     tag: 0.13.1
     pullPolicy: IfNotPresent
   prisma:
-    repository: astronomerinc/ap-prisma
+    repository: quay.io/astronomer/ap-prisma
     tag: 1.34.8
     pullPolicy: IfNotPresent
   e2eTest:
-    repository: astronomerinc/ap-e2e-test
+    repository: quay.io/astronomer/ap-e2e-test
     tag: 0.0.7
     pullPolicy: IfNotPresent
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -4,23 +4,23 @@ tolerations: []
 
 images:
   es:
-    repository: astronomerinc/ap-elasticsearch
+    repository: quay.io/astronomer/ap-elasticsearch
     tag: 7.7.1
     pullPolicy: IfNotPresent
   init:
-    repository: astronomerinc/ap-base
+    repository: quay.io/astronomer/ap-base
     tag: 3.11.5-3
     pullPolicy: IfNotPresent
   curator:
-    repository: astronomerinc/ap-curator
+    repository: quay.io/astronomer/ap-curator
     tag: 3.11.5-4
     pullPolicy: IfNotPresent
   exporter:
-    repository: astronomerinc/ap-elasticsearch-exporter
+    repository: quay.io/astronomer/ap-elasticsearch-exporter
     tag: 1.1.0
     pullPolicy: IfNotPresent
   nginx:
-    repository: astronomerinc/ap-nginx-es
+    repository: quay.io/astronomer/ap-nginx-es
     tag: 3.11.5-3
     pullPolicy: IfNotPresent
 

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -4,7 +4,7 @@ tolerations: []
 
 images:
   fluentd:
-    repository: astronomerinc/ap-fluentd
+    repository: quay.io/astronomer/ap-fluentd
     tag: 1.9.2-r1
     pullPolicy: IfNotPresent
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -8,11 +8,11 @@ tolerations: []
 
 images:
   grafana:
-    repository: astronomerinc/ap-grafana
+    repository: quay.io/astronomer/ap-grafana
     tag: "7.0.1-r1"
     pullPolicy: IfNotPresent
   dbBootstrapper:
-    repository: astronomerinc/ap-db-bootstrapper
+    repository: quay.io/astronomer/ap-db-bootstrapper
     tag: 0.13.2
     pullPolicy: IfNotPresent
 

--- a/charts/keda/values.yaml
+++ b/charts/keda/values.yaml
@@ -3,8 +3,8 @@ enabled: true
 keda:
   image:
     # Enable KEDA POC in cloud
-    keda: "astronomerinc/ap-keda:1.3.0"
-    metricsAdapter: "astronomerinc/ap-keda-metrics-adapter:1.3.0"
+    keda: "quay.io/astronomer/ap-keda:1.3.0"
+    metricsAdapter: "quay.io/astronomer/ap-keda-metrics-adapter:1.3.0"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -4,7 +4,7 @@ tolerations: []
 
 images:
   kibana:
-    repository: astronomerinc/ap-kibana
+    repository: quay.io/astronomer/ap-kibana
     tag: 7.7.1
     pullPolicy: IfNotPresent
 

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -8,7 +8,7 @@ tolerations: []
 
 images:
   kubeState:
-    repository: astronomerinc/ap-kube-state
+    repository: quay.io/astronomer/ap-kube-state
     tag: 1.7.2
     pullPolicy: IfNotPresent
 

--- a/charts/kubed/values.yaml
+++ b/charts/kubed/values.yaml
@@ -4,7 +4,7 @@
 
 images:
   kubed:
-    repository: astronomerinc/ap-kubed
+    repository: quay.io/astronomer/ap-kubed
     tag: 0.12.0-rc.2
     pullPolicy: IfNotPresent
 

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -8,11 +8,11 @@ tolerations: []
 
 images:
   nginx:
-    repository: astronomerinc/ap-nginx
+    repository: quay.io/astronomer/ap-nginx
     tag: 0.30.0
     pullPolicy: IfNotPresent
   defaultBackend:
-    repository: astronomerinc/ap-default-backend
+    repository: quay.io/astronomer/ap-default-backend
     tag: 0.16.1
     pullPolicy: IfNotPresent
 

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
   type: RollingUpdate
 
 image:
-  repository: astronomerinc/ap-blackbox-exporter
+  repository: quay.io/astronomer/ap-blackbox-exporter
   tag: 0.16.0
   pullPolicy: IfNotPresent
 

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -8,7 +8,7 @@
 replicaCount: 2
 
 image:
-  repository: astronomerinc/ap-postgres-exporter
+  repository: quay.io/astronomer/ap-postgres-exporter
   tag: 0.8.0
   pullPolicy: IfNotPresent
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -17,11 +17,11 @@ replicas: 1
 
 images:
   init:
-    repository: astronomerinc/ap-base
+    repository: quay.io/astronomer/ap-base
     tag: 3.11.5-3
     pullPolicy: IfNotPresent
   prometheus:
-    repository: astronomerinc/ap-prometheus
+    repository: quay.io/astronomer/ap-prometheus
     tag: 2.17.1
     pullPolicy: IfNotPresent
 

--- a/configs/dev.yaml
+++ b/configs/dev.yaml
@@ -7,31 +7,31 @@
 astronomer:
   images:
     commander:
-      repository: astronomerinc/ap-commander
+      repository: quay.io/astronomer/ap-commander
       tag: dev
       pullPolicy: Always
     registry:
-      repository: astronomerinc/ap-registry
+      repository: quay.io/astronomer/ap-registry
       tag: master
       pullPolicy: Always
     houston:
-      repository: astronomerinc/ap-houston-api
+      repository: quay.io/astronomer/ap-houston-api
       tag: dev
       pullPolicy: Always
     astroUI:
-      repository: astronomerinc/ap-astro-ui
-      tag: dev
+      repository: quay.io/astronomer/ap-astro-ui
+      tag: master
       pullPolicy: Always
     dbBootstrapper:
-      repository: astronomerinc/ap-db-bootstrapper
+      repository: quay.io/astronomer/ap-db-bootstrapper
       tag: master
       pullPolicy: Always
     cliInstall:
-      repository: astronomerinc/ap-cli-install
+      repository: quay.io/astronomer/ap-cli-install
       tag: master
       pullPolicy: Always
     prisma:
-      repository: astronomerinc/ap-prisma
+      repository: quay.io/astronomer/ap-prisma
       tag: master
       pullPolicy: Always
 
@@ -42,11 +42,11 @@ astronomer:
 nginx:
   images:
     nginx:
-      repository: astronomerinc/ap-nginx
+      repository: quay.io/astronomer/ap-nginx
       tag: master
       pullPolicy: Always
     defaultBackend:
-      repository: astronomerinc/ap-default-backend
+      repository: quay.io/astronomer/ap-default-backend
       tag: master
       pullPolicy: Always
 
@@ -57,11 +57,11 @@ nginx:
 grafana:
   images:
     grafana:
-      repository: astronomerinc/ap-grafana
+      repository: quay.io/astronomer/ap-grafana
       tag: master
       pullPolicy: Always
     dbBootstrapper:
-      repository: astronomerinc/ap-db-bootstrapper
+      repository: quay.io/astronomer/ap-db-bootstrapper
       tag: master
       pullPolicy: IfNotPresent
 
@@ -72,7 +72,7 @@ grafana:
 kibana:
   images:
     kibana:
-      repository: astronomerinc/ap-kibana
+      repository: quay.io/astronomer/ap-kibana
       tag: master
       pullPolicy: Always
 
@@ -83,23 +83,23 @@ kibana:
 elasticsearch:
   images:
     es:
-      repository: astronomerinc/ap-elasticsearch
+      repository: quay.io/astronomer/ap-elasticsearch
       tag: master
       pullPolicy: Always
     init:
-      repository: astronomerinc/ap-base
+      repository: quay.io/astronomer/ap-base
       tag: master
       pullPolicy: Always
     curator:
-      repository: astronomerinc/ap-curator
+      repository: quay.io/astronomer/ap-curator
       tag: master
       pullPolicy: Always
     exporter:
-      repository: astronomerinc/ap-elasticsearch-exporter
+      repository: quay.io/astronomer/ap-elasticsearch-exporter
       tag: master
       pullPolicy: Always
     nginx:
-      repository: astronomerinc/ap-nginx-es
+      repository: quay.io/astronomer/ap-nginx-es
       tag: master
       pullPolicy: Always
 
@@ -110,7 +110,7 @@ elasticsearch:
 fluentd:
   images:
     fluentd:
-      repository: astronomerinc/ap-fluentd
+      repository: quay.io/astronomer/ap-fluentd
       tag: master
       pullPolicy: Always
 
@@ -121,7 +121,7 @@ fluentd:
 kube-state:
   images:
     kubeState:
-      repository: astronomerinc/ap-kube-state
+      repository: quay.io/astronomer/ap-kube-state
       tag: master
       pullPolicy: Always
 
@@ -132,7 +132,7 @@ kube-state:
 kubed:
   images:
     kubed:
-      repository: astronomerinc/ap-kubed
+      repository: quay.io/astronomer/ap-kubed
       tag: master
       pullPolicy: Always
 
@@ -143,11 +143,11 @@ kubed:
 prometheus:
   images:
     init:
-      repository: astronomerinc/ap-base
+      repository: quay.io/astronomer/ap-base
       tag: master
       pullPolicy: Always
     prometheus:
-      repository: astronomerinc/ap-prometheus
+      repository: quay.io/astronomer/ap-prometheus
       tag: master
       pullPolicy: Always
 
@@ -158,7 +158,7 @@ prometheus:
 alertmanager:
   images:
     alertmanager:
-      repository: astronomerinc/ap-alertmanager
+      repository: quay.io/astronomer/ap-alertmanager
       tag: master
       pullPolicy: IfNotPresent
 

--- a/configs/master.yaml
+++ b/configs/master.yaml
@@ -7,31 +7,31 @@
 astronomer:
   images:
     commander:
-      repository: astronomerinc/ap-commander
+      repository: quay.io/astronomer/ap-commander
       tag: master
       pullPolicy: Always
     registry:
-      repository: astronomerinc/ap-registry
+      repository: quay.io/astronomer/ap-registry
       tag: master
       pullPolicy: Always
     houston:
-      repository: astronomerinc/ap-houston-api
+      repository: quay.io/astronomer/ap-houston-api
       tag: master
       pullPolicy: Always
     astroUI:
-      repository: astronomerinc/ap-astro-ui
+      repository: quay.io/astronomer/ap-astro-ui
       tag: master
       pullPolicy: Always
     dbBootstrapper:
-      repository: astronomerinc/ap-db-bootstrapper
+      repository: quay.io/astronomer/ap-db-bootstrapper
       tag: master
       pullPolicy: Always
     cliInstall:
-      repository: astronomerinc/ap-cli-install
+      repository: quay.io/astronomer/ap-cli-install
       tag: master
       pullPolicy: Always
     prisma:
-      repository: astronomerinc/ap-prisma
+      repository: quay.io/astronomer/ap-prisma
       tag: master
       pullPolicy: Always
 
@@ -42,11 +42,11 @@ astronomer:
 nginx:
   images:
     nginx:
-      repository: astronomerinc/ap-nginx
+      repository: quay.io/astronomer/ap-nginx
       tag: master
       pullPolicy: Always
     defaultBackend:
-      repository: astronomerinc/ap-default-backend
+      repository: quay.io/astronomer/ap-default-backend
       tag: master
       pullPolicy: Always
 
@@ -57,11 +57,11 @@ nginx:
 grafana:
   images:
     grafana:
-      repository: astronomerinc/ap-grafana
+      repository: quay.io/astronomer/ap-grafana
       tag: master
       pullPolicy: Always
     dbBootstrapper:
-      repository: astronomerinc/ap-db-bootstrapper
+      repository: quay.io/astronomer/ap-db-bootstrapper
       tag: master
       pullPolicy: IfNotPresent
 
@@ -72,7 +72,7 @@ grafana:
 kibana:
   images:
     kibana:
-      repository: astronomerinc/ap-kibana
+      repository: quay.io/astronomer/ap-kibana
       tag: master
       pullPolicy: Always
 
@@ -83,23 +83,23 @@ kibana:
 elasticsearch:
   images:
     es:
-      repository: astronomerinc/ap-elasticsearch
+      repository: quay.io/astronomer/ap-elasticsearch
       tag: master
       pullPolicy: Always
     init:
-      repository: astronomerinc/ap-base
+      repository: quay.io/astronomer/ap-base
       tag: master
       pullPolicy: Always
     curator:
-      repository: astronomerinc/ap-curator
+      repository: quay.io/astronomer/ap-curator
       tag: master
       pullPolicy: Always
     exporter:
-      repository: astronomerinc/ap-elasticsearch-exporter
+      repository: quay.io/astronomer/ap-elasticsearch-exporter
       tag: master
       pullPolicy: Always
     nginx:
-      repository: astronomerinc/ap-nginx-es
+      repository: quay.io/astronomer/ap-nginx-es
       tag: master
       pullPolicy: Always
 
@@ -110,7 +110,7 @@ elasticsearch:
 fluentd:
   images:
     fluentd:
-      repository: astronomerinc/ap-fluentd
+      repository: quay.io/astronomer/ap-fluentd
       tag: master
       pullPolicy: Always
 
@@ -121,7 +121,7 @@ fluentd:
 kube-state:
   images:
     kubeState:
-      repository: astronomerinc/ap-kube-state
+      repository: quay.io/astronomer/ap-kube-state
       tag: master
       pullPolicy: Always
 
@@ -132,7 +132,7 @@ kube-state:
 kubed:
   images:
     kubed:
-      repository: astronomerinc/ap-kubed
+      repository: quay.io/astronomer/ap-kubed
       tag: master
       pullPolicy: Always
 
@@ -143,11 +143,11 @@ kubed:
 prometheus:
   images:
     init:
-      repository: astronomerinc/ap-base
+      repository: quay.io/astronomer/ap-base
       tag: master
       pullPolicy: Always
     prometheus:
-      repository: astronomerinc/ap-prometheus
+      repository: quay.io/astronomer/ap-prometheus
       tag: master
       pullPolicy: Always
 
@@ -158,6 +158,6 @@ prometheus:
 alertmanager:
   images:
     alertmanager:
-      repository: astronomerinc/ap-alertmanager
+      repository: quay.io/astronomer/ap-alertmanager
       tag: master
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Description

Switch all docker image references to point to quay.io in release-0.16 branch.

These changes should only be merged to 0.16 and not cherry-picked back to master because they are irrelevant. master already has these changes, but the diff was so large I couldn't just cherry-pick.

## 🎟 Issue(s)

Related to astronomer/issues#1355

Closes astronomer/issues#2181

## 🧪  Testing

I manually checked that all updated images exist via:

```sh
git diff --staged  |
grep -E 'repository.*quay|tag' |
awk '{print $NF}' |
sed 's/"//g' |
paste -s -d ':\n' - |
xargs -n1 docker manifest inspect > /dev/null
```

All images that did not exist were migrated via:

```sh
pull_tag_push() {
  for image in "$@" ; do
    new_image="${image}"
    new_image="${new_image/astronomerinc/quay.io\/astronomer}";
    new_image="${new_image/astronomerio/quay.io\/astronomer}";
    echo "Old image is: ${image}"
    echo "New image is: ${new_image}"
    DOCKER_CLI_EXPERIMENTAL=enabled docker manifest inspect "${new_image}" >/dev/null && continue
    docker pull "$image";
    docker tag "$image" "${new_image}";
    docker push "${new_image}";
  done;
}
```

The `ap-astro-ui:dev` tag was missing in the source, so I updated this reference in configs/dev.yaml to be `ap-astro-ui:master`