### PR TITLE
Remove Makefile cruft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,11 @@
-# Public repository for charts.
-DOMAIN ?= helm.astronomer.io
-URL ?= https://${DOMAIN}
-BUCKET ?= gs://${DOMAIN}
-
 # List of charts to build
 CHARTS := astronomer nginx grafana prometheus alertmanager elasticsearch kibana fluentd kube-state postgresql
 
-# Output directory
-OUTPUT := repository
-
-# Temp directory
-TEMP := /tmp/${DOMAIN}
-
+# TEMPDIR directory
+TEMPDIR := /tmp/astro-temp
 
 .PHONY: lint
 lint: lint-prep lint-astro lint-charts
-#lint-prom (omitted)
 
 .PHONY: lint-venv
 lint-venv:
@@ -24,13 +14,13 @@ lint-venv:
 
 .PHONY: lint-prep
 lint-prep:
-	rm -rf ${TEMP}/astronomer || true
-	mkdir -p ${TEMP}
-	cp -R . ${TEMP}/astronomer
+	rm -rf ${TEMPDIR}/astronomer || true
+	mkdir -p ${TEMPDIR}
+	cp -R . ${TEMPDIR}/astronomer
 
 .PHONY: lint-astro
 lint-astro:
-	helm lint ${TEMP}/astronomer
+	helm lint ${TEMPDIR}/astronomer
 
 .PHONY: unittest-charts
 unittest-charts:
@@ -40,72 +30,28 @@ unittest-charts:
 .PHONY: lint-charts
 lint-charts:
 	# Check that nothing accidentally is using release name instead of namespace for metadata.namespace
-	! helm template --namespace samplenamespace samplerelease . | grep 'namespace: samplerelease'
+	! helm TEMPDIRlate --namespace samplenamespace samplerelease . | grep 'namespace: samplerelease'
 	# get a copy of the global values for helm lint'n the dependent charts
-	python3 -c "import yaml; from pathlib import Path; globals = {'global': yaml.safe_load(Path('${TEMP}/astronomer/values.yaml').read_text())['global']}; Path('${TEMP}/globals.yaml').write_text(yaml.dump(globals))"
-	find "${TEMP}/astronomer/charts" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n1 helm lint -f ${TEMP}/globals.yaml
+	python3 -c "import yaml; from pathlib import Path; globals = {'global': yaml.safe_load(Path('${TEMPDIR}/astronomer/values.yaml').read_text())['global']}; Path('${TEMPDIR}/globals.yaml').write_text(yaml.dump(globals))"
+	find "${TEMPDIR}/astronomer/charts" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n1 helm lint -f ${TEMPDIR}/globals.yaml
 
 .PHONY: lint-prom
 lint-prom:
 	# Lint the Prometheus alerts configuration
-	helm template -s ${TEMP}/astronomer/charts/prometheus/templates/prometheus-alerts-configmap.yaml ${TEMP}/astronomer > ${TEMP}/prometheus_alerts.yaml
+	helm TEMPDIRlate -s ${TEMPDIR}/astronomer/charts/prometheus/TEMPDIRlates/prometheus-alerts-configmap.yaml ${TEMPDIR}/astronomer > ${TEMPDIR}/prometheus_alerts.yaml
 	# Parse the alerts.yaml data from the config map resource
-	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMP}/prometheus_alerts.yaml').read_text())['data']['alerts']; Path('${TEMP}/prometheus_alerts.yaml').write_text(alerts)"
-	promtool check rules ${TEMP}/prometheus_alerts.yaml
+	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMPDIR}/prometheus_alerts.yaml').read_text())['data']['alerts']; Path('${TEMPDIR}/prometheus_alerts.yaml').write_text(alerts)"
+	promtool check rules ${TEMPDIR}/prometheus_alerts.yaml
 
 .PHONY: lint-clean
 lint-clean:
-	rm -rf ${TEMP}
+	rm -rf ${TEMPDIR}
 
 .PHONY: build
 build:
 	helm repo add kedacore https://kedacore.github.io/charts
