### PR TITLE
Update lts script to allow - names in helm releases to work

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
@@ -5,7 +5,7 @@ ARG KUBECTL_VERSION="1.18.15"
 
 # Install Ansible and the modules we will use for upgrade
 RUN apk add build-base libffi-dev openssl-dev postgresql-dev bash curl postgresql-client
-RUN pip install ansible==2.9.14 psycopg2==2.8.6 openshift==0.11.2
+RUN pip install ansible==2.9.14 psycopg2==2.8.6 openshift==0.11.2 cryptography==3.1.1
 RUN ansible-galaxy collection install community.general:1.2.0 community.kubernetes:1.1.0
 # Install kubectl
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -24,6 +24,7 @@
   set_fact:
     namespace: "{{ (lookup('file', '{{ astro_save }}/helm-status.json') | from_json).namespace }}"
     release_name: "{{ (lookup('file', '{{ astro_save }}/helm-status.json') | from_json).name }}"
+    database_name: "{{ (lookup('file', '{{ astro_save }}/helm-status.json') | from_json).name | regex_replace('-', '_') }}"
 
 - debug:
     msg: "Namespace: {{ namespace }}"
@@ -79,7 +80,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    db: "{{ release_name }}_houston"
+    db: "{{ database_name }}_houston"
     query: |
       SET search_path to "houston$default";
 
@@ -231,7 +232,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    db: "{{ release_name }}_houston"
+    db: "{{ database_name }}_houston"
     query: "drop table migrations;"
 
 - name: Rollback with Helm (no hooks)

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -21,6 +21,7 @@
     release_name: "{{ (helm_releases.stdout | from_json | selectattr('chart', 'match', 'astronomer-.*') | list)[0].name }}"
     namespace: "{{ (helm_releases.stdout | from_json | selectattr('chart', 'match', 'astronomer-.*') | list)[0].namespace }}"
     airflow_releases: "{{ helm_releases.stdout | from_json | selectattr('chart', 'match', 'airflow-.*') | list | map(attribute='name') | list }}"
+    database_name: "{{ (helm_releases.stdout | from_json | selectattr('chart', 'match', 'astronomer-.*') | list)[0].name | regex_replace( '-', '_') }}"
 
 - name: Show Airflow releases
   debug:
@@ -119,7 +120,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    db: "{{ release_name }}_houston"
+    db: "{{ database_name }}_houston"
     query: |
       SET search_path to "houston$default";
 
@@ -137,7 +138,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    db: "{{ release_name }}_houston"
+    db: "{{ database_name }}_houston"
     query: |
       SET search_path to "houston$default";
       SELECT "localCredential" FROM "houston$default"."User";
@@ -222,7 +223,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    name: "{{ release_name }}_houston"
+    name: "{{ database_name }}_houston"
     state: dump
     target: "{{ astro_save_dir.path }}/astronomer-db-backup.tar"
     target_opts: '--clean --create --format=tar'
@@ -235,7 +236,7 @@
     login_host: "{{ db_hostname }}"
     login_user: "{{ db_username }}"
     login_password: "{{ db_password }}"
-    db: "{{ release_name }}_houston"
+    db: "{{ database_name }}_houston"
     path_to_script: "files/prisma1_to_prisma2.sql"
 
 # The db migration container waits on NATs, and for that, we need the new pods.


### PR DESCRIPTION
## Allow helm releases to be upgraded with the lts upgrade script that contain a hyphen

## 🎟 Issue(s)

Resolves astronomer/issues#2618


## 🧪  Testing

1. EKS cluster with helm release ice-ice in astronomer namespace upgrade and downgrade from 0.16 -> 0.23 -> 0.16 - PASS
2. EKS cluster with helm release ice in astronomer namespace upgrade and downgrade from 0.16 -> 0.23 -> 0.16 - PASS

## 📋 Checklist

- [x] The PR title is informative to the user experience
