### PR TITLE
Execute git-rev-parse from the script dir, not PWD. Bump some CI things.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-06
+      - image: quay.io/astronomer/ci-pre-commit:2021-07
     steps:
       - checkout
       - run:
@@ -59,7 +59,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-06
+      - image: quay.io/astronomer/ci-helm-release:2021-07
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -112,12 +112,12 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   release-to-public:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -127,13 +127,13 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 
   platform-1-16-15:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.16.15
@@ -150,7 +150,7 @@ jobs:
 
   platform-1-17-17:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.17.17
@@ -167,7 +167,7 @@ jobs:
 
   platform-1-18-19:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.18.19
@@ -184,7 +184,7 @@ jobs:
 
   platform-1-19-11:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.19.11
@@ -201,7 +201,7 @@ jobs:
 
   platform-1-20-7:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.20.7
@@ -218,7 +218,7 @@ jobs:
 
   lts-23-to-25-test:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.20.7
@@ -460,6 +460,6 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             pip install astronomer_e2e_test
             astronomer-ci publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -100,7 +100,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -110,12 +110,12 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   release-to-public:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -125,13 +125,13 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 {% for version in kube_versions %}
   platform-{{ version | replace(".", "-") }}:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}
@@ -150,7 +150,7 @@ jobs:
 {% for version in [kube_versions[-1]] %}
   lts-23-to-25-test:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}
@@ -383,6 +383,6 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-            pyenv global 3.9.1
+            pyenv global 3.9.4
             pip install astronomer_e2e_test
             astronomer-ci publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,7 +8,7 @@ executors:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2021-06
+      - image: quay.io/astronomer/ci-pre-commit:2021-07
     steps:
       - checkout
       - run:
@@ -57,7 +57,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2021-06
+      - image: quay.io/astronomer/ci-helm-release:2021-07
     steps:
       - checkout
       - run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
+    rev: v2.20.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/bin/install-platform
+++ b/bin/install-platform
@@ -4,7 +4,7 @@ set -euo pipefail
 set -x
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 HELM_CHART_PATH=${HELM_CHART_PATH:-$GIT_ROOT}
 RELEASE_NAME="${RELEASE_NAME:-astronomer}"
 NAMESPACE="${NAMESPACE:-astronomer}"

--- a/bin/lts-23-to-25-test
+++ b/bin/lts-23-to-25-test
@@ -3,7 +3,7 @@
 set -euo pipefail
 set -x
 
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 BIN_DIR="${GIT_ROOT}/bin"
 
 source "$GIT_ROOT/bin/install-ci-tools" 1

--- a/bin/prep-k8s
+++ b/bin/prep-k8s
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 
 echo "Generating SSL keys..."
 

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -42,7 +42,7 @@ done
 shift $((OPTIND - 1))
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 
 if [[ -z "${USE_HA+x}" ]]; then
   CONFIG_FILE="$GIT_ROOT/configs/local-dev.yaml"

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 BIN_DIR="${GIT_ROOT}/bin"
 
 source "$BIN_DIR/install-ci-tools" 1

--- a/bin/setup-kind
+++ b/bin/setup-kind
@@ -5,7 +5,7 @@ set -euo pipefail
 export KUBE_VERSION="${KUBE_VERSION:-v1.18.15}"
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 
 echo "Beginning KIND setup with KUBE_VERSION=${KUBE_VERSION}"
 echo "Checking tools are installed"

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 
 helm3 repo add astronomer-internal https://internal-helm.astronomer.io
 helm3 repo update

--- a/bin/waitfor-platform
+++ b/bin/waitfor-platform
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse --show-toplevel)"
+GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
 source "$GIT_ROOT/bin/helpers.sh"
 
 set +ex


### PR DESCRIPTION
There are a bunch of places in this repo where we assign `GIT_ROOT` from the output of `git rev-parse --show-toplevel`, but this command is issued from the PWD of the shell that is issuing the command, which may not always be within the same repo as where the command resides, particularly if we are debugging and running these scripts manually. This change set specifies the repo to always be that of the script where `git rev-parse` is run from by issuing `-C <path>    Run as if git was started in <path> instead of the current working directory` from the directory of the script itself, determined by stripping `/*` from script name via `"${0%/*}"`.

Also bump some CI things.