### PR TITLE
Bump ap-configmap-reloader to 0.5.0-1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,7 @@ build: ## Build the Astronomer helm chart
 update-requirements: ## Update all requirements.txt files
 	for FILE in requirements/*.in ; do pip-compile --quiet --allow-unsafe --upgrade --generate-hashes $${FILE} ; done ;
 	-pre-commit run requirements-txt-fixer --all-files --show-diff-on-failure
+
+.PHONY: show-docker-images
+show-docker-images: ## Show all docker images and versions used in the helm chart
+	helm template . --set global.baseDomain=foo.com 2>/dev/null | awk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -23,7 +23,7 @@ images:
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.5.0
+    tag: 0.5.0-1
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
* Bump ap-configmap-reloader to 0.5.0-1
* Add make target: show-docker-images
    ```
    $ make show-docker-images
    helm template . --set global.baseDomain=foo.com 2>/dev/null | awk '/image: / {match($2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
    https://quay.io/astronomer/ap-alertmanager            quay.io/astronomer/ap-alertmanager:0.23.0
    https://quay.io/astronomer/ap-astro-ui                quay.io/astronomer/ap-astro-ui:0.25.4
    https://quay.io/astronomer/ap-base                    quay.io/astronomer/ap-base:3.14.2
    https://quay.io/astronomer/ap-cli-install             quay.io/astronomer/ap-cli-install:0.25.2
    https://quay.io/astronomer/ap-commander               quay.io/astronomer/ap-commander:0.25.3
    https://quay.io/astronomer/ap-configmap-reloader      quay.io/astronomer/ap-configmap-reloader:0.5.0-1
    https://quay.io/astronomer/ap-curator                 quay.io/astronomer/ap-curator:5.8.4-4
    https://quay.io/astronomer/ap-db-bootstrapper         quay.io/astronomer/ap-db-bootstrapper:0.25.2
    https://quay.io/astronomer/ap-default-backend         quay.io/astronomer/ap-default-backend:0.25.3
    https://quay.io/astronomer/ap-elasticsearch           quay.io/astronomer/ap-elasticsearch:7.10.2-3
    https://quay.io/astronomer/ap-elasticsearch-exporter  quay.io/astronomer/ap-elasticsearch-exporter:1.2.1
    https://quay.io/astronomer/ap-fluentd                 quay.io/astronomer/ap-fluentd:1.13.3-5
    https://quay.io/astronomer/ap-grafana                 quay.io/astronomer/ap-grafana:7.5.10
    https://quay.io/astronomer/ap-houston-api             quay.io/astronomer/ap-houston-api:0.25.12
    https://quay.io/astronomer/ap-kibana                  quay.io/astronomer/ap-kibana:7.10.2-2
    https://quay.io/astronomer/ap-kube-state              quay.io/astronomer/ap-kube-state:1.7.2
    https://quay.io/astronomer/ap-kubed                   quay.io/astronomer/ap-kubed:0.12.0
    https://quay.io/astronomer/ap-nats-exporter           quay.io/astronomer/ap-nats-exporter:0.8.0-1
    https://quay.io/astronomer/ap-nats-server             quay.io/astronomer/ap-nats-server:2.3.2-3
    https://quay.io/astronomer/ap-nats-streaming          quay.io/astronomer/ap-nats-streaming:0.22.0-2
    https://quay.io/astronomer/ap-nginx                   quay.io/astronomer/ap-nginx:0.49.0-1
    https://quay.io/astronomer/ap-nginx-es                quay.io/astronomer/ap-nginx-es:3.13.5-4
    https://quay.io/astronomer/ap-prometheus              quay.io/astronomer/ap-prometheus:2.21.0
    https://quay.io/astronomer/ap-registry                quay.io/astronomer/ap-registry:3.14.2
    https://quay.io/prometheus/node-exporter              quay.io/prometheus/node-exporter:v1.2.2
    ```