### PR TITLE
added line to ignore rolling daemonsets for 10m before alerts fire fo…

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -736,6 +736,8 @@ data:
             kube_daemonset_status_number_ready{job="{{.Release.Name}}-kube-state"}
               /
             kube_daemonset_status_desired_number_scheduled{job="{{.Release.Name}}-kube-state"} < 1.00
+            and
+            increase(kube_daemonset_metadata_generation{job="{{.Release.Name}}-kube-state"}[10m]) == 0
           for: 15m
           labels:
             severity: critical


### PR DESCRIPTION
## Description

rolling daemonsets are kicking off alerts due to the length of how many need updated.  it causes false alerts to go out.  this change ignores a daemonset for 10m after it starts rolling giving it time to move through nodes.
## PR Title

## 🎟 Issue(s)
https://github.com/astronomer/issues/issues/2902

## 🧪  Testing

i tested these queries side by side in our gen1 environment and this would reduce/eliminate the `calico-node` alerts we get from vertical scaling happening during expansion and contraction of the nodes.