### PR TITLE
Add flag to enable values unique to Azure 

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -85,6 +85,11 @@ data:
           # Disable creation of initial user.
           defaultUser:
             enabled: false
+    {{- if .Values.global.azure.enabled }}
+          livenessProbe:
+            failureThreshold: 25
+            periodSeconds: 10
+    {{- end }}
 
         # Worker configuration (applies to Celery and Kubernetes task pods).
         workers:

--- a/values.yaml
+++ b/values.yaml
@@ -77,6 +77,10 @@ global:
   # Enable security context constraints required for OpenShift
   sccEnabled: false
 
+  # Enable values required for use with Microsoft Azure
+  azure:
+    enabled: false
+
   # Set nodeSelector, affinity, and tolerations values for platform and deployment related pods.
   # This allows for separation of platform and airflow pods between kubernetes node pools.
   # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui, prisma,


### PR DESCRIPTION
## Description
- Add flag `.Values.global.azure.enabled` for toggling any values that may be unique to Azure.
- This is being implemented for webserver livenessProbe values required when using Azure and PostgreSQL Flexible Server.
  - Set the following values in houston config when enabled:
  ```
  deployments:
    helm:
      webserver:
        livenessProbe:
          failureThreshold: 25
          periodSeconds: 10
  ```
- This flag can be used for any other unique values that may be required in the future.

## 🎟 Issue(s)

- Related to https://github.com/astronomer/issues/issues/2417

## 🧪  Testing

Confirmed the values are passed through to the webserver deployment when enabled:
```
k get deployment -n astronomer-optical-cluster-6838 optical-cluster-6838-webserver -o yaml
...
        livenessProbe:
          failureThreshold: 25
          httpGet:
            path: /optical-cluster-6838/airflow/health
            port: 8080
            scheme: HTTP
          initialDelaySeconds: 15
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 30
        name: webserver
```

## 📋 Checklist

- [x] The PR title is informative to the user experience
