### PR TITLE
upgrade houston-api 0.25.7

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.25.6
+    tag: 0.25.7
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION

## Description
upgrade houston to 0.25.7
includes: 
- fix for workspace service accounts not being able to CRUD
- fix CVE issues