### PR TITLE
Revert "add concat long logs (#1114)"

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -56,14 +56,6 @@ data:
       max_bytes 500000
       max_lines 1000
     </match>
-    # Concat log truncated by docker 16KB limit, single line JSON, https://github.com/fluent-plugins-nursery/fluent-plugin-concat
-    <filter **>
-      @type concat
-      key message
-      multiline_end_regexp /\n$/
-      separator ""
-    </filter>
-
   forward.input.conf: |-
     # Takes the messages sent over TCP
     <source>


### PR DESCRIPTION
This reverts commit 1743b9b9aaf61f65508d8d15e2a881f7b6cd763e.

Revert concat filter that was introduced to solve an edge case with long log lines. This change caused problems in all versions of kubernetes, which differed depending on whether the cluster was >=1.20 or <1.20. Removal of this change does leave the original problem, but that problem is an edge case which should be dealt with by writing large data directly to files and not stdout. Due to the multi-stream nature of our dag workers, it is technologically infeasible for us to fix the long-line problem in our application stack. Instead, that problem should be better handled by the CRI.

There is a long discussion about this with lots of debugging info and learning in a private thread: https://github.com/astronomer/issues/issues/3113