### PR TITLE
bump airflow chart version to 1.0.0-rc1-build11945

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.0.0-rc1-build11885
+airflowChartVersion: 1.0.0-rc1-build11945
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
This new version bumps pgbouncer from version 1.8.1 to 1.16.0