### PR TITLE
Add LTS 25, remove pre 16 versions from CI rules.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16|23)/'
+                - '/release-0\.(16|23|25)/'
 
       - release-to-public:
           requires:
@@ -228,7 +228,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16|23)/'
+                - '/release-0\.(16|23|25)/'
 
 commands:
   push-to-quay-io:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(16|23|25)/'
+                - '/release-0\.\d+/'
 
       - release-to-public:
           requires:
@@ -228,7 +228,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(16|23|25)/'
+                - '/release-0\.\d+/'
 
 commands:
   push-to-quay-io:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -197,7 +197,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16|23)/'
+                - '/release-0\.(16|23|25)/'
 
       - release-to-public:
           requires:
@@ -205,7 +205,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(12|13|14|15|16|23)/'
+                - '/release-0\.(16|23|25)/'
 
 commands:
   push-to-quay-io:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -197,7 +197,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(16|23|25)/'
+                - '/release-0\.\d+/'
 
       - release-to-public:
           requires:
@@ -205,7 +205,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/release-0\.(16|23|25)/'
+                - '/release-0\.\d+/'
 
 commands:
   push-to-quay-io:


### PR DESCRIPTION
Tune up some LTS CI configs. I thought this would be bigger when I opened the original ticket.

Now that all releases will be public, we can reduce this logic back to a simple regex instead of matching against specific version numbers that were approved for public release.

Related to https://github.com/astronomer/issues/issues/2828