### PR TITLE
bump ap-default-backend

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.25.2
+    tag: 0.25.4
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION
Solve https://github.com/astronomer/issues/issues/3402 in release-0.25 branch by bumping to known fixed ap-default-backend image.