### PR TITLE
Drop k8s 1.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,22 +117,6 @@ jobs:
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 
-  platform-1-17-17:
-    machine:
-      image: ubuntu-2004:202107-02
-      resource_class: xlarge
-    environment:
-      KUBE_VERSION: v1.17.17
-    steps:
-      - helm-install:
-          astronomer-tags: "platform postgresql monitoring logging kubed keda"
-      - run:
-          name: Check chart for k8s 1.17.17 compatibility with kubent
-          command: |
-            set -o pipefail
-            helm template --kube-version=v1.17.17 -f values.yaml --set global.baseDomain=example.com . |
-            kubent --cluster=false --helm2=false --helm3=false --filename -
-          when: always
   platform-1-18-19:
     machine:
       image: ubuntu-2004:202107-02
@@ -213,14 +197,9 @@ workflows:
       - approve-test-all-platforms:
           type: approval
 
-      - platform-1-17-17:
-          requires:
-            - build-artifact
       - platform-1-18-19:
           requires:
-            - approve-test-all-platforms
             - build-artifact
-
       - platform-1-19-11:
           requires:
             - approve-test-all-platforms
@@ -241,13 +220,12 @@ workflows:
             - gcp-astronomer-prod
           requires:
             - approve-internal-release
-            - platform-1-17-17
+            - platform-1-18-19
             - platform-1-21-2
       - approve-public-release:
           type: approval
           requires:
             - release-to-internal
-            - platform-1-18-19
             - platform-1-19-11
             - platform-1-20-7
           filters:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 # recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-KUBE_VERSIONS = ["1.17.17", "1.18.19", "1.19.11", "1.20.7", "1.21.2"]
+KUBE_VERSIONS = ["1.18.19", "1.19.11", "1.20.7", "1.21.2"]
 
 
 def main():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,4 +7,4 @@ git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 
 # This should match the major.minor version list in .circleci/generate_circleci_config.py
 # Patch version should always be 0
-supported_k8s_versions = ["1.17.0", "1.18.0", "1.19.0", "1.20.0", "1.21.0"]
+supported_k8s_versions = ["1.18.0", "1.19.0", "1.20.0", "1.21.0"]


### PR DESCRIPTION
k8s 1.17 is not supported by any public clouds as of January 2022. This change set drops testing for 1.17. There are no other 1.17 specific changes that are needed.

<https://github.com/astronomer/issues/issues/3863>