### PR TITLE
Bump fluentd to 1.13.3-1

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.1
+    tag: 1.13.3-1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
Bump ap-fluentd to 1.13.3-1 to solve a few CVEs. This change also includes the new plugin [fluent-plugin-cloudwatch-logs](https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs)

Solves https://github.com/astronomer/issues/issues/3325