### PR TITLE
fluentd_concatenation issue_github_issue_1030

### DIFF
--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -47,10 +47,10 @@ Full image name.
 </assume_role_credentials>
 s3_bucket {{ .Values.s3.s3_bucket }}
 s3_region {{ .Values.s3.s3_region }}
-{{- if .Values.s3.path -}}
+{{- if .Values.s3.path }}
 path {{ .Values.s3.path }}
-{{- end -}}
-{{- if .Values.s3.use_server_side_encryption -}}
+{{- end }}
+{{- if .Values.s3.use_server_side_encryption }}
 use_server_side_encryption {{ .Values.s3.use_server_side_encryption }}
-{{- end -}}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description
This Issue is regarding to the 2 new params added in fluentd chart having concatenation Issue.

Note: - Earlier created PR - Unable to merge due to branch conflict - Now created a flunentd_issue branch and this can be merged with master - So please check and approve this.

<!--
Describe the purpose of this pull request.

-->

## PR Title
fluentd 2 params string concatenation fix.

<!--
Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.
-->

## 🎟 Issue(s)
New parameters added for the fluentd Configuration has concatenation issue - which is basically implemented in Astronomer platform 0.23.11

<!--
Resolves astronomer/issues#XXXX
-->

## 🧪  Testing
Fix is to remove the "-" underscore syntax at the end of the if loop and end loop.
Tested and working as expected in local env.
Please find the below screenshots and reference links for ref
https://astronomer.zendesk.com/agent/tickets/3700



<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots
![image](https://user-images.githubusercontent.com/43725655/109769645-80678e00-7c20-11eb-9543-b6791fd8caae.png)
![image](https://user-images.githubusercontent.com/43725655/109769681-8bbab980-7c20-11eb-9752-0afa5238f8cc.png)
![image](https://user-images.githubusercontent.com/43725655/109769716-970de500-7c20-11eb-98a8-1fde4829651e.png)


<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
