### PR TITLE
Correct git -C syntax

### DIFF
--- a/bin/install-platform
+++ b/bin/install-platform
@@ -4,7 +4,7 @@ set -euo pipefail
 set -x
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 HELM_CHART_PATH=${HELM_CHART_PATH:-$GIT_ROOT}
 RELEASE_NAME="${RELEASE_NAME:-astronomer}"
 NAMESPACE="${NAMESPACE:-astronomer}"

--- a/bin/lts-23-to-25-test
+++ b/bin/lts-23-to-25-test
@@ -3,7 +3,7 @@
 set -euo pipefail
 set -x
 
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 BIN_DIR="${GIT_ROOT}/bin"
 
 source "$GIT_ROOT/bin/install-ci-tools" 1

--- a/bin/prep-k8s
+++ b/bin/prep-k8s
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 
 echo "Generating SSL keys..."
 

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -42,7 +42,7 @@ done
 shift $((OPTIND - 1))
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 
 if [[ -z "${USE_HA+x}" ]]; then
   CONFIG_FILE="$GIT_ROOT/configs/local-dev.yaml"

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 BIN_DIR="${GIT_ROOT}/bin"
 
 source "$BIN_DIR/install-ci-tools" 1

--- a/bin/setup-kind
+++ b/bin/setup-kind
@@ -5,7 +5,7 @@ set -euo pipefail
 export KUBE_VERSION="${KUBE_VERSION:-v1.18.15}"
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 
 echo "Beginning KIND setup with KUBE_VERSION=${KUBE_VERSION}"
 echo "Checking tools are installed"

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 
 helm3 repo add astronomer-internal https://internal-helm.astronomer.io
 helm3 repo update

--- a/bin/waitfor-platform
+++ b/bin/waitfor-platform
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # The path to the working directory - the root of the repo
-GIT_ROOT="$(git rev-parse -C "${0%/*}" --show-toplevel)"
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
 source "$GIT_ROOT/bin/helpers.sh"
 
 set +ex


### PR DESCRIPTION
The [recently added syntax](https://github.com/astronomer/astronomer/pull/1149) to always execute `git rev-parse` from the astronomer repo was invalid. [This was in fact caught by CI](https://app.circleci.com/pipelines/github/astronomer/astronomer/2795/workflows/2d28cd30-07fe-4d10-b246-f8c21d08f7e3/jobs/19710), but somehow I missed this and merged it. This change set fixes that syntax to work as expected. Shout out to @aliotta for catching this!

FWIW during testing I tested this on prehistoric bash `3.2.57(1)-release (x86_64-apple-darwin20)` which is still the default on MacOS 11, and modern bash `5.1.8(1)-release (x86_64-apple-darwin20.3.0)`