### PR TITLE
fix for  fluentd queue large issue

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -224,7 +224,7 @@ data:
           retry_max_interval 30
           chunk_limit_size "#{ENV['OUTPUT_BUFFER_CHUNK_LIMIT']}"
           queue_limit_length "#{ENV['OUTPUT_BUFFER_QUEUE_LIMIT']}"
-          overflow_action block
+          overflow_action drop_oldest_chunk
         </buffer>
       </store>
       {{- end }}


### PR DESCRIPTION
## Description

fluentd queues keep growing until the old ones gets processed causing huge alerts

## PR Title

fix for  fluentd queue large issue

## 🎟 Issue(s)

Fluentd Queue Large Alert #2935

## 🧪  Testing


## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
