### PR TITLE
Add disableClustering as an alertmanager option

### DIFF
--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -50,6 +50,9 @@ spec:
           {{- if .Values.global.baseDomain }}
             - --web.external-url=https://alertmanager.{{ .Values.global.baseDomain }}
           {{- end }}
+          {{- if .Values.disableClustering }}
+            - --cluster.listen-address=
+          {{- end }}
           ports:
             - containerPort: {{ .Values.ports.http }}
               name: alertmanager

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -36,6 +36,9 @@ env: {}
 ports:
   http: 9093
 
+# Set to true to disable alertmanager clustering
+disableClustering: false
+
 receivers:
   # Configs for platform alerts
   platform: {}


### PR DESCRIPTION
## Description

Adds an option to disable Alertmanagers clustering for internal networks

## PR Title

Adds option to disable Alertmanager clustering for private networks where the gossip protocol causes failures

## 🎟 Issue(s)

Resolves astronomer/issues#2592

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [x] The PR title is informative to the user experience
