### PR TITLE
Enable non-RFC address space for Alertmanager

### DIFF
--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
           image: {{ template "alertmanager.image" . }}
           imagePullPolicy: {{ .Values.images.alertmanager.pullPolicy }}
           env:
-            {{- if .Values.enableNonRFC }}
+            {{- if .Values.enableNonRFC1918 }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -61,7 +61,7 @@ spec:
           {{- if .Values.disableClustering }}
             - --cluster.listen-address=
           {{- end }}
-          {{- if .Values.enableNonRFC }}
+          {{- if .Values.enableNonRFC1918 }}
             - --cluster.advertise-address=$(POD_IP):9094
           {{- end }}
           ports:

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -42,6 +42,12 @@ spec:
           image: {{ template "alertmanager.image" . }}
           imagePullPolicy: {{ .Values.images.alertmanager.pullPolicy }}
           env:
+            {{- if .Values.enableNonRFC }}
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value }}
@@ -54,6 +60,9 @@ spec:
           {{- end }}
           {{- if .Values.disableClustering }}
             - --cluster.listen-address=
+          {{- end }}
+          {{- if .Values.enableNonRFC }}
+            - --cluster.advertise-address=$(POD_IP):9094
           {{- end }}
           ports:
             - containerPort: {{ .Values.ports.http }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -58,4 +58,4 @@ customRoutes: []
 #     tier: platform
 #     namespace: ^(test-ns.*)
 
-enableNonRFC: false
+enableNonRFC1918: false

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -57,3 +57,5 @@ customRoutes: []
 #   match_re:
 #     tier: platform
 #     namespace: ^(test-ns.*)
+
+enableNonRFC: false

--- a/tests/alertmanager-statefulset_test.yaml
+++ b/tests/alertmanager-statefulset_test.yaml
@@ -42,7 +42,7 @@ tests:
   - it: should have POD_IP environment variable and cluster.advertise args if enableNonRFC1918 is true
     template: charts/alertmanager/templates/alertmanager-statefulset.yaml
     set:
-      enableNonRFC1918: false
+      enableNonRFC1918: true
     assert:
       contains:
         path: containers.env.name

--- a/tests/alertmanager-statefulset_test.yaml
+++ b/tests/alertmanager-statefulset_test.yaml
@@ -34,3 +34,21 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.fsGroup
           value: 65534
+  - it: should work
+    template: charts/alertmanager/templates/alertmanager-statefulset.yaml
+    asserts:
+      - isKind:
+          of: StatefulSet
+  - it: should have POD_IP environment variable and cluster.advertise args if enableNonRFC1918 is true
+    template: charts/alertmanager/templates/alertmanager-statefulset.yaml
+    set:
+      enableNonRFC1918: false
+    assert:
+      contains:
+        path: containers.env.name
+        content:
+          name: POD_IP
+      matchRegex:
+        path: containers.args
+        pattern: --cluster.advertise-address=\$\(POD_IP\):9094$
+      


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

<!--
Describe the purpose of this pull request.
-->

Some enterprises use private networks outside of RFC 1918, for example Class E networks. These are necessary for enterprises that have exhausted or otherwise allocated all RFC 1918 address space. When this is done Alertmanager  crash loops because it is not able to use these address spaces. 

https://github.com/prometheus/alertmanager/issues/2438

This PR adds the ability to `enableNonRFC` address range usage by adding the related `env` and `args` to the helm chart. 

## Enable non-RFC address space for Alertmanager

<!--
Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.
-->

🎟 Issue(s)

Resolves astronomer/issues#3028

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

- This has been tested in a sandbox on GKE as a helm chart, by both enabling and disabling the flag.
- Also has been tested with a customer deployment by editing the STS with the same values directly.
- Risks are that the values are not created properly thus non-RFC address spaces are still not supported by the helm chart.

## 📋 Checklist

- [x] The PR title is informative to the user experience
