### PR TITLE
Bump ap-curator astronomer/issues#2952

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4
+    tag: 5.8.4-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
Resolves the crypto library problem in astronomer/issues#2952 verified by @pgvishnuram in dev

I have also verified on my laptop that the crypto error does not occur anymore.

```
$ docker run quay.io/astronomer/ap-curator:5.8.4 --help
Traceback (most recent call last):
  File "/usr/bin/curator", line 6, in <module>
    import urllib3.contrib.pyopenssl
  File "/usr/lib/python3.8/site-packages/urllib3/contrib/pyopenssl.py", line 50, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3.8/site-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3.8/site-packages/OpenSSL/crypto.py", line 14, in <module>
    from cryptography import utils, x509
ModuleNotFoundError: No module named 'cryptography'
```
```
$ docker run quay.io/astronomer/ap-curator:5.8.4-1 --help
Usage: curator [OPTIONS] ACTION_FILE

  Curator for Elasticsearch indices.

  See http://elastic.co/guide/en/elasticsearch/client/curator/current

Options:
  --config PATH  Path to configuration file. Default: ~/.curator/curator.yml
  --dry-run      Do not perform any changes.
  --version      Show the version and exit.
  --help         Show this message and exit.
```