### PR TITLE
Bump to 0.23.15-rc1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.23.14
-appVersion: 0.23.14
+version: 0.23.15-rc1
+appVersion: 0.23.15-rc1
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.23.14
+version: 0.23.15-rc1
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/tests/deployment_test.yaml
+++ b/charts/astronomer/tests/deployment_test.yaml
@@ -8,4 +8,4 @@ tests:
         of: Deployment
     - equal:
         path: spec.template.spec.containers[0].image
-        value: quay.io/astronomer/ap-commander:0.21.0
+        value: quay.io/astronomer/ap-commander:0.23.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.21.0
+    tag: 0.23.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -23,7 +23,7 @@ images:
     pullPolicy: IfNotPresent
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.23.22
+    tag: 0.23.23
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
Bump astronomer to 0.23.15-rc1 with upgraded components for that release. LTS upgrade tests will likely fail, but we will fix those in parallel to rc1 testing.