### PR TITLE
Add AC 1.10.12-2 to list of supported images

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -193,6 +193,12 @@ data:
         - version: 1.10.12
           channel: stable
           tag: 1.10.12-1-buster-onbuild
+        - version: 1.10.12
+          channel: stable
+          tag: 1.10.12-2-alpine3.10-onbuild
+        - version: 1.10.12
+          channel: stable
+          tag: 1.10.12-2-buster-onbuild
 
       # Kubernetes labels to add on each airflow deployment namespace
       namespaceLabels:


### PR DESCRIPTION
This PR adds 1.10.12-2 support to 0.16 of the platform

https://github.com/astronomer/updates.astronomer.io/pull/29

Changelog:
https://github.com/astronomer/ap-airflow/blob/master/1.10.12/CHANGELOG.md#astronomer-certified-11012-2-2020-12-04