### PR TITLE
Add release-0.23 to publicly releasable branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)/'
+                - '/release-0\.(12|13|14|15|16|23)/'
 
       - release-to-public:
           requires:
@@ -192,7 +192,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16)/'
+                - '/release-0\.(12|13|14|15|16|23)/'
 
 commands:
   helm-install:


### PR DESCRIPTION
# Description

Only LTS release branches are able to be approved for public release. This adds release-0.23 to that list.