### PR TITLE
🚧 POC of OpenShift Router -> Nginx Ingress -> Apps

### DIFF
--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -2,6 +2,36 @@
 ## alertmanager Ingress
 #################################
 {{- if .Values.global.baseDomain }}
+{{- if .Values.global.openShift.useRouter }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "alertmanager.fullname" . }}
+  labels:
+    tier: alertmanager-networking
+    component: alertmanager-ingress
+    chart: {{ template "alertmanager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  host: {{ template "alertmanager.url" . }}
+  to:
+    kind: Service
+    name: "{{ .Release.Name }}-nginx"
+    weight: 100
+  wildcardPolicy: None
+  {{- if or .Values.global.acme .Values.global.tlsSecret }}
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  {{- else }}
+  port:
+    targetPort: http
+  {{- end }}
+---
+{{- end }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -12,12 +42,18 @@ metadata:
     chart: {{ template "alertmanager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.global.openShift.useRouter }}
+    astronomerIngress: internal
+{{- end }}
   annotations:
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+{{- if .Values.global.openShift.useRouter }}
+    haproxy.router.openshift.io/ip_whitelist: "127.0.0.1/32"
+{{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -2,12 +2,53 @@
 ## Astronomer Ingress
 #################################
 {{- if .Values.global.baseDomain }}
+{{- if .Values.global.openShift.useRouter }}
+{{- range $prefix := (list "" "app." "houston." "registry." "install.") }}
+# Route {{ . }}
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ list $.Release.Name "public" (trimSuffix "." $prefix) | compact | join "-" }}
+  labels:
+    component: public-ingress
+    tier: astronomer
+    release: {{ $.Release.Name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+spec:
+  host: {{ $prefix }}{{ $.Values.global.baseDomain }}
+  to:
+    kind: Service
+    name: {{ $.Release.Name }}-nginx
+    weight: 100
+  wildcardPolicy: None
+  {{- if or $.Values.global.acme $.Values.global.tlsSecret }}
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  {{- else }}
+  port:
+    targetPort: http
+  {{- end }}
+---
+{{- end }}
+{{- end }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
+{{- if .Values.global.openShift.useRouter }}
+  name: {{ .Release.Name }}-internal-ingress
+  labels:
+    component: internal-ingress
+    astronomerIngress: internal
+{{- else }}
   name: {{ .Release.Name }}-public-ingress
   labels:
     component: public-ingress
+{{- end }}
     tier: astronomer
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -20,6 +61,9 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+{{- if .Values.global.openShift.useRouter }}
+    haproxy.router.openshift.io/ip_whitelist: "127.0.0.1/32"
+{{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -2,6 +2,36 @@
 ## Grafana Ingress
 #################################
 {{- if .Values.global.baseDomain }}
+{{- if .Values.global.openShift.useRouter }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "grafana.fullname" . }}
+  labels:
+    tier: grafana-networking
+    component: grafana-ingress
+    chart: {{ template "grafana.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  host: {{ template "grafana.url" . }}
+  to:
+    kind: Service
+    name: "{{ .Release.Name }}-nginx"
+    weight: 100
+  wildcardPolicy: None
+  {{- if or .Values.global.acme .Values.global.tlsSecret }}
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  {{- else }}
+  port:
+    targetPort: http
+  {{- end }}
+---
+{{- end }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -12,12 +42,18 @@ metadata:
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.global.openShift.useRouter }}
+    astronomerIngress: internal
+{{- end }}
   annotations:
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+{{- if .Values.global.openShift.useRouter }}
+    haproxy.router.openshift.io/ip_whitelist: "127.0.0.1/32"
+{{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -2,6 +2,36 @@
 ## Kibana Ingress
 #################################
 {{- if .Values.global.baseDomain }}
+{{- if .Values.global.openShift.useRouter }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "kibana.fullname" . }}
+  labels:
+    tier: kibana-networking
+    component: kibana-ingress
+    chart: {{ template "kibana.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  host: {{ template "kibana.url" . }}
+  to:
+    kind: Service
+    name: "{{ .Release.Name }}-nginx"
+    weight: 100
+  wildcardPolicy: None
+  {{- if or .Values.global.acme .Values.global.tlsSecret }}
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  {{- else }}
+  port:
+    targetPort: http
+  {{- end }}
+---
+{{- end }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -12,12 +42,18 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ template "kibana.chart" . }}
     heritage: {{ .Release.Service }}
+{{- if .Values.global.openShift.useRouter }}
+    astronomerIngress: internal
+{{- end }}
   annotations:
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+{{- if .Values.global.openShift.useRouter }}
+    haproxy.router.openshift.io/ip_whitelist: "127.0.0.1/32"
+{{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -30,6 +30,9 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.ports.metrics | quote }}
 spec:
+{{- if .Values.global.openShift.useRouter }}
+  type: ClusterIP
+{{- else }}
   type: LoadBalancer
   {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
@@ -40,6 +43,7 @@ spec:
   {{- if .Values.preserveSourceIP }}
   externalTrafficPolicy: "Cluster"
   {{- end }}
+{{- end }}
   selector:
     tier: {{ template "nginx.name" . }}
     component: ingress-controller

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -2,6 +2,36 @@
 ## Prometheus Ingress
 #################################
 {{- if .Values.global.baseDomain }}
+{{- if .Values.global.openShift.useRouter }}
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: {{ template "prometheus.fullname" . }}
+  labels:
+    tier: prometheus-networking
+    component: prometheus-ingress
+    chart: {{ template "prometheus.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  host: {{ template "prometheus.url" . }}
+  to:
+    kind: Service
+    name: "{{ .Release.Name }}-nginx"
+    weight: 100
+  wildcardPolicy: None
+  {{- if or .Values.global.acme .Values.global.tlsSecret }}
+  port:
+    targetPort: https
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  {{- else }}
+  port:
+    targetPort: http
+  {{- end }}
+---
+{{- end }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -18,6 +48,9 @@ metadata:
     nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+{{- if .Values.global.openShift.useRouter }}
+    haproxy.router.openshift.io/ip_whitelist: "127.0.0.1/32"
+{{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/values.yaml
+++ b/values.yaml
@@ -113,6 +113,11 @@ global:
   # volumes to use the one specified here.
   # storageClass: ~
 
+  openShift:
+    # If running on an OpenShift cluster, use the existing Router for public traffic ingress. This sets up
+    # routes to form the Router to our Nginx (which enforces wuth), and then from there to the actual sercie
+    useRouter: false
+
 #################################
 ## Default tagged groups enabled
 #################################


### PR DESCRIPTION
This draft PR proposes a mechnaism to allow the platform (and Airflow deployments) to run on an OpenShift cluster.

It operates under the assumption that we **will not** be able to make any global config changes to OpenShift components (such as the router) and so we have to work around some limitations.

This approach is under the assumption that the customer wishes all HTTP access to go via their existing configured OpenShift router. If they are happy to have an additional router/IngressController that is externally accessible to the cluster then there are better approaches we could take (i.e. Sharding Routes by labels.)

## Background

Under the current design of the platform, all of the apps (Kibana, Grafana, Registry) and all Airflow deployments are protected by the Nginx Ingress controller sending a _separate_ auth request to Houston before allowing the request to proceed to the backend service. This behaviour is a requirement to enforce authentication and authorization without heavy and serious rework of all the components.

## How this approach works

This aims to be the most minimally disruptive from an architectural point of view, and have all traffic still go through an single Nginx Ingress Controller.

The main difference here is that when `openShift.useRouter` value is set to true we make our Nginx Ingress controller only listen on a ClusterIP (instead of the more common LoadBalancer) meaning it is only accessible inside the cluster.

It then creates `route.openshift.io/v1.Route` resources to connect up the existing "public" ingress to send all traffic for relevant subdomains to the Nginx controller (which then sends it on to the backend service)

```
                                                                      ┌───────────────────┐
                  ┌───────────────┐        ┌──────────────────┐       │┌──────────────────┴┐
Incoming          │               │        │                  │       ││                   │
HTTP Request      │  OpenShift    │        │ Nginx Ingress    │       ││   Backend         │
      ───────────►│  Router       ├───────►│ Controller       ├──────►││   Service         │
                  │               │        │                  │       └┤                   │
                  └───────────────┘        └──────────────────┘        └───────────────────┘


```

## Drawbacks

There is a race condition when _first_ deploying the platform, where depending on which of the "internal" Ingress routes and the "public" onces get picked up by the Router.

This is because the Router only allows one Route to "own" a domain, so if the wrong route owns the domain in the router the internal ingress resource is the config which is used (and due to the NetworkPolicy we attach on those components, is inaccessible as they only allow traffic from our Nginx IC)

- If the external/public ones are picked up first, then this is the case we want. and everything works
- If the internal route is picked up first, we need to manually fix it up.

It can be checked by running `kubectl -n astronomer get route -l astronomerIngress=internal` and seeing if any of those are _not_ showing HostAlreadyClaimed.

The manual fix up steps are:

  - delete the conflicting ingress resource
  - run helm upgrade to get it back.

As soon as we delete the conflicting resource the Router will then give the host to the public route, so when it's re-created it will "loose" the race (as we want)

A better fix for this would be to set up the Router to use sharding so that ignores these internal Routes, but that requires a global config change to the cluster.


