### PR TITLE
bump to json version to v2

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -188,7 +188,7 @@ houston:
     enabled: true
 
     # url for update service
-    url: https://updates.astronomer.io/astronomer-certified
+    url: https://updates.astronomer.io/astronomer-certified-v2
 
     # Default here is to run at midnight every night
     schedule: "0 0 * * *"


### PR DESCRIPTION
There are backwardly incompatible changes to the new desired update json. We are bumping the version so as not to break enterprise customers older code.

Related houston PR: https://github.com/astronomer/houston-api/pull/830