### PR TITLE
Support k8s 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,12 +216,29 @@ jobs:
             kubent --cluster=false --helm2=false --helm3=false --filename -
           when: always
 
+  platform-1-21-1:
+    machine:
+      image: ubuntu-2004:202101-01
+      resource_class: xlarge
+    environment:
+      KUBE_VERSION: v1.21.1
+    steps:
+      - helm-install:
+          astronomer-tags: "platform postgresql monitoring logging kubed keda"
+      - run:
+          name: Check chart for k8s 1.21.1 compatibility with kubent
+          command: |
+            set -o pipefail
+            helm template --kube-version=v1.21.1 -f values.yaml --set global.baseDomain=example.com . |
+            kubent --cluster=false --helm2=false --helm3=false --filename -
+          when: always
+
   lts-23-to-25-test:
     machine:
       image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
-      KUBE_VERSION: v1.20.7
+      KUBE_VERSION: v1.21.1
     steps:
       - lts-23-to-25-test
 
@@ -295,6 +312,11 @@ workflows:
 
       - platform-1-20-7:
           requires:
+            - test-all-platforms
+            - build-artifact
+
+      - platform-1-21-1:
+          requires:
             - build-artifact
       - approve-internal-release:
           type: approval
@@ -304,7 +326,7 @@ workflows:
           requires:
             - approve-internal-release
             - platform-1-16-15
-            - platform-1-20-7
+            - platform-1-21-1
       - approve-public-release:
           type: approval
           requires:
@@ -312,6 +334,7 @@ workflows:
             - platform-1-17-17
             - platform-1-18-19
             - platform-1-19-11
+            - platform-1-20-7
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,7 +218,7 @@ jobs:
 
   platform-1-21-1:
     machine:
-      image: ubuntu-2004:202101-01
+      image: ubuntu-2004:202104-01
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.21.1

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 # recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-KUBE_VERSIONS = ["1.16.15", "1.17.17", "1.18.19", "1.19.11", "1.20.7"]
+KUBE_VERSIONS = ["1.16.15", "1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.1"]
 
 
 def main():

--- a/bin/setup-kind
+++ b/bin/setup-kind
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1090
 set -euo pipefail
 
-export KUBE_VERSION="${KUBE_VERSION:-v1.18.15}"
+export KUBE_VERSION="${KUBE_VERSION:-v1.18.19}"
 
 # The path to the working directory - the root of the repo
 GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,4 +7,4 @@ git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 
 # This should match the major.minor version list in .circleci/generate_circleci_config.py
 # Patch version should always be 0
-supported_k8s_versions = ["1.16.0", "1.17.0", "1.18.0", "1.19.0", "1.20.0"]
+supported_k8s_versions = ["1.16.0", "1.17.0", "1.18.0", "1.19.0", "1.20.0", "1.21.0"]


### PR DESCRIPTION
This PR adds testing for kubernetes 1.21. All tests are passing, likely because of some work that was done for 1.19 and 1.20.

Related to <https://github.com/astronomer/issues/issues/3126>