### PR TITLE
Add ingressAnnotations. Improve other syntaxes.

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -13,6 +13,11 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+{{- if .Values.ingressAnnotations -}}
+{{ range $key, $value := .Values.ingressAnnotations }}
+    {{ $key }}: {{ $value }}
+{{- end -}}
+{{- end -}}
     {{- if .Values.privateLoadBalancer }}
     # This annotation is detected by EKS to indicate that
     # it should provision a private ("internal") load balancer

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -12,7 +12,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 {{- if .Values.ingressAnnotations -}}
 {{ range $key, $value := .Values.ingressAnnotations }}
     {{ $key }}: {{ $value }}

--- a/charts/nginx/tests/nginx-service_test.yaml
+++ b/charts/nginx/tests/nginx-service_test.yaml
@@ -37,3 +37,28 @@ tests:
       - equal:
           path: spec.loadBalancerIP
           value: 5.5.5.5
+
+  - it: works without loadBalancerSourceRanges
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - isNull:
+          path: spec.loadBalancerSourceRanges
+
+  - it: works with loadBalancerSourceRanges
+    set:
+      loadBalancerSourceRanges:
+        - "1.1.1.1/32"
+        - "2.2.2.2/32"
+        - "3.3.3.3/32"
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: spec.loadBalancerSourceRanges
+          value:
+            - "1.1.1.1/32"
+            - "2.2.2.2/32"
+            - "3.3.3.3/32"

--- a/charts/nginx/tests/nginx-service_test.yaml
+++ b/charts/nginx/tests/nginx-service_test.yaml
@@ -3,7 +3,37 @@ suite: Test nginx-service
 templates:
   - nginx-service.yaml
 tests:
-  - it: should work
+  - it: nginx service exists
     asserts:
       - isKind:
           of: Service
+
+  - it: works with ingressAnnotations
+    set:
+      ingressAnnotations:
+        foo1: foo
+        foo2: foo
+        foo3: foo
+    asserts:
+      - equal:
+          path: metadata.annotations.foo1
+          value: foo
+      - equal:
+          path: metadata.annotations.foo2
+          value: foo
+      - equal:
+          path: metadata.annotations.foo3
+          value: foo
+
+  - it: works without loadBalancerIP
+    asserts:
+      - isNull:
+          path: spec.loadBalancerIP
+
+  - it: works with loadBalancerIP
+    set:
+      loadBalancerIP: 5.5.5.5
+    asserts:
+      - equal:
+          path: spec.loadBalancerIP
+          value: 5.5.5.5

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -38,7 +38,7 @@ ingressAnnotations: {}
 # AntiAffinity can be "hard" or "soft"
 antiAffinity: "soft"
 
-# IP address the nginx ingress should bind to
+# String IP address the nginx ingress should bind to
 loadBalancerIP: ~
 
 # List used to restrict IPs which can reach the nginx ingress

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -32,7 +32,7 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
-# ingressAnnotations should be a dict of annotations to add to th ingress-controller
+# dict of annotations to add to the ingress controller
 ingressAnnotations: {}
 
 # AntiAffinity can be "hard" or "soft"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -32,11 +32,14 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+# ingressAnnotations should be a dict of annotations to add to th ingress-controller
+ingressAnnotations: {}
+
 # AntiAffinity can be "hard" or "soft"
 antiAffinity: "soft"
 
 # IP address the nginx ingress should bind to
-loadBalancerIP:
+loadBalancerIP: ~
 
 # Used to restrict IPs which can reach the nginx ingress
 loadBalancerSourceRanges:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -42,7 +42,7 @@ antiAffinity: "soft"
 loadBalancerIP: ~
 
 # Used to restrict IPs which can reach the nginx ingress
-loadBalancerSourceRanges:
+loadBalancerSourceRanges: {}
 
 # Set to 'true' when deploying to a private EKS cluster
 privateLoadBalancer: false

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -41,8 +41,8 @@ antiAffinity: "soft"
 # IP address the nginx ingress should bind to
 loadBalancerIP: ~
 
-# Used to restrict IPs which can reach the nginx ingress
-loadBalancerSourceRanges: {}
+# List used to restrict IPs which can reach the nginx ingress
+loadBalancerSourceRanges: []
 
 # Set to 'true' when deploying to a private EKS cluster
 privateLoadBalancer: false

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -41,7 +41,7 @@ antiAffinity: "soft"
 # String IP address the nginx ingress should bind to
 loadBalancerIP: ~
 
-# List used to restrict IPs which can reach the nginx ingress
+# List used to restrict IPs that can reach the nginx ingress
 loadBalancerSourceRanges: []
 
 # Set to 'true' when deploying to a private EKS cluster

--- a/values.yaml
+++ b/values.yaml
@@ -196,8 +196,8 @@ nginx:
   # String IP address the nginx ingress should bind to
   loadBalancerIP: ~
 
