### PR TITLE
LTS Upgrader: use private helm repo only when testing

### DIFF
--- a/bin/lts-0-23-upgrade-tests/requirements.txt
+++ b/bin/lts-0-23-upgrade-tests/requirements.txt
@@ -1,5 +1,6 @@
-pytest==6.0.1
-testinfra==5.2.2
 docker==4.3.1
+GitPython==3.1.14
 kubernetes==11.0.0
+pytest==6.0.1
 PyYAML==5.3.1
+testinfra==5.2.2

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -9,7 +9,7 @@ from packaging.version import parse as semver
 
 # The top-level path of this repository
 git_root_dir = Path(__file__).absolute().parent.parent.parent
-print(f"{git_root_dir=}")
+print(f"DEBUG: {git_root_dir=}")
 
 
 def test_upgrade():
@@ -26,12 +26,12 @@ def test_upgrade():
         git_root_dir
         / "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml"
     )
-    print(f"{upgrade_manifest_path=}")
+    print(f"DEBUG: {upgrade_manifest_path=}")
     rollback_manifest_path = Path(
         git_root_dir
         / "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml"
     )
-    print(f"{rollback_manifest_path=}")
+    print(f"DEBUG: {rollback_manifest_path=}")
 
     namespace = environ.get("NAMESPACE")
     release_name = environ.get("RELEASE_NAME")
@@ -68,7 +68,9 @@ def test_upgrade():
                 for container in containers:
                     if not container.get("env"):
                         container["env"] = []
-                    container["env"].append({"USE_INTERNAL_HELM_REPO": True})
+                    container["env"].append(
+                        {"name": "USE_INTERNAL_HELM_REPO", "value": True}
+                    )
                 upgrade_manifest_yaml[i] = doc
             except KeyError:
                 pass
@@ -76,7 +78,7 @@ def test_upgrade():
     upgrade_manifest_data = yaml.safe_dump_all(upgrade_manifest_yaml)
 
     modified_upgrade_manifest_path = f"{upgrade_manifest_path}.test.yaml"
-    print(f"{modified_upgrade_manifest_path=}")
+    print(f"DEBUG: {modified_upgrade_manifest_path=}")
     with open(modified_upgrade_manifest_path, "w") as f:
         f.write(upgrade_manifest_data)
     check_output(f"kubectl apply -f {modified_upgrade_manifest_path}", shell=True)

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -9,7 +9,6 @@ from packaging.version import parse as semver
 
 # The top-level path of this repository
 git_root_dir = Path(__file__).absolute().parent.parent.parent
-print(f"DEBUG: {git_root_dir=}")
 
 
 def test_upgrade():
@@ -26,12 +25,10 @@ def test_upgrade():
         git_root_dir
         / "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml"
     )
-    print(f"DEBUG: {upgrade_manifest_path=}")
     rollback_manifest_path = Path(
         git_root_dir
         / "bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml"
     )
-    print(f"DEBUG: {rollback_manifest_path=}")
 
     namespace = environ.get("NAMESPACE")
     release_name = environ.get("RELEASE_NAME")
@@ -78,7 +75,6 @@ def test_upgrade():
     upgrade_manifest_data = yaml.safe_dump_all(upgrade_manifest_yaml)
 
     modified_upgrade_manifest_path = f"{upgrade_manifest_path}.test.yaml"
-    print(f"DEBUG: {modified_upgrade_manifest_path=}")
     with open(modified_upgrade_manifest_path, "w") as f:
         f.write(upgrade_manifest_data)
     check_output(f"kubectl apply -f {modified_upgrade_manifest_path}", shell=True)

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -8,7 +8,8 @@ from subprocess import check_output
 from packaging.version import parse as semver
 
 # The top-level path of this repository
-git_root_dir = Path(__file__).absolute().parent.parent
+git_root_dir = Path(__file__).absolute().parent.parent.parent
+print(f"{git_root_dir=}")
 
 
 def test_upgrade():

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -6,9 +6,11 @@ import yaml
 from time import sleep, time
 from subprocess import check_output
 from packaging.version import parse as semver
+import git
 
 # The top-level path of this repository
-git_root_dir = Path(__file__).absolute().parent.parent.parent
+git_repo = git.Repo(__file__, search_parent_directories=True)
+git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 
 
 def test_upgrade():

--- a/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
+++ b/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py
@@ -69,7 +69,7 @@ def test_upgrade():
                     if not container.get("env"):
                         container["env"] = []
                     container["env"].append(
-                        {"name": "USE_INTERNAL_HELM_REPO", "value": True}
+                        {"name": "USE_INTERNAL_HELM_REPO", "value": "True"}
                     )
                 upgrade_manifest_yaml[i] = doc
             except KeyError:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.9-alpine3.12
 ARG HELM3_VERSION="3.5.3"
 ARG KUBECTL_VERSION="1.18.15"
 
