### PR TITLE
Bump docker images for 0.25.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:
@@ -36,7 +36,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:
@@ -45,7 +45,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,7 +8,7 @@ executors:
 jobs:
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:
@@ -34,7 +34,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:
@@ -43,7 +43,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.1.3
+      - image: quay.io/astronomer/ap-build:0.2.0
     steps:
       - checkout
       - run:

--- a/charts/astronomer/tests/deployment_test.yaml
+++ b/charts/astronomer/tests/deployment_test.yaml
@@ -8,4 +8,4 @@ tests:
         of: Deployment
     - equal:
         path: spec.template.spec.containers[0].image
-        value: quay.io/astronomer/ap-commander:0.21.0
+        value: quay.io/astronomer/ap-commander:0.25.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.21.0
+    tag: 0.25.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.13.2
+    tag: 3.13.5
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 3.13.4-1
+    tag: 3.13.5
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 3.13.2
+    tag: 3.13.5
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.10.2
+    tag: 7.10.2-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 7.3.7
+    tag: 7.5.4
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.10.2
+    tag: 7.10.2-1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 0.43.0
+    tag: 0.45.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.16.1
+    tag: 0.15.0
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.15.0
+    tag: 0.25.1
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 3.13.2
+  tag: 3.13.5
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.13.2
+    tag: 3.13.5
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
This bumps a bunch of docker images for the 0.25.0 release. There are a LOT of changes in here and I have done no testing of any of these images.

Releated to https://github.com/astronomer/issues/issues/2749