### PR TITLE
Use image with old fluentd es components

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.3
+    tag: 1.14.3-1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
Use an ap-fluentd docker image that has the pre-license-change ES components so fluentd can connect into all ES clusters.