### PR TITLE
Point LTS 23 upgrade manifest URLs to the release-0.23 branch

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/README.md
@@ -60,7 +60,7 @@ Ensure that you have the default namespace in your kubernetes context, not neces
 ## Run the Astronomer upgrade automation
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.23/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml
 ```
 
 Watch the logs of the upgrade pod, you can find pod name with:
@@ -88,7 +88,7 @@ If the upgrade has some issues and you need to recover, you can rollback to the 
 ## Apply the rollback automation
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
+kubectl apply -f https://raw.githubusercontent.com/astronomer/astronomer/release-0.23/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml
 ```
 
 ## Wait for platform to come back up


### PR DESCRIPTION
Two manifest URLs in the LTS 16-to23 flow point to master, which is wrong. These need to point to the branch of the release that they are upgrading to, which is release 23.

Until this is merged, customers will be unable to upgrade from 16 to 23 using our instructions because the old URLs are 404.

## Old URLs:

- <https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml>
- <https://raw.githubusercontent.com/astronomer/astronomer/master/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml>

## New URLs:
- <https://raw.githubusercontent.com/astronomer/astronomer/release-0.23/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/upgrade-0.16-to-0.23.yaml>
- <https://raw.githubusercontent.com/astronomer/astronomer/release-0.23/bin/migration-scripts/lts-to-lts/0.16-to-0.23/manifests/rollback-0.16-to-0.23.yaml>