### PR TITLE
Add AC 1.10.7-16 & 1.10.10-6 to list of supported images

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -151,6 +151,12 @@ data:
         - version: 1.10.7
           channel: stable
           tag: 1.10.7-15-buster-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-16-alpine3.10-onbuild
+        - version: 1.10.7
+          channel: stable
+          tag: 1.10.7-16-buster-onbuild
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-alpine3.10-onbuild
@@ -187,6 +193,12 @@ data:
         - version: 1.10.10
           channel: stable
           tag: 1.10.10-5-buster-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-6-alpine3.10-onbuild
+        - version: 1.10.10
+          channel: stable
+          tag: 1.10.10-6-buster-onbuild
         - version: 1.10.12
           channel: stable
           tag: 1.10.12-1-alpine3.10-onbuild


### PR DESCRIPTION
- https://github.com/astronomer/updates.astronomer.io/pull/30
- https://github.com/astronomer/ap-airflow/pull/178

Resolves https://github.com/astronomer/issues/issues/2394