### PR TITLE
Allow customization of cert-copy image

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @danielhoherd @andriisoldatenko 
+*       @danielhoherd @andriisoldatenko

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:
       - name: cert-copy
-        image: alpine
+        image: {{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
         command:
           - "sh"
           - "-c"

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -104,9 +104,11 @@ def render_chart(
             if not templates:
                 return None
         except subprocess.CalledProcessError as error:
-            print(
-                f"ERROR: subprocess.CalledProcessError:\n{error.output=}\n{error.stderr=}"
-            )
+            print("ERROR: subprocess.CalledProcessError:")
+            print(f"helm command: {' '.join(command)}")
+            print(f"Values file contents:\n{'-' * 21}\n{yaml.dump(values)}\n{'-' * 21}")
+            print(f"{error.output=}\n{error.stderr=}")
+
             if "could not find template" in error.stderr.decode("utf-8"):
                 print(
                     "ERROR: command is probably using templates with null output, which "

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -106,7 +106,7 @@ def render_chart(
         except subprocess.CalledProcessError as error:
             print("ERROR: subprocess.CalledProcessError:")
             print(f"helm command: {' '.join(command)}")
-            print(f"Values file contents:\n{'-' * 21}\n{yaml.dump(values)}\n{'-' * 21}")
+            print(f"Values file contents:\n{'-' * 21}\n{yaml.dump(values)}{'-' * 21}")
             print(f"{error.output=}\n{error.stderr=}")
 
             if "could not find template" in error.stderr.decode("utf-8"):

--- a/tests/test_privateca.py
+++ b/tests/test_privateca.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError
     "kube_version",
     supported_k8s_versions,
 )
-class TestDameonset:
+class TestDaemonset:
     @staticmethod
     def common_tests_daemonset(doc):
         """Test things common to all daemonsets"""

--- a/tests/test_privateca.py
+++ b/tests/test_privateca.py
@@ -1,0 +1,65 @@
+from tests.helm_template_generator import render_chart
+import jmespath
+import pytest
+from . import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestDameonset:
+    @staticmethod
+    def common_tests_daemonset(doc):
+        """Test things common to all daemonsets"""
+        assert "DaemonSet" == jmespath.search("kind", doc)
+        assert "RELEASE-NAME-private-ca" == jmespath.search("metadata.name", doc)
+        assert "cert-copy" == jmespath.search(
+            "spec.template.spec.containers[0].name", doc
+        )
+
+    def test_privateca_daemonset(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/trust-private-ca-on-all-nodes/daemonset.yaml"],
+            values={
+                "global": {
+                    "privateCaCertsAddToHost": {
+                        "enabled": True,
+                    }
+                }
+            },
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        self.common_tests_daemonset(doc)
+        assert any(
+            "alpine:3.14" in item
+            for item in jmespath.search("spec.template.spec.containers[*].image", doc)
+        )
+
+    def test_privateca_daemonset_with_custom_image(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/trust-private-ca-on-all-nodes/daemonset.yaml"],
+            values={
+                "global": {
+                    "privateCaCertsAddToHost": {
+                        "enabled": True,
+                        "certCopier": {
+                            "repository": "snarks",
+                            "tag": "boojums",
+                        },
+                    }
+                }
+            },
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        self.common_tests_daemonset(doc)
+        assert any(
+            "snarks:boojums" in item
+            for item in jmespath.search("spec.template.spec.containers[*].image", doc)
+        )

--- a/tests/test_privateca.py
+++ b/tests/test_privateca.py
@@ -2,6 +2,7 @@ from tests.helm_template_generator import render_chart
 import jmespath
 import pytest
 from . import supported_k8s_versions
+from subprocess import CalledProcessError
 
 
 @pytest.mark.parametrize(
@@ -18,7 +19,21 @@ class TestDameonset:
             "spec.template.spec.containers[0].name", doc
         )
 
-    def test_privateca_daemonset(self, kube_version):
+    def test_privateca_daemonset_disabled(self, kube_version):
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only=["templates/trust-private-ca-on-all-nodes/daemonset.yaml"],
+                values={
+                    "global": {
+                        "privateCaCertsAddToHost": {
+                            "enabled": False,
+                        }
+                    }
+                },
+            )
+
+    def test_privateca_daemonset_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             show_only=["templates/trust-private-ca-on-all-nodes/daemonset.yaml"],
@@ -39,7 +54,7 @@ class TestDameonset:
             for item in jmespath.search("spec.template.spec.containers[*].image", doc)
         )
 
-    def test_privateca_daemonset_with_custom_image(self, kube_version):
+    def test_privateca_daemonset_enabled_with_custom_image(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             show_only=["templates/trust-private-ca-on-all-nodes/daemonset.yaml"],
@@ -63,3 +78,58 @@ class TestDameonset:
             "snarks:boojums" in item
             for item in jmespath.search("spec.template.spec.containers[*].image", doc)
         )
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestPSP:
+    def test_privateca_psp_enabled_cacertaddtohost_disabled(self, kube_version):
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only=["templates/trust-private-ca-on-all-nodes/psp.yaml"],
+                values={
+                    "global": {
+                        "pspEnabled": True,
+                        "privateCaCertsAddToHost": {
+                            "enabled": False,
+                        },
+                    }
+                },
+            )
+
+    def test_privateca_psp_disabled_cacertaddtohost_enabled(self, kube_version):
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                show_only=["templates/trust-private-ca-on-all-nodes/psp.yaml"],
+                values={
+                    "global": {
+                        "pspEnabled": False,
+                        "privateCaCertsAddToHost": {
+                            "enabled": True,
+                        },
+                    }
+                },
+            )
+
+    def test_privateca_psp_enabled(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["templates/trust-private-ca-on-all-nodes/psp.yaml"],
+            values={
+                "global": {
+                    "pspEnabled": True,
+                    "privateCaCertsAddToHost": {
+                        "enabled": True,
+                    },
+                }
+            },
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "PodSecurityPolicy" == jmespath.search("kind", doc)
+        assert "RELEASE-NAME-private-ca" == jmespath.search("metadata.name", doc)

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,11 @@ global:
   privateCaCertsAddToHost:
     enabled: false
     hostDirectory: /etc/docker/certs.d
+    certCopier:
+      repository: alpine
+      tag: 3.14
+      pullPolicy: IfNotPresent
+
 
   # Use kube-lego
   acme: false


### PR DESCRIPTION
First crack at allowing customization of cert-copy image. I'm not sure everything here is in the right place, so feedback is welcome.

This change also alters the way that pytest reports failures, attempting to be more helpful. Here is an example exception:
```
ERROR: subprocess.CalledProcessError:
helm command: helm template --kube-version 1.20.0 RELEASE-NAME /Users/danielh/a/astronomer --set global.baseDomain=example.com --values /var/folders/9p/kbxv3fnn447706mqhnf7bncm0000z8/T/tmpmovq26rc --show-only templates/trust-private-ca-on-all-nodes/daemonset.yaml
Values file contents:
---------------------
global:
  privateCaCerts:
  - private-ca-cert-foo
  - private-ca-cert-bar
  privateCaCertsAddToHost:
    enabled: false
---------------------
error.output=b''
error.stderr=b'Error: could not find template templates/trust-private-ca-on-all-nodes/daemonset.yaml in chart\n'
ERROR: command is probably using templates with null output, which usually means there is a helm value that needs to be set to render the content of the chart.
command: helm template --kube-version 1.20.0 RELEASE-NAME /Users/danielh/a/astronomer --set global.baseDomain=example.com --values /var/folders/9p/kbxv3fnn447706mqhnf7bncm0000z8/T/tmpmovq26rc --show-only templates/trust-private-ca-on-all-nodes/daemonset.yaml
```

Related to <https://github.com/astronomer/issues/issues/3088>