### PR TITLE
change scrape from service to endpoints

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -91,7 +91,7 @@ data:
 
       - job_name: nginx
         kubernetes_sd_configs:
-          - role: service
+          - role: endpoints
             namespaces:
               names:
                 - {{ .Release.Namespace }}


### PR DESCRIPTION
# overview

we are scraping the service endpoint for nginx, resulting in only scraping one pod at a time randomly.  we are not getting accurate alerts and our dashboard isn't reflecting the real world.

## testing

i have not tested this yet in dev, but i believe jim already tested this somewhere.  we can easily deploy this to dev before this gets merged if we want to...
