### PR TITLE
Auth Sidecar Enhancements

### DIFF
--- a/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
@@ -20,7 +20,6 @@ data:
     server {
       server_name {{ template "alertmanager.url" . }} ;
       listen {{ .Values.global.authSidecar.port }}  ;
-      listen [::]:{{ .Values.global.authSidecar.port }}  ;
 
       # Disable Nginx Server version
       server_tokens off;

--- a/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
@@ -1,6 +1,6 @@
-################################
+######################################
 ## Alertmanager auth sidecar ConfigMap
-#################################
+######################################
 {{- if .Values.global.authSidecar.enabled }}
 kind: ConfigMap
 apiVersion: v1
@@ -19,8 +19,12 @@ data:
     }
     server {
       server_name {{ template "alertmanager.url" . }} ;
-      listen 8080  ;
-      listen [::]:8080  ;
+      listen {{ .Values.global.authSidecar.port }}  ;
+      listen [::]:{{ .Values.global.authSidecar.port }}  ;
+
+      # Disable Nginx Server version
+      server_tokens off;
+
       location  = /auth {
         proxy_set_header Host houston.{{ .Values.global.baseDomain }};
         proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
@@ -36,6 +40,9 @@ data:
         proxy_set_header  Host  {{ template "alertmanager.url" . }};
         proxy_pass http://astro-alertmanager;
 {{ .Values.global.authSidecar.default_nginx_settings_location  |  indent 8 }}
+      }
+      location /healthz {
+          return 200;
       }
     }
 {{- end }}

--- a/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
+++ b/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
@@ -42,5 +42,5 @@ spec:
       port: {{ .Values.ports.http }}
     {{- if .Values.global.authSidecar.enabled  }}
     - protocol: TCP
-      port: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- end }}

--- a/charts/alertmanager/templates/alertmanager-service.yaml
+++ b/charts/alertmanager/templates/alertmanager-service.yaml
@@ -23,8 +23,7 @@ spec:
       port: {{ .Values.ports.http }}
       targetPort: {{ .Values.ports.http }}
     {{- if .Values.global.authSidecar.enabled }}
-    - name: nginx-ui
+    - name: auth-proxy
       protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- end}}

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -81,16 +81,30 @@ spec:
             - name: data
               mountPath: {{ .Values.dataDir }}
         {{- if .Values.global.authSidecar.enabled  }}
-        - name: nginx
-          image: {{ .Values.global.authSidecar.image }}
+        - name: auth-proxy
+          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}
           resources: {{- toYaml .Values.global.authSidecar.resources | nindent 12 }}
           {{- end }}
           ports:
-          - containerPort: 8080
-            name: nginx-ui
+          - containerPort: {{ .Values.global.authSidecar.port }}
+            name: auth-proxy
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
           - mountPath: /etc/nginx/conf.d/
             name: alertmanager-sidecar-conf

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
             backend:
               serviceName: {{ template "alertmanager.fullname" . }}
               {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: nginx-ui
+              servicePort: auth-proxy
               {{- else }}
               servicePort: http
               {{- end }}
@@ -56,7 +56,7 @@ spec:
                 name: {{ template "alertmanager.fullname" . }}
                 port:
                   {{- if .Values.global.authSidecar.enabled  }}
-                  name: nginx-ui
+                  name: auth-proxy
                   {{- else }}
                   name: http
                   {{- end }}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -14,9 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-    {{- range $key, $value := .Values.global.extraAnnotations}}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -261,7 +261,9 @@ data:
         # enables nginx auth sidecar for airflow deployments
         authSidecar:
           enabled: true
-          image: {{ .Values.global.authSidecar.image }}
+          repository: {{ .Values.global.authSidecar.repository }}
+          tag: {{ .Values.global.authSidecar.tag }}
+          port: {{ .Values.global.authSidecar.port }}
           pullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           annotations:
             {{- range $key, $value := .Values.global.extraAnnotations}}

--- a/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
+++ b/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
@@ -19,8 +19,12 @@ data:
     }
     server {
       server_name {{ template "grafana.url" . }} ;
-      listen 8080  ;
-      listen [::]:8080  ;
+      listen {{ .Values.global.authSidecar.port }}  ;
+      listen [::]:{{ .Values.global.authSidecar.port }}  ;
+
+      # Disable Nginx Server version
+      server_tokens off;
+
       location  = /auth {
         proxy_set_header Host houston.{{ .Values.global.baseDomain }};
         proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
@@ -36,6 +40,10 @@ data:
         proxy_set_header  Host  {{ template "grafana.url" . }};
         proxy_pass http://astro-grafana;
 {{ .Values.global.authSidecar.default_nginx_settings_location  |  indent 8 }}
+      }
+
+      location /healthz {
+          return 200;
       }
     }
 {{- end }}

