### PR TITLE
Add support for specifying nodePorts when seviceType is set to NodePort

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -53,11 +53,20 @@ spec:
       targetPort: {{ .Values.ports.http }}
       protocol: TCP
       name: http
+      {{- if .Values.httpNodePort }}
+      nodePort: {{ .Values.httpNodePort }}
+      {{- end }}
     - port: 443
       targetPort: {{ .Values.ports.https }}
       protocol: TCP
       name: https
+      {{- if .Values.httpsNodePort }}
+      nodePort: {{ .Values.httpsNodePort }}
+      {{- end }}
     - port: {{ .Values.ports.metrics }}
       targetPort: {{ .Values.ports.metrics }}
       protocol: TCP
       name: metrics
+      {{- if .Values.metricsNodePort }}
+      nodePort: {{ .Values.metricsNodePort }}
+      {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -35,6 +35,11 @@ resources: {}
 # Service type that Nginx can be. Default is LoadBalancer but "ClusterIP" and "NodePort" are both valid.
 serviceType: "LoadBalancer"
 
+# NodePort, requiers serviceType NodePort. Default of nil auto-assigns a port
+httpNodePort: ~
+httpsNodePort: ~
+metricsNodePort: ~
+
 # dict of annotations to add to the ingress controller
 ingressAnnotations: {}
 

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -50,6 +50,27 @@ class TestNginx:
         doc = docs[0]
         assert doc["spec"]["type"] == "NodePort"
 
+    def test_nginx_type_nodeport_specifying_nodeports(self):
+        # sourcery skip: extract-duplicate-method
+        httpNodePort, httpsNodePort, metricsNodePort = [ 30401, 30402, 30403 ]
+        docs = render_chart(
+            values={"nginx": {
+             "serviceType": "NodePort",
+              "httpNodePort": httpNodePort,
+              "httpsNodePort": httpsNodePort,
+              "metricsNodePort":metricsNodePort,
+            }},
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        ports = doc["spec"]["ports"]
+        ports_by_name = { x["name"]:x["nodePort"] for x in ports }
+        assert ports_by_name["http"] == httpNodePort 
+        assert ports_by_name["https"] == httpsNodePort 
+        assert ports_by_name["metrics"] == metricsNodePort 
+
     def test_nginx_enabled_externalips(self):
         # sourcery skip: extract-duplicate-method
         docs = render_chart(


### PR DESCRIPTION
## Description

Add support for specifying the default ports used by services on the default ingress service via nginx(http|https|metrics)NodePort. Only valid when nginx.seviceType is set to NodePort.

## PR Title

Add support for specifying httpNodePort, httpsNodePort, and metricsNodePort

## 🎟 Issue(s)

Resolves astronomer/issues#3538

## 🧪  Testing

No identified risks. Basic unit test added for conformity. 

## 📋 Checklist

- [X ] The PR title is informative to the user experience
