### PR TITLE
Test disappearing secret

### DIFF
--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -21,7 +21,7 @@ def create_kube_client(in_cluster=False):
         config.load_kube_config()
     return client.CoreV1Api()
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def nginx(request):
     """ This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
@@ -42,7 +42,7 @@ def nginx(request):
     pod = pods[0]
     yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=nginx&namespace={namespace}')
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def houston_api(request):
     """ This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
@@ -63,8 +63,7 @@ def houston_api(request):
     pod = pods[0]
     yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=houston&namespace={namespace}')
 
-# Create a test fixture for the prometheus pod
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='function')
 def prometheus(request):
     """ This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -13,6 +13,7 @@ import os
 import docker
 import time
 import yaml
+import testinfra
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
@@ -166,3 +167,44 @@ def test_prometheus_config_reloader_works(prometheus, kube_client):
     assert (
         y_parsed["global"]["scrape_interval"] != "30s"
     ), f"Expected the prometheus config file to change"
+
+
+def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart(houston_api, kube_client):
+    """
+    Test when helm upgrade occurs without Houston pods restarting that a
+    Houston container restart will not miss the Houston connection backend secret
+
+    Regression test for: https://github.com/astronomer/issues/issues/2251
+    """
+    helm_chart_path = os.environ.get("HELM_CHART_PATH")
+    if not helm_chart_path:
+        raise Exception("This test only works with HELM_CHART_PATH set to the path of the chart to be tested")
+    namespace = os.environ.get('NAMESPACE')
+    release_name = os.environ.get('RELEASE_NAME')
+    if not namespace:
+        print("NAMESPACE env var is not present, using 'astronomer' namespace")
+        namespace = 'astronomer'
+    if not release_name:
+        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
+        release_name = 'astronomer'
+    # attempt downgrade with the documented procedure
+    print("Performing a Helm upgrade without hooks twice:\n")
+    command = \
+        "helm3 upgrade --reuse-values " + \
+        "--no-hooks " + \
+        f"-n {namespace} " + \
+        f"{release_name} " + \
+        helm_chart_path
+    print(command)
+    print(check_output(command, shell=True))
+    # Run the command twice to ensure the most
+    # recent change is a no-operation change
+    print(check_output(command, shell=True))
+    print("")
+    # Kill houston in this pod so the container restarts
+    houston_api.check_output("kill 1")
+    # give time for container to restart
+    time.sleep(2)
+    result = houston_api.check_output("env | grep DATABASE_URL")
+    # check that the connection is not reset
+    assert "postgres" in result


### PR DESCRIPTION
This PR is into @andriisoldatenko 's branch where he is working on this issue: https://github.com/astronomer/issues/issues/2251

These commits include a test that reproduces an error under the following conditions:

- helm upgrade such that no houston pods are restarted (by using --no-hooks). This will clear out the connection secret with the current issue with helm upgrade clearing the 'connection' key in the release_name-houston-backend secret.
- delete houston container so that it restarts, it will start crashlooping because the connection secret is missing.

This test fails with error 'container not found' because the pod is crashlooping due to the secret missing. So, this test is reproducing the issue.

This test shows that using the init container for initializing the secret is not sufficient because the connection secret being cleared out at any time leads to houston failing if the container restarts for some reason.

Adding this test at @tommyk suggestion, thank you Tommy!