### PR TITLE
bumping ap-astro-ui version 

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.25.1
+    tag: 0.25.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
Bumps the version of the astro ui to 0.25.2

Among the most important fixes:
- fix deployment access list as a deployment viewer gets stuck in loading.