### PR TITLE
registry: add securityContext to registry container

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -50,14 +50,14 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
+      securityContext:
+			  fsGroup: 1000
+		    runAsGroup: 1000
+		    runAsUser: 1000
       containers:
         - name: registry
           image: {{ template  "registry.image" . }}
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
-          securityContext:
-            fsGroup: 1000
-            runAsGroup: 1000
-            runAsUser: 1000
           env:
           - name: REGISTRY_HTTP_SECRET
             {{- if .Values.registry.httpSecret }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -54,6 +54,10 @@ spec:
         - name: registry
           image: {{ template  "registry.image" . }}
           imagePullPolicy: {{ .Values.images.registry.pullPolicy }}
+          securityContext:
+            fsGroup: 1000
+            runAsGroup: 1000
+            runAsUser: 1000
           env:
           - name: REGISTRY_HTTP_SECRET
             {{- if .Values.registry.httpSecret }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -51,9 +51,9 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
       securityContext:
-			  fsGroup: 1000
-		    runAsGroup: 1000
-		    runAsUser: 1000
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsUser: 1000
       containers:
         - name: registry
           image: {{ template  "registry.image" . }}


### PR DESCRIPTION
https://github.com/astronomer/issues/issues/3252

some trouble shooting why it's working in qa cluster (google env) and don't work in AWS:
```
 {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
            {{- include "registry.gcsVolumeMount" . | indent 12 }}
            {{- end }}
11:25
helm get values astronomer | rg registry -C5
        cpu: 1000m
        memory: 1Gi
      requests:
        cpu: 500m
        memory: 512Mi
  registry:
    gcs:
      bucket: qa-astronomer-qa-registry
      enabled: true
    podLabels:
      spotinst.io/node-lifecycle: od
    replicas: 2
elasticsearch:
```


```
/ $ ps
PID   USER     TIME  COMMAND
    1 registry 16:40 registry serve /etc/docker/registry/config.yml
   33 registry  0:00 sh
   39 registry  0:00 ps
11:27
/ $ cat /etc/docker/registry/config.yml
version: 0.1
log:
  fields:
    service: registry
storage:
  cache:
    blobdescriptor: inmemory
  gcs:
    bucket: qa-astronomer-qa-registry
    keyfile: /var/gcs-keyfile/astronomer-gcs-keyfile
    rootdirectory: /
    chunksize: 5242880
  delete:
```