### PR TITLE
customRoutes should be a list not a dictonary, helm was throwing warn…

### DIFF
--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -51,7 +51,7 @@ receivers:
   # Configs for airflow alerts
   airflow: {}
 
-customRoutes: {}
+customRoutes: []
 # Example
 # - receiver: blackhole-receiver
 #   match_re:


### PR DESCRIPTION
## Description

When defining customRoutes in values file helm is complaining with:
coalesce.go:200: warning: cannot overwrite table with non table for customRoutes (map[])

This is because in values.yaml customRoutes are initially defined as a dictionary but in fact they are a list.

## PR Title

Fix helm working about customRoutes in Alertmanager configuration


- [x] The PR title is informative to the user experience
