### PR TITLE
Update packages that have 'don't run as root' fixes

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.1.0
+    tag: 1.2.1
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es


### PR DESCRIPTION
Updating ap-elasticsearch-exporter

Resolves astronomer/issues#2937