### PR TITLE
Run the airflow updates check job instead of platform update check one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,14 +139,15 @@ workflows:
     jobs:
       - lint
       - unittest-charts
+
+      - approve-lts-upgrader-build:
+          type: approval
+
       - build-lts-upgrade:
           requires:
             - lint
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'lts-to-lts'
+            - approve-lts-upgrader-build
+
       - build-artifact:
           requires:
             - lint
@@ -173,11 +174,6 @@ workflows:
           requires:
             - build-lts-upgrade
             - release-to-internal
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'lts-to-lts'
 
       - approve-internal-release:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -117,14 +117,15 @@ workflows:
     jobs:
       - lint
       - unittest-charts
+
+      - approve-lts-upgrader-build:
+          type: approval
+
       - build-lts-upgrade:
           requires:
             - lint
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'lts-to-lts'
+            - approve-lts-upgrader-build
+
       - build-artifact:
           requires:
             - lint
@@ -147,11 +148,6 @@ workflows:
           requires:
             - build-lts-upgrade
             - release-to-internal
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'lts-to-lts'
 
       - approve-internal-release:
           type: approval

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -276,4 +276,4 @@
 
 - name: Update supported Airflow versions list
   shell: |
-    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-check airflow-update-check-first-run
+    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-airflow-update-check airflow-update-check-first-run

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -276,4 +276,4 @@
 
 - name: Update supported Airflow versions list
   shell: |
-    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-airflow-update-check airflow-update-check-first-run
+    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-airflow-check airflow-update-check-first-run


### PR DESCRIPTION
## Description

Even though the intention was to, we are currently not running the airflow-update-check job during the LTS-to-LTS upgrade. This fix will hopefully take care of that.

## 🎟 Issue(s)

Resolves astronomer/issues#2487


