### PR TITLE
Add service annotations to allow usage of ACM certificates on NGINX

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -22,6 +22,18 @@ metadata:
     service.kubernetes.io/ibm-load-balancer-cloud-provider-ip-type: "private"
     {{- end }}
 
+    {{- if .Values.loadBalancerType }}
+    service.beta.kubernetes.io/aws-load-balancer-type: {{ .Values.loadBalancerType | quote }}
+    {{- end }}
+
+    {{- if .Values.loadBalancerAcmCertificate }}
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: {{ .Values.loadBalancerAcmCertificate | quote }}
+    {{- end }}
+
+    {{- if .Values.loadBalancerBackendProtocol }}
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: {{ .Values.loadBalancerBackendProtocol | quote }}
+    {{- end }}
+
     # Metrics annotations
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.ports.metrics | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -197,13 +197,13 @@ nginx:
   loadBalancerSourceRanges:
 
   # On AWS, set to "nlb" to provision a network load balancer for NGINX instead of a classic load balancer
-  loadBalancerType:
+  loadBalancerType: ~
 
   # Set to "ssl" if TLS termination is performed at the load balancer, but NGINX still expects to receive TLS traffic
-  loadBalancerBackendProtocol:
+  loadBalancerBackendProtocol: ~
 
   # If using ACM, enter the ARN of the certificate to use on the load balancer
-  loadBalancerAcmCertificate:
+  loadBalancerAcmCertificate: ~
 
 
 #################################

--- a/values.yaml
+++ b/values.yaml
@@ -196,6 +196,15 @@ nginx:
   # Used to restrict IPs which can reach the nginx ingress
   loadBalancerSourceRanges:
 
+  # On AWS, set to "nlb" to provision a network load balancer for NGINX instead of a classic load balancer
+  loadBalancerType:
+
+  # Set to "ssl" if TLS termination is performed at the load balancer, but NGINX still expects to receive TLS traffic
+  loadBalancerBackendProtocol:
+
+  # If using ACM, enter the ARN of the certificate to use on the load balancer
+  loadBalancerAcmCertificate:
+
 
 #################################
 ## Grafana configuration


### PR DESCRIPTION
## Add service annotations to allow usage of ACM certificates on NGINX

## Description

This PR adds the following:
- Allows the user to specify "ssl" as backend protocol. The user should provision a self-signed certificate to terminate SSL 
-  between the load balancer and the NGINX pod;
- Allows the user to specify "nlb" as load balancer type on the service resource;
- Allows the user to specify the ARN of a ACM certificate to terminate SSL at the load balancer.

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📋 Checklist

- [x] The PR title is informative to the user experience

Resolves astronomer/issues#2616