### PR TITLE
Remove irrelevant LTS tests from master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,13 +144,13 @@ workflows:
           type: approval
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
 
       - build-lts-upgrade:
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
           requires:
             - lint
@@ -181,7 +181,7 @@ workflows:
       - lts-upgrade-0-23-test:
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
           requires:
             - build-lts-upgrade

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,15 +145,13 @@ workflows:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
 
       - build-lts-upgrade:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -184,8 +182,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
           requires:
             - build-lts-upgrade
             - release-to-internal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,8 +142,16 @@ workflows:
 
       - approve-lts-upgrader-build:
           type: approval
+          filters:
+            branches:
+              not:
+                - 'master'
 
       - build-lts-upgrade:
+          filters:
+            branches:
+              not:
+                - 'master'
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -171,6 +179,10 @@ workflows:
             - build-artifact
 
       - lts-upgrade-0-23-test:
+          filters:
+            branches:
+              not:
+                - 'master'
           requires:
             - build-lts-upgrade
             - release-to-internal
@@ -199,7 +211,6 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
-                - 'master'
                 - 'lts-to-lts'
 
       - approve-public-release:
@@ -222,7 +233,6 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
-                - 'master'
                 - 'lts-to-lts'
 
       - release-to-public:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,13 +145,15 @@ workflows:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
 
       - build-lts-upgrade:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -182,7 +184,8 @@ workflows:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
           requires:
             - build-lts-upgrade
             - release-to-internal

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -123,13 +123,15 @@ workflows:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
 
       - build-lts-upgrade:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -156,7 +158,8 @@ workflows:
           filters:
             branches:
               ignore:
-                - 'master'
+                - remote-lts-upgrader-from-master
+                - master
           requires:
             - build-lts-upgrade
             - release-to-internal

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -123,15 +123,13 @@ workflows:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
 
       - build-lts-upgrade:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -158,8 +156,7 @@ workflows:
           filters:
             branches:
               ignore:
-                - remote-lts-upgrader-from-master
-                - master
+                - 'master'
           requires:
             - build-lts-upgrade
             - release-to-internal

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -120,8 +120,16 @@ workflows:
 
       - approve-lts-upgrader-build:
           type: approval
+          filters:
+            branches:
+              not:
+                - 'master'
 
       - build-lts-upgrade:
+          filters:
+            branches:
+              not:
+                - 'master'
           requires:
             - lint
             - approve-lts-upgrader-build
@@ -145,6 +153,10 @@ workflows:
 {% endif %}{% endfor %}
 
       - lts-upgrade-0-23-test:
+          filters:
+            branches:
+              not:
+                - 'master'
           requires:
             - build-lts-upgrade
             - release-to-internal
@@ -172,7 +184,6 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
-                - 'master'
                 - 'lts-to-lts'
 
       - approve-public-release:
@@ -195,7 +206,6 @@ workflows:
             branches:
               only:
                 - 'release-0.23'
-                - 'master'
                 - 'lts-to-lts'
 
       - release-to-public:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -122,13 +122,13 @@ workflows:
           type: approval
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
 
       - build-lts-upgrade:
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
           requires:
             - lint
@@ -155,7 +155,7 @@ workflows:
       - lts-upgrade-0-23-test:
           filters:
             branches:
-              not:
+              ignore:
                 - 'master'
           requires:
             - build-lts-upgrade


### PR DESCRIPTION
## Description

Remove LTS related CI jobs from master branch, since they won't work there now that master is on 0.24. These changes still allow LTS tests to be run on feature branches in case they pertain to 0.23.

## Screenshots

Master will look like

<img width="1013" alt="Screen Shot 2021-02-01 at 4 04 32 PM" src="https://user-images.githubusercontent.com/1323808/106533612-61ea6780-64a7-11eb-8389-6387faea344c.png">

Feature branches will look like

<img width="1008" alt="Screen Shot 2021-02-01 at 4 05 21 PM" src="https://user-images.githubusercontent.com/1323808/106533627-67e04880-64a7-11eb-87c9-8c36114a22a5.png">