### PR TITLE
Duplicate key `livenessProbe` in `elasticsearch-exporter`

### DIFF
--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -91,7 +91,7 @@ spec:
               port: http
             initialDelaySeconds: 30
             timeoutSeconds: 10
-          livenessProbe:
+          readinessProbe:
             httpGet:
               path: /health
               port: http


### PR DESCRIPTION
Maybe we meant `readinessProbe` ?