### PR TITLE
Make alertmanager HA

### DIFF
--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -20,7 +20,7 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
-replicas: 1
+replicas: 2
 
 dataDir: "/data"
 


### PR DESCRIPTION
I tested this in QA by manually increasing replicas to 2 and checking prometheus.basedomain/status and it showed both alertmanagers as being available, so I think this is the only change we need to do in order to make alertmanager HA.

Related to: https://github.com/astronomer/issues/issues/949