### PR TITLE
Make platform KEDA 2.0 compliant

### DIFF
--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -61,6 +61,7 @@ echo "Deploying Astronomer..."
 helm install -f "$CONFIG_FILE" \
   --namespace astronomer astronomer \
   --set global.postgresqlEnabled=true \
+  --set global.kedaEnabled=true \
   "$REPO_DIR"
 
 

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -61,7 +61,6 @@ echo "Deploying Astronomer..."
 helm install -f "$CONFIG_FILE" \
   --namespace astronomer astronomer \
   --set global.postgresqlEnabled=true \
-  --set global.kedaEnabled=true \
   "$REPO_DIR"
 
 

--- a/charts/keda/requirements.lock
+++ b/charts/keda/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: keda
   repository: https://kedacore.github.io/charts
-  version: 1.2.0
-digest: sha256:b52be8faa2b6b9f69a43b6b7eb6b5854d1e5ce0686c45bea3e380da5b36dc650
-generated: "2020-02-13T11:16:09.680773-08:00"
+  version: 2.0.1
+digest: sha256:dd8b084c9d9f79fb633a2852fe74b6f0ea7a19f7f672cd75b4dcb8165d4b9907
+generated: "2021-01-05T13:06:28.139805-08:00"

--- a/charts/keda/requirements.yaml
+++ b/charts/keda/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: keda
-  version: 1.2.0
+  version: 2.0.1
   repository: "@kedacore"
   condition: enabled

--- a/charts/keda/values.yaml
+++ b/charts/keda/values.yaml
@@ -3,8 +3,12 @@ enabled: true
 keda:
   image:
     # Enable KEDA POC in cloud
-    keda: "quay.io/astronomer/ap-keda:1.3.0"
-    metricsAdapter: "quay.io/astronomer/ap-keda-metrics-adapter:1.3.0"
+    keda:
+      repository: "quay.io/astronomer/ap-keda"
+      tag: "2.0.0"
+    metricsApiServer:
+      repository: "quay.io/astronomer/ap-keda-metrics-apiserver"
+      tag: "2.0.0"
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -21,6 +21,7 @@ global:
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls
+  kedaEnabled: true
   postgresqlEnabled: true
   nats:
     replicas: 1

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -21,7 +21,7 @@ global:
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls
-  kedaEnabled: true
+  kedaEnabled: false
   postgresqlEnabled: true
   nats:
     replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ global:
   blackboxExporterEnabled: false
 
   # Used to enable Celery autoscaling
-  kedaEnabled: true
+  kedaEnabled: false
 
   # Used to enable nats-server
   nats:

--- a/values.yaml
+++ b/values.yaml
@@ -45,7 +45,7 @@ global:
 
   # Enable default postgresql database.
   # This is not recommended for production.
-  postgresqlEnabled: false
+  postgresqlEnabled: true
 
   # Enables a node exporter DaemonSet for node-level metrics
   nodeExporterEnabled: true
@@ -56,7 +56,7 @@ global:
   blackboxExporterEnabled: false
 
   # Used to enable Celery autoscaling
-  kedaEnabled: false
+  kedaEnabled: true
 
   # Used to enable nats-server
   nats:

--- a/values.yaml
+++ b/values.yaml
@@ -45,7 +45,7 @@ global:
 
   # Enable default postgresql database.
   # This is not recommended for production.
-  postgresqlEnabled: true
+  postgresqlEnabled: false
 
   # Enables a node exporter DaemonSet for node-level metrics
   nodeExporterEnabled: true


### PR DESCRIPTION
Uses KEDA 2.0 chart and docker images. Requires this PR to be merged and
released before it will work

https://github.com/astronomer/airflow-chart/pull/183