### PR TITLE
Blacken python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
     hooks:
-      - id: check-byte-order-marker
       - id: check-case-conflict
       - id: check-json
       - id: check-merge-conflict
@@ -26,7 +25,7 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         args:

--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import docker
 import testinfra
 from kubernetes import client, config
-from kubernetes import client, config
+
 
 def create_kube_client(in_cluster=False):
     """
@@ -21,74 +21,97 @@ def create_kube_client(in_cluster=False):
         config.load_kube_config()
     return client.CoreV1Api()
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def nginx(request):
-    """ This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
-    namespace = os.environ.get('NAMESPACE')
-    release_name = os.environ.get('RELEASE_NAME')
+    namespace = os.environ.get("NAMESPACE")
+    release_name = os.environ.get("RELEASE_NAME")
     if not namespace:
         print("NAMESPACE env var is not present, using 'astronomer' namespace")
-        namespace = 'astronomer'
+        namespace = "astronomer"
     if not release_name:
-        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
-        release_name = 'astronomer'
+        print(
+            "RELEASE_NAME env var is not present, assuming 'astronomer' is the release name"
+        )
+        release_name = "astronomer"
     kube = create_kube_client()
-    pods = kube.list_namespaced_pod(namespace, label_selector="component=ingress-controller")
+    pods = kube.list_namespaced_pod(
+        namespace, label_selector="component=ingress-controller"
+    )
     pods = pods.items
-    assert len(pods) > 0, "Expected to find at least one pod with label 'component: ingress-controller'"
+    assert (
+        len(pods) > 0
+    ), "Expected to find at least one pod with label 'component: ingress-controller'"
     pod = pods[0]
-    yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=nginx&namespace={namespace}')
+    yield testinfra.get_host(
+        f"kubectl://{pod.metadata.name}?container=nginx&namespace={namespace}"
+    )
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def houston_api(request):
-    """ This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
-    namespace = os.environ.get('NAMESPACE')
-    release_name = os.environ.get('RELEASE_NAME')
+    namespace = os.environ.get("NAMESPACE")
+    release_name = os.environ.get("RELEASE_NAME")
     if not namespace:
         print("NAMESPACE env var is not present, using 'astronomer' namespace")
-        namespace = 'astronomer'
+        namespace = "astronomer"
     if not release_name:
-        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
-        release_name = 'astronomer'
+        print(
+            "RELEASE_NAME env var is not present, assuming 'astronomer' is the release name"
+        )
+        release_name = "astronomer"
     kube = create_kube_client()
-    pods = kube.list_namespaced_pod(namespace, label_selector=f"component=houston")
+    pods = kube.list_namespaced_pod(namespace, label_selector="component=houston")
     pods = pods.items
-    assert len(pods) > 0, "Expected to find at least one pod with label 'component: houston'"
+    assert (
+        len(pods) > 0
+    ), "Expected to find at least one pod with label 'component: houston'"
     pod = pods[0]
-    yield testinfra.get_host(f'kubectl://{pod.metadata.name}?container=houston&namespace={namespace}')
+    yield testinfra.get_host(
+        f"kubectl://{pod.metadata.name}?container=houston&namespace={namespace}"
+    )
 
-@pytest.fixture(scope='function')
+
+@pytest.fixture(scope="function")
 def prometheus(request):
-    """ This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
-    namespace = os.environ.get('NAMESPACE')
-    release_name = os.environ.get('RELEASE_NAME')
+    namespace = os.environ.get("NAMESPACE")
+    release_name = os.environ.get("RELEASE_NAME")
     if not namespace:
         print("NAMESPACE env var is not present, using 'astronomer' namespace")
-        namespace = 'astronomer'
+        namespace = "astronomer"
     if not release_name:
