### PR TITLE
bump platform images

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.0
+    tag: 0.26.1
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.0
+    tag: 0.26.1
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -173,7 +173,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.8.0-1
+  image: quay.io/astronomer/ap-nats-exporter:0.9.0
   pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.25.3
+    tag: 0.25.4
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -147,7 +147,7 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.8.0-1
+  image: quay.io/astronomer/ap-nats-exporter:0.9.0
   pullPolicy: IfNotPresent
   resources: {}
   #  limits:


### PR DESCRIPTION
## Itemized Changes

* db bootstrapper image version 0.26.0 -> 0.26.1
* ap-default-backend image version 0.25.3 -> 0.25.4
* ap-nats-exporter image version 0.8.0-1 -> 0.9.0

## 🎟 Issue(s)

Resolves https://github.com/astronomer/issues/issues/3765