### PR TITLE
Fix local dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.1
+    rev: v2.23.3
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
       - id: flake8
         args:
           - --ignore=E501,W503
-  - repo: https://github.com/detailyang/pre-commit-shell
-    rev: 1.0.5
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.7.2.1
     hooks:
-      - id: shell-lint
+      - id: shellcheck
   - repo: local
     hooks:
       - id: circle-config-yaml

--- a/bin/create-initial-user
+++ b/bin/create-initial-user
@@ -11,7 +11,7 @@ fi
 
 BIN_DIR="${0%/*}"
 
-HOST="https://houston.local.astronomer-development.com/v1"
+HOST="https://houston.localtest.me/v1"
 
 USER="$1"
 PASS="$2"

--- a/bin/generate_ssl_keys
+++ b/bin/generate_ssl_keys
@@ -3,5 +3,5 @@ set -euo pipefail
 
 # https://github.com/FiloSottile/mkcert
 mkcert -install
-mkcert -cert-file /tmp/fullchain.pem -key-file /tmp/privkey.pem app.local.astronomer-development.com local.astronomer-development.com "*.local.astronomer-development.com"
+mkcert -cert-file /tmp/fullchain.pem -key-file /tmp/privkey.pem app.localtest.me localtest.me "*.localtest.me"
 cat "$(mkcert -CAROOT)/rootCA.pem" >> /tmp/fullchain.pem

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -82,7 +82,7 @@ echo '
      sudo -E kubectl port-forward -n astronomer svc/astronomer-nginx 443
 
 
- Then you can access the service here: https://app.local.astronomer-development.com
+ Then you can access the service here: https://app.localtest.me
 
  You can clean up like this:
 

--- a/bin/run-ci
+++ b/bin/run-ci
@@ -27,8 +27,6 @@ sleep 5
 
 "$BIN_DIR/waitfor-platform"
 
-"$BIN_DIR/setup-hosts"
-
 # "$BIN_DIR/create-initial-user" "tester@astronomer.io" "password"
 
 sudo kill -9 $WATCH_PID

--- a/bin/setup-hosts
+++ b/bin/setup-hosts
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-grep "^[^#]*localtest.me" /etc/hosts ||
-echo "172.17.0.1 localtest.me" |
-sudo tee -a /etc/hosts

--- a/bin/setup-hosts
+++ b/bin/setup-hosts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-grep "^[^#]*local.astronomer-development.com" /etc/hosts ||
-echo "172.17.0.1 local.astronomer-development.com" |
+grep "^[^#]*localtest.me" /etc/hosts ||
+echo "172.17.0.1 localtest.me" |
 sudo tee -a /etc/hosts

--- a/configs/local-dev-ha.yaml
+++ b/configs/local-dev-ha.yaml
@@ -1,7 +1,7 @@
 ############################
 ## Astronomer configuration
 ## For local Kubernetes development
-## There should be an A record on *.local.astronomer-development.com
+## There should be an A record on *.localtest.me
 ## with the value 127.0.0.1 and you should set up
 ## the secrets and TLS cert normally.
 ############################
@@ -16,7 +16,7 @@ tags:
 
 global:
   # Base domain for all subdomains exposed through ingress
-  baseDomain: local.astronomer-development.com
+  baseDomain: localtest.me
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -1,7 +1,7 @@
 ############################
 ## Astronomer configuration
 ## For local Kubernetes development
-## There should be an A record on *.local.astronomer-development.com
+## There should be an A record on *.localtest.me
 ## with the value 127.0.0.1 and you should set up
 ## the secrets and TLS cert normally.
 ############################
@@ -17,7 +17,7 @@ tags:
 
 global:
   # Base domain for all subdomains exposed through ingress
-  baseDomain: local.astronomer-development.com
+  baseDomain: localtest.me
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls


### PR DESCRIPTION
# Description

The DNS zone *.astronomer-development.com was deleted recently during a scheduled spin-down of an old developer account. This updates references to it with a globally resolvable domain name that points itself and all subdomains to 127.0.0.1, which fixes the local dev workflow.

This change also replaces the shellcheck pre-commit hook with one that installs shellcheck into the env.

# Itemized changes

- `gsed -i 's/local.astronomer-development.com/localtest.me/' ...files...`
- `gsed -E -i 's#https://github.com/detailyang/pre-commit-shell#https://github.com/shellcheck-py/shellcheck-py#'` and stuff
- `pre-commit auto-update`
- `rm -f bin/setup-hosts` and delete the reference from `bin/run-ci`

# Testing

I manually ran the `bin/reset-local-dev` flow a few times and tested in a few browsers to make sure it works.