### PR TITLE
Fluentd:updates image to 1.13.3-4

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.3-3
+    tag: 1.13.3-4
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
<!--
Please fill out the sections below, deleting anything that is irrelevant or empty.
-->


## Description

<!--
Describe the purpose of this pull request.
-->
Update to pull image version `1.13.3-4` which includes new-relic plugin gem introduced in https://github.com/astronomer/ap-vendor/pull/137


## 🎟 Issue(s)

<!--
Resolves astronomer/issues#XXXX
-->
https://github.com/astronomer/issues/issues/3359

## 🧪  Testing

<!--
What are the main risks associated with this change, and how are they addressed by tests added in this PR?

Please add helm unit testing, if applicable. The docs are regretfully sparse for helm unit testing, [here](https://github.com/astronomer/helm-unittest/blob/main/DOCUMENT.md) is what we have to work with. In general, these kind of tests can be used for specific assertions like 'when these values are set, the resource ends up looking like XYZ' but not for generalized assertions like 'for all resources, make sure the namespace is not set to the release name'.

Please also add to the system testing [here](../bin/functional-tests), if applicable. This kind of testing allows you to connect into any live, running pod to make assertions about how they are operating. For example, one test connects to a Prometheus pod, queries the Prometheus API, and makes assertions about the Prometheus scrape targets being healthy.
-->

1. pulled new image to EKS cluster with chart version `0.25.4`
2. verified pods ran 
3. edited configmap to include new-relic specific details
4. redeployed pods, verified logs streaming to both es/kibana and new-relic



## 📸 Screenshots

<!--
Add screenshots to illustrate the changes, if applicable.
-->

![Screen Shot 2021-08-20 at 9 46 58 AM](https://user-images.githubusercontent.com/6012231/130243045-1c8ebd84-c6a6-44db-add0-b75db471d7b0.png)



## 📋 Checklist

- [x] The PR title is informative to the user experience
