### PR TITLE
Fix flaky test by merging master version of test_config.py

### DIFF
--- a/bin/functional-tests/requirements.txt
+++ b/bin/functional-tests/requirements.txt
@@ -1,5 +1,6 @@
-pytest==6.0.1
-testinfra==5.2.2
-docker==4.3.1
-kubernetes==11.0.0
-PyYAML==5.4
+docker==5.0.0
+kubernetes==17.17.0
+pytest==6.2.4
+pytest-rerunfailures==9.1.1
+PyYAML==5.4.1
+testinfra==6.0.0


### PR DESCRIPTION
A flaky prometheus test was fixed in release-0.25, but was not backported to release-0.23. We are now experiencing that flaky test, so this backports the workaround by using the version of test_config.py that is currently found in master. Also bump some library versions and add the required pytest rerunfailures module.