### PR TITLE
Only check image name, not tag version

### DIFF
--- a/tests/test_astronomer_commander.py
+++ b/tests/test_astronomer_commander.py
@@ -21,8 +21,8 @@ def test_astronomer_commander_deployment(kube_version):
     assert doc["apiVersion"] == "apps/v1"
     assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
     assert any(
-        img_name.startswith("quay.io/astronomer/ap-commander:")
-        for img_name in jmespath.search("spec.template.spec.containers[*].image", doc)
+        image_name.startswith("quay.io/astronomer/ap-commander:")
+        for image_name in jmespath.search("spec.template.spec.containers[*].image", doc)
     )
     assert len(doc["spec"]["template"]["spec"]["containers"]) == 1
     env_vars = {
@@ -50,8 +50,8 @@ def test_astronomer_commander_deployment_upgrade_timeout(kube_version):
     assert doc["apiVersion"] == "apps/v1"
     assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
     assert any(
-        img_name.startswith("quay.io/astronomer/ap-commander:")
-        for img_name in jmespath.search("spec.template.spec.containers[*].image", doc)
+        image_name.startswith("quay.io/astronomer/ap-commander:")
+        for image_name in jmespath.search("spec.template.spec.containers[*].image", doc)
     )
 
     assert len(doc["spec"]["template"]["spec"]["containers"]) == 1

--- a/tests/test_astronomer_commander.py
+++ b/tests/test_astronomer_commander.py
@@ -20,8 +20,9 @@ def test_astronomer_commander_deployment(kube_version):
     assert doc["kind"] == "Deployment"
     assert doc["apiVersion"] == "apps/v1"
     assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
-    assert "quay.io/astronomer/ap-commander:0.25.2" in jmespath.search(
-        "spec.template.spec.containers[*].image", doc
+    assert any(
+        img_name.startswith("quay.io/astronomer/ap-commander:")
+        for img_name in jmespath.search("spec.template.spec.containers[*].image", doc)
     )
     assert len(doc["spec"]["template"]["spec"]["containers"]) == 1
     env_vars = {
@@ -48,9 +49,11 @@ def test_astronomer_commander_deployment_upgrade_timeout(kube_version):
     assert doc["kind"] == "Deployment"
     assert doc["apiVersion"] == "apps/v1"
     assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
-    assert "quay.io/astronomer/ap-commander:0.25.2" in jmespath.search(
-        "spec.template.spec.containers[*].image", doc
+    assert any(
+        img_name.startswith("quay.io/astronomer/ap-commander:")
+        for img_name in jmespath.search("spec.template.spec.containers[*].image", doc)
     )
+
     assert len(doc["spec"]["template"]["spec"]["containers"]) == 1
     env_vars = {
         x["name"]: x["value"]


### PR DESCRIPTION
Only check that the image name matches, not the version tag. This gives us at least a test that we're using the right image, while not requiring us to update this test every time we bump the version tag for the image.