### PR TITLE
Break LTS upgrader into its own workflow. 'prettier' cleanup.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - docker-build:
           image_name: lts-016-023-upgrade
-          path: './bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/'
+          path: "./bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/"
 
   push-lts-upgrade:
     executor: docker-executor
@@ -54,9 +54,9 @@ jobs:
             source ./bin/install-ci-tools 1
             make build
       - persist_to_workspace:
-          root: '.'
+          root: "."
           paths:
-            - './*.tgz'
+            - "./*.tgz"
 
   release-to-internal:
     machine:
@@ -130,11 +130,9 @@ jobs:
 
 workflows:
   version: 2.1
-  build-and-release-helm-chart:
+  build-and-release-upgrader:
     jobs:
       - lint
-      - unittest-charts
-
       - approve-lts-upgrader-build:
           type: approval
 
@@ -142,6 +140,37 @@ workflows:
           requires:
             - lint
             - approve-lts-upgrader-build
+
+      - lts-upgrade-0-23-test:
+          requires:
+            - build-lts-upgrade
+
+      - approve-lts-upgrader-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - "release-0.23"
+                - "master"
+                - "lts-to-lts"
+
+      - push-lts-upgrade:
+          requires:
+            - approve-lts-upgrader-release
+            - lts-upgrade-0-23-test
+          context:
+            - quay.io
+          filters:
+            branches:
+              only:
+                - "release-0.23"
+                - "master"
+                - "lts-to-lts"
+
+  build-and-release-helm-chart:
+    jobs:
+      - lint
+      - unittest-charts
 
       - build-artifact:
           requires:
@@ -165,10 +194,6 @@ workflows:
           requires:
             - build-artifact
 
-      - lts-upgrade-0-23-test:
-          requires:
-            - build-lts-upgrade
-
       - approve-internal-release:
           type: approval
           filters:
@@ -187,15 +212,6 @@ workflows:
               only:
                 - '/release-0\.\d+/'
 
-      - approve-lts-upgrader-release:
-          type: approval
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'master'
-                - 'lts-to-lts'
-
       - approve-public-release:
           type: approval
           requires:
@@ -205,19 +221,6 @@ workflows:
             branches:
               only:
                 - '/release-0\.(12|13|14|15|16|23)/'
-
-      - push-lts-upgrade:
-          requires:
-            - approve-lts-upgrader-release
-            - lts-upgrade-0-23-test
-          context:
-            - quay.io
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'master'
-                - 'lts-to-lts'
 
       - release-to-public:
           requires:
@@ -306,7 +309,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - './<< parameters.image_name >>.tar'
+            - "./<< parameters.image_name >>.tar"
 
   upgrade-0-23-test:
     description: "Test LTS to LTS upgrade automation"

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -23,7 +23,7 @@ jobs:
     steps:
       - docker-build:
           image_name: lts-016-023-upgrade
-          path: './bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/'
+          path: "./bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/"
 
   push-lts-upgrade:
     executor: docker-executor
@@ -52,9 +52,9 @@ jobs:
             source ./bin/install-ci-tools 1
             make build
       - persist_to_workspace:
-          root: '.'
+          root: "."
           paths:
-            - './*.tgz'
+            - "./*.tgz"
 
   release-to-internal:
     machine:
@@ -112,11 +112,9 @@ jobs:
 
 workflows:
   version: 2.1
-  build-and-release-helm-chart:
+  build-and-release-upgrader:
     jobs:
       - lint
-      - unittest-charts
-
       - approve-lts-upgrader-build:
           type: approval
 
@@ -124,6 +122,37 @@ workflows:
           requires:
             - lint
             - approve-lts-upgrader-build
+
+      - lts-upgrade-0-23-test:
+          requires:
+            - build-lts-upgrade
+
+      - approve-lts-upgrader-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - "release-0.23"
+                - "master"
+                - "lts-to-lts"
+
+      - push-lts-upgrade:
+          requires:
+            - approve-lts-upgrader-release
+            - lts-upgrade-0-23-test
+          context:
+            - quay.io
+          filters:
+            branches:
+              only:
+                - "release-0.23"
+                - "master"
+                - "lts-to-lts"
+
+  build-and-release-helm-chart:
+    jobs:
+      - lint
+      - unittest-charts
 
       - build-artifact:
           requires:
@@ -143,10 +172,6 @@ workflows:
             - build-artifact
 {% endif %}{% endfor %}
 
-      - lts-upgrade-0-23-test:
-          requires:
-            - build-lts-upgrade
-
       - approve-internal-release:
           type: approval
           filters:
@@ -164,15 +189,6 @@ workflows:
               only:
                 - '/release-0\.\d+/'
 
-      - approve-lts-upgrader-release:
-          type: approval
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'master'
-                - 'lts-to-lts'
-
       - approve-public-release:
           type: approval
           requires:
@@ -182,19 +198,6 @@ workflows:
             branches:
               only:
                 - '/release-0\.(12|13|14|15|16|23)/'
-
-      - push-lts-upgrade:
-          requires:
-            - approve-lts-upgrader-release
-            - lts-upgrade-0-23-test
-          context:
-            - quay.io
-          filters:
-            branches:
-              only:
-                - 'release-0.23'
-                - 'master'
-                - 'lts-to-lts'
 
       - release-to-public:
           requires:
@@ -283,7 +286,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - './<< parameters.image_name >>.tar'
+            - "./<< parameters.image_name >>.tar"
 
   upgrade-0-23-test:
     description: "Test LTS to LTS upgrade automation"


### PR DESCRIPTION
These are CI changes only.

# Description

Break release-upgrader into its own workflow. See astronomer/issues#2789 for further reasoning.

# View of changes

## Before

EG: <https://app.circleci.com/pipelines/github/astronomer/astronomer/2266/workflows/ff4a5c91-c621-467e-a9cb-5cb23cbc649c>

<img width="1393" alt="Screen Shot 2021-04-06 at 12 06 47 PM" src="https://user-images.githubusercontent.com/1323808/113765216-d07aba00-96d0-11eb-895e-dce644db791a.png">

## After

EG:
- <https://app.circleci.com/pipelines/github/astronomer/astronomer/2268/workflows/11732fac-a012-4f47-8bd0-02aef4990bfb>
- <https://app.circleci.com/pipelines/github/astronomer/astronomer/2268/workflows/7d2f63ff-f61d-49c3-a137-f2b0245d9d78>

<img width="1014" alt="Screen Shot 2021-04-06 at 12 07 13 PM" src="https://user-images.githubusercontent.com/1323808/113765230-d53f6e00-96d0-11eb-9eed-4f59d6dc9c3a.png">
<img width="1010" alt="Screen Shot 2021-04-06 at 12 07 19 PM" src="https://user-images.githubusercontent.com/1323808/113765231-d6709b00-96d0-11eb-89a3-952cad0f96ce.png">
