### PR TITLE
Bump a bunch of ap docker image versions

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,11 +15,11 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.26.4
+    tag: 0.26.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.14.2-2
+    tag: 3.15.0
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.0
+    tag: 0.26.1
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.14.2-1
+    tag: 3.15.0
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.2
+    tag: 1.14.2-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/prometheus/node-exporter
-  tag: v1.2.2
+  tag: v1.3.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.14.2-1
+    tag: 3.15.0
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
Bump versions of:

- quay.io/astronomer/ap-commander
- quay.io/astronomer/ap-registry
- quay.io/astronomer/ap-cli-install
- quay.io/astronomer/ap-base
- quay.io/astronomer/ap-fluentd
- quay.io/prometheus/node-exporter

Also FWIW I opened an issue to vendor node-exporter, so for now don't worry about that being third party.