### PR TITLE
Do not require release-to-internal for lts-upgrade-0-23-test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,6 @@ workflows:
       - lts-upgrade-0-23-test:
           requires:
             - build-lts-upgrade
-            - release-to-internal
 
       - approve-internal-release:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -147,7 +147,6 @@ workflows:
       - lts-upgrade-0-23-test:
           requires:
             - build-lts-upgrade
-            - release-to-internal
 
       - approve-internal-release:
           type: approval


### PR DESCRIPTION
This allows lts-upgrad-test to run without having a release-to-internal, which is needed when we want to fix bugs in the upgrader without having to release a new version of the astronomer helm chart.

<img width="1014" alt="Screen Shot 2021-02-24 at 5 38 07 PM" src="https://user-images.githubusercontent.com/1323808/109090049-3b46d780-76c7-11eb-9e84-1cb379fc9cc4.png">