-  # Dict used to restrict IPs which can reach the nginx ingress
-  loadBalancerSourceRanges: {}
+  # List used to restrict IPs which can reach the nginx ingress
+  loadBalancerSourceRanges: []
 
   # Dict of arbitrary annotations to add to the nginx ingress
   ingressAnnotations: {}

--- a/values.yaml
+++ b/values.yaml
@@ -196,7 +196,7 @@ nginx:
   # String IP address the nginx ingress should bind to
   loadBalancerIP: ~
 
-  # List used to restrict IPs which can reach the nginx ingress
+  # List used to restrict IPs that can reach the nginx ingress
   loadBalancerSourceRanges: []
 
   # Dict of arbitrary annotations to add to the nginx ingress

--- a/values.yaml
+++ b/values.yaml
@@ -253,16 +253,14 @@ keda:
       <<: *platformNodeSelector
     affinity:
       <<: *platformAffinity
-    tolerations:
-      <<: *platformTolerations
+    tolerations: *platformTolerations
 
 nats:
   nodeSelector:
     <<: *platformNodeSelector
     affinity:
       <<: *platformAffinity
-    tolerations:
-      <<: *platformTolerations
+    tolerations: *platformTolerations
   resources:
     requests:
       cpu: "75m"
@@ -276,8 +274,7 @@ stan:
     <<: *platformNodeSelector
     affinity:
       <<: *platformAffinity
-    tolerations:
-      <<: *platformTolerations
+    tolerations: *platformTolerations
   resources:
     requests:
       cpu: "75m"

--- a/values.yaml
+++ b/values.yaml
@@ -107,7 +107,7 @@ global:
   # Storage class for persistent volumes. If you have multiple storage classes available this will force all charts with persistent
   # volumes to use the one specified here.
   # storageClass: ~
-  
+
 #################################
 ## Default tagged groups enabled
 #################################
@@ -180,7 +180,6 @@ astronomer:
         cpu: "500m"
         memory: "1024Mi"
 
-
 #################################
 ## Nginx configuration
 #################################
@@ -194,12 +193,14 @@ nginx:
       cpu: "1"
       memory: "2048Mi"
 
-  # IP address the nginx ingress should bind to
-  loadBalancerIP:
+  # String IP address the nginx ingress should bind to
+  loadBalancerIP: ~
 
-  # Used to restrict IPs which can reach the nginx ingress
-  loadBalancerSourceRanges:
+  # Dict used to restrict IPs which can reach the nginx ingress
+  loadBalancerSourceRanges: {}
 
+  # Dict of arbitrary annotations to add to the nginx ingress
+  ingressAnnotations: {}
 
 #################################
 ## Grafana configuration
@@ -214,10 +215,11 @@ grafana:
       cpu: "500m"
       memory: "1024Mi"
 
-  dashboards: {}
-   # default:
-   #   velero:
-   #     file: dashboards/velero.json
+  dashboards:
+    {}
+    # default:
+    #   velero:
+    #     file: dashboards/velero.json
 
 #################################
 ## Prometheus configuration
@@ -252,7 +254,7 @@ keda:
     affinity:
       <<: *platformAffinity
     tolerations:
-      *platformTolerations
+      <<: *platformTolerations
 
 nats:
   nodeSelector:
@@ -260,7 +262,7 @@ nats:
     affinity:
       <<: *platformAffinity
     tolerations:
-      *platformTolerations
+      <<: *platformTolerations
   resources:
     requests:
       cpu: "75m"
@@ -275,7 +277,7 @@ stan:
     affinity:
       <<: *platformAffinity
     tolerations:
-      *platformTolerations
+      <<: *platformTolerations
   resources:
     requests:
       cpu: "75m"
@@ -297,9 +299,9 @@ prometheus-blackbox-exporter:
       cpu: "100m"
       memory: "200Mi"
 
-# define what astronomer platform services will be checked
-# for up/down status. Enable this will also include
-# the required network policies
+  # define what astronomer platform services will be checked
+  # for up/down status. Enable this will also include
+  # the required network policies
   astroServices:
     commander:
       enabled: true
@@ -370,7 +372,6 @@ elasticsearch:
     persistence:
       size: "20Gi"
 
-
 #################################
 ## Kibana configuration
 #################################
@@ -384,7 +385,6 @@ kibana:
       cpu: "500m"
       memory: "1024Mi"
 
-
 #################################
 ## Fluentd configuration
 #################################
@@ -397,7 +397,6 @@ kibana:
 #     limits:
 #       cpu: "500m"
 #       memory: "1024Mi"
-
 
 #################################
 ## Kube State configuration


### PR DESCRIPTION
Related to <https://github.com/astronomer/issues/issues/2640>, which talks about GCP Global Access, and offers a solution of allowing arbitrary ingress annotations.

# Description

* Add default null string for loadBalancerIP
* Add default null dict for loadBalancerSourceRanges
* Fix yaml anchor syntax for platformTolerations
* Whitespace
* Add test for these changes and other existing behaviors of the NGINX Service
* Auto-formatting applied by vscode `prettier` that removed some whitespace, re-aligned some braces.