### PR TITLE
Use ap-fluentd:1.13.3

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.1
+    tag: 1.13.3-2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.3-2
+    tag: 1.13.3
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
Use ap-fluentd:1.13.3 which solves some CVEs but does not include some newer packages that are breaking the image.

Related to https://github.com/astronomer/issues/issues/3326