### PR TITLE
add ability to use options for random data

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -60,9 +60,16 @@
 {{ define "registry.docker.config" -}}
   {{- $domain := printf "registry.%v" .Values.global.baseDomain }}
   {{- $email := printf "admin@%v" .Values.global.baseDomain }}
+  {{- if .Values.global.privateRegistry.user }}
+  {{- $user := .Values.global.privateRegistry.user }}
+  {{- else }}
   {{- $user := randAlphaNum 16 -}}
-  {{- $pass := randAlphaNum 32 -}}
-
+  {{- end }}
+	{{- if .Values.global.privateRegistry.password }}
+	{{- $pass := .Values.global.privateRegistry.password -}}
+	{{- else }}
+	{{- $pass := randAlphaNum 32 -}}
+	{{- end }}
   {{- $config := dict "auths" -}}
   {{- $auth := dict -}}
   {{- $data := dict -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -65,11 +65,11 @@
   {{- else }}
   {{- $user := randAlphaNum 16 -}}
   {{- end }}
-	{{- if .Values.global.privateRegistry.password }}
-	{{- $pass := .Values.global.privateRegistry.password -}}
-	{{- else }}
-	{{- $pass := randAlphaNum 32 -}}
-	{{- end }}
+  {{- if .Values.global.privateRegistry.password }}
+  {{- $pass := .Values.global.privateRegistry.password -}}
+  {{- else }}
+  {{- $pass := randAlphaNum 32 -}}
+  {{- end }}
   {{- $config := dict "auths" -}}
   {{- $auth := dict -}}
   {{- $data := dict -}}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -52,7 +52,11 @@ spec:
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
           env:
           - name: REGISTRY_HTTP_SECRET
-            value: {{ randAlphaNum 32 }}
+					  {{- if .Values.registry.httpSecret }}
+            value: {{ .Values.registry.httpSecret }}
+						{{- else }}
+						value: {{ randAlphaNum 32 }}
+						{{- end }}
           resources:
 {{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -52,11 +52,11 @@ spec:
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
           env:
           - name: REGISTRY_HTTP_SECRET
-					  {{- if .Values.registry.httpSecret }}
+            {{- if .Values.registry.httpSecret }}
             value: {{ .Values.registry.httpSecret }}
-						{{- else }}
-						value: {{ randAlphaNum 32 }}
-						{{- end }}
+            {{- else }}
+            value: {{ randAlphaNum 32 }}
+            {{- end }}
           resources:
 {{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -21,6 +21,7 @@ images:
     repository: quay.io/astronomer/ap-registry
     tag: 3.13.7
     pullPolicy: IfNotPresent
+    # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
     tag: 0.25.5

--- a/values.yaml
+++ b/values.yaml
@@ -98,6 +98,8 @@ global:
   privateRegistry:
     enabled: false
     repository: ~
+    # user: ~
+    # password: ~
 
   # SSL support for using SSL connections to encrypt client/server communication between database and Astronomer platform
   ssl:


### PR DESCRIPTION
resolves 3rd part of https://github.com/astronomer/issues/issues/3007

>Our chart uses Helm's random number generator in certain areas. This random number generator changes each time Argo evaluates those sections and marks the application as not in sync. It would be useful if there was an option to specify the variable instead of only having the Random Data generate those values. This is used in 6 places in our current repository but the houston-backend-secret and registry-statefulset appear to be the only places that a production grade Astronomer deployment would use.