### PR TITLE
Add Cacert file to fluentd if enabled

### DIFF
--- a/charts/fluentd/templates/_helpers.tpl
+++ b/charts/fluentd/templates/_helpers.tpl
@@ -54,3 +54,23 @@ path {{ .Values.s3.path }}
 use_server_side_encryption {{ .Values.s3.use_server_side_encryption }}
 {{- end }}
 {{- end }}
+
+{{- define "custom_ca_volume_mounts" }}
+{{ if .Values.global.privateCaCerts }}
+{{ range $secret_name := (.Values.global.privateCaCerts) }}
+- name: {{ $secret_name }}
+  mountPath: /usr/local/share/ca-certificates/{{ $secret_name }}.pem
+  subPath: cert.pem
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "custom_ca_volumes"}}
+{{ if .Values.global.privateCaCerts }}
+{{ range .Values.global.privateCaCerts }}
+- name: {{ . }}
+  secret:
+    secretName: {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fluentd/templates/fluentd-daemonset.yaml
+++ b/charts/fluentd/templates/fluentd-daemonset.yaml
@@ -78,6 +78,7 @@ spec:
         {{- if .Values.additionalVolumeMounts }}
         {{- toYaml .Values.additionalVolumeMounts | nindent 8 }}
         {{- end }}
+        {{- include "custom_ca_volume_mounts" . | nindent 8 }}
         - name: varlog
           mountPath: /var/log
         - name: varlibdockercontainers
@@ -98,6 +99,7 @@ spec:
       {{- if .Values.additionalVolumes }}
       {{- toYaml .Values.additionalVolumes | nindent 6 }}
       {{- end }}
+      {{- include "custom_ca_volumes" . | nindent 6 }}
       - name: varlog
         hostPath:
           path: /var/log

--- a/charts/fluentd/tests/fluentd-daemonset_test.yaml
+++ b/charts/fluentd/tests/fluentd-daemonset_test.yaml
@@ -1,9 +1,0 @@
----
-suite: Test fluentd-daemonset
-templates:
-  - fluentd-daemonset.yaml
-tests:
-  - it: should work
-    asserts:
-      - isKind:
-          of: DaemonSet

--- a/charts/fluentd/tests/fluentd-psp-rolebinding_test.yaml
+++ b/charts/fluentd/tests/fluentd-psp-rolebinding_test.yaml
@@ -1,9 +1,0 @@
----
-suite: Test fluentd-psp-rolebinding
-templates:
-  - fluentd-psp-rolebinding.yaml
-tests:
-  - it: should work
-    asserts:
-      - isKind:
-          of: RoleBinding

--- a/tests/fluentd-clusterrolebinding_test.yaml
+++ b/tests/fluentd-clusterrolebinding_test.yaml
@@ -1,7 +1,9 @@
 ---
 suite: Test fluentd-clusterrolebinding
 templates:
-  - fluentd-clusterrolebinding.yaml
+  - charts/fluentd/templates/fluentd-clusterrolebinding.yaml
+set:
+  global.rbacEnabled: true
 tests:
   - it: should work
     asserts:

--- a/tests/fluentd-daemonset_test.yaml
+++ b/tests/fluentd-daemonset_test.yaml
@@ -1,0 +1,39 @@
+suite: Test fluentd-daemonset
+templates:
+  - charts/fluentd/templates/fluentd-daemonset.yaml
+  - charts/fluentd/templates/fluentd-configmap.yaml
+tests:
+  - it: should work
+    template: charts/fluentd/templates/fluentd-daemonset.yaml
+    set:
+      global.platformNodePool:
+        platformNodePool:
+          nodeSelector: {}
+          affinity: {}
+          tolerations: []
+    asserts:
+      - isKind:
+          of: DaemonSet
+  - it: Fluentd should have a private cert volumemounts and volume
+    template: charts/fluentd/templates/fluentd-daemonset.yaml
+    set:
+      global.platformNodePool:
+        platformNodePool:
+          nodeSelector: {}
+          affinity: {}
+          tolerations: []
+      global.privateCaCerts:
+        - private-root-ca
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: private-root-ca
+            mountPath: /usr/local/share/ca-certificates/private-root-ca.pem
+            subPath: cert.pem
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: private-root-ca
+            secret:
+              secretName: private-root-ca

--- a/tests/fluentd-psp-clusterrole_test.yaml
+++ b/tests/fluentd-psp-clusterrole_test.yaml
@@ -1,7 +1,9 @@
 ---
 suite: Test fluentd-psp-clusterrole
 templates:
-  - fluentd-psp-clusterrole.yaml
+  - charts/fluentd/templates/fluentd-psp-clusterrole.yaml
+set:
+  global.pspEnabled: true
 tests:
   - it: should work
     asserts:

--- a/tests/fluentd-psp-rolebinding_test.yaml
+++ b/tests/fluentd-psp-rolebinding_test.yaml
@@ -1,0 +1,11 @@
+---
+suite: Test fluentd-psp-rolebinding
+templates:
+  - charts/fluentd/templates/fluentd-psp-rolebinding.yaml
+set:
+  global.pspEnabled: true
+tests:
+  - it: should work
+    asserts:
+      - isKind:
+          of: RoleBinding

--- a/tests/fluentd-psp_test.yaml
+++ b/tests/fluentd-psp_test.yaml
@@ -1,7 +1,9 @@
 ---
 suite: Test fluentd-psp
 templates:
-  - fluentd-psp.yaml
+  - charts/fluentd/templates/fluentd-psp.yaml
+set:
+  global.pspEnabled: true
 tests:
   - it: should work
     asserts:


### PR DESCRIPTION
## Description

Added the private ca cert file to the fluentd pod for external usage


## 🎟 Issue(s)


Resolves astronomer/issues#3063


## 🧪  Testing

Verified that the private root ca volumes and volumemounts existed properly following the change. Added fluentd daemonset testing to this pull request as well which pass.

## 📸 Screenshots

```
      volumeMounts:
        - name: private-root-ca
          mountPath: /usr/local/share/ca-certificates/private-root-ca.pem
          subPath: cert.pem
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
        - name: libsystemddir
          mountPath: /host/lib
          readOnly: true
        - name: config-volume-astronomer-fluentd
          mountPath: /etc/fluent/config.d
        resources:
            {}
        ports:
          - name: monitor-agent
            containerPort: 24231
      terminationGracePeriodSeconds: 30
      volumes:
      - name: private-root-ca
        secret:
          secretName: private-root-ca
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers
      - name: libsystemddir
        hostPath:
          path: /usr/lib64
      - name: config-volume-astronomer-fluentd
        configMap:
          name: astronomer-fluentd
```

Added unittests to the fluentd daemonset when enabled. This doesn't use the cacerts in any way which is left up to the customer but it does make the cert available to reference in any additional plugins

## 📋 Checklist

- [x] The PR title is informative to the user experience
