### PR TITLE
Fix missing urllib3, requests

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 3.12.3
+    tag: 3.13.4-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
The root of this change is to fix an error about missing urllib3 in the latest published version of curator. This was done by adding urllib3, and py3-requests. This change also bumps the base image to a newer version of alpine.

See:
- https://github.com/astronomer/issues/issues/2773
- https://github.com/astronomer/ap-vendor/pull/77
- https://github.com/astronomer/ap-vendor/pull/78