### PR TITLE
Bump ap-houston to 0.27.7 and ui to 0.27.5 to fix Astro-ui bug that still shows kabana on dropdown when customLogging enabled

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.27.5
+    tag: 0.27.7
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.27.3
+    tag: 0.27.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

- fixes issue in astro-ui that stil shows kibana on drop down even when user has customLogging turned on

## 🎟 Issue(s)

Related astronomer/issues#3680
