### PR TITLE
update ap-fluentd to allow export to Cloudwatch logs and elasticSearch

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.3
+    tag: 1.13.3-3
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
update ap-fluentd to allow export to Cloudwatch logs and elasticSearch