### PR TITLE
bump houston-api to 0.25.1

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.25.0
+    tag: 0.25.1
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
Bump houston-api:
- https://github.com/astronomer/houston-api/commit/5978253784d68e85a117dbd440ae0450031b6eb6
- https://github.com/astronomer/houston-api/pull/677
- https://github.com/astronomer/houston-api/pull/675