### PR TITLE
Added the port-name of prometheus-data instead of prometheus in Prometheus Ingress

### DIFF
--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -56,7 +56,7 @@ spec:
                   {{- if .Values.global.authSidecar.enabled  }}
                   name: auth-proxy
                   {{- else }}
-                  name: prometheus
+                  name: prometheus-data
                   {{- end }}
             {{- end -}}
 {{- end }}

--- a/tests/test_prometheus_ingress.py
+++ b/tests/test_prometheus_ingress.py
@@ -9,7 +9,7 @@ from . import supported_k8s_versions
     supported_k8s_versions,
 )
 class TestIngress:
-    def test_basic_ingress(self, kube_version):
+    def test_prometheus_ingress(self, kube_version):
         # sourcery skip: extract-duplicate-method
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/test_prometheus_ingress.py
+++ b/tests/test_prometheus_ingress.py
@@ -28,7 +28,7 @@ class TestIngress:
 
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
-            assert "RELEASE-NAME-prometheus-ingress" in [
+            assert "RELEASE-NAME-prometheus" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.service.name", doc
@@ -43,7 +43,7 @@ class TestIngress:
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
-            assert "RELEASE-NAME-prometheus-ingress" in [
+            assert "RELEASE-NAME-prometheus" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.serviceName", doc

--- a/tests/test_prometheus_ingress.py
+++ b/tests/test_prometheus_ingress.py
@@ -1,0 +1,57 @@
+from tests.helm_template_generator import render_chart
+import jmespath
+import pytest
+from . import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestIngress:
+    def test_basic_ingress(self, kube_version):
+        # sourcery skip: extract-duplicate-method
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/prometheus/templates/ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+
+        doc = docs[0]
+
+        annotations = jmespath.search("metadata.annotations", doc)
+        assert len(annotations) > 1
+        assert annotations["kubernetes.io/ingress.class"] == "RELEASE-NAME-nginx"
+
+        _, minor, _ = (int(x) for x in kube_version.split("."))
+
+        if minor >= 19:
+            assert doc["apiVersion"] == "networking.k8s.io/v1"
+            assert "RELEASE-NAME-prometheus-ingress" in [
+                name[0]
+                for name in jmespath.search(
+                    "spec.rules[*].http.paths[*].backend.service.name", doc
+                )
+            ]
+            assert "prometheus-data" in [
+                port[0]
+                for port in jmespath.search(
+                    "spec.rules[*].http.paths[*].backend.service.port.name", doc
+                )
+            ]
+
+        if minor < 19:
+            assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
+            assert "RELEASE-NAME-prometheus-ingress" in [
+                name[0]
+                for name in jmespath.search(
+                    "spec.rules[*].http.paths[*].backend.serviceName", doc
+                )
+            ]
+            assert "prometheus-data" in [
+                port[0]
+                for port in jmespath.search(
+                    "spec.rules[*].http.paths[*].backend.servicePort", doc
+                )
+            ]


### PR DESCRIPTION
## Description

When using a newer k8s version the prometheus ingress port name isn't correct causing a 503 error because of the port name.

## 🎟 Issue(s)

Part of astronomer/issues#3126


## 🧪  Testing

Verified that my clusters prometheus page now works without manually changing the port name 

## 📸 Screenshots

Broken:

```
spec:
  rules:
  - host: prometheus.airflow.ralphbankston.com
    http:
      paths:
      - backend:
          service:
            name: uat-prometheus
            port:
              name: prometheus
        path: /
        pathType: Prefix
```
Fixed:

```
spec:
  rules:
  - host: prometheus.airflow.ralphbankston.com
    http:
      paths:
      - backend:
          service:
            name: uat-prometheus
            port:
              name: prometheus-data
        path: /
        pathType: Prefix
```
## 📋 Checklist

- [x] The PR title is informative to the user experience
