### PR TITLE
[bugfix] fixes elasticsearch on openshift

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -73,11 +73,12 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count=262144"]
         securityContext:
           privileged: true
-      serviceAccountName: {{ template "elasticsearch.fullname" . }}          
+      serviceAccountName: {{ template "elasticsearch.fullname" . }}
       containers:
       - name: es-client
         securityContext:
-          privileged: false
+          privileged: true
+          runAsUser: 0
           capabilities:
             add:
               - IPC_LOCK

--- a/templates/scc/astronomer-scc-privileged.yaml
+++ b/templates/scc/astronomer-scc-privileged.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.global.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  name: {{ .Release.Name }}-privileged
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-elasticsearch
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: true
+allowedCapabilities: null
+{{- end }}

--- a/tests/astronomer-scc-privileged_test.yaml
+++ b/tests/astronomer-scc-privileged_test.yaml
@@ -1,0 +1,20 @@
+---
+suite: Test astronomer-scc-privileged
+templates:
+  - scc/astronomer-scc-privileged.yaml
+tests:
+  - it: should exist
+    set:
+      global:
+        sccEnabled: True
+    asserts:
+      - isKind:
+          of: SecurityContextConstraints
+  - it: should not exist
+    set:
+      global:
+        sccEnabled: False
+    asserts:
+      - hasDocuments:
+          count: 0
+


### PR DESCRIPTION
## Description

elasticsearch was failing on openshift clusters because it was trying to run as user 0 with privileged mode.  This adds a SCC with the correct permissions for it.

elasticsearch-client was failing because it needs to run as user 0 with privileged mode like the masters do. 

Logs of elasticsearch-client without ^ set:

```
kubectl logs astronomer-elasticsearch-client-656bfdf6c7-zhpb8
chroot: cannot change root directory to '/': Operation not permitted
```


## 📋 Checklist

- [ ] The PR title is informative to the user experience
