### PR TITLE
bump ap-houston 0.27.8

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.27.7
+    tag: 0.27.8
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Fix issue in houston where when running upgrade script it will set labels to empty causing deployment to not work and update commander version in Houston

## Related Issues

astronomer/issues#3878 

## Testing

andrii did testing locally in his kind cluster with these changes
