### PR TITLE
update prometheus ephemeral storage alert threshold

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -72,16 +72,16 @@ data:
             description: {{ printf "%q" "{{ $labels.release }} has been using over 95% of its pod quota for over 10 minutes." }}
 
         - alert: AirflowEphemeralStorageLimit
-          expr: (container_fs_usage_bytes{pod_name=~".*(scheduler|webserver|worker).*"}) >= 1800000000
-          for: 5m
+          expr: (container_fs_usage_bytes{pod_name=~".*(scheduler|webserver|worker).*"}) >= 5000000000
+          for: 10m
           labels:
             tier: airflow
             component: {{ printf "%q" "{{ $labels.component_name }}" }}
             workspace: {{ printf "%q" "{{ $labels.workspace }}" }}
             deployment: {{ printf "%q" "{{ $labels.deployment }}" }}
           annotations:
-            summary: {{ printf "%q" "{{ $labels.deployment }} {{ $labels.component_name }} is near its ephemeral storage limit" }}
-            description: {{ printf "%q" "{{ $labels.deployment }} {{ $labels.component_name }} has been using 90% of its ephemeral storage for over 5 minutes." }}
+            summary: {{ printf "%q" "{{ $labels.deployment }} {{ $labels.component_name }} is experiencing high ephemeral storage usage" }}
+            description: {{ printf "%q" "{{ $labels.deployment }} {{ $labels.component_name }} has been using >=5GB of its ephemeral storage for over 10 minutes." }}
 
         - alert: AirflowTasksPendingIncreasing
           expr: (max_over_time(airflow_scheduler_tasks_pending[5m]) - max_over_time(airflow_scheduler_tasks_pending[5m] offset 5m)) > 0


### PR DESCRIPTION
## Description

increasing the ephemeral storage alert to "5gb for 10 minutes"

this isn't a perfect threshold, but it's better than the legacy values we have currently. i'll be working to find a way to alert based on percentage rather than a hardcoded value. 


## 📋 Checklist

- [x] The PR title is informative to the user experience
