### PR TITLE
Add logs for Houston Worker messages

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.23.0
+    tag: 0.23.1
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Adding logs into Houston Workers NATS messages

## 🎟 Issue(s)

Resolves astronomer/issues#2267

## 🧪  Testing

View the Houston Worker logs and notice the full messages for deployments being logged.

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
