### PR TITLE
Add circleci context 'github-repo' to release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,6 +223,7 @@ workflows:
       - release-to-public:
           context:
             - gcp-astronomer-prod
+            - github-repo
           requires:
             - approve-public-release
           filters:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -200,6 +200,7 @@ workflows:
       - release-to-public:
           context:
             - gcp-astronomer-prod
+            - github-repo
           requires:
             - approve-public-release
           filters:


### PR DESCRIPTION
Release-to-public step failed because of a missing security credential. This is fallout from astronomer/issues#2841