### PR TITLE
update nginx-es-networkpolicy.yaml to allow comms from webservers to elasticsearch-nginx pod

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
@@ -15,10 +15,9 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      tier: logging
-      component: {{ template "elasticsearch.name" . }}
+      tier: elasticsearch
+      component: es-ingress-controller
       release: {{ .Release.Name }}
-      role: nginx
   policyTypes:
   - Ingress
   ingress:


### PR DESCRIPTION
## Description

correct the selectors on the network policy so webservers can talk to the elasticsearch-nginx pod


## 🎟 Issue(s)

Resolves astronomer/issues#2598


## 📋 Checklist

- [x] The PR title is informative to the user experience
