### PR TITLE
Add basic helm chart museum deployment and service for Airgapped / Network Restricted

### DIFF
--- a/charts/chart-museum/Chart.yaml
+++ b/charts/chart-museum/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+name: chart-museum
+version: 0.1.0
+description: A Helm chart to wrap the Helm Chart Museum
+keywords:
+  - astronomer

--- a/charts/chart-museum/templates/deployment.yaml
+++ b/charts/chart-museum/templates/deployment.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.global.chartMuseumEnabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-museum
+  namespace: astronomer
+spec:
+  selector:
+    matchLabels:
+      app: helm-museum
+  template:
+    metadata:
+      labels:
+        app: helm-museum
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: helm-museum
+        image: ghcr.io/helm/chartmuseum:v0.13.1
+        env:
+          - name: STORAGE
+            value: "local"
+          - name: STORAGE_LOCAL_ROOTDIR
+            value: "/charts"
+        volumeMounts:
+          - mountPath: "/charts"
+            name: helm-chart-museum
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "100m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 8080
+      volumes:
+        - name: helm-chart-museum
+          persistentVolumeClaim:
+            claimName: helm-chart-museum
+{{- end }}

--- a/charts/chart-museum/templates/deployment.yaml
+++ b/charts/chart-museum/templates/deployment.yaml
@@ -2,21 +2,36 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: helm-museum
+  name: {{ .Release.Name }}-chartmuseum
+  labels:
+    component: chartmuseum
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
   namespace: astronomer
 spec:
   selector:
     matchLabels:
-      app: helm-museum
+      component: chartmuseum
   template:
     metadata:
       labels:
-        app: helm-museum
+        tier: astronomer
+        component: chartmuseum
+        release: {{ .Release.Name }}
     spec:
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      restartPolicy: Always
       securityContext:
         fsGroup: 1000
       containers:
-      - name: helm-museum
+      - name: chartmuseum
         image: ghcr.io/helm/chartmuseum:v0.13.1
         env:
           - name: STORAGE
@@ -25,18 +40,13 @@ spec:
             value: "/charts"
         volumeMounts:
           - mountPath: "/charts"
-            name: helm-chart-museum
+            name: chartmuseum
         resources:
-          requests:
-            memory: "32Mi"
-            cpu: "100m"
-          limits:
-            memory: "128Mi"
-            cpu: "500m"
+{{ toYaml .Values.chartmuseum.resources | indent 10 }}
         ports:
         - containerPort: 8080
       volumes:
-        - name: helm-chart-museum
+        - name: chartmuseum
           persistentVolumeClaim:
-            claimName: helm-chart-museum
+            claimName: chartmuseum
 {{- end }}

--- a/charts/chart-museum/templates/pvc.yaml
+++ b/charts/chart-museum/templates/pvc.yaml
@@ -5,11 +5,13 @@ metadata:
   name: chartmuseum
 spec:
   accessModes:
-  - ReadWriteOnce
+    {{- range .Values.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
   resources:
     requests:
-      storage: 1Gi
-    {{- if .Values.common.persistence.storageClassName }}
-      storageClassName: {{ .Values.common.persistence.storageClassName }}
+      storage: {{ .Values.persistence.size | quote }}
+    {{- if .Values.persistence.storageClassName }}
+      storageClassName: {{ .Values.persistence.storageClassName }}
     {{- end }}
 {{- end }}

--- a/charts/chart-museum/templates/pvc.yaml
+++ b/charts/chart-museum/templates/pvc.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.chartMuseumEnabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: helm-chart-museum
+  namespace: astronomer
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+{{- end }}

--- a/charts/chart-museum/templates/pvc.yaml
+++ b/charts/chart-museum/templates/pvc.yaml
@@ -2,12 +2,14 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: helm-chart-museum
-  namespace: astronomer
+  name: chartmuseum
 spec:
   accessModes:
   - ReadWriteOnce
   resources:
     requests:
       storage: 1Gi
+    {{- if .Values.common.persistence.storageClassName }}
+      storageClassName: {{ .Values.common.persistence.storageClassName }}
+    {{- end }}
 {{- end }}

--- a/charts/chart-museum/templates/service.yaml
+++ b/charts/chart-museum/templates/service.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.global.chartMuseumEnabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: helm-museum
+spec:
+  type: ClusterIP
+  selector:
+    app: helm-museum
+  ports:
+  - port: 8080
+    targetPort: 8080
+{{- end }}

--- a/charts/chart-museum/templates/service.yaml
+++ b/charts/chart-museum/templates/service.yaml
@@ -2,11 +2,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: helm-museum
+  name: chartmuseum
 spec:
   type: ClusterIP
   selector:
-    app: helm-museum
+    app: chartmuseum
   ports:
   - port: 8080
     targetPort: 8080

--- a/charts/chart-museum/values.yaml
+++ b/charts/chart-museum/values.yaml
@@ -11,3 +11,10 @@ chartmuseum:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+persistence:
+  enabled: true
+  # storageClassName: default
+  accessModes:
+    - ReadWriteOnce
+  size: 1Gi

--- a/charts/chart-museum/values.yaml
+++ b/charts/chart-museum/values.yaml
@@ -1,0 +1,13 @@
+
+nodeSelector: {}
+affinity: {}
+tolerations: []
+
+chartmuseum:
+  resources: { }
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi


### PR DESCRIPTION
## Description
For airgapped installs - one method to host our `airflow` helm chart is to include a helm chart museum locally in the client environment. This should be an opt-in only feature, that the client can then use `helm pull` / `helm push` to.

See more info here: https://www.notion.so/astronomerio/WIP-Airgapped-Install-744136e9a04041539283ff0ed910d9ba

More info is needed from chart maintainers around best practices for helm charts

## 🧪  Testing
- [ ] ` helm template astronomer --namespace=astronomer --set global.chartMuseumEnabled=true . | less` - everything shows up correctly