-        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
-        release_name = 'astronomer'
-    pod = f'{release_name}-prometheus-0'
-    yield testinfra.get_host(f'kubectl://{pod}?container=prometheus&namespace={namespace}')
+        print(
+            "RELEASE_NAME env var is not present, assuming 'astronomer' is the release name"
+        )
+        release_name = "astronomer"
+    pod = f"{release_name}-prometheus-0"
+    yield testinfra.get_host(
+        f"kubectl://{pod}?container=prometheus&namespace={namespace}"
+    )
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def docker_client(request):
-    """ This is a text fixture for the docker client,
+    """This is a text fixture for the docker client,
     should it be needed in a test
     """
     client = docker.from_env()
     yield client
     client.close()
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def kube_client(request):
     yield create_kube_client()

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -129,7 +129,7 @@ def test_prometheus_config_reloader_works(prometheus, kube_client):
             name="astronomer-prometheus-config", namespace="astronomer", body=new_body
         )
     except ApiException as e:
-        print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
+        print(f"Exception when calling CoreV1Api->patch_namespaced_config_map: {e}\n")
 
     # This can take more than a minute.
     i = 0
@@ -161,7 +161,7 @@ def test_prometheus_config_reloader_works(prometheus, kube_client):
             name="astronomer-prometheus-config", namespace="astronomer", body=new_body
         )
     except ApiException as e:
-        print("Exception when calling CoreV1Api->patch_namespaced_config_map: %s\n" % e)
+        print(f"Exception when calling CoreV1Api->patch_namespaced_config_map: {e}\n")
 
     assert (
         y_parsed["global"]["scrape_interval"] != "30s"

--- a/bin/functional-tests/test_network_security.py
+++ b/bin/functional-tests/test_network_security.py
@@ -6,28 +6,27 @@ from time import sleep, time
 from contextlib import contextmanager
 import xml.etree.ElementTree as xml_parser
 
-import pytest
 import testinfra
 from kubernetes import client, config
 
-if os.environ.get('DEBUG'):
+if os.environ.get("DEBUG"):
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 else:
     logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
-class ScanFinding():
 
+class ScanFinding:
     def __init__(self, name="", ip_address="", ports=[]):
         self.name = name
         self.ip_address = ip_address
         self.ports = ports
 
     def add_port(self, port):
-        if not port in self.ports:
+        if port not in self.ports:
             self.ports.append(port)
 
-class ScanResult():
 
+class ScanResult:
     def __init__(self, findings=[]):
         self.findings = findings
 
@@ -37,27 +36,31 @@ class ScanResult():
     def remove_finding(self, finding):
         self.findings.remove(finding)
 
-class ScanTarget():
 
+class ScanTarget:
     def __init__(self, name, ip_address, _type, ports=[], namespace=None):
         self.name = name
         self.ip_address = ip_address
-        assert isinstance(self.ip_address, str), \
-            f"Expected to find str, but found: {type(ip_address)}"
+        assert isinstance(
+            self.ip_address, str
+        ), f"Expected to find str, but found: {type(ip_address)}"
         self._type = _type
-        assert self._type in ["pod", "service"], \
-            f"Expected to find 'pod' or 'service', but found {self._type}"
+        assert self._type in [
+            "pod",
+            "service",
+        ], f"Expected to find 'pod' or 'service', but found {self._type}"
         self.ports = ports
         for port in self.ports:
-            assert isinstance(port, int), \
-                f"Expected to find int, but found: {type(port)}"
+            assert isinstance(
+                port, int
+            ), f"Expected to find int, but found: {type(port)}"
         self.namespace = namespace
-        assert isinstance(self.namespace, str), \
-            f"Expected to find str, but found: {type(self.namespace)}"
+        assert isinstance(
+            self.namespace, str
+        ), f"Expected to find str, but found: {type(self.namespace)}"
 
 
-class KubernetesNetworkChecker():
-
+class KubernetesNetworkChecker:
     def __init__(self):
         config.load_kube_config()
         self.targets = []
@@ -78,8 +81,7 @@ class KubernetesNetworkChecker():
                     continue
                 for port in container.ports:
                     ports.append(port.container_port)
-            target = \
-                ScanTarget(name, ip, "pod", ports=ports, namespace=namespace)
+            target = ScanTarget(name, ip, "pod", ports=ports, namespace=namespace)
             if ports:
                 self.targets.append(target)
         services = self.v1.list_service_for_all_namespaces(watch=False)
@@ -90,27 +92,21 @@ class KubernetesNetworkChecker():
             ports = []
             for port in service.spec.ports:
                 ports.append(port.port)
-            target = ScanTarget(name,
-                                ip,
-                                "service",
-                                ports=ports,
-                                namespace=namespace)
+            target = ScanTarget(name, ip, "service", ports=ports, namespace=namespace)
             if ports:
                 self.targets.append(target)
 
     @contextmanager
     def _scanning_pod(self):
-        namespace = 'astronomer-scan-test'
-        pod_name = f'network-scanner-{randint(0,100000)}'
-        v1container = client.V1Container(name='scanner')
+        namespace = "astronomer-scan-test"
+        pod_name = f"network-scanner-{randint(0,100000)}"
+        v1container = client.V1Container(name="scanner")
         v1container.command = ["sleep", "300"]
         v1container.image = "alpine"
         v1podspec = client.V1PodSpec(containers=[v1container])
         v1objectmeta = client.V1ObjectMeta(name=pod_name)
-        v1pod = client.V1Pod(spec=v1podspec,
-                             metadata=v1objectmeta)
-        logging.info(
-            f"Creating {pod_name} pod in namespace {namespace}")
+        v1pod = client.V1Pod(spec=v1podspec, metadata=v1objectmeta)
+        logging.info(f"Creating {pod_name} pod in namespace {namespace}")
         # --as=system:serviceaccount:astronomer:default
         pod = self.v1.create_namespaced_pod(namespace, v1pod)
         # allow pod to become 'Pending'
@@ -122,21 +118,20 @@ class KubernetesNetworkChecker():
                 if time() - start > timeout:
                     raise Exception("Timed out waiting for pod to start")
                 sleep(1)
-                check_pod = self.v1.read_namespaced_pod(
-                    pod.metadata.name, namespace)
+                check_pod = self.v1.read_namespaced_pod(pod.metadata.name, namespace)
                 if check_pod.status.container_statuses[0].ready:
                     logging.info("network-scanner is ready")
                     break
             test_fixture = testinfra.get_host(
-                    f'kubectl://{pod.metadata.name}?' +
-                    f'container={v1container.name}&namespace={namespace}')
+                f"kubectl://{pod.metadata.name}?"
+                + f"container={v1container.name}&namespace={namespace}"
+            )
             logging.info("Installing nmap into network-scanner")
-            test_fixture.check_output('apk add nmap')
-            test_fixture.exists('nmap')
+            test_fixture.check_output("apk add nmap")
+            test_fixture.exists("nmap")
             yield test_fixture
         finally:
-            logging.info(
-                f"Cleaning up network-scanner pod from namespace {namespace}")
+            logging.info(f"Cleaning up network-scanner pod from namespace {namespace}")
             self.v1.delete_namespaced_pod(v1pod.metadata.name, namespace)
 
     def scan_all_targets(self):
@@ -152,13 +147,15 @@ class KubernetesNetworkChecker():
         # Nmap does not have an option to specify ports-per-target,
         # so we scan all ports for any target on all hosts.
         with self._scanning_pod() as scanner:
-            scanner.check_output('whoami')
-            ports_string = ','.join([str(port) for port in all_ports])
-            addresses_string = ' '.join(all_ips)
+            scanner.check_output("whoami")
+            ports_string = ",".join([str(port) for port in all_ports])
+            addresses_string = " ".join(all_ips)
             logging.info("Executing scan...")
-            command = "nmap --max-retries 2 -T5 --max-rtt-timeout 100ms " + \
-                "-Pn -oX /scan-results.xml " + \
-                f"-p{ports_string} {addresses_string}"
+            command = (
+                "nmap --max-retries 2 -T5 --max-rtt-timeout 100ms "
+                + "-Pn -oX /scan-results.xml "
+                + f"-p{ports_string} {addresses_string}"
+            )
             logging.info(f"running command: {command}")
             start = time()
             scanner.check_output(command)
@@ -172,7 +169,7 @@ class KubernetesNetworkChecker():
                 ip_address = None
                 for grandchild in child:
                     if grandchild.tag == "address":
-                        ip_address = grandchild.attrib['addr']
+                        ip_address = grandchild.attrib["addr"]
                     if grandchild.tag == "ports":
                         # sample XML at the "ports" level:
                         # <ports>
@@ -189,11 +186,13 @@ class KubernetesNetworkChecker():
                             for state in port:
                                 if not state.tag == "state":
                                     continue
-                                is_open = state.attrib['state'] == "open"
+                                is_open = state.attrib["state"] == "open"
                             if is_open:
                                 if ip_address not in open_ports:
                                     open_ports[ip_address] = []
-                                open_ports[ip_address].append(int(port.attrib['portid']))
+                                open_ports[ip_address].append(
+                                    int(port.attrib["portid"])
+                                )
         result = ScanResult()
         # def __init__(self, name, ip_address, ports=[]):
         for address in open_ports.keys():
@@ -215,23 +214,28 @@ class KubernetesNetworkChecker():
 
 def test_network(kube_client):
     try:
-        kube_client.create_namespace(client.V1Namespace(
-            metadata=client.V1ObjectMeta(name='astronomer-scan-test')))
+        kube_client.create_namespace(
+            client.V1Namespace(
+                metadata=client.V1ObjectMeta(name="astronomer-scan-test")
+            )
+        )
     except Exception as e:
-        if not 'already exists' in str(e):
+        if "already exists" not in str(e):
             raise e
         print("namespace astronomer-scan-test already exists, proceeding")
     network_assessment = KubernetesNetworkChecker()
     network_assessment.collect_scan_targets()
     logging.info(f"Collected {len(network_assessment.targets)} scan targets")
     scan_result = network_assessment.scan_all_targets()
-    allow_list = ["pod/coredns-",
-                  "service/kube-dns",
-                  "service/kubernetes",
-                  "service/astronomer-nginx",
-                  "pod/astronomer-nginx",
-                  "service/astronomer-prometheus-node-exporter",
-                  "pod/astronomer-prometheus-node-exporter"]
+    allow_list = [
+        "pod/coredns-",
+        "service/kube-dns",
+        "service/kubernetes",
+        "service/astronomer-nginx",
+        "pod/astronomer-nginx",
+        "service/astronomer-prometheus-node-exporter",
+        "pod/astronomer-prometheus-node-exporter",
+    ]
     for finding in scan_result.findings:
         allowed = False
         for allow in allow_list:

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-KIND_VERSION="0.9.0"
-HELM2_VERSION="2.16.8"
-HELM3_VERSION="3.3.4"
-GCLOUD_VERSION="292.0.0"
-MKCERT_VERSION="1.4.1"
+KIND_VERSION="0.10.0"
+HELM2_VERSION="2.17.0"
+HELM3_VERSION="3.5.3"
+GCLOUD_VERSION="334.0.0"
+MKCERT_VERSION="1.4.3"
 
 OS=$(uname | tr '[:upper:]' '[:lower:]')
 

--- a/bin/lts-0-23-upgrade-tests/conftest.py
+++ b/bin/lts-0-23-upgrade-tests/conftest.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
-import os
 import pytest
 import docker
-import testinfra
 from kubernetes import client, config
-from kubernetes import client, config
+
 
 def create_kube_client(in_cluster=False):
     """
