### PR TITLE
Fix this reference that does not exist

### DIFF
--- a/configs/dev.yaml
+++ b/configs/dev.yaml
@@ -20,7 +20,7 @@ astronomer:
       pullPolicy: Always
     astroUI:
       repository: quay.io/astronomer/ap-astro-ui
-      tag: dev
+      tag: master
       pullPolicy: Always
     dbBootstrapper:
       repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Update ap-astro-ui tag with one that exists. I found this broken reference while validating changes for release-0.16. The `dev` tag does not exist in docker hub or quay.