### PR TITLE
add new field for settign sslmode

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -68,6 +68,9 @@ data:
 
       # These values get passed directly into the airflow helm deployments
       helm:
+      {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
+        sslmode: {{ .Values.global.ssl.mode }}
+      {{- end }}
       {{- if .Values.global.sccEnabled }}
         # If security context constraints are enabled, enable SCCs for airflow-chart
         sccEnabled: true

--- a/values.schema.json
+++ b/values.schema.json
@@ -103,9 +103,6 @@
                         "sccEnabled": {
                           "type": "boolean"
                         },
-                        "sslmode": {
-                          "type": "string"
-                        },
                         "workers": {
                           "type": "object",
                           "additionalProperties": false,

--- a/values.schema.json
+++ b/values.schema.json
@@ -103,6 +103,9 @@
                         "sccEnabled": {
                           "type": "boolean"
                         },
+                        "sslmode": {
+                          "type": "string"
+                        },
                         "workers": {
                           "type": "object",
                           "additionalProperties": false,


### PR DESCRIPTION
Currently the OSS chart only allows you to specify an sslmode on the resultBackendConnection and metadataConnection if you define the whole object. We need this param to allow our users to overide just this field and use what we specify for the other values.