### PR TITLE
Different max-age for internal helm

### DIFF
--- a/bin/release-helm-chart
+++ b/bin/release-helm-chart
@@ -108,7 +108,7 @@ process_and_release_chart_file() {
   helm repo index . --url "https://${target_repo}" --merge /tmp/index.yaml.current
 
   gsutil cp "$helm_chart_path" "gs://${target_repo}"
-  gsutil -h "Cache-Control: public, max-age=300" cp ./index.yaml "gs://${target_repo}"
+  gsutil -h "Cache-Control: public, max-age=${max_age}" cp ./index.yaml "gs://${target_repo}"
 
   set +x
   hr
@@ -122,6 +122,7 @@ release_to_dev() {
   # Copy the artifact
   cp "$helm_chart_path" .
 
+  max_age="30"
   process_and_release_chart_file
 }
 
@@ -132,6 +133,7 @@ release_to_pub() {
   # Fetch artifact from helm-dev
   wget "http://$dev_repo/${helm_chart_path##*/}"
 
+  max_age="300"
   process_and_release_chart_file
 }
 


### PR DESCRIPTION
As a follow up to #1133, we should allow internal helm to have a shorter HTTP cache TTL, since we will be using it for more feature branch testing, not just release testing.