-	rm -rf ${TEMP}/astronomer || true
-	mkdir -p ${TEMP}
-	cp -R . ${TEMP}/astronomer
-	find "${TEMP}/astronomer/charts" -name requirements.yaml -type f -print | while read -r FILE ; do ( set -x ; cd `dirname $$FILE` && helm dep update ; ) ; done ;
-	helm package ${TEMP}/astronomer
-
-.PHONY: build-index
-build-index:
-	wget ${DOMAIN}/index.yaml -O ${TEMP}
-	helm repo index ${OUTPUT} --url ${URL} --merge ${TEMP}
-
-.PHONY: push
-push: build
-	@read -p "Are you sure you want to push a production release? Ctrl+c to abort." ans;
-	$(MAKE) push-repo
-
-.PHONY: push-repo
-push-repo:
-	for chart in ${CHARTS} ; do \
-		gsutil cp ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz ${BUCKET} || exit 1; \
-	done; \
-	$(MAKE) push-index
-
-.PHONY: push-index
-push-index: build-index
-	gsutil -h "Cache-Control: public, max-age=300" cp ${OUTPUT}/index.yaml ${BUCKET}
-
-.PHONY: clean
-clean:
-	for chart in ${CHARTS} ; do \
-		rm ${OUTPUT}/$${chart}-${ASTRONOMER_VERSION}.tgz || exit 1; \
-	done; \
-
-.PHONY: update-image-tags
-update-image-tags: check-env
-	find charts -name 'values.yaml' -exec sed -i -E 's/tag: (0|[1-9][[:digit:]]*)\.(0|[1-9][[:digit:]]*)\.(0|[1-9][[:digit:]]*)(-(0|[1-9][[:digit:]]*|[[:digit:]]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][[:digit:]]*|[[:digit:]]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?/tag: ${ASTRONOMER_VERSION}/g' {} \;
-
-.PHONY: update-chart-versions
-update-chart-versions: check-env
-	find . -name Chart.yaml -exec sed -i -E 's/(0|[1-9][[:digit:]]*)\.(0|[1-9][[:digit:]]*)\.(0|[1-9][[:digit:]]*)(-(0|[1-9][[:digit:]]*|[[:digit:]]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][[:digit:]]*|[[:digit:]]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?/${ASTRONOMER_VERSION}/g' {} \;
-
-.PHONY: update-version
-update-version: check-env update-image-tags update-chart-versions
-
-.PHONY: check-env
-check-env:
-ifndef ASTRONOMER_VERSION
-	$(error ASTRONOMER_VERSION is not set)
-endif
+	rm -rf ${TEMPDIR}/astronomer || true
+	mkdir -p ${TEMPDIR}
+	cp -R . ${TEMPDIR}/astronomer
+	find "${TEMPDIR}/astronomer/charts" -name requirements.yaml -type f -print | while read -r FILE ; do ( set -x ; cd `dirname $$FILE` && helm dep update ; ) ; done ;
+	helm package ${TEMPDIR}/astronomer

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 # List of charts to build
 CHARTS := astronomer nginx grafana prometheus alertmanager elasticsearch kibana fluentd kube-state postgresql
 
-# TEMPDIR directory
 TEMPDIR := /tmp/astro-temp
 
 .PHONY: lint
@@ -30,7 +29,7 @@ unittest-charts:
 .PHONY: lint-charts
 lint-charts:
 	# Check that nothing accidentally is using release name instead of namespace for metadata.namespace
-	! helm TEMPDIRlate --namespace samplenamespace samplerelease . | grep 'namespace: samplerelease'
+	! helm template --namespace samplenamespace samplerelease . | grep 'namespace: samplerelease'
 	# get a copy of the global values for helm lint'n the dependent charts
 	python3 -c "import yaml; from pathlib import Path; globals = {'global': yaml.safe_load(Path('${TEMPDIR}/astronomer/values.yaml').read_text())['global']}; Path('${TEMPDIR}/globals.yaml').write_text(yaml.dump(globals))"
 	find "${TEMPDIR}/astronomer/charts" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n1 helm lint -f ${TEMPDIR}/globals.yaml
@@ -38,7 +37,7 @@ lint-charts:
 .PHONY: lint-prom
 lint-prom:
 	# Lint the Prometheus alerts configuration
-	helm TEMPDIRlate -s ${TEMPDIR}/astronomer/charts/prometheus/TEMPDIRlates/prometheus-alerts-configmap.yaml ${TEMPDIR}/astronomer > ${TEMPDIR}/prometheus_alerts.yaml
+	helm template -s ${TEMPDIR}/astronomer/charts/prometheus/templates/prometheus-alerts-configmap.yaml ${TEMPDIR}/astronomer > ${TEMPDIR}/prometheus_alerts.yaml
 	# Parse the alerts.yaml data from the config map resource
 	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMPDIR}/prometheus_alerts.yaml').read_text())['data']['alerts']; Path('${TEMPDIR}/prometheus_alerts.yaml').write_text(alerts)"
 	promtool check rules ${TEMPDIR}/prometheus_alerts.yaml


### PR DESCRIPTION
There is a bunch of old (circa 2018) cruft in the `Makefile` related to releasing a helm charts outside of CI. This code isn't used these days, and is potentially dangerous.

* Remove old helm build and release code from Makefile
* Rename `TEMP` to `TEMPDIR`

I'm not sure if the `lint-prom` step should be deleted too. We are not using it, and haven't ever used it since I started here ~8 months ago. I feel like if we are going to use it, we should redo it.