### PR TITLE
Update Houston config map to properly label pods launched by the Kubernetes Pod Operator

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -124,8 +124,6 @@ data:
 
           # Airflow Local Settings.
           airflowLocalSettings: |
-            from airflow.contrib.kubernetes.pod import Pod
-            from airflow.configuration import conf
             # This pod mutation hook runs for all pods dynamically created by Airflow
             # in Kubernetes (K8s). This includes K8s executor Airflow-workers, which is
             # an alternative executor to Celery, and K8s Pod Operator (KPO) pods, which is
@@ -134,14 +132,16 @@ data:
             # This function is responsible for two things. It assigns labels to disambiguate
             # between KPO and K8s executor pods. Also, it handles writing the entrypoint for
             # K8s executor pods. Why we do this second part, you can read below.
-            def pod_mutation_hook(pod: Pod):
+            from airflow.configuration import conf
+            from airflow.version import version
+            def pod_mutation_hook_deprecated(pod):
+              from airflow.contrib.kubernetes.pod import Pod
               extra_labels = {
-                  "kubernetes-executor": "False",
                   "kubernetes-pod-operator": "False"
               }
-              if 'airflow-worker' in pod.labels.keys() or \
+              if 'airflow-worker' in pod.labels.keys() and \
                       conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
-                  extra_labels["kubernetes-executor"] = "True"
+                  # extra_labels["kubernetes-executor"] = "True"
                   # By default, Airflow overwrites the entrypoint
                   # of KPO and K8s executor Airflow-worker pods.
                   # K8s worker pods are Airflow containers, and we can assume these
@@ -149,17 +149,54 @@ data:
                   # an entrypoint in these containers to handle waiting for the network
                   # and the database to be ready, so we do not want this entrypoint
                   # to be overwritten. This helps with the stability of the K8s executor.
-                  if not pod.args:
-                    pod.args = []
-                  pod.args = pod.cmds + pod.args
+                  if "1.10" in version:
+                      if not pod.args:
+                          pod.args = []
+                      pod.args = pod.cmds + pod.args
                   pod.cmds = ["tini", "--", "/entrypoint"]
               else:
-                  extra_labels["kubernetes-pod-operator"] = "True"
                   # In the case of KPO, we allow Airflow to overwrite the entrypoint
                   # because we do not know what the container will be (and it's probably
-                  # not a container vendored by Astronomer, and it's definitely not
+                  # not a container vendored by Astronomer, and it's definately not
                   # an Airflow container).
+                  extra_labels["kubernetes-pod-operator"] = "True"
+                  extra_labels["kubernetes-executor"] = "False"
               pod.labels.update(extra_labels)
+            def pod_mutation_hook_new(pod):
+              extra_labels = {
+                  "kubernetes-pod-operator": "False"
+              }
+              if 'airflow-worker' in pod.metadata.labels.keys() and \
+                      conf.get('core', 'EXECUTOR') == "KubernetesExecutor":
+                  # extra_labels["kubernetes-executor"] = "True"
+                  # By default, Airflow overwrites the entrypoint
+                  # of KPO and K8s executor Airflow-worker pods.
+                  # K8s worker pods are Airflow containers, and we can assume these
+                  # Airflow containers are vendored by Astronomer. Astronomer provides
+                  # an entrypoint in these containers to handle waiting for the network
+                  # and the database to be ready, so we do not want this entrypoint
+                  # to be overwritten. This helps with the stability of the K8s executor.
+                  container = pod.spec.containers[0]
+                  if "1.10" in version:
+                      if not container.args:
+                          container.args = []
+                      container.args = container.command + container.args
+                  container.command = ["tini", "--", "/entrypoint"]
+                  pod.spec.containers[0] = container
+              else:
+                  # In the case of KPO, we allow Airflow to overwrite the entrypoint
+                  # because we do not know what the container will be (and it's probably
+                  # not a container vendored by Astronomer, and it's definately not
+                  # an Airflow container).
+                  extra_labels["kubernetes-pod-operator"] = "True"
+                  extra_labels["kubernetes-executor"] = "False"
+              pod.metadata.labels.update(extra_labels)
+            def pod_mutation_hook(pod):
+              try:
+                pod_mutation_hook_new(pod)
+              except Exception as e:
+                pod_mutation_hook_deprecated(pod)
+
           resources:
             limits:
               ephemeral-storage: "2Gi"

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -157,7 +157,7 @@ data:
               else:
                   # In the case of KPO, we allow Airflow to overwrite the entrypoint
                   # because we do not know what the container will be (and it's probably
-                  # not a container vendored by Astronomer, and it's definately not
+                  # not a container vendored by Astronomer, and it's definitely not
                   # an Airflow container).
                   extra_labels["kubernetes-pod-operator"] = "True"
                   extra_labels["kubernetes-executor"] = "False"


### PR DESCRIPTION
## Description

Updated houston-configmap local airflow settings to allow kubernetes pod operator pods to be labeled properly

## 🎟 Issue(s)

Resolves astronomer/issues#2822


## 🧪  Testing

Tested with this change on my local cluster to verify that pods launched by the Kubernetes Pod Operator pods are tagged

