### PR TITLE
Enhance 0.16 -> 0.23 Script

### DIFF
--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -25,6 +25,10 @@
   set_fact:
     COMMANDER_UPGRADE_TIMEOUT: "{{ lookup('env', 'COMMANDER_UPGRADE_TIMEOUT') | default('300', True) }}"
 
+- name: "Disable deployment upgrades"
+  set_fact:
+    disable_upgrade_timeout: "{{ lookup('env', 'DISABLE_UPGRADE_DEPLOYMENT') | default('false', True) }}"
+
 - name: Show Airflow releases
   debug:
     msg: "{{ airflow_releases }}"
@@ -303,7 +307,7 @@
     --set astronomer.houston.upgradeDeployments.enabled=true 
     --set astronomer.commander.upgradeTimeout={{ COMMANDER_UPGRADE_TIMEOUT }} 
     --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
+  when: not disable_upgrade_timeout
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: >
@@ -314,4 +318,4 @@
     --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false 
     --set astronomer.commander.upgradeTimeout=300 
     --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
+  when: not disable_upgrade_timeout

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -27,7 +27,7 @@
 
 - name: "Disable deployment upgrades"
   set_fact:
-    disable_upgrade_timeout: "{{ lookup('env', 'DISABLE_UPGRADE_DEPLOYMENT') | default('false', True) }}"
+    disable_deployment_upgrades: "{{ lookup('env', 'DISABLE_DEPLOYMENT_UPGRADES') | default('false', True) }}"
 
 - name: Show Airflow releases
   debug:
@@ -307,7 +307,7 @@
     --set astronomer.houston.upgradeDeployments.enabled=true 
     --set astronomer.commander.upgradeTimeout={{ COMMANDER_UPGRADE_TIMEOUT }} 
     --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: not disable_upgrade_timeout
+  when: not disable_deployment_upgrades
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: >
@@ -318,4 +318,4 @@
     --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false 
     --set astronomer.commander.upgradeTimeout=300 
     --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: not disable_upgrade_timeout
+  when: not disable_deployment_upgrades

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -21,6 +21,10 @@
     airflow_releases: "{{ helm_releases.stdout | from_json | selectattr('chart', 'match', 'airflow-.*') | list | map(attribute='name') | list }}"
     database_name: "{{ (helm_releases.stdout | from_json | selectattr('chart', 'match', 'astronomer-.*') | list)[0].name | regex_replace( '-', '_') }}"
 
+- name: "Set commander upgrade timeout"
+  set_fact:
+    COMMANDER_UPGRADE_TIMEOUT: "{{ lookup('env', 'COMMANDER_UPGRADE_TIMEOUT') | default('300', True) }}"
+
 - name: Show Airflow releases
   debug:
     msg: "{{ airflow_releases }}"
@@ -281,10 +285,10 @@
 
 - name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is defined) and (DISABLE_UPGRADE_DEPLOYMENT | bool)
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.commander.upgradeTimeout={{ COMMANDER_UPGRADE_TIMEOUT }} --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is defined) and (DISABLE_UPGRADE_DEPLOYMENT | bool)
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --set astronomer.commander.upgradeTimeout=300 --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -250,13 +250,24 @@
 # The db migration container waits on NATs, and for that, we need the new pods.
 # Also, there are new network security policies we need to apply before the db migration.
 - name: "(1/6) Upgrade Astronomer: Helm upgrade - Update software in Astronomer. Watch for 'helm list' to show new version."
-  shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  shell: >
+    helm upgrade 
+    --namespace {{ namespace }} 
+    --reset-values 
+    -f {{ astro_save_dir.path }}/helm-user-values.json 
+    --no-hooks 
+    --set astronomer.houston.upgradeDeployments.enabled=false 
+    --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Run DB migration container
 - name: "(2/6) Upgrade Astronomer: Helm upgrade - Run Astronomer DB migration. Watch for houston db migrations pod to exit in success."
