### PR TITLE
Match both postres and postgresql protocol strings.

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -45,12 +45,12 @@
     db_connection: "{{ astronomer_bootstrap.resources[0].data.connection | b64decode }}"
 
 - set_fact:
-    db_username: "{{ db_connection | regex_search(regex, '\\1') | first }}"
-    db_password: "{{ db_connection | regex_search(regex, '\\2') | first }}"
-    db_hostname: "{{ db_connection | regex_search(regex, '\\3') | first }}"
-    db_port: "{{ db_connection | regex_search(regex, '\\4') | first }}"
+    db_username: "{{ db_connection | regex_search(regex, '\\g<username>') | first }}"
+    db_password: "{{ db_connection | regex_search(regex, '\\g<password>') | first }}"
+    db_hostname: "{{ db_connection | regex_search(regex, '\\g<hostname>') | first }}"
+    db_port: "{{ db_connection | regex_search(regex, '\\g<port>') | first }}"
   vars:
-    regex: 'postgres:\/\/([^:]*):([^@]*)@([^:]*):(\d*).*'
+    regex: 'postgres(ql)?:\/\/(?P<username>[^:]+):(?P<password>[^@]+)@(?P<hostname>[^:]+):(?P<port>\d+)'
 
 - debug:
     msg: "DB username: {{ db_username }}"


### PR DESCRIPTION
## Description

Match both `postgres://` and `postgresql://` db connection strings in the LTS upgrader. Use named capture groups.

Related to https://github.com/astronomer/issues/issues/2537

## Testing

- Manually validated this logic here: <https://github.com/danielhoherd/ansible-playground/tree/master/regex-groups>
- Validated the regex at <https://regex101.com/r/kZ2w3t/1> using:
  - `postgres://user:pw@host.com:234`
  - `postgresql://user:pw@host.com:234`
  - `postgres://user:pw@host.com:5678/something`
  - `postgresql://user:pw@host.com:5678/something`
  - `postgres://user@host.com:234`
  - `postgresql://user@host.com:234`
  - `postgres://host.com:5678/something`
  - `postgresql://host.com/something`
