### PR TITLE
Setting suppress_type_name true in fluentd configmap

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -189,6 +189,7 @@ data:
         reload_on_failure true
         reload_connections false
         request_timeout 120s
+        suppress_type_name true
         host "#{ENV['OUTPUT_HOST']}"
         port "#{ENV['OUTPUT_PORT']}"
         index_name fluentd.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}


### PR DESCRIPTION
Relates to astronomer/issues#2975

Steps to apply the fix:
1. Added `suppress_type_name true` to fluentd configmap. 
2. Restart fluentd pods. 