### PR TITLE
fluentd 2 params string concatenation fix

### DIFF
--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -47,10 +47,10 @@ Full image name.
 </assume_role_credentials>
 s3_bucket {{ .Values.s3.s3_bucket }}
 s3_region {{ .Values.s3.s3_region }}
-{{- if .Values.s3.path -}}
+{{- if .Values.s3.path }}
 path {{ .Values.s3.path }}
-{{- end -}}
-{{- if .Values.s3.use_server_side_encryption -}}
+{{- end }}
+{{- if .Values.s3.use_server_side_encryption }}
 use_server_side_encryption {{ .Values.s3.use_server_side_encryption }}
-{{- end -}}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description
This Issue is regarding to the 2 new params added in fluentd chart having concatenation Issue.
<!--



-->

## PR Title
fluentd 2 params string concatenation fix.

<!--



-->

## 🎟 Issue(s)
 New parameters added for the fluentd Configuration has concatenation issue - which is basically implemented in Astronomer platform 0.23.11

<!--



-->

## 🧪  Testing
Fix is to remove the "-" underscore syntax at the end of the if loop and end loop. 
Tested and working as expected in local env.
Please find the below screenshots and reference links for ref
https://astronomer.zendesk.com/agent/tickets/3700

<!--



-->

![image](https://user-images.githubusercontent.com/43725655/109386801-49912f80-7923-11eb-855a-5a79d335e34c.png)
![image](https://user-images.githubusercontent.com/43725655/109386811-59a90f00-7923-11eb-9ada-e1881caa1220.png)
![image](https://user-images.githubusercontent.com/43725655/109386821-6ded0c00-7923-11eb-8386-3440484e79e2.png)

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
