### PR TITLE
bumping ap-astro-ui version

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.25.0
+    tag: 0.25.1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description
 
Bumps the version of the astro ui to `0.25.1`

Among the most important fixes:
 * Workspace admins will be able to have god-mode in their workspace they are admins of. Previously due to an implementation error, admins could not see deployments created by service accounts.
 * Deployment counts regardless of user now show correctly in the workspace nav
 * Side bar now correctly shows the deployments any given user has access to
 * Historical deployment logs are finally working.
 * Improvements to live logs
