### PR TITLE
fix: missing custom ca volume mount for houston-worker

### DIFF
--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -83,6 +83,7 @@ spec:
 {{ toYaml .Values.houston.resources | indent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}
+            {{- include "custom_ca_volume_mounts" . | indent 12 }}
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -100,4 +101,5 @@ spec:
               value: "kubernetes/deployment"
       volumes:
         {{- include "houston_volumes" . | indent 8 }}
+        {{- include "custom_ca_volumes" . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
Just did debug with client  (and with @pgagnon )and they are using custom ca certificates, so houston-worker can have this error:

```
/houston $ node --experimental-repl-await
Welcome to Node.js v14.17.1.
Type ".help" for more information.
> const config = require('config');
undefined
> const { allowRootAccess, enabled, connection } = config.get(
... "deployments.database"
... );
undefined
> const { ssl } = config.get("database");
undefined
> const knex = require('knex');
undefined
> const conn = knex({ client: "postgres", connection: connection });
undefined
> await conn.raw('CREATE DATABASE test9');
Uncaught Error: unable to get issuer certificate
    at TLSSocket.onConnectSecure (_tls_wrap.js:1514:34)
    at TLSSocket.emit (events.js:375:28)
    at TLSSocket.emit (domain.js:532:15)
    at TLSSocket._finishInit (_tls_wrap.js:936:8)
    at TLSWrap.ssl.onhandshakedone (_tls_wrap.js:708:12)
    at TLSWrap.callbackTrampoline (internal/async_hooks.js:131:17) {
  code: 'UNABLE_TO_GET_ISSUER_CERT'


```

Resolves astronomer/issues#3334