--- a/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
+++ b/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
@@ -20,7 +20,6 @@ data:
     server {
       server_name {{ template "grafana.url" . }} ;
       listen {{ .Values.global.authSidecar.port }}  ;
-      listen [::]:{{ .Values.global.authSidecar.port }}  ;
 
       # Disable Nginx Server version
       server_tokens off;

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -124,16 +124,30 @@ spec:
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
         {{- if .Values.global.authSidecar.enabled }}
-        - name: nginx
-          image: {{ .Values.global.authSidecar.image }}
+        - name: auth-proxy
+          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}
           resources: {{- toYaml .Values.global.authSidecar.resources | nindent 12 }}
           {{- end }}
           ports:
-          - containerPort: 8080
-            name: nginx-ui
+          - containerPort: {{ .Values.global.authSidecar.port }}
+            name: auth-proxy
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
           - mountPath: /etc/nginx/conf.d/
             name: grafana-sidecar-conf

--- a/charts/grafana/templates/grafana-networkpolicy.yaml
+++ b/charts/grafana/templates/grafana-networkpolicy.yaml
@@ -35,7 +35,7 @@ spec:
     ports:
     {{- if .Values.global.authSidecar.enabled  }}
     - protocol: TCP
-      port: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- else }}
     - protocol: TCP
       port: {{ .Values.ports.http }}

--- a/charts/grafana/templates/grafana-service.yaml
+++ b/charts/grafana/templates/grafana-service.yaml
@@ -23,8 +23,7 @@ spec:
       port: {{ .Values.ports.http }}
       targetPort: {{ .Values.ports.http }}
     {{- if .Values.global.authSidecar.enabled  }}
-    - name: nginx-ui
+    - name: auth-proxy
       protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- end}}

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
             backend:
               serviceName: {{ template "grafana.fullname" . }}
               {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: nginx-ui
+              servicePort: auth-proxy
               {{- else }}
               servicePort: grafana-ui
               {{- end }}
@@ -56,7 +56,7 @@ spec:
                 name:  {{ template "grafana.fullname" . }}
                 port:
                   {{- if .Values.global.authSidecar.enabled  }}
-                  name: nginx-ui
+                  name: auth-proxy
                   {{- else }}
                   name: grafana-ui
                   {{- end }}

--- a/charts/grafana/templates/ingress.yaml
+++ b/charts/grafana/templates/ingress.yaml
@@ -14,9 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-    {{- range $key, $value := .Values.global.extraAnnotations}}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -14,9 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-    {{- range $key, $value := .Values.global.extraAnnotations}}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -14,8 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-    kubernetes.io/ingress.class: "default"
-    route.openshift.io/termination: "reencrypt"
+    {{- range $key, $value := .Values.global.extraAnnotations}}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
@@ -44,7 +45,7 @@ spec:
             backend:
               serviceName: {{ template "kibana.fullname" . }}
               {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: nginx-ui
+              servicePort: auth-proxy
               {{- else }}
               servicePort: kibana-ui
               {{- end }}
@@ -55,7 +56,7 @@ spec:
                 name: {{ template "kibana.fullname" . }}
                 port:
                   {{- if .Values.global.authSidecar.enabled  }}
-                  name: nginx-ui
+                  name: auth-proxy
                   {{- else }}
                   name: kibana-ui
                   {{- end }}

--- a/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
+++ b/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
@@ -21,6 +21,10 @@ data:
       server_name {{ template "kibana.url" . }} ;
       listen 8080  ;
       listen [::]:8080  ;
+
+      # Disable Nginx Server version
+      server_tokens off;
+
       location  = /auth {
         proxy_set_header Host houston.{{ .Values.global.baseDomain }};
         proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
@@ -36,6 +40,9 @@ data:
         proxy_set_header  Host  {{ template "kibana.url" . }};
         proxy_pass http://astro-kibana;
 {{ .Values.global.authSidecar.default_nginx_settings_location  |  indent 8 }}
+      }
+      location /healthz {
+        return 200;
       }
     }
 {{- end }}

--- a/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
+++ b/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
@@ -20,7 +20,6 @@ data:
     server {
       server_name {{ template "kibana.url" . }} ;
       listen {{ .Values.global.authSidecar.port }}  ;
-      listen [::]:{{ .Values.global.authSidecar.port }}  ;
 
       # Disable Nginx Server version
       server_tokens off;

--- a/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
+++ b/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
@@ -19,8 +19,8 @@ data:
     }
     server {
       server_name {{ template "kibana.url" . }} ;
-      listen 8080  ;
-      listen [::]:8080  ;
+      listen {{ .Values.global.authSidecar.port }}  ;
+      listen [::]:{{ .Values.global.authSidecar.port }}  ;
 
       # Disable Nginx Server version
       server_tokens off;

--- a/charts/kibana/templates/kibana-deployment.yaml
+++ b/charts/kibana/templates/kibana-deployment.yaml
@@ -53,16 +53,30 @@ spec:
           name: kibana-ui
           protocol: TCP
       {{- if .Values.global.authSidecar.enabled  }}
-      - name: nginx
-        image: {{ .Values.global.authSidecar.image }}
+      - name: auth-proxy
+        image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
         imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
         {{- if .Values.global.authSidecar.resources }}
         resources: {{- toYaml .Values.global.authSidecar.resources | nindent 12 }}
         {{- end }}
         ports:
-        - containerPort: 8080
-          name: nginx-ui
+        - containerPort: {{ .Values.global.authSidecar.port }}
+          name: auth-proxy
           protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.global.authSidecar.port }}
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.global.authSidecar.port }}
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
         volumeMounts:
         - mountPath: /etc/nginx/conf.d/
           name: kibana-sidecar-conf

--- a/charts/kibana/templates/kibana-networkpolicy.yaml
+++ b/charts/kibana/templates/kibana-networkpolicy.yaml
@@ -35,7 +35,7 @@ spec:
     ports:
     {{- if .Values.global.authSidecar.enabled  }}
     - protocol: TCP
-      port: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- else }}
     - protocol: TCP
       port: {{ .Values.ports.http }}

--- a/charts/kibana/templates/kibana-service.yaml
+++ b/charts/kibana/templates/kibana-service.yaml
@@ -23,8 +23,7 @@ spec:
     targetPort: {{ .Values.ports.http }}
     protocol: TCP
   {{- if .Values.global.authSidecar.enabled  }}
-  - name: nginx-ui
+  - name: auth-proxy
     protocol: TCP
-    port: 8080
-    targetPort: 8080
+    port: {{ .Values.global.authSidecar.port }}
   {{- end}}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
             backend:
               serviceName: {{ template "prometheus.fullname" . }}
               {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: nginx-ui
+              servicePort: auth-proxy
               {{- else }}
               servicePort: prometheus-data
               {{- end }}
@@ -56,7 +56,7 @@ spec:
                 name: {{ template "prometheus.fullname" . }}
                 port:
                   {{- if .Values.global.authSidecar.enabled  }}
-                  name: nginx-ui
+                  name: auth-proxy
                   {{- else }}
                   name: prometheus
                   {{- end }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -14,9 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-    {{- range $key, $value := .Values.global.extraAnnotations}}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}

--- a/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
@@ -1,6 +1,6 @@
-#################################
+####################################
 ## Prometheus auth sidecar ConfigMap
-#################################
+####################################
 {{- if .Values.global.authSidecar.enabled }}
 kind: ConfigMap
 apiVersion: v1
@@ -19,8 +19,12 @@ data:
     }
     server {
       server_name {{ template "prometheus.url" . }} ;
-      listen 8080  ;
-      listen [::]:8080  ;
+      listen {{ .Values.global.authSidecar.port }}  ;
+      listen [::]:{{ .Values.global.authSidecar.port }}  ;
+
+      # Disable Nginx Server version
+      server_tokens off;
+
       location  = /auth {
         proxy_set_header Host houston.{{ .Values.global.baseDomain }};
         proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
@@ -37,6 +41,9 @@ data:
         proxy_set_header  Host  {{ template "prometheus.url" . }};
         proxy_pass http://astro-prometheus;
 {{.Values.global.authSidecar.default_nginx_settings_location | indent 8  }}
+      }
+      location /healthz {
+        return 200;
       }
     }
 {{- end }}

--- a/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
@@ -20,7 +20,6 @@ data:
     server {
       server_name {{ template "prometheus.url" . }} ;
       listen {{ .Values.global.authSidecar.port }}  ;
-      listen [::]:{{ .Values.global.authSidecar.port }}  ;
 
       # Disable Nginx Server version
       server_tokens off;

--- a/charts/prometheus/templates/prometheus-networkpolicy.yaml
+++ b/charts/prometheus/templates/prometheus-networkpolicy.yaml
@@ -53,5 +53,5 @@ spec:
       port: {{ .Values.ports.http }}
     {{- if .Values.global.authSidecar.enabled  }}
     - protocol: TCP
-      port: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- end }}

--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -65,8 +65,7 @@ spec:
       port: {{ $.Values.ports.http }}
       targetPort: {{ $.Values.ports.http }}
     {{- if .Values.global.authSidecar.enabled }}
-    - name: nginx-ui
+    - name: auth-proxy
       protocol: TCP
-      port: 8080
-      targetPort: 8080
+      port: {{ .Values.global.authSidecar.port }}
     {{- end}}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -44,16 +44,30 @@ spec:
       serviceAccountName: {{ template "prometheus.fullname" . }}
       containers:
         {{- if .Values.global.authSidecar.enabled  }}
-        - name: nginx
-          image: {{ .Values.global.authSidecar.image }}
+        - name: auth-proxy
+          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}
           resources: {{- toYaml .Values.global.authSidecar.resources | nindent 12 }}
           {{- end }}
           ports:
-          - containerPort: 8080
-            name: nginx-ui
+          - containerPort: {{ .Values.global.authSidecar.port }}
+            name: auth-proxy
             protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.global.authSidecar.port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
           - mountPath: /etc/nginx/conf.d/
             name: prometheus-sidecar-conf

--- a/values.yaml
+++ b/values.yaml
@@ -80,7 +80,8 @@ global:
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false
-    image: nginxinc/nginx-unprivileged
+    repository: nginxinc/nginx-unprivileged
+    tag: stable
     pullPolicy: IfNotPresent
     default_nginx_settings: |
       internal;

--- a/values.yaml
+++ b/values.yaml
@@ -83,6 +83,7 @@ global:
     repository: nginxinc/nginx-unprivileged
     tag: stable
     pullPolicy: IfNotPresent
+    port: 8084
     default_nginx_settings: |
       internal;
       proxy_pass_request_body     off;


### PR DESCRIPTION
## Description
This PR created for enhancement of sidecar configs

## PR Title

**Auth Sidecar Enhancements**

 🎟 Issue(s)
health check was missing for all sidecar services
houston configmap didnt had updated sidecar values 
sidecar port configuration found hardcoded
 resource naming are  inappropriate


## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
