### PR TITLE
Update supported Airflow list after LTS upgrade

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
@@ -56,7 +56,7 @@ Ensure that you have the default namespace in your kubernetes context, not neces
 ## Run the Astronomer upgrade automation
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml
 ```
 
 Watch the logs of the upgrade pod, you can find pod name with:
@@ -84,7 +84,7 @@ If the upgrade has some issues and you need to recover, you can rollback to the 
 ## Apply the rollback automation
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
 ```
 
 ## Wait for platform to come back up

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -273,3 +273,7 @@
 - name: "Upgrade Astronomer: Helm upgrade (5/5) Turn off airflow auto upgrade configuration"
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer-internal/astronomer
+
+- name: Update supported Airflow versions list
+  shell: |
+    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-check airflow-update-check-first-run


### PR DESCRIPTION
## Description

This checks for Airflow updates after LTS 0.16 to LTS 0.23 upgrade
<!--
Describe the purpose of this pull request.
-->


## 🎟 Issue(s)

Resolves astronomer/issues#2428

## 🧪  Testing

The LTS upgrade automation has a smoke test where it ensures that the upgrader and rollback works. That protects against errors in the automation. To make sure that the automation does the expected thing, I captured these logs in my development environment:
```
 k logs -f airflow-update-check-first-run-n6hfj
Running update-ca-certificates
WARNING: ca-certificates.crt does not contain exactly one certificate or CRL: skipping
WARNING: ca-cert-registry.pem does not contain exactly one certificate or CRL: skipping
Waiting for host: astro-commander 50051
Received response from: astro-commander 50051
Waiting for host: astro-registry 5000
Received response from: astro-registry 5000
Waiting for host: astro-nats-0.astro-nats.default.svc 4222
Received response from: astro-nats-0.astro-nats.default.svc 4222
yarn run v1.22.4
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
$ prisma generate && babel-node src/scripts/check-platform-updates/index.js ' --url=https://updates.astronomer.io/astronomer-platform'

Prisma schema loaded from prisma/schema.prisma
info The preview flag "atomicNumberOperations" is not needed anymore, please remove it from your schema.prisma

✔ Generated Prisma Client (version: 2.10.1) to ./node_modules/@prisma/client in 210ms

You can now start using Prisma Client in your code:

```
import { PrismaClient } from '@prisma/client'
// or const { PrismaClient } = require('@prisma/client')

const prisma = new PrismaClient()
```

Explore the full API: http://pris.ly/d/client
info The preview flags `atomicNumberOperations` were removed, you can now safely remove them from your schema.prisma.
2021-01-06T22:22:30 INFO Starting update platform versions
2021-01-06T22:22:30 DEBUG Fetching platform updates from https://updates.astronomer.io/astronomer-platform
2021-01-06T22:22:30 INFO Checking possible new release version 0.11.1
2021-01-06T22:22:30 ERROR Argument releaseDate: Got invalid value '2020-01-31T00:00:00+00:00' on prisma.upsertOnePlatformRelease. Provided String, expected DateTime.
Argument releaseDate: Got invalid value '2020-01-31T00:00:00+00:00' on prisma.upsertOnePlatformRelease. Provided String, expected DateTime or DateTimeFieldUpdateOperationsInput:
type DateTimeFieldUpdateOperationsInput {
  set?: DateTime
}
type DateTimeFieldUpdateOperationsInput {
  set?: DateTime
}

Done in 3.17s.
```
<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [x] The PR title is informative to the user experience
