### PR TITLE
Add connection limit for db bootstrapper

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.24.0
-appVersion: 0.24.0
+version: 0.24.1
+appVersion: 0.24.1
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.24.0
+version: 0.24.1
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -31,7 +31,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.23.0
+    tag: 0.24.0
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install


### PR DESCRIPTION
## Description

Add connection limit flag db_bootstrapper image


## 🎟 Issue(s)

Resolves astronomer/issues#2476

## 🧪  Testing

Test that the `PRISMA_CONNECTION_LIMIT` is set and Houston API & Workers are taking less idle connections.
We need to check this in dev, staging and finally prod and monitor this update.

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
