### PR TITLE
Rollback 0.23 to 0.16 fix

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -236,9 +236,8 @@
 
 # Delete scheduler deployment before rollback, in order to prevent the init container
 # 'wait-for-airflow-migrations' from getting appended in scheduler deployment definition,
-# which
-# leads to 2 init containers wait-for-airflow-migrations(0.19.0) + run-airflow-migrations
-# when performing rollback to 0.15.7 airflow chart
+# which leads to 2 init containers wait-for-airflow-migrations(0.19.0) +
+# run-airflow-migrations when performing rollback to 0.15.7 airflow chart
 - name: Delete All Scheduler Deployemnts
   kubernetes.core.k8s:
     api_version: v1

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -234,8 +234,10 @@
     db: "{{ database_name }}_houston"
     query: "drop table migrations;"
 
-# Prevents to append scheduler deployment definition ,which
-# lead to 2 init containers wait-for-airflow-migrations(0.19.0) + run-airflow-migrations
+# Delete scheduler deployment before rollback, in order to prevent the init container
+# 'wait-for-airflow-migrations' from getting appended in scheduler deployment definition,
+# which
+# leads to 2 init containers wait-for-airflow-migrations(0.19.0) + run-airflow-migrations
 # when performing rollback to 0.15.7 airflow chart
 - name: Delete All Scheduler Deployemnts
   kubernetes.core.k8s:

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -238,7 +238,7 @@
 # to prevent init container wait-for-airflow-migrations 
 # to append in existing 0.15.7 airflow chart preventing 
 # creation of 2 init containers (run-airflow-migrations + wait-for-airflow-migrations)
-- name: Delete all All Scheduler Deployemnts
+- name: Delete All Scheduler Deployemnts
   kubernetes.core.k8s:
     api_version: v1
     state: absent

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -234,6 +234,16 @@
     db: "{{ database_name }}_houston"
     query: "drop table migrations;"
 
+# Delete Scheduler deployment before rollback
+# to prevent init container wait-for-airflow-migrations 
+# to append in existing 0.15.7 airflow chart preventing 
+# creation of 2 init containers (run-airflow-migrations + wait-for-airflow-migrations)
+- name: Delete all All Scheduler Deployemnts
+  kubernetes.core.k8s:
+    api_version: v1
+    state: absent
+    definition: "{{ lookup('kubernetes.core.k8s', api_version='apps/v1', kind='Deployment', label_selector='component = scheduler') }}"
+
 - name: Rollback with Helm (no hooks)
   shell: |
     helm rollback {{ release_name }} {{ helm_history.revision }} --no-hooks --namespace {{ namespace }}

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/rollback.yaml
@@ -234,10 +234,9 @@
     db: "{{ database_name }}_houston"
     query: "drop table migrations;"
 
-# Delete Scheduler deployment before rollback
-# to prevent init container wait-for-airflow-migrations 
-# to append in existing 0.15.7 airflow chart preventing 
-# creation of 2 init containers (run-airflow-migrations + wait-for-airflow-migrations)
+# Prevents to append scheduler deployment definition ,which
+# lead to 2 init containers wait-for-airflow-migrations(0.19.0) + run-airflow-migrations
+# when performing rollback to 0.15.7 airflow chart
 - name: Delete All Scheduler Deployemnts
   kubernetes.core.k8s:
     api_version: v1


### PR DESCRIPTION
<!--
-->

## Description
Adding Deletion of Scheduler deployment box in current Rollback script from 0.23.14 to 0.16.15.
Ref: Zendesk [5619](https://astronomer.zendesk.com/agent/tickets/5619)

<!--
Describe the purpose of this pull request.
-->

## PR Title

<!--
Please make the PR title informative to the user experience. For example when adding a feature, say "Add metrics tab for Deployments" instead of "Bump Astro-UI to version X.Y.Z". Bugs are sometimes harder to make customer-facing because they are very detailed, but do what you can. Instead of "Fix metrics cardinality bug" (user does not know what 'cardinality' means and does not matter to them), say "Fix bug slowing down the metrics tab". The PR title will be used for the commit message when it's merged, and these commit messages are used to generate customer-facing release notes.

If there is only one commit in the PR, when clicking the merge button, be sure to copy the PR title into the PR squash and merge option's commit message. By default with a single commit, it will use the commit message instead of the PR title.
-->

## 🎟 Issue(s)

<!--
Resolves astronomer/issues#XXXX
-->

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

## 📋 Checklist

- [ ] The PR title is informative to the user experience
