### PR TITLE
bump nginx to .47 to fix CVE issues

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 0.46.0
+    tag: 0.47.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION

## Description

Upgrade nginx to latest version to fix CVE issues 
