### PR TITLE
Removed 24 hour storage space filling up warning.

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -441,25 +441,6 @@ data:
           annotations:
             description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
               has only {{`{{ printf "%.2f" $value }}`}}% available space left and is filling
-              up.
-            runbook_url:
-            summary: Filesystem is predicted to run out of space within the next 24 hours.
-          expr: |
-            (
-              node_filesystem_avail_bytes{job="node-exporter",fstype!=""} / node_filesystem_size_bytes{job="node-exporter",fstype!=""} * 100 < 40
-            and
-              predict_linear(node_filesystem_avail_bytes{job="node-exporter",fstype!=""}[6h], 24*60*60) < 0
-            and
-              node_filesystem_readonly{job="node-exporter",fstype!=""} == 0
-            )
-          for: 1h
-          labels:
-            severity: warning
-            tier: platform
-        - alert: NodeFilesystemSpaceFillingUp
-          annotations:
-            description: Filesystem on {{`{{ $labels.device }}`}} at {{`{{ $labels.instance }}`}}
-              has only {{`{{ printf "%.2f" $value }}`}}% available space left and is filling
               up fast.
             runbook_url:
             summary: Filesystem is predicted to run out of space within the next 4 hours.


### PR DESCRIPTION

## Description
We currently already have a 4 hour high alert, and a 5% remaining critical. The 24 hour warning to slack creates too much noise.


## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/2215

