### PR TITLE
bump houston-api to 0.25.3

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.25.2
+    tag: 0.25.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
Changing deployment from NFS to Image type should remove reference to the mount #2931 https://github.com/astronomer/issues/issues/2931