### PR TITLE
Quit using helm_devel mechanic in favor of appending -0 to version.

### DIFF
--- a/migrations/scripts/lts-to-lts/0.23-to-0.25/playbooks/tasks/upgrade.yaml
+++ b/migrations/scripts/lts-to-lts/0.23-to-0.25/playbooks/tasks/upgrade.yaml
@@ -9,7 +9,7 @@
     backup_dir: "/astronomer-backups"
     timestamp: "{{ lookup('pipe','date +%Y-%m-%d-%H-%M-%S') }}"
     upgrade_to_version: "0.25"
-    upgrade_to_version_airflow: "0.18"
+    upgrade_to_version_airflow: "0.19"
     # db_hostname: "localhost"
     # db_username: "postgres"
     # db_password: "postgres"
@@ -231,9 +231,6 @@
         set -xe
         helm repo add astronomer https://helm.astronomer.io
         helm repo update
-    - name: Use only final versions
-      set_fact:
-        helm_devel: ''
   when: (USE_INTERNAL_HELM_REPO is not defined) or not (USE_INTERNAL_HELM_REPO | bool)
 
 - name: Configure for dev usage
@@ -245,7 +242,7 @@
         helm repo update
     - name: Use development versions
       set_fact:
-        helm_devel: '--devel'
+        upgrade_to_version: "{{ upgrade_to_version }}-0"
   when: (USE_INTERNAL_HELM_REPO is defined) and (USE_INTERNAL_HELM_REPO | bool)
 
 - name: Backup Astronomer database
@@ -264,7 +261,6 @@
 - name: "(1/4) Upgrade Astronomer: Helm upgrade - Update software in Astronomer. Watch for 'helm list' to show new version."
   shell: >
     helm upgrade
-    {{ helm_devel }}
     --namespace {{ namespace }}
     --reset-values
     -f {{ astro_save_dir.path }}/helm-user-values.json
@@ -285,7 +281,6 @@
 - name: "(3/4) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: >
     helm upgrade
-    {{ helm_devel }}
     --namespace {{ namespace }}
     --reset-values
     -f {{ astro_save_dir.path }}/helm-user-values.json
@@ -298,7 +293,6 @@
 - name: "(4/4) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: >
     helm upgrade
-    {{ helm_devel }}
     --namespace {{ namespace }}
     --reset-values
     -f {{ astro_save_dir.path }}/helm-user-values.json


### PR DESCRIPTION
- Quit using `helm_devel` mechanic in favor of appending `-0` to version
- Upgrade to airflow chart 0.19

# Description

This change fixes an issue where `helm upgrade --version --devel` ignored the `--devel` option, meaning we were not testing pre-release charts. This is a desired behavior of helm. We instead append a `-0` to the end of the chart version, which tells helm to also include pre-release versions. This syntax does work as expected.

# Before

Taken from <https://app.circleci.com/pipelines/github/astronomer/astronomer/2479/workflows/94b467f3-f679-4236-a710-094c3aaee4f4/jobs/17936/parallel-runs/0/steps/0-104>

```
Helm history: (pre-upgrade)
REVISION	UPDATED                 	STATUS  	CHART             	APP VERSION	DESCRIPTION     
1       	Mon May 17 03:15:42 2021	deployed	astronomer-0.23.14	0.23.14    	Install complete

Modified test env with USE_INTERNAL_HELM_REPO=True
Performing upgrade from 0.23 to 0.25
Upgrade pod finished in success
Helm history: (post-upgrade)
REVISION	UPDATED                 	STATUS    	CHART             	APP VERSION	DESCRIPTION     
1       	Mon May 17 03:15:42 2021	superseded	astronomer-0.23.14	0.23.14    	Install complete
2       	Mon May 17 03:20:47 2021	superseded	astronomer-0.25.1 	0.25.1     	Upgrade complete
3       	Mon May 17 03:22:39 2021	superseded	astronomer-0.25.1 	0.25.1     	Upgrade complete
4       	Mon May 17 03:23:19 2021	deployed  	astronomer-0.25.1 	0.25.1     	Upgrade complete

Rollback pod finished in success
Helm history: (post-rollback)
REVISION	UPDATED                 	STATUS    	CHART             	APP VERSION	DESCRIPTION     
1       	Mon May 17 03:15:42 2021	superseded	astronomer-0.23.14	0.23.14    	Install complete
2       	Mon May 17 03:20:47 2021	superseded	astronomer-0.25.1 	0.25.1     	Upgrade complete
3       	Mon May 17 03:22:39 2021	superseded	astronomer-0.25.1 	0.25.1     	Upgrade complete
4       	Mon May 17 03:23:19 2021	superseded	astronomer-0.25.1 	0.25.1     	Upgrade complete
5       	Mon May 17 03:23:48 2021	deployed  	astronomer-0.23.14	0.23.14    	Rollback to 1   

```

Notice how we upgraded to 0.25.1, which is the newest non-development release version of the chart. Testing this already released version is not helpful to us when we want to test the changes we are making in pre-release versions.

# After

Taken from <https://app.circleci.com/pipelines/github/astronomer/astronomer/2487/workflows/7b8e74a8-aa43-4a09-b681-2caed6b3aefd/jobs/17975/parallel-runs/0/steps/0-104>

```
Helm history: (pre-upgrade)
REVISION	UPDATED                 	STATUS  	CHART             	APP VERSION	DESCRIPTION     
1       	Mon May 17 21:33:37 2021	deployed	astronomer-0.23.14	0.23.14    	Install complete

Modified test env with USE_INTERNAL_HELM_REPO=True
Performing upgrade from 0.23 to 0.25
Upgrade pod finished in success
Helm history: (post-upgrade)
REVISION	UPDATED                 	STATUS    	CHART                	APP VERSION	DESCRIPTION     
1       	Mon May 17 21:33:37 2021	superseded	astronomer-0.23.14   	0.23.14    	Install complete
2       	Mon May 17 21:38:16 2021	superseded	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete
3       	Mon May 17 21:40:07 2021	superseded	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete
4       	Mon May 17 21:40:58 2021	deployed  	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete

Rollback pod finished in success
Helm history: (post-rollback)
REVISION	UPDATED                 	STATUS    	CHART                	APP VERSION	DESCRIPTION     
1       	Mon May 17 21:33:37 2021	superseded	astronomer-0.23.14   	0.23.14    	Install complete
2       	Mon May 17 21:38:16 2021	superseded	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete
3       	Mon May 17 21:40:07 2021	superseded	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete
4       	Mon May 17 21:40:58 2021	superseded	astronomer-0.25.2-rc2	0.25.2-rc2 	Upgrade complete
5       	Mon May 17 21:41:29 2021	deployed  	astronomer-0.23.14   	0.23.14    	Rollback to 1   
```