### PR TITLE
LTS to LTS upgrade: update airflow versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,6 +199,7 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
+                - 'master'
                 - 'lts-to-lts'
 
       - approve-public-release:
@@ -221,6 +222,7 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
+                - 'master'
                 - 'lts-to-lts'
 
       - release-to-public:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -172,6 +172,7 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
+                - 'master'
                 - 'lts-to-lts'
 
       - approve-public-release:
@@ -194,6 +195,7 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
+                - 'master'
                 - 'lts-to-lts'
 
       - release-to-public:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -272,7 +272,7 @@
     kubectl delete job --namespace {{ namespace }} airflow-update-check-first-run || true
     sleep 30
     kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-airflow-check airflow-update-check-first-run
-    kubectl wait --for=condition=complete --timeout=300s --namespace {{ namespace }} airflow-update-check-first-run
+    kubectl wait --for=condition=complete --timeout=300s --namespace {{ namespace }} job/airflow-update-check-first-run
 
 - name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: |

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -266,7 +266,7 @@
     namespace: "{{ namespace }}"
   register: astronomer_houston_backend
 
-  - name: Update supported Airflow versions list (look for pod airflow-upgrade-check-first-run to appear after 30 seconds)
+- name: Update supported Airflow versions list (look for pod airflow-upgrade-check-first-run to appear after 30 seconds)
   shell: |
     set -xe
     kubectl delete job --namespace {{ namespace }} airflow-update-check-first-run || true

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -240,21 +240,21 @@
 
 # The db migration container waits on NATs, and for that, we need the new pods.
 # Also, there are new network security policies we need to apply before the db migration.
-- name: "Upgrade Astronomer: Helm upgrade (1/5) Update software in Astronomer"
+- name: "(1/6) Upgrade Astronomer: Helm upgrade - Update software in Astronomer. Watch for 'helm list' to show new version."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Run DB migration container
-- name: "Upgrade Astronomer: Helm upgrade (2/5) Run Astronomer DB migration"
+- name: "(2/6) Upgrade Astronomer: Helm upgrade - Run Astronomer DB migration. Watch for houston db migrations pod to exit in success."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Ensure Houston initializes after DB migration container runs
-- name: "Upgrade Astronomer: Helm upgrade (3/5) Initialize Astronomer Secrets"
+- name: "(3/6) Upgrade Astronomer: Helm upgrade - Initialize Astronomer Secrets. Watch for houston pods to become ready again."
   shell: |
     kubectl rollout restart --namespace {{ namespace }} deployments
 
-- name: Wait until the houston backend secret is updated
+- name: "Wait until the houston backend secret is updated (waiting on previous step to finish)"
   until: astronomer_houston_backend.resources[0].data.connection | length > 0
   retries: 48
   delay: 5
@@ -266,7 +266,7 @@
     namespace: "{{ namespace }}"
   register: astronomer_houston_backend
 
-- name: Update supported Airflow versions list (look for pod airflow-upgrade-check-first-run to appear after 30 seconds)
+- name: "(4/6) Update supported Airflow versions list. Look for pod airflow-upgrade-check-first-run to appear after 40 seconds then complete in success"
   shell: |
     set -xe
     kubectl delete job --namespace {{ namespace }} airflow-update-check-first-run || true
@@ -274,10 +274,10 @@
     kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-airflow-check airflow-update-check-first-run
     kubectl wait --for=condition=complete --timeout=300s --namespace {{ namespace }} airflow-update-check-first-run
 
-- name: "Upgrade Astronomer: Helm upgrade (4/5) Update Airflow configurations"
+- name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.airflowChartVersion={{ upgrade_to_version_airflow }} --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
-- name: "Upgrade Astronomer: Helm upgrade (5/5) Turn off airflow auto upgrade configuration"
+- name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -242,12 +242,12 @@
 # Also, there are new network security policies we need to apply before the db migration.
 - name: "Upgrade Astronomer: Helm upgrade (1/5) Update software in Astronomer"
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer-internal/astronomer
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Run DB migration container
 - name: "Upgrade Astronomer: Helm upgrade (2/5) Run Astronomer DB migration"
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer-internal/astronomer
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Ensure Houston initializes after DB migration container runs
 - name: "Upgrade Astronomer: Helm upgrade (3/5) Initialize Astronomer Secrets"
@@ -266,14 +266,18 @@
     namespace: "{{ namespace }}"
   register: astronomer_houston_backend
 
+  - name: Update supported Airflow versions list (look for pod airflow-upgrade-check-first-run to appear after 30 seconds)
+  shell: |
+    set -xe
+    kubectl delete job --namespace {{ namespace }} airflow-update-check-first-run || true
+    sleep 30
+    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-airflow-check airflow-update-check-first-run
+    kubectl wait --for=condition=complete --timeout=300s --namespace {{ namespace }} airflow-update-check-first-run
+
 - name: "Upgrade Astronomer: Helm upgrade (4/5) Update Airflow configurations"
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.airflowChartVersion={{ upgrade_to_version_airflow }} --version={{ upgrade_to_version }} {{ release_name }} astronomer-internal/astronomer
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.airflowChartVersion={{ upgrade_to_version_airflow }} --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 - name: "Upgrade Astronomer: Helm upgrade (5/5) Turn off airflow auto upgrade configuration"
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer-internal/astronomer
-
-- name: Update supported Airflow versions list
-  shell: |
-    kubectl create job --namespace {{ namespace }} --from=cronjob/{{ release_name }}-houston-update-airflow-check airflow-update-check-first-run
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

We need to check for new airflow versions before performing the Airflow chart upgrades.


## 🎟 Issue(s)

No issue for the re ordering of checking Airflow upgrades, but also

Closes: https://github.com/astronomer/issues/issues/2534

## 🧪  Testing

The upgrader smoke testing will make sure the upgrader pod runs in success

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [x] The PR title is informative to the user experience