@@ -21,15 +19,17 @@ def create_kube_client(in_cluster=False):
         config.load_kube_config()
     return client.CoreV1Api()
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def docker_client(request):
-    """ This is a text fixture for the docker client,
+    """This is a text fixture for the docker client,
     should it be needed in a test
     """
     client = docker.from_env()
     yield client
     client.close()
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def kube_client(request):
     yield create_kube_client()

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -1,55 +1,60 @@
 #!/usr/bin/env python3
 
 import os
-import json
 import yaml
 from time import sleep, time
 from subprocess import check_output
 from packaging.version import parse as semver
 
 # The top-level path of this repository
-git_root_dir = os.path.join(
-    os.path.dirname(os.path.realpath(__file__)),
-    "..","..")
+git_root_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", "..")
+
 
 def test_upgrade():
     """
     Functional test for the LTS to LTS upgrade (0.16 to 0.23)
     """
-    with open(os.path.join(git_root_dir,
-                           "Chart.yaml"), "r") as f:
+    with open(os.path.join(git_root_dir, "Chart.yaml"), "r") as f:
         astro_chart_dot_yaml = yaml.safe_load(f.read())
-    major, minor, patch = semver(astro_chart_dot_yaml['version']).release
+    major, minor, patch = semver(astro_chart_dot_yaml["version"]).release
 
     assert major == 0 and minor == 23, "This test is only applicable for 0.23"
 
-    upgrade_manifest_path  = os.path.join(git_root_dir,
-                                          "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml")
-    rollback_manifest_path = os.path.join(git_root_dir,
-                                           "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml")
+    upgrade_manifest_path = os.path.join(
+        git_root_dir,
+        "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml",
+    )
+    rollback_manifest_path = os.path.join(
+        git_root_dir,
+        "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml",
+    )
 
-    namespace = os.environ.get('NAMESPACE')
-    release_name = os.environ.get('RELEASE_NAME')
+    namespace = os.environ.get("NAMESPACE")
+    release_name = os.environ.get("RELEASE_NAME")
     if not namespace:
         print("NAMESPACE env var is not present, using 'astronomer' namespace")
-        namespace = 'astronomer'
+        namespace = "astronomer"
     if not release_name:
-        print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
-        release_name = 'astronomer'
+        print(
+            "RELEASE_NAME env var is not present, assuming 'astronomer' is the release name"
+        )
+        release_name = "astronomer"
 
-    config_path = os.path.join(git_root_dir, "upgrade_test_config.yaml")
     # Get the existing values
-    result = check_output(f"helm3 history { release_name } -n { namespace } | tail -n 1", shell=True).decode('utf8')
+    result = check_output(
+        f"helm3 history { release_name } -n { namespace } | tail -n 1", shell=True
+    ).decode("utf8")
     assert "0.16" in result
     # rewrite manifest to replace with CI image for Kind test
     with open(upgrade_manifest_path, "r") as f:
         upgrade_manifest_data = f.read()
     upgrade_manifest_data = upgrade_manifest_data.replace(
         "image: quay.io/astronomer/lts-016-023-upgrade:latest",
-        "image: lts-016-023-upgrade:latest")
+        "image: lts-016-023-upgrade:latest",
+    )
     upgrade_manifest_data = upgrade_manifest_data.replace(
-        "imagePullPolicy: Always",
-        "imagePullPolicy: Never")
+        "imagePullPolicy: Always", "imagePullPolicy: Never"
+    )
     with open(f"{upgrade_manifest_path}.test.yaml", "w") as f:
         f.write(upgrade_manifest_data)
     check_output(f"kubectl apply -f {upgrade_manifest_path}.test.yaml", shell=True)
@@ -57,29 +62,42 @@ def test_upgrade():
     start_time = time()
     while True:
         sleep(5)
-        result = check_output(f"kubectl get pods -n default | grep upgrade-astronomer", shell=True).decode('utf8')
+        result = check_output(
+            "kubectl get pods -n default | grep upgrade-astronomer", shell=True
+        ).decode("utf8")
         if "Completed" in result:
             print("Upgrade pod finished in success")
             break
         if "Error" in result:
             print("Upgrade pod finished in error")
-            logs = check_output(f"kubectl logs $(kubectl get pods -n default | grep upgrade-astronomer | awk " + "'{ print $1 }')", shell=True).decode('utf8')
+            logs = check_output(
+                "kubectl logs $(kubectl get pods -n default | grep upgrade-astronomer | awk "
+                + "'{ print $1 }')",
+                shell=True,
+            ).decode("utf8")
             print(logs)
             assert False, "Failed to perform upgrade, see logs"
         if time() - start_time > timeout:
-            logs = check_output(f"kubectl logs $(kubectl get pods -n default | grep upgrade-astronomer | awk " + "'{ print $1 }')", shell=True).decode('utf8')
+            logs = check_output(
+                "kubectl logs $(kubectl get pods -n default | grep upgrade-astronomer | awk "
+                + "'{ print $1 }')",
+                shell=True,
+            ).decode("utf8")
             print(logs)
             assert False, "Failed to perform upgrade (timeout!), see logs"
-    result = check_output(f"helm3 history astronomer -n astronomer | tail -n 1", shell=True).decode('utf8')
+    result = check_output(
+        "helm3 history astronomer -n astronomer | tail -n 1", shell=True
+    ).decode("utf8")
     assert "0.23" in result and "deployed" in result, "Expected upgrade to be performed"
     with open(rollback_manifest_path, "r") as f:
         rollback_manifest_data = f.read()
     rollback_manifest_data = rollback_manifest_data.replace(
         "image: quay.io/astronomer/lts-016-023-upgrade:latest",
-        "image: lts-016-023-upgrade:latest")
+        "image: lts-016-023-upgrade:latest",
+    )
     rollback_manifest_data = rollback_manifest_data.replace(
-        "imagePullPolicy: Always",
-        "imagePullPolicy: Never")
+        "imagePullPolicy: Always", "imagePullPolicy: Never"
+    )
     with open(f"{rollback_manifest_path}.test.yaml", "w") as f:
         f.write(rollback_manifest_data)
     check_output(f"kubectl apply -f {rollback_manifest_path}.test.yaml", shell=True)
@@ -87,18 +105,32 @@ def test_upgrade():
     start_time = time()
     while True:
         sleep(5)
-        result = check_output(f"kubectl get pods -n default | grep rollback", shell=True).decode('utf8')
+        result = check_output(
+            "kubectl get pods -n default | grep rollback", shell=True
+        ).decode("utf8")
         if "Completed" in result:
             print("Rollback pod finished in success")
             break
         if "Error" in result:
             print("Rollback pod finished in error")
-            logs = check_output(f"kubectl logs $(kubectl get pods -n default | grep rollback | awk " + "'{ print $1 }')", shell=True).decode('utf8')
+            logs = check_output(
+                "kubectl logs $(kubectl get pods -n default | grep rollback | awk "
+                + "'{ print $1 }')",
+                shell=True,
+            ).decode("utf8")
             print(logs)
             assert False, "Failed to perform rollback, see logs"
         if time() - start_time > timeout:
-            logs = check_output(f"kubectl logs $(kubectl get pods -n default | grep rollback | awk " + "'{ print $1 }')", shell=True).decode('utf8')
+            logs = check_output(
+                "kubectl logs $(kubectl get pods -n default | grep rollback | awk "
+                + "'{ print $1 }')",
+                shell=True,
+            ).decode("utf8")
             print(logs)
             assert False, "Failed to perform rollback (timeout!), see logs"
-    result = check_output(f"helm3 history astronomer -n astronomer | tail -n 1", shell=True).decode('utf8')
-    assert "0.16" in result and "deployed" in result, "Expected rollback to be performed"
+    result = check_output(
+        "helm3 history astronomer -n astronomer | tail -n 1", shell=True
+    ).decode("utf8")
+    assert (
+        "0.16" in result and "deployed" in result
+    ), "Expected rollback to be performed"

--- a/bin/migration-scripts/README.md
+++ b/bin/migration-scripts/README.md
@@ -49,6 +49,7 @@ To perform the Kubernetes upgrade, please contact your cloud provider's support 
 - Namespace in which the Astronomer platform is installed (example: 'astronomer')
 - Helm release name of the Astronomer platform (example: 'astronomer')
 - You can confirm the namespace with
+
 ```sh
 kubectl get pods -n <namespace here>
 ```
@@ -223,13 +224,14 @@ Usually to solve an issue, it involves understanding what went wrong and manuall
 
 Helm 2to3 plugin is the least reliable part of this. I have found that it fails to migrate sometimes. In the event that the script fails due to helm 2to3 migration, then you can manually migrate releases like this:
 
-
 If the release exists in helm 2 but not helm 3:
+
 ```sh
 helm 2to3 convert --delete-v2-releases $release
 ```
 
 If the release exists in helm 2 and helm 3:
+
 ```sh
 helm 2to3 cleanup --name $release
 ```

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
@@ -8,12 +8,15 @@ The Astronomer upgrade will run in a pod in the cluster.
 
 - Kubernetes version must be greater than or equal to 1.14 and less than 1.19. If you need help to upgrade, please contact your cloud provider's support or your Kubernetes administrator.
 - You must be using Astronomer Certified Airflow images, and your version must be 1.10.5 or greater. These images are in the form:
+
 ```
 astronomerinc/ap-airflow:<airflow-version>-<build number>-<distribution>-onbuild
 ```
+
 The "onbuild" part is optional, but recommended. This enables features in the astro-cli, such as using requirements.txt and packages.txt. The "build number" part is optional but recommended. Excluding the build number will reference a mutable Docker image that is occasionally replaced with underlying pip modules updated, this is typically not preferred and instead it's best to plan when updates will occur in your Docker image. If you have your own build, test, and publish workflows that are layered on top of the Astronomer Airflow images, then it is appropriate to use the mutable image.
 
 Valid examples:
+
 ```
 astronomerinc/ap-airflow:1.10.12-1-alpine3.10-onbuild
 astronomerinc/ap-airflow:1.10.12-1-alpine3.10
@@ -21,7 +24,8 @@ astronomerinc/ap-airflow:1.10.5-9-buster-onbuild
 astronomerinc/ap-airflow:1.10.5-9-buster
 ```
 
-This is an example of a legacy images that should *not* be used:
+This is an example of a legacy images that should _not_ be used:
+
 ```
 astronomerinc/ap-airflow:<astronomer version>-<airflow version>
 astronomerinc/ap-airflow:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
@@ -12,17 +12,17 @@ spec:
       serviceAccountName: astronomer-upgrader-service-account
       restartPolicy: Never
       containers:
-      - image: quay.io/astronomer/lts-016-023-upgrade:latest
-        imagePullPolicy: Always
-        name: upgrade
-        command:
-          - ansible-playbook
-          - rollback-astronomer.yaml
-        volumeMounts:
-        - mountPath: /astronomer-backups
-          name: astronomer-upgrades-backup
+        - image: quay.io/astronomer/lts-016-023-upgrade:latest
+          imagePullPolicy: Always
+          name: upgrade
+          command:
+            - ansible-playbook
+            - rollback-astronomer.yaml
+          volumeMounts:
+            - mountPath: /astronomer-backups
+              name: astronomer-upgrades-backup
       terminationGracePeriodSeconds: 300
       volumes:
-      - name: astronomer-upgrades-backup
-        persistentVolumeClaim:
-          claimName: astronomer-upgrades-backup
+        - name: astronomer-upgrades-backup
+          persistentVolumeClaim:
+            claimName: astronomer-upgrades-backup

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml
@@ -10,7 +10,7 @@ metadata:
   name: astronomer-upgrades-backup
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 20Gi
@@ -29,29 +29,29 @@ spec:
       serviceAccountName: astronomer-upgrader-service-account
       restartPolicy: Never
       containers:
-      - image: quay.io/astronomer/lts-016-023-upgrade:latest
-        imagePullPolicy: Always
-        name: upgrade
-        volumeMounts:
-        - mountPath: /astronomer-backups
-          name: astronomer-upgrades-backup
+        - image: quay.io/astronomer/lts-016-023-upgrade:latest
+          imagePullPolicy: Always
+          name: upgrade
+          volumeMounts:
+            - mountPath: /astronomer-backups
+              name: astronomer-upgrades-backup
       terminationGracePeriodSeconds: 300
       volumes:
-      - name: astronomer-upgrades-backup
-        persistentVolumeClaim:
-          claimName: astronomer-upgrades-backup
+        - name: astronomer-upgrades-backup
+          persistentVolumeClaim:
+            claimName: astronomer-upgrades-backup
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: astronomer-upgrader-cluster-role
 rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - '*'
+  - apiGroups:
+      - "*"
+    resources:
+      - "*"
+    verbs:
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -62,6 +62,6 @@ roleRef:
   kind: ClusterRole
   name: astronomer-upgrader-cluster-role
 subjects:
-- kind: ServiceAccount
-  name: astronomer-upgrader-service-account
-  namespace: default
+  - kind: ServiceAccount
+    name: astronomer-upgrader-service-account
+    namespace: default

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine3.12
 
-ARG HELM3_VERSION="3.2.1"
+ARG HELM3_VERSION="3.5.3"
 ARG KUBECTL_VERSION="1.18.15"
 
 # Install Ansible and the modules we will use for upgrade

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set up variables
   set_fact:
     astro_save_dir: "/astronomer-backups"
@@ -12,7 +11,7 @@
   register: saves
 
 - debug:
-   msg: "{{ saves }}"
+    msg: "{{ saves }}"
 - set_fact:
     astro_save: "{{ (saves.files | sort(attribute='mtime', reverse=true) | first).path }}"
 
@@ -62,7 +61,7 @@
 - name: Ensure DB network policy is removed
   community.kubernetes.k8s:
     state: absent
-    api_version: 'networking.k8s.io/v1'
+    api_version: "networking.k8s.io/v1"
     kind: NetworkPolicy
     namespace: "{{ namespace }}"
     name: "{{ item }}"

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -208,15 +208,13 @@
     dest: "{{ astro_save_dir.path }}/helm-status.json"
     content: "{{ helm_status | to_json }}"
 
-- name: "Add private helm repo (for testing only)"
-  command: helm repo add astronomer https://internal-helm.astronomer.io
-  when: (CIRCLECI is defined) and (CIRCLECI | bool)
-
-- name: Add public helm repo
+- name: Add helm repos
   shell: |
     set -xe
     helm repo add astronomer https://helm.astronomer.io
+    helm repo add astronomer-internal https://internal-helm.astronomer.io
     helm repo update
+
 
 - name: Backup Astronomer database
   postgresql_db:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -209,13 +209,15 @@
     dest: "{{ astro_save_dir.path }}/helm-status.json"
     content: "{{ helm_status | to_json }}"
 
-- name: Add helm repos
+- name: "Add private helm repo (for testing only)"
+  command: helm repo add astronomer https://internal-helm.astronomer.io
+  when: (CIRCLECI is defined) and (CIRCLECI | bool)
+
+- name: Add public helm repo
   shell: |
     set -xe
     helm repo add astronomer https://helm.astronomer.io
-    helm repo add astronomer-internal https://internal-helm.astronomer.io
     helm repo update
-
 
 - name: Backup Astronomer database
   postgresql_db:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -1,5 +1,4 @@
 ---
-
 - name: Set up variables
   set_fact:
     backup_dir: "/astronomer-backups"
@@ -32,17 +31,17 @@
     msg: |
       Release Name: {{ release_name }}, Namespace: {{ namespace }}
 
-- name: 'Check that release name and namespace are correctly configured (1/3): helm status'
+- name: "Check that release name and namespace are correctly configured (1/3): helm status"
   changed_when: false
   register: helm_status_raw
   shell: |
     helm status -o json --namespace {{ namespace }} {{ release_name }}
 
-- name: 'Check that release name and namespace are correctly configured (2/3): parse json'
+- name: "Check that release name and namespace are correctly configured (2/3): parse json"
   set_fact:
     helm_status: "{{ helm_status_raw.stdout | from_json }}"
 
-- name: 'Check that release name and namespace are correctly configured (3/3): assert contents look right'
+- name: "Check that release name and namespace are correctly configured (3/3): assert contents look right"
   changed_when: false
   assert:
     that:
@@ -50,13 +49,13 @@
       - helm_status.info.status == 'deployed'
       - helm_status.namespace == namespace
 
-- name: 'Fetch Helm history from Astronomer (1/2): helm history'
+- name: "Fetch Helm history from Astronomer (1/2): helm history"
   changed_when: false
   register: helm_history_raw
   shell: |
     helm history -o json --namespace {{ namespace }} {{ release_name }}
 
-- name: 'Fetch Helm history from Astronomer (2/2): parse json'
+- name: "Fetch Helm history from Astronomer (2/2): parse json"
   set_fact:
     # this will select only the current revision from the helm history
     helm_history: "{{ helm_history_raw.stdout | from_json | last }}"
@@ -77,13 +76,13 @@
       - "Current revision is: {{ helm_history.revision }}"
       - "Status is: {{ helm_history.status }}"
 
-- name: 'Fetch Helm values from Astronomer (1/2): helm get values'
+- name: "Fetch Helm values from Astronomer (1/2): helm get values"
   register: helm_values_raw
   changed_when: false
   shell: |
     helm get values -o json --namespace {{ namespace }} {{ release_name }}
 
-- name: 'Fetch Helm values from Astronomer (2/2): parse json'
+- name: "Fetch Helm values from Astronomer (2/2): parse json"
   set_fact:
     helm_values: "{{ helm_values_raw.stdout | from_json }}"
 
@@ -228,7 +227,7 @@
     name: "{{ database_name }}_houston"
     state: dump
     target: "{{ astro_save_dir.path }}/astronomer-db-backup.tar"
-    target_opts: '--clean --create --format=tar'
+    target_opts: "--clean --create --format=tar"
 
 - name: Run SQL for Prisma 1 to Prisma 2 migration
   register: prisma1_to_2

--- a/bin/migration-scripts/upgrade-to-lts.sh
+++ b/bin/migration-scripts/upgrade-to-lts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: "${TILLER_NAMESPACE:=kube-system}"
+TILLER_NAMESPACE="${TILLER_NAMESPACE:-kube-system}"
 
 backup_dir=helm-values-backup
 

--- a/bin/validate-helm-unittest-templates.py
+++ b/bin/validate-helm-unittest-templates.py
@@ -31,7 +31,9 @@ def validate_test_suite(test_suite: Dict, file: PosixPath) -> None:
 
     for test in test_suite["tests"]:
         if "template" in test:
-            validate_template_file(Path(file.parent.parent) / "templates" / test["template"])
+            validate_template_file(
+                Path(file.parent.parent) / "templates" / test["template"]
+            )
 
 
 def validate_template_file(file: PosixPath) -> None:


### PR DESCRIPTION
# Description

Almost everything in here was flagged by pre-commit. This should all be functionally identical. The reverted `CIRCLECI=true` commits are because I began this work on a different branch, then branched off that because I wanted to keep those changes separate from these housekeeping changes.

- apply `black` to our python scripts (pre-commit)
- fix some flake8 complaints related to unnecessary f-strings, unused imports (pre-commit)
- Tweak pre-commit
- Apply `flynt` to one file.