### PR TITLE
Add Support for GCP workload identity functionality for GCS backend registry 

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -133,7 +133,9 @@
 {{- define "registry.gcsConfig" }}
 gcs:
   bucket: {{ .Values.registry.gcs.bucket }}
+  {{- if .Values.registry.gcs.useKeyfile }}
   keyfile: {{ .Values.registry.gcs.keyfile }}
+  {{- end }}
   rootdirectory: {{ .Values.registry.gcs.rootdirectory }}
   chunksize: {{ .Values.registry.gcs.chunksize }}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
               mountPath: /etc/docker/ssl
             - name: data
               mountPath: /var/lib/registry
-            {{- if .Values.registry.gcs.enabled }}
+            {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
             {{- include "registry.gcsVolumeMount" . | indent 12 }}
             {{- end }}
           ports:
@@ -94,7 +94,7 @@ spec:
         - name: certificate
           secret:
             secretName: {{ .Values.global.tlsSecret }}
-        {{- if .Values.registry.gcs.enabled }}
+        {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
         {{- include "registry.gcsVolume" . | indent 8 }}
         {{- end }}
   {{- if or (not .Values.registry.persistence.enabled) (.Values.registry.gcs.enabled) (.Values.registry.azure.enabled) (.Values.registry.s3.enabled)}}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -278,6 +278,7 @@ registry:
   gcs:
     enabled: false
     bucket: ~
+    useKeyfile: true
     keyfile: /var/gcs-keyfile/astronomer-gcs-keyfile
     rootdirectory: /
     chunksize: "5242880"


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

To support/configure GCS as registry backend in astronomer platform leveraging workload identity functionality of GCP without Service Account Key secret


## PR Title

Add Support for GCP workload identity functionality for GCS backend registry 
<!--
Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.
-->

## 🎟 Issue(s)


Resolves astronomer/issues##2985

<!--
## 🧪  Testing


What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.


## 📸 Screenshots


Add screenshots to illustrate the changes, if applicable.


## 📋 Checklist

- [ ] The PR title is informative to the user experience
-->