### PR TITLE
Concat Long logs that are split up by Dockers 16kb limit with fluentd plugin

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -56,6 +56,14 @@ data:
       max_bytes 500000
       max_lines 1000
     </match>
+    # Concat log truncated by docker 16KB limit, single line JSON, https://github.com/fluent-plugins-nursery/fluent-plugin-concat
+    <filter **>
+      @type concat
+      key message
+      multiline_end_regexp /\n$/
+      separator ""
+    </filter>
+
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>


### PR DESCRIPTION
## Description

Docker breaks logs that are bigger than 16kb and fluentd currently doesn't merge those logs back together. Customers expect long logs to continue being found as a single entry in elastic. This adds the configuration so that long logs get merged back together.

## PR Title

<!--
Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.
-->

## 🎟 Issue(s)

Resolves astronomer/issues#3029

## 🧪  Testing

1. create a DAG that prints out really long messages over (16kb)
2. execute DAG 
3. look for log in kabana and make sure that the whole log shows up instead of a part of the log

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots
Example since screen shot wouldnt really show much:  [here](https://kibana.dev.astrodev.io/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-05-28T14:30:00.000Z',to:now))&_a=(columns:!(_source),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'2697b5d0-2437-11eb-9842-2d41c29d05c4',key:_id,negate:!f,params:(query:cN54s3kBGCrb6c2Q_tqV),type:phrase),query:(match_phrase:(_id:cN54s3kBGCrb6c2Q_tqV)))),index:'2697b5d0-2437-11eb-9842-2d41c29d05c4',interval:auto,query:(language:kuery,query:'release:%20%22barren-declination-8584%22'),sort:!()))
<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
