### PR TITLE
Bump CI image to recommendation from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -75,7 +75,7 @@ jobs:
 
   release-to-public:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -91,7 +91,7 @@ jobs:
 
   platform-1-16-15:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.16.15
@@ -101,7 +101,7 @@ jobs:
 
   platform-1-17-11:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.17.11
@@ -111,7 +111,7 @@ jobs:
 
   platform-1-18-8:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.18.8
@@ -124,7 +124,7 @@ jobs:
 
   lts-upgrade-0-23-test:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.18.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,7 @@ workflows:
       - lts-upgrade-0-23-test:
           requires:
             - build-lts-upgrade
+            - release-to-internal
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -146,6 +146,7 @@ workflows:
       - lts-upgrade-0-23-test:
           requires:
             - build-lts-upgrade
+            - release-to-internal
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -58,7 +58,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -73,7 +73,7 @@ jobs:
 
   release-to-public:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -89,7 +89,7 @@ jobs:
 {% for version in kube_versions %}
   platform-{{ version | replace(".", "-") }}:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}
@@ -102,7 +102,7 @@ jobs:
 
   lts-upgrade-0-23-test:
     machine:
-      image: ubuntu-2004:202008-01
+      image: ubuntu-2004:202010-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}


### PR DESCRIPTION
- Bump CI image to recommendation from https://circleci.com/docs/2.0/executor-intro/
- Make lts-upgrade-0-23-test require release-to-internal, since it does.