### PR TITLE
bump astro-ui to 0.26.6  and houston-api to 0.26.4 for 0.26 release

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description
- bug fix- ui old deployments being able to update deployments after tirggerer changes

bump ui to 0.26.6
