### PR TITLE
Update Prometheus Alerts Config to fix missing field on emails

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -40,7 +40,7 @@ data:
             deployment: {{ printf "%q" "{{ $labels.release }}" }}
           annotations:
             summary: {{ printf "%q" "{{ $labels.release }} deployment is unhealthy" }}
-            description: {{ printf "%q" "The {{ $labels.deployment }} deployment is not completely available." }}
+            description: {{ printf "%q" "The {{ $labels.release }} deployment is not completely available." }}
 
 
         # This alert depends on the scheduler_heartbeat metric being a counter.


### PR DESCRIPTION



## Description
AirflowDeploymentUnhealthy on the description is missing the value for deployments but the release label  is available so changing it for that

## PR Title

## 🎟 Issue(s)

Related astronomer/issues#3037


## 🧪  Testing
Can only test in QA (need to test)

## 📸 Screenshots

![emailTemplateAlert](https://user-images.githubusercontent.com/5323384/121396376-ef880900-c918-11eb-94a7-a326b127fec7.gif)
screen shot above you can see broken link and missing string inbetween 
this should be fixed with this pr and https://github.com/astronomer/houston-api/pull/711#issuecomment-857839998


## 📋 Checklist

- [ ] The PR title is informative to the user experience