+ENV USE_INTERNAL_HELM_REPO False
+
 # Install Ansible and the modules we will use for upgrade
 RUN apk add build-base libffi-dev openssl-dev postgresql-dev bash curl postgresql-client
 RUN pip install ansible==2.9.14 psycopg2==2.8.6 openshift==0.11.2 cryptography==3.1.1
@@ -22,4 +24,4 @@ WORKDIR /lts-upgrade
 
 COPY . .
 
-ENTRYPOINT ["ansible-playbook", "upgrade-astronomer.yaml"]
+ENTRYPOINT ansible-playbook -e "USE_INTERNAL_HELM_REPO=$USE_INTERNAL_HELM_REPO" upgrade-astronomer.yaml

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -208,13 +208,15 @@
     dest: "{{ astro_save_dir.path }}/helm-status.json"
     content: "{{ helm_status | to_json }}"
 
-- name: Add helm repos
+- name: "Add private helm repo (for testing only)"
+  command: helm repo add astronomer https://internal-helm.astronomer.io
+  when: (CIRCLECI is defined) and (CIRCLECI | bool)
+
+- name: Add public helm repo
   shell: |
     set -xe
     helm repo add astronomer https://helm.astronomer.io
-    helm repo add astronomer-internal https://internal-helm.astronomer.io
     helm repo update
-
 
 - name: Backup Astronomer database
   postgresql_db:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -208,15 +208,19 @@
     dest: "{{ astro_save_dir.path }}/helm-status.json"
     content: "{{ helm_status | to_json }}"
 
-- name: "Add private helm repo (for testing only)"
-  command: helm repo add astronomer https://internal-helm.astronomer.io
-  when: (USE_INTERNAL_HELM_REPO is defined) and (USE_INTERNAL_HELM_REPO | bool)
-
 - name: Add public helm repo
   shell: |
     set -xe
     helm repo add astronomer https://helm.astronomer.io
     helm repo update
+  when: (USE_INTERNAL_HELM_REPO is not defined) or not (USE_INTERNAL_HELM_REPO | bool)
+
+- name: "Add private helm repo (for testing only)"
+  shell: |
+    set -xe
+    helm repo add astronomer https://internal-helm.astronomer.io
+    helm repo update
+  when: (USE_INTERNAL_HELM_REPO is defined) and (USE_INTERNAL_HELM_REPO | bool)
 
 - name: Backup Astronomer database
   postgresql_db:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -210,7 +210,7 @@
 
 - name: "Add private helm repo (for testing only)"
   command: helm repo add astronomer https://internal-helm.astronomer.io
-  when: (CIRCLECI is defined) and (CIRCLECI | bool)
+  when: (USE_INTERNAL_HELM_REPO is defined) and (USE_INTERNAL_HELM_REPO | bool)
 
 - name: Add public helm repo
   shell: |


### PR DESCRIPTION
# Description

Only use internal-helm repo when testing the LTS upgrader, use the public helm repo at any other time. This is done in order to prevent customers from picking up pre-release versions of the chart.

This is done through a new variable `USE_INTERNAL_HELM_REPO` which tells ansible (the component that performs the LTS upgrade) to use the internal helm repo instead of the public helm repo. This var is passed from [the test script into k8s](https://github.com/astronomer/astronomer/blob/e6ef341f/bin/lts-0-23-upgrade-tests/test_lts_upgrade.py#L60-L80) [into Docker into Ansible](https://github.com/astronomer/astronomer/blob/e6ef341f/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/Dockerfile#L27).

Related to astronomer/issues#2596

# Testing

Normal testing env shows:
```
/lts-upgrade # circleci@default-37dd162a-e01a-4065-8720-9462520e9153:~$ kubectl exec -ti upgrade-astronomer-ztjsr -- sh
/lts-upgrade # echo $USE_INTERNAL_HELM_REPO
True
/lts-upgrade # helm repo list -o yaml
- name: astronomer
  url: https://internal-helm.astronomer.io
```

I modified the test script to always set `USE_INTERNAL_HELM_REPO: False`:
```
circleci@default-37dd162a-e01a-4065-8720-9462520e9153:~$ kubectl exec -ti upgrade-astronomer-s5v28 -- sh
/lts-upgrade # echo $USE_INTERNAL_HELM_REPO
False
/lts-upgrade # helm repo list -o yaml
- name: astronomer
  url: https://helm.astronomer.io
```