### PR TITLE
Bump docker images to the latest builds

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.25.1
+    tag: 0.25.2
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.14.1
+    tag: 3.14.2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.13.3-4
+    tag: 1.13.3-5
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.25.1
+    tag: 0.25.2
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.3.2-2
+    tag: 2.3.2-3
     pullPolicy: IfNotPresent
 
 nats:
@@ -173,7 +173,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.8.0
+  image: quay.io/astronomer/ap-nats-exporter:0.8.0-1
   pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,11 +6,11 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.14.1
+    tag: 3.14.2
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.22.0-1
+    tag: 0.22.0-2
     pullPolicy: IfNotPresent
 
 stan:
@@ -147,7 +147,7 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.8.0
+  image: quay.io/astronomer/ap-nats-exporter:0.8.0-1
   pullPolicy: IfNotPresent
   resources: {}
   #  limits:


### PR DESCRIPTION
```
$ helm template . --set global.baseDomain=foo.com -f /Users/danielh/a/google-environments/prod/cloud/app/config.yaml 2>/dev/null |
> awk '/image: / {match($2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' |
> sort -u |
> column -t
2021-09-27T18:16:50-0700
https://quay.io/astronomer/ap-alertmanager            quay.io/astronomer/ap-alertmanager:0.23.0
https://quay.io/astronomer/ap-astro-ui                quay.io/astronomer/ap-astro-ui:0.25.4
https://quay.io/astronomer/ap-base                    quay.io/astronomer/ap-base:3.14.2
https://quay.io/astronomer/ap-cli-install             quay.io/astronomer/ap-cli-install:0.25.2
https://quay.io/astronomer/ap-commander               quay.io/astronomer/ap-commander:0.25.3
https://quay.io/astronomer/ap-configmap-reloader      quay.io/astronomer/ap-configmap-reloader:0.5.0
https://quay.io/astronomer/ap-curator                 quay.io/astronomer/ap-curator:5.8.4-4
https://quay.io/astronomer/ap-db-bootstrapper         quay.io/astronomer/ap-db-bootstrapper:0.25.2
https://quay.io/astronomer/ap-default-backend         quay.io/astronomer/ap-default-backend:0.25.3
https://quay.io/astronomer/ap-elasticsearch           quay.io/astronomer/ap-elasticsearch:7.10.2-3
https://quay.io/astronomer/ap-elasticsearch-exporter  quay.io/astronomer/ap-elasticsearch-exporter:1.2.1
https://quay.io/astronomer/ap-fluentd                 quay.io/astronomer/ap-fluentd:1.13.3-5
https://quay.io/astronomer/ap-grafana                 quay.io/astronomer/ap-grafana:7.5.10
https://quay.io/astronomer/ap-houston-api             quay.io/astronomer/ap-houston-api:0.25.12
https://quay.io/astronomer/ap-kibana                  quay.io/astronomer/ap-kibana:7.10.2-2
https://quay.io/astronomer/ap-kube-state              quay.io/astronomer/ap-kube-state:1.7.2
https://quay.io/astronomer/ap-kubed                   quay.io/astronomer/ap-kubed:0.12.0
https://quay.io/astronomer/ap-nats-exporter           quay.io/astronomer/ap-nats-exporter:0.8.0-1
https://quay.io/astronomer/ap-nats-server             quay.io/astronomer/ap-nats-server:2.3.2-3
https://quay.io/astronomer/ap-nats-streaming          quay.io/astronomer/ap-nats-streaming:0.22.0-2
https://quay.io/astronomer/ap-nginx                   quay.io/astronomer/ap-nginx:0.49.0-1
https://quay.io/astronomer/ap-nginx-es                quay.io/astronomer/ap-nginx-es:3.13.5-4
https://quay.io/astronomer/ap-postgres-exporter       quay.io/astronomer/ap-postgres-exporter:3.13.5
https://quay.io/astronomer/ap-prometheus              quay.io/astronomer/ap-prometheus:2.21.0
https://quay.io/astronomer/ap-registry                quay.io/astronomer/ap-registry:3.14.2
https://quay.io/prometheus/node-exporter              quay.io/prometheus/node-exporter:v1.2.2
```

Went through the above list and verified that all images are the latest.