### PR TITLE
Modernize 16 ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:
@@ -17,7 +17,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:
@@ -26,7 +26,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,7 @@ jobs:
       - run:
           name: Release the Astronomer chart to internal
           command: |
-            set -e
-            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            set -xe
             pyenv global 3.8.5
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
@@ -64,8 +63,7 @@ jobs:
       - run:
           name: Release the Astronomer chart to prod
           command: |
-            set -e
-            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            set -xe
             pyenv global 3.8.5
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -47,8 +47,7 @@ jobs:
       - run:
           name: Release the Astronomer chart to internal
           command: |
-            set -e
-            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            set -xe
             pyenv global 3.8.5
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
@@ -62,8 +61,7 @@ jobs:
       - run:
           name: Release the Astronomer chart to prod
           command: |
-            set -e
-            sudo apt-get update && sudo apt-get install -y ca-certificates curl
+            set -xe
             pyenv global 3.8.5
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:
@@ -15,7 +15,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:
@@ -24,7 +24,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.1.5
     steps:
       - checkout
       - run:

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -46,7 +46,7 @@ else
 fi
 
 # Add stable helm repo
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 
 if [[ $FORCE -eq 0 && -f /tmp/bin/kubectl ]]; then
   echo "kubectl is already installed."


### PR DESCRIPTION
Modernize some CI aspects that need to be updated, but are not in sync with master. **This change should not be cherry-picked or merged to any other branch.**

- Use latest ap-build
- Do not install packages during CI runs (packages already existed in base image, plus this is a bad behavior)
- Replace deprecated and delete helm stable repo with merely deprecated one
- `set -x`