### PR TITLE
updated alert to use release name to drill into correct nodes. added …

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1029,7 +1029,7 @@ data:
             runbook_url:
             summary: Too many pods on '{{`{{ $labels.node }}`}}'
           expr: |
-            max(max(kubelet_running_pod_count{job="kubernetes-nodes"}) by(instance) * on(instance) group_left(node) kubelet_node_name{job="kubernetes-nodes"}) by(node) / max(kube_node_status_capacity_pods{job="{{.Release.Name}}-kube-state"}) by(node) > 0.95
+            count by(node) ( (kube_pod_status_phase{job="{{.Release.Name}}-kube-state",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="{{.Release.Name}}-kube-state"}) ) / max by(node) ( kube_node_status_capacity_pods{job="{{.Release.Name}}-kube-state"} != 1 ) > 0.95
           for: 15m
           labels:
             severity: warning

--- a/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
+++ b/charts/prometheus/tests/prometheus-alerts-configmap_test.yaml
@@ -44,3 +44,17 @@ tests:
       - matchRegex:
           path: data.alerts
           pattern: '.*If more than 2 Airflow Schedulers are not heartbeating for more than 5 minutes, this alarm fires..*'
+  - it: renders the release name correctly on KubeletTooManyPods alert
+    release:
+      name: mr-coolio
+    asserts:
+      - matchRegex:
+          path: data.alerts
+          pattern: '.*kube_node_status_capacity_pods{job="mr-coolio-kube-state"}.*'
+      - matchRegex:
+          path: data.alerts
+          pattern: '.*kube_pod_info{job="mr-coolio-kube-state"}.*'
+      - matchRegex:
+          path: data.alerts
+          pattern: '.*kube_pod_status_phase{job="mr-coolio-kube-state",.*'
+      


### PR DESCRIPTION
this is the change for an alert change to make it more accurate.  it was taken from `kubernetes-mixin` repo.  i have tested this in dev and the query works correctly from what i can tell...