### PR TITLE
Add functional tests for cve-2021-44228

### DIFF
--- a/bin/functional-tests/conftest.py
+++ b/bin/functional-tests/conftest.py
@@ -17,30 +17,14 @@ if not (release_name := getenv("RELEASE_NAME")):
     release_name = "astronomer"
 
 
-def create_kube_client(in_cluster=False):
-    """
-    Load and store authentication and cluster information from kube-config
-    file; if running inside a pod, use Kubernetes service account. Use that to
-    instantiate Kubernetes client.
-    """
-    if in_cluster:
-        print("Using in cluster kubernetes configuration")
-        config.load_incluster_config()
-    else:
-        print("Using kubectl kubernetes configuration")
-        config.load_kube_config()
-    return client.CoreV1Api()
-
-
 @pytest.fixture(scope="function")
-def nginx(request):
+def nginx(request, kube_client):
     """This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    kube = create_kube_client()
-    pods = kube.list_namespaced_pod(
+    pods = kube_client.list_namespaced_pod(
         namespace, label_selector="component=ingress-controller"
     ).items
     assert (
@@ -51,14 +35,15 @@ def nginx(request):
 
 
 @pytest.fixture(scope="function")
-def houston_api(request):
+def houston_api(request, kube_client):
     """This is the host fixture for testinfra. To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    kube = create_kube_client()
-    pods = kube.list_namespaced_pod(namespace, label_selector="component=houston").items
+    pods = kube_client.list_namespaced_pod(
+        namespace, label_selector="component=houston"
+    ).items
     assert (
         len(pods) > 0
     ), "Expected to find at least one pod with label 'component: houston'"
@@ -94,10 +79,9 @@ def es_data(request):
 
 
 @pytest.fixture(scope="function")
-def es_client(request):
+def es_client(request, kube_client):
 
-    kube = create_kube_client()
-    pods = kube.list_namespaced_pod(
+    pods = kube_client.list_namespaced_pod(
         namespace, label_selector="component=elasticsearch,role=client"
     ).items
     assert (
@@ -120,5 +104,15 @@ def docker_client(request):
 
 
 @pytest.fixture(scope="session")
-def kube_client(request):
-    yield create_kube_client()
+def kube_client(request, in_cluster=False):
+    """
+    Return a kubernetes client. By default, use kube-config. If running in a pod, use k8s service account.
+    """
+
+    if in_cluster:
+        print("Using in cluster kubernetes configuration")
+        config.load_incluster_config()
+    else:
+        print("Using kubectl kubernetes configuration")
+        config.load_kube_config()
+    yield client.CoreV1Api()

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -2,10 +2,8 @@
 """
 This file is for system testing the Astronomer Helm chart.
 
-Testinfra is used to create test fixtures.
-
-testinfra simplifies and provides syntactic sugar for doing
-execs into a running pods.
+Many of these tests use pytest fixtures that use testinfra to exec
+into running pods so we can inspect the run-time environment.
 """
 
 import json

--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -242,3 +242,33 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
     assert (
         "postgres" in result
     ), "Expected to find DB connection string after Houston restart"
+
+
+def test_cve_2021_44228_es_client(es_client):
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    assert (
+        es_client.check_output(
+            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
+        )
+        == "-Dlog4j2.formatMsgNoLookups=true"
+    )
+
+
+def test_cve_2021_44228_es_data(es_data):
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    assert (
+        es_data.check_output(
+            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
+        )
+        == "-Dlog4j2.formatMsgNoLookups=true"
+    )
+
+
+def test_cve_2021_44228_es_master(es_master):
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    assert (
+        es_master.check_output(
+            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
+        )
+        == "-Dlog4j2.formatMsgNoLookups=true"
+    )


### PR DESCRIPTION
## Description

As a follow up to #1310 which included unit tests, this PR includes functional tests that probe the running ES processes to verify they are configured with the right flags.

These changes should be merged into 0.23, 0.25, 0.26, 0.27, and possibly 0.16.

## Related Issues

- https://github.com/astronomer/issues/issues/3880
- https://github.com/astronomer/issues/issues/3881
- https://github.com/astronomer/astronomer/pull/1310

## Itemized changes

- create functional test for cve-2021-44228 that probe the running processes in the container for correct config
- create pytest fixtures for es_client, es_data, es_master
- rework the kube_client ptest fixture to be simpler
- create get_pod_by_label_selector helper function
- DRY up some code

## Testing

I ran it locally
I ran it in CI
I ran it with code duplicated
And I ran it DRY 🎤