### PR TITLE
Allow commander-role to PATCH namespaces

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -32,7 +32,7 @@ rules:
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["create", "delete", "get", "patch"]


### PR DESCRIPTION
## Description

A forthcoming version of commander will patch namespace objects to update the list of labels and annotations - this adds the PATCH verb to the commander-role.

## 🎟 Issue(s)

https://github.com/astronomer/issues/issues/3674
https://github.com/astronomer/commander/pull/72

## 📋 Checklist

- [X] The PR title is informative to the user experience
