### PR TITLE
Fix the Houston Worker Queries

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.23.1
+    tag: 0.23.2
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

The Houston Worker queries have a bug where the query and application code does not filter out deletedAt deployments from the NATS Message.  Normally this isn't a problem, but there is a race condition that we found while doing automated and rapid testing where we quickly create and delete deployments.  The NATS message can get into a bad state in this case and continue to resend messages that are unacknowledged.

## 🎟 Issue(s)

Resolves astronomer/issues#2267

## 🧪  Testing

Confirm that the volume of messages for NATS on dev decreases.

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