-  shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  shell: >
+    helm upgrade 
+    --namespace {{ namespace }} 
+    --reset-values 
+    -f {{ astro_save_dir.path }}/helm-user-values.json 
+    --set astronomer.houston.upgradeDeployments.enabled=false 
+    --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
 
 # Ensure Houston initializes after DB migration container runs
 - name: "(3/6) Upgrade Astronomer: Helm upgrade - Initialize Astronomer Secrets. Watch for houston pods to become ready again."
@@ -284,11 +295,23 @@
     kubectl wait --for=condition=complete --timeout=300s --namespace {{ namespace }} job/airflow-update-check-first-run
 
 - name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
-  shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.commander.upgradeTimeout={{ COMMANDER_UPGRADE_TIMEOUT }} --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  shell: >
+    helm upgrade 
+    --namespace {{ namespace }} 
+    --reset-values 
+    -f {{ astro_save_dir.path }}/helm-user-values.json 
+    --set astronomer.houston.upgradeDeployments.enabled=true 
+    --set astronomer.commander.upgradeTimeout={{ COMMANDER_UPGRADE_TIMEOUT }} 
+    --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
   when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
-  shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --set astronomer.commander.upgradeTimeout=300 --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  shell: >
+    helm upgrade 
+    --namespace {{ namespace }} 
+    --reset-values 
+    -f {{ astro_save_dir.path }}/helm-user-values.json 
+    --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false 
+    --set astronomer.commander.upgradeTimeout=300 
+    --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
   when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -4,7 +4,6 @@
     backup_dir: "/astronomer-backups"
     timestamp: "{{ lookup('pipe','date +%Y-%m-%d-%H-%M-%S') }}"
     upgrade_to_version: "0.23"
-    upgrade_to_version_airflow: "0.18"
     # db_hostname: "localhost"
     # db_username: "postgres"
     # db_password: "postgres"
@@ -282,8 +281,10 @@
 
 - name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: |
-    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --set astronomer.airflowChartVersion={{ upgrade_to_version_airflow }} --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+    helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
+  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)

--- a/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
+++ b/bin/migration-scripts/lts-to-lts/0.16-to-0.23/playbooks/tasks/upgrade.yaml
@@ -282,9 +282,9 @@
 - name: "(5/6) Upgrade Astronomer: Helm upgrade - Update Airflow configurations. Watch for Airflow charts to upgrade version with 'helm list --all-namespaces', watch for airflow pods to start back up."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --set astronomer.houston.upgradeDeployments.enabled=true --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
+  when: (DISABLE_UPGRADE_DEPLOYMENT is defined) and (DISABLE_UPGRADE_DEPLOYMENT | bool)
 
 - name: "(6/6) Upgrade Astronomer: Helm upgrade - Turn off airflow auto upgrade configuration. Perfunctory step, nothing to look for."
   shell: |
     helm upgrade --namespace {{ namespace }} --reset-values -f {{ astro_save_dir.path }}/helm-user-values.json --no-hooks --set astronomer.houston.upgradeDeployments.enabled=false --version={{ upgrade_to_version }} {{ release_name }} astronomer/astronomer
-  when: (DISABLE_UPGRADE_DEPLOYMENT is not defined) or not (DISABLE_UPGRADE_DEPLOYMENT | bool)
+  when: (DISABLE_UPGRADE_DEPLOYMENT is defined) and (DISABLE_UPGRADE_DEPLOYMENT | bool)


### PR DESCRIPTION
## Description

Enhances the 0.23 upgrade script
- [x] Removes the Upgrade deployment step with a variable. 
- [x] Removes the 0.18 airflow chart hard coding. 
- [x] Commander timeout to pull from a default environment variable.


## 🎟 Issue(s)

Resolves astronomer/issues#2637

## 🧪  Testing

Have used removing the upgrade deployments section twice with @shmanu017 on a cluster that had previously failed. Also tested the flags so that the behavior described works as intended.

## 📋 Checklist

- [x] The PR title is informative to the user experience
