### PR TITLE
bump: ap-cli-install to 0.25.0 and other ap-vendor images to fix container running as root user problem

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.13.2
+    tag: 0.25.0
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.13.7
+    tag: 3.13.7-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.25.0
+    tag: 0.25.1
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.10.2-1
+    tag: 7.10.2-3
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.2.1
+    tag: 2.3.2
     pullPolicy: IfNotPresent
 
 nats:
@@ -173,7 +173,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.6.2
+  image: quay.io/astronomer/ap-nats-exporter:0.6.2-1
   pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.21.2
+    tag: 0.22.0
     pullPolicy: IfNotPresent
 
 stan:
@@ -148,7 +148,7 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.6.2
+  image: quay.io/astronomer/ap-nats-exporter:0.6.2-1
   pullPolicy: IfNotPresent
   resources: {}
   #  limits:


### PR DESCRIPTION
Bump vendored images:

- `quay.io/astronomer/ap-cli-install:0.25.1`
- `quay.io/astronomer/ap-registry:3.13.7-1`
- `quay.io/astronomer/ap-nats-server:2.3.2`
- `quay.io/astronomer/ap-nats-streaming:0.22.0`
- `quay.io/astronomer/ap-nats-exporter:0.6.2-1`
- `quay.io/astronomer/ap-elasticsearch:7.10.2-3`