### PR TITLE
Allow registry to use workload identity

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -133,7 +133,9 @@
 {{- define "registry.gcsConfig" }}
 gcs:
   bucket: {{ .Values.registry.gcs.bucket }}
+  {{- if .Values.registry.gcs.useKeyfile }}
   keyfile: {{ .Values.registry.gcs.keyfile }}
+  {{- end }}
   rootdirectory: {{ .Values.registry.gcs.rootdirectory }}
   chunksize: {{ .Values.registry.gcs.chunksize }}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-serviceaccount.yaml
+++ b/charts/astronomer/templates/registry/registry-serviceaccount.yaml
@@ -1,0 +1,24 @@
+################################
+## Registry service account
+#################################
+#
+# I the case of using workload identity,
+# this service account can be mapped to a
+# cloud identity in order to grant access
+# to to a blob storage backend such as
+# S3 or GCS
+#
+{{- if .Values.global.rbacEnabled }}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-registry
+  {{- if .Values.registry.serviceAccount.annotations }}
+  annotations: {{ toYaml .Values.registry.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    component: registry
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+{{- end }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-configmap.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.global.rbacEnabled }}
+      serviceAccountName: {{ .Release.Name }}-registry
+      {{- end }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
@@ -62,7 +65,7 @@ spec:
               mountPath: /etc/docker/ssl
             - name: data
               mountPath: /var/lib/registry
-            {{- if .Values.registry.gcs.enabled }}
+            {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
             {{- include "registry.gcsVolumeMount" . | indent 12 }}
             {{- end }}
           ports:
@@ -94,7 +97,7 @@ spec:
         - name: certificate
           secret:
             secretName: {{ .Values.global.tlsSecret }}
-        {{- if .Values.registry.gcs.enabled }}
+        {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
         {{- include "registry.gcsVolume" . | indent 8 }}
         {{- end }}
   {{- if or (not .Values.registry.persistence.enabled) (.Values.registry.gcs.enabled) (.Values.registry.azure.enabled) (.Values.registry.s3.enabled)}}

--- a/charts/astronomer/tests/registry-serviceaccount_test.yaml
+++ b/charts/astronomer/tests/registry-serviceaccount_test.yaml
@@ -1,0 +1,16 @@
+suite: Test registry service account
+templates:
+- registry/registry-serviceaccount.yaml
+tests:
+- it: should be created on default configuration
+  asserts:
+    - isKind:
+        of: ServiceAccount
+- it: Adding annotations the the service account works
+  set:
+    registry.serviceAccount.annotations:
+      test-key: test-value
+  asserts:
+    - equal:
+        path: metadata.annotations.test-key
+        value: test-value

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -191,7 +191,7 @@ houston:
 
     # Default here is to run at midnight every night
     schedule: "0 0 * * *"
-  
+
   # this option allows to override airflow releases config
 
   #
@@ -252,6 +252,8 @@ commander:
 
 registry:
   replicas: 1
+  serviceAccount:
+    annotations: {}
   podLabels: {}
   resources: {}
   #  limits:
@@ -278,6 +280,7 @@ registry:
   gcs:
     enabled: false
     bucket: ~
+    useKeyfile: true
     keyfile: /var/gcs-keyfile/astronomer-gcs-keyfile
     rootdirectory: /
     chunksize: '5242880'


### PR DESCRIPTION


## Description

Create a service account for the registry so that the registry can be configured to access a cloud bucket using workload identity (mapping of cloud identity to k8s service account). Make the key file optional when using registry backed by a bucket.

## 🎟 Issue(s)

No issue, for a customer

## 🧪  Testing

Added helm unit tests

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [x] The PR title is informative to the user experience
