### PR TITLE
Support Argo Sync-waves for Helm chart for a better Argo installation experience#2960

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -12,6 +12,10 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
 rules:
 - apiGroups: ["*"]
   resources: ["*"]

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -7,6 +7,10 @@ apiVersion: {{ template "apiVersion.rbac.v1beta1" . }}
 kind: {{ if $singleNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 metadata:
   name: {{ .Release.Name }}-commander
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: {{ if $singleNamespace }}Role{{ else }}ClusterRole{{ end }}

--- a/charts/astronomer/templates/commander/commander-serviceaccount.yaml
+++ b/charts/astronomer/templates/commander/commander-serviceaccount.yaml
@@ -11,4 +11,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-rolebinding.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-rolebinding.yaml
@@ -11,6 +11,10 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
@@ -11,4 +11,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
 {{- end }}

--- a/charts/astronomer/tests/commander_commander-role_test.yaml
+++ b/charts/astronomer/tests/commander_commander-role_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
     - isKind:
         of: ClusterRole
-  - it: should not contains argoCD annotations by default
+  - it: should not contain argoCD annotations by default
     asserts:
       - isNull:
           path: metadata.annotations

--- a/charts/astronomer/tests/commander_commander-role_test.yaml
+++ b/charts/astronomer/tests/commander_commander-role_test.yaml
@@ -2,7 +2,11 @@ suite: Test commander/commander-role.yaml
 templates:
 - commander/commander-role.yaml
 tests:
-- it: should work
-  asserts:
+  - it: should work
+    asserts:
     - isKind:
         of: ClusterRole
+  - it: should not contains argoCD annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/astronomer/tests/commander_commander-rolebinding_test.yaml
+++ b/charts/astronomer/tests/commander_commander-rolebinding_test.yaml
@@ -1,8 +1,12 @@
 suite: Test commander/commander-rolebinding.yaml
 templates:
-- commander/commander-rolebinding.yaml
+  - commander/commander-rolebinding.yaml
 tests:
-- it: should work
-  asserts:
-    - isKind:
-        of: ClusterRoleBinding
+  - it: should work
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+  - it: should not contains argoCD annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/astronomer/tests/commander_commander-rolebinding_test.yaml
+++ b/charts/astronomer/tests/commander_commander-rolebinding_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - isKind:
           of: ClusterRoleBinding
-  - it: should not contains argoCD annotations by default
+  - it: should not contain argoCD annotations by default
     asserts:
       - isNull:
           path: metadata.annotations

--- a/charts/astronomer/tests/commander_commander-service_test.yaml
+++ b/charts/astronomer/tests/commander_commander-service_test.yaml
@@ -1,8 +1,12 @@
 suite: Test commander/commander-service.yaml
 templates:
-- commander/commander-service.yaml
+  - commander/commander-service.yaml
 tests:
-- it: should work
-  asserts:
-    - isKind:
-        of: Service
+  - it: should work
+    asserts:
+      - isKind:
+          of: Service
+  - it: should not contains argoCD annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/astronomer/tests/commander_commander-service_test.yaml
+++ b/charts/astronomer/tests/commander_commander-service_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - isKind:
           of: Service
-  - it: should not contains argoCD annotations by default
+  - it: should not contain argoCD annotations by default
     asserts:
       - isNull:
           path: metadata.annotations

--- a/charts/astronomer/tests/houston_api_houston-bootstrap-role_test.yaml
+++ b/charts/astronomer/tests/houston_api_houston-bootstrap-role_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - isKind:
           of: Role
-  - it: should not contains argoCD annotations by default
+  - it: should not contain argoCD annotations by default
     asserts:
       - isNull:
           path: metadata.annotations

--- a/charts/astronomer/tests/houston_api_houston-bootstrap-role_test.yaml
+++ b/charts/astronomer/tests/houston_api_houston-bootstrap-role_test.yaml
@@ -1,8 +1,12 @@
 suite: Test houston/api/houston-bootstrap-role.yaml
 templates:
-- houston/api/houston-bootstrap-role.yaml
+  - houston/api/houston-bootstrap-role.yaml
 tests:
-- it: should work
-  asserts:
-    - isKind:
-        of: Role
+  - it: should work
+    asserts:
+      - isKind:
+          of: Role
+  - it: should not contains argoCD annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/charts/astronomer/tests/houston_api_houston-bootstrap-serviceaccount_test.yaml
+++ b/charts/astronomer/tests/houston_api_houston-bootstrap-serviceaccount_test.yaml
@@ -6,7 +6,7 @@ tests:
     asserts:
       - isKind:
           of: ServiceAccount
-  - it: should not contains argoCD annotations by default
+  - it: should not contain argoCD annotations by default
     asserts:
       - isNull:
           path: metadata.annotations

--- a/charts/astronomer/tests/houston_api_houston-bootstrap-serviceaccount_test.yaml
+++ b/charts/astronomer/tests/houston_api_houston-bootstrap-serviceaccount_test.yaml
@@ -1,8 +1,12 @@
 suite: Test houston/api/houston-bootstrap-serviceaccount.yaml
 templates:
-- houston/api/houston-bootstrap-serviceaccount.yaml
+  - houston/api/houston-bootstrap-serviceaccount.yaml
 tests:
-- it: should work
-  asserts:
-    - isKind:
-        of: ServiceAccount
+  - it: should work
+    asserts:
+      - isKind:
+          of: ServiceAccount
+  - it: should not contains argoCD annotations by default
+    asserts:
+      - isNull:
+          path: metadata.annotations

--- a/values.yaml
+++ b/values.yaml
@@ -112,6 +112,11 @@ global:
   # Storage class for persistent volumes. If you have multiple storage classes available this will force all charts with persistent
   # volumes to use the one specified here.
   # storageClass: ~
+  
+  # Enable argo CD annotations currently available only for:
+  # ServiceAccounts, ClusterRoles, RoleBindings, ClusterRoleBindings
+  # https://github.com/argoproj/argo-cd/blob/master/docs/user-guide/sync-waves.md
+  enableArgoCDAnnotation: false
 
 #################################
 ## Default tagged groups enabled


### PR DESCRIPTION
resolves https://github.com/astronomer/issues/issues/2960

based in slack conversation with @rbankston:

Add:
```
metadata:
  annotations:
    argocd.argoproj.io/sync-wave: "-1"
```

 to  ServiceAccounts, ClusterRoles, RoleBindings, ClusterRoleBindings
 
 
 @rbankston do i need to add annotations also to elasticsearch, kubed etc?