### PR TITLE
Add edgeEnabled flag to top level

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,9 @@ global:
   # Single namespace mode
   singleNamespace: false
 
+  # Enables the deployment of Astronomer Core Edge (astronomer/core:edge)
+  edgeEnabled: false
+
   # Enables necessary components for compatibility with Istio Service Mesh
   istio:
     enabled: false


### PR DESCRIPTION
Adds a top level flag to designate that the Astronomer deployment allows Astronomer Core Edge deployments. 

re: [Astronomer Core Action Plan](https://www.notion.so/astronomerio/Astronomer-Core-Action-Plan-fea56f20e06c44138ddb54d9fd230de6) and https://github.com/astronomer/issues/issues/1742