### PR TITLE
bump houston-api and astro-ui

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,11 +23,11 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.23.8
+    tag: 0.23.9
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.23.2
+    tag: 0.23.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
resolves:
- Airflow2.0rc2: Astro Deploy does not load the DAGS defined by the user. and related issues:
https://github.com/astronomer/issues/issues/2380 
https://github.com/astronomer/issues/issues/2375 
https://github.com/astronomer/issues/issues/2379
and
Hofix: Deployment XYZ.resources defensive checks https://github.com/astronomer/astro-ui/pull/948