### PR TITLE
houston release 0.25.6

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.25.5
+    tag: 0.25.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION

## Description
- fix links to the deployment in the email is not working (Missing Workspace details)
- workspace_admin's now have access to all deployments under that workspace and can create,read,update,delete
- open shift support
- fix so only workspace admins and system admins should have privileges to invite users to a workspace.
- mixmatch email wording rework
- log search better-querying support
- add by pass email invite option for sso users
- fix CVE-2021-23369, CVE-2021-23337, CVE-2021-23358

