### PR TITLE
Add absolute value threshold to NginxIngressHigh[45]XXRate

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -1343,19 +1343,25 @@ data:
       - name: Ingress
         rules:
         - alert: NginxIngressHigh4XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="{{.Release.Namespace}}"}[5m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[5m])) * 100 > 5
+          expr: >-
+            sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="{{.Release.Namespace}}"}[5m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!="", namespace="{{.Release.Namespace}}"}[5m])) * 100 > 5
+            and
+            sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..", namespace="astronomer"}[5m])) > 5
           for: 10m
           labels:
             tier: platform
             component: nginx
           annotations:
             summary: {{ printf "%q" "NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf \"%.2f\" $value }}%." }}
-            description: "This alert fires if the failure rate (the rate of 4xx)
-              measured on a time window of 2 minutes was higher than 5% in the last
-              10 minutes."
+            description: "This alert fires if the failure rate (the rate of 4xx responses)
+              measured on a time window of 5 minutes was higher than 5% of all traffic
+              AND more than 5 per minute for the last 10 minutes."
 
         - alert: NginxIngressHigh5XXRate
-          expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..",  namespace="{{.Release.Namespace}}" }[5m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!=""}[5m])) * 100 > 1
+          expr: >-
+            sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..",  namespace="{{.Release.Namespace}}"}[5m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!="", namespace="{{.Release.Namespace}}"}[5m])) * 100 > 5
+            and
+            sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^5..", namespace="astronomer"}[5m])) > 5
           for: 5m
           labels:
             tier: platform
@@ -1363,8 +1369,8 @@ data:
           annotations:
             summary: {{ printf "%q" "NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf \"%.2f\" $value }}%." }}
             description: "This alert fires if the failure rate (the rate of 5xx responses)
-              measured on a time window of 2 minutes was higher than 1% in the last
-              5 minutes."
+              measured on a time window of 5 minutes was higher than 5% of all traffic
+              AND more than 5 per minute for the last 10 minutes."
 
       - name: logging
         rules:

--- a/tests/test_prometheus_alerts_configmap.py
+++ b/tests/test_prometheus_alerts_configmap.py
@@ -3,13 +3,19 @@ from tests.helm_template_generator import render_chart
 
 
 def process_record(rule):
-    """Process a record rule."""
+    """Process a record rule.
+
+    https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/
+    """
     assert isinstance(rule.get("expr"), str)
     assert isinstance(rule.get("record"), str)
 
 
 def process_alert(rule):
-    """Process an alert rule."""
+    """Process an alert rule.
+
+    https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+    """
     assert isinstance(rule.get("alert"), str)
     assert isinstance(rule.get("expr"), str)
     if rule["alert"] != "Watchdog":

--- a/tests/test_prometheus_alerts_configmap.py
+++ b/tests/test_prometheus_alerts_configmap.py
@@ -1,0 +1,44 @@
+import yaml
+from tests.helm_template_generator import render_chart
+
+
+def process_record(rule):
+    """Process a record rule."""
+    assert isinstance(rule.get("expr"), str)
+    assert isinstance(rule.get("record"), str)
+
+
+def process_alert(rule):
+    """Process an alert rule."""
+    assert isinstance(rule.get("alert"), str)
+    assert isinstance(rule.get("expr"), str)
+    if rule["alert"] != "Watchdog":
+        assert isinstance(rule.get("for"), str)
+    assert isinstance(rule.get("labels"), dict)
+    assert isinstance(rule.get("annotations"), dict)
+
+
+def test_prometheus_alerts_configmap():
+    """Validate the prometheus alerts configmap and its embedded data."""
+    docs = render_chart(
+        show_only=["charts/prometheus/templates/prometheus-alerts-configmap.yaml"],
+    )
+
+    assert len(docs) == 1
+
+    doc = docs[0]
+
+    assert doc["kind"] == "ConfigMap"
+    assert doc["apiVersion"] == "v1"
+    assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus-alerts"
+
+    # Validate the contents of an embedded yaml doc
+    groups = yaml.safe_load(doc["data"]["alerts"])["groups"]
+    for group in groups:
+        assert isinstance(group.get("name"), str)
+        assert isinstance(group.get("rules"), list)
+        for rule in group["rules"]:
+            if rule.get("alert"):
+                process_alert(rule)
+            else:
+                process_record(rule)


### PR DESCRIPTION
## Related to issues
- https://github.com/astronomer/issues/issues/2531
- https://github.com/astronomer/issues/issues/2532
- https://github.com/astronomer/issues/issues/2874

## Itemized changes

- Add an absolute value threshold to the NginxIngressHigh[45]XXRage alerts.
- Correct some wording and make both rule wordings match.
- Add tests for alerts configmap and its embedded yaml document

## Testing

### Verified that the `>-` syntax formats the lines as expected:

The below script was inspiration for the tests I added. The tests could've been done with `promtool` too, but testing this way was easier in context.

```
$ cat /Users/danielh/temp/2021-06-28/parse.py
#!/usr/bin/env python3
import yaml

with open('/dev/stdin') as f:
    outer = yaml.safe_load(f)

inner = outer["data"]["alerts"]
parsed = yaml.load(inner, Loader=yaml.SafeLoader)

print(yaml.dump(parsed))
$ helm template . --show-only charts/prometheus/templates/prometheus-alerts-configmap.yaml | /Users/danielh/temp/2021-06-28/parse.py | yaml-to-json.py | json-to-yaml.py | bat -l yaml -r 1248:1262
───────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
       │ STDIN
───────┼────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
1248   │   - alert: NginxIngressHigh4XXRate
1249   │     annotations:
1250   │       description: This alert fires if the failure rate (the rate of 4xx responses)
1251   │         measured on a time window of 5 minutes was higher than 5% of all traffic AND
1252   │         more than 5 per minute for the last 10 minutes.
1253   │       summary: NGINX Ingress {{ $labels.ingress }} failure rate is {{ printf "%.2f"
1254   │         $value }}%.
1255   │     expr: sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..",
1256   │       namespace="default"}[5m])) / sum by (ingress) (rate(nginx_ingress_controller_requests{ingress!="",
1257   │       namespace="default"}[5m])) * 100 > 5 and sum by (ingress) (rate(nginx_ingress_controller_requests{status=~"^4..",
1258   │       namespace="astronomer"}[5m])) > 5
1259   │     for: 10m
1260   │     labels:
1261   │       component: nginx
1262   │       tier: platform
```

### Verified that the graphs in prometheus

#### Before

LOTS of noise in the alerts channel.

<img width="1388" alt="Screen Shot 2021-06-28 at 5 58 58 PM" src="https://user-images.githubusercontent.com/1323808/123721154-8a9a4180-d83a-11eb-88d4-bdee4a54faa2.png">

#### After

This is just empty

<img width="1390" alt="Screen Shot 2021-06-28 at 5 57 25 PM" src="https://user-images.githubusercontent.com/1323808/123721183-9ab22100-d83a-11eb-9993-5a820a2801f2.png">

#### After with a tiny time range

Use a tiny time range in the new rule to show that the two rules do work together.

<img width="1389" alt="Screen Shot 2021-06-28 at 5 57 11 PM" src="https://user-images.githubusercontent.com/1323808/123721260-c59c7500-d83a-11eb-9f37-51800e5cd9f0.png">


