### PR TITLE
Fix Non-Ascii Quotes 😡

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.houston.updateAirflowCheck.schedule }}
-  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn’t finished yet, the cron job skips the new job run
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.houston.updateCheck.schedule }}
-  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn’t finished yet, the cron job skips the new job run
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.houston.cleanupDeployments.schedule }}
-  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn’t finished yet, the cron job skips the new job run
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
Interfering with `kustomize` parsing of our helm chart - non-ascii quote characters snuck in