### PR TITLE
Bump airflow chart to 0.15.7

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 0.15.6
+airflowChartVersion: 0.15.7
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
Airflow chart 0.15.7 changes docker image source from docker hub to quay.io. Airflow chart 0.15 is what users of Astronomer 0.16 use, so this change should only be applied to the release-0.16 branch.

Related to astronomer/issues#1355