### PR TITLE
Remediate CVE-2021-44228 at runtime through env configs

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -95,6 +95,8 @@ spec:
               fieldPath: metadata.name
         - name: DISCOVERY_SERVICE
           value: {{ template "elasticsearch.fullname" . }}-headless-discovery
+        - name: "ES_JAVA_OPTS"
+          value: "-Xms{{ .Values.client.heapMemory }} -Xmx{{ .Values.client.heapMemory }} -Dlog4j2.formatMsgNoLookups=true"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
@@ -103,8 +105,6 @@ spec:
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}
         {{- end }}
-        - name: "ES_JAVA_OPTS"
-          value: "-Xms{{ .Values.client.heapMemory }} -Xmx{{ .Values.client.heapMemory }}"
         resources:
 {{ toYaml .Values.client.resources | indent 10 }}
         ports:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -124,7 +124,7 @@ spec:
         - name: DISCOVERY_SERVICE
           value: {{ template "elasticsearch.fullname" . }}-headless-discovery
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }}"
+          value: "-Xms{{ .Values.data.heapMemory }} -Xmx{{ .Values.data.heapMemory }} -Dlog4j2.formatMsgNoLookups=true"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
         - name: DISCOVERY_SERVICE
           value: {{ template "elasticsearch.fullname" . }}-headless-discovery
         - name: ES_JAVA_OPTS
-          value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }}"
+          value: "-Xms{{ .Values.master.heapMemory }} -Xmx{{ .Values.master.heapMemory }} -Dlog4j2.formatMsgNoLookups=true"
         {{- range $key, $value :=  .Values.common.env }}
         - name: {{ $key | upper | replace "-" "_" }}
           value: {{ $value | quote }}

--- a/tests/test_cves.py
+++ b/tests/test_cves.py
@@ -1,0 +1,27 @@
+from tests.helm_template_generator import render_chart
+import pytest
+from . import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_log4shell(kube_version):
+    """Ensure remediation settings are in place for log4j log4shell CVE-2021-44228"""
+    docs = render_chart(
+        kube_version=kube_version,
+        show_only=[
+            "charts/elasticsearch/templates/client/es-client-deployment.yaml",
+            "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+            "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+        ],
+    )
+    # Assert that all containers have an env var ES_JAVA_OPTS that includes the string -Dlog4j2.formatMsgNoLookups=true
+    assert all(
+        "-Dlog4j2.formatMsgNoLookups=true" in env_var["value"]
+        for doc in docs
+        for c in doc["spec"]["template"]["spec"]["containers"]
+        for env_var in c["env"]
+        if env_var["name"] == "ES_JAVA_OPTS"
+    )


### PR DESCRIPTION
## Description

Remediate CVE-2021-44228 by setting `ES_JAVA_OPTS=-Dlog4j2.formatMsgNoLookups=true` by default for all containers.

## Related Issues

- https://github.com/astronomer/issues/issues/3880
- https://github.com/astronomer/issues/issues/3881

## Testing

This includes unit tests. Manual testing has been done to show that the configs do work in run time. Better tests would have an integration test that probes the running process to check if the remediation is in place.