### PR TITLE
Bump elastic.co related versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,4 +68,14 @@ update-requirements: ## Update all requirements.txt files
 
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
-	helm template . --set global.postgresqlEnabled=True --set global.baseDomain=foo.com 2>/dev/null | awk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
+	helm template . \
+		--set global.baseDomain=foo.com \
+		--set global.blackboxExporterEnabled=True \
+		--set global.kedaEnabled=True \
+		--set global.postgresqlEnabled=True \
+		--set global.postgresqlEnabled=True \
+		--set global.prometheusPostgresExporterEnabled=True \
+		--set global.pspEnabled=True \
+		--set global.veleroEnabled=True \
+		2>/dev/null \
+		| awk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ update-requirements: ## Update all requirements.txt files
 
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
-	helm template . \
+	@helm template . \
 		--set global.baseDomain=foo.com \
 		--set global.blackboxExporterEnabled=True \
 		--set global.kedaEnabled=True \

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.10.2-3
+    tag: 7.15.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
@@ -18,11 +18,11 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-6
+    tag: 5.8.4-7
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.2.1
+    tag: 1.3.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-5
+    tag: 5.8.4-6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.2-1
+    tag: 1.14.3
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.10.2-2
+    tag: 7.15.2
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-3
+  tag: 0.19.0-5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
This bumps all images that include elastic.co components to versions that are post 2020 license change.

Also add line breaks in `make show-docker-images` to be easier to modify.