### PR TITLE
Add ServiceType of NGINX to be configurable and externalIPs

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   type: {{ .Values.serviceType }}
   {{- if .Values.externalIPs }}
-  externalIps: 
+  externalIps:
     - {{ .Values.externalIPs }}
   {{- end }}
   {{- if .Values.loadBalancerIP }}

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -30,7 +30,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: {{ .Values.ports.metrics | quote }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.serviceType }}
   {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -31,6 +31,10 @@ metadata:
     prometheus.io/port: {{ .Values.ports.metrics | quote }}
 spec:
   type: {{ .Values.serviceType }}
+  {{- if .Values.externalIPs }}
+  externalIps: 
+    - {{ .Values.externalIPs }}
+  {{- end }}
   {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -32,6 +32,9 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+# Service type that Nginx can be. Default is LoadBalancer but "ClusterIP" and "NodePort" are both valid.
+serviceType: "LoadBalancer"
+
 # dict of annotations to add to the ingress controller
 ingressAnnotations: {}
 

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -42,7 +42,10 @@ ingressAnnotations: {}
 antiAffinity: "soft"
 
 # String IP address the nginx ingress should bind to
-loadBalancerIP: ~
+loadBalancerIPs: ~
+
+# String IP address that the service should list as an external IP. Currently only 1 address is supported
+externalIPs: ~
 
 # List used to restrict IPs that can reach the nginx ingress
 loadBalancerSourceRanges: []

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -1,0 +1,56 @@
+from tests.helm_template_generator import render_chart
+import jmespath
+import pytest
+
+
+class TestNginx:
+    def test_nginx_service_basics(self):
+        # sourcery skip: extract-duplicate-method
+        docs = render_chart(
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+
+        doc = docs[0]
+
+        assert doc["kind"] == "Service"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
+
+    def test_nginx_type_loadbalancer(self):
+        
+        docs = render_chart(
+            values={"nginx": {"serviceType": "LoadBalancer"}},
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["spec"]["type"] == "LoadBalancer"
+
+    def test_nginx_type_clusterip(self):
+        
+        docs = render_chart(
+            values={"nginx": {"serviceType": "ClusterIP"}},
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["spec"]["type"] == "ClusterIP"    
+
+    def test_nginx_type_nodeport(self):
+        
+        docs = render_chart(
+            values={"nginx": {"serviceType": "NodePort"}},
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["spec"]["type"] == "NodePort"    
+

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -36,7 +36,7 @@ class TestNginx:
 
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["spec"]["type"] == "ClusterIP"    
+        assert doc["spec"]["type"] == "ClusterIP"
 
     def test_nginx_type_nodeport(self):
         # sourcery skip: extract-duplicate-method
@@ -47,7 +47,7 @@ class TestNginx:
 
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["spec"]["type"] == "NodePort"    
+        assert doc["spec"]["type"] == "NodePort"
 
     def test_nginx_enabled_externalips(self):
         # sourcery skip: extract-duplicate-method

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -19,7 +19,7 @@ class TestNginx:
         assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
 
     def test_nginx_type_loadbalancer(self):
-        
+        # sourcery skip: extract-duplicate-method
         docs = render_chart(
             values={"nginx": {"serviceType": "LoadBalancer"}},
             show_only=["charts/nginx/templates/nginx-service.yaml"],
@@ -31,7 +31,7 @@ class TestNginx:
         assert doc["spec"]["type"] == "LoadBalancer"
 
     def test_nginx_type_clusterip(self):
-        
+        # sourcery skip: extract-duplicate-method
         docs = render_chart(
             values={"nginx": {"serviceType": "ClusterIP"}},
             show_only=["charts/nginx/templates/nginx-service.yaml"],
@@ -43,7 +43,7 @@ class TestNginx:
         assert doc["spec"]["type"] == "ClusterIP"    
 
     def test_nginx_type_nodeport(self):
-        
+        # sourcery skip: extract-duplicate-method
         docs = render_chart(
             values={"nginx": {"serviceType": "NodePort"}},
             show_only=["charts/nginx/templates/nginx-service.yaml"],
@@ -55,7 +55,7 @@ class TestNginx:
         assert doc["spec"]["type"] == "NodePort"    
 
     def test_nginx_enabled_externalips(self):
-        
+        # sourcery skip: extract-duplicate-method
         docs = render_chart(
             values={"nginx": {"externalIPs": "1.2.3.4"}},
             show_only=["charts/nginx/templates/nginx-service.yaml"],

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -1,7 +1,4 @@
 from tests.helm_template_generator import render_chart
-import jmespath
-import pytest
-
 
 class TestNginx:
     def test_nginx_service_basics(self):
@@ -39,7 +36,6 @@ class TestNginx:
 
         assert len(docs) == 1
         doc = docs[0]
-
         assert doc["spec"]["type"] == "ClusterIP"    
 
     def test_nginx_type_nodeport(self):
@@ -51,7 +47,6 @@ class TestNginx:
 
         assert len(docs) == 1
         doc = docs[0]
-
         assert doc["spec"]["type"] == "NodePort"    
 
     def test_nginx_enabled_externalips(self):
@@ -63,6 +58,5 @@ class TestNginx:
 
         assert len(docs) == 1
         doc = docs[0]
-
         assert len(doc["spec"]["externalIps"]) > 0
         assert "1.2.3.4" in doc["spec"]["externalIps"]

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -1,5 +1,6 @@
 from tests.helm_template_generator import render_chart
 
+
 class TestNginx:
     def test_nginx_service_basics(self):
         # sourcery skip: extract-duplicate-method

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -54,3 +54,15 @@ class TestNginx:
 
         assert doc["spec"]["type"] == "NodePort"    
 
+    def test_nginx_enabled_externalips(self):
+        
+        docs = render_chart(
+            values={"nginx": {"externalIPs": "1.2.3.4"}},
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert len(doc["spec"]["externalIps"]) > 0
+        assert "1.2.3.4" in doc["spec"]["externalIps"]


### PR DESCRIPTION
## Description

Allows the NGINX ServiceType to be configurable within our chart. Default is left at LoadBalancer so only folks that need it would go looking for it.

Also adds ability to add an external ip to the NGINX service.

## 🎟 Issue(s)

Resolves astronomer/issues#3136
Resolves astronomer/issues#3204


## 🧪  Testing

Created tests for the nginx service for LoadBalancer, NodePort, and ClusterIP. Most people wouldn't notice this change unless it is needed for a customized on-prem configuration

Also added tests for adding an externalip

## 📸 Screenshots

LoadBalancer:
  sessionAffinity: None
  type: LoadBalancer

ClusterIP:
  sessionAffinity: None
  type: ClusterIP

NodePort:
  sessionAffinity: None
  type: NodePort

## 📋 Checklist

- [x] The PR title is informative to the user experience
- [x] Passing tests
