### PR TITLE
Change approval in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,10 @@ workflows:
             - platform-1-16-15
             - platform-1-17-11
             - platform-1-18-8
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - approve-lts-upgrader-release:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,10 +180,6 @@ workflows:
 
       - approve-internal-release:
           type: approval
-          requires:
-            - platform-1-16-15
-            - platform-1-17-11
-            - platform-1-18-8
           filters:
             branches:
               only:
@@ -192,6 +188,9 @@ workflows:
       - release-to-internal:
           requires:
             - approve-internal-release
+            - platform-1-16-15
+            - platform-1-17-11
+            - platform-1-18-8
 
       - approve-lts-upgrader-release:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -164,6 +164,10 @@ workflows:
             - approve-internal-release
 {%- for version in kube_versions %}
             - platform-{{ version | replace(".", "-") }}{% endfor %}
+          filters:
+            branches:
+              only:
+                - '/release-0\.\d+/'
 
       - approve-lts-upgrader-release:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -154,9 +154,6 @@ workflows:
 
       - approve-internal-release:
           type: approval
-          requires:
-{%- for version in kube_versions %}
-            - platform-{{ version | replace(".", "-") }}{% endfor %}
           filters:
             branches:
               only:
@@ -165,6 +162,8 @@ workflows:
       - release-to-internal:
           requires:
             - approve-internal-release
+{%- for version in kube_versions %}
+            - platform-{{ version | replace(".", "-") }}{% endfor %}
 
       - approve-lts-upgrader-release:
           type: approval


### PR DESCRIPTION
This small change allows you to approve the internal release without waiting for tests to pass, but the release still depends on the tests passing.