### PR TITLE
1308-templating-grafana-extra-env-vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ server.key
 upgrade_test_config.yaml
 .unittest-requirements
 prof
+.python-version

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -123,6 +123,9 @@ spec:
             {{- end }}
             - name: GF_AUTH_ANONYMOUS_ENABLED
               value: "true"
+{{- if .Values.extraEnvVars}}
+{{ toYaml .Values.extraEnvVars | indent 12 }}
+{{- end }}
         {{- if .Values.global.authSidecar.enabled }}
         - name: auth-proxy
           image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -58,7 +58,7 @@ dashboards:
 extraEnvVars:
   []
   # - name: GF_SMTP_ENABLED
-  #   value: true
+  #   value: "true"
   # - name: GF_SMTP_HOST
   #   value: smtp.astronomer.io
   # - name: GF_SMTP_USER

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -50,3 +50,21 @@ dashboards:
   #       $RAW_JSON
   #   custom-dashboard:
   #     file: dashboards/custom-dashboard.json
+
+
+## Configure extra environment variables for grafana.
+## This allows you to change configuration settings
+## withing grafana such as SMTP configuration for alerts.
+extraEnvVars:
+  []
+  # - name: GF_SMTP_ENABLED
+  #   value: true
+  # - name: GF_SMTP_HOST
+  #   value: smtp.astronomer.io
+  # - name: GF_SMTP_USER
+  #   value: grafana
+  # - name: GF_SMTP_PASSWORD
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: grafana-smtp-secret
+  #       key: smtp_password

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -12,7 +12,7 @@ DEPLOYMENT_FILE = "charts/grafana/templates/grafana-deployment.yaml"
     "kube_version",
     supported_k8s_versions,
 )
-def test_deployment_renders(kube_version):
+def test_deployment_should_render(kube_version):
     """Test that the grafana-deployment renders without error."""
     docs = render_chart(
         kube_version=kube_version,

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -1,0 +1,68 @@
+import pytest
+
+from tests.helm_template_generator import render_chart
+
+from . import supported_k8s_versions
+
+
+DEPLOYMENT_FILE = "charts/grafana/templates/grafana-deployment.yaml"
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_deployment_renders(kube_version):
+    docs = render_chart(
+        kube_version=kube_version,
+        show_only=[DEPLOYMENT_FILE],
+    )
+    assert len(docs) == 1
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_deployment_should_render_extra_env(kube_version):
+    """Test that helm renders a good ClusterRoleBinding template for fluentd when rbacEnabled=True."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={"global": {"ssl": {"enabled": True}}},
+        show_only=[DEPLOYMENT_FILE],
+    )
+
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc["kind"] == "Deployment"
+    grafana_container = None
+    for container in doc["spec"]["template"]["spec"]["containers"]:
+        if container["name"] == "grafana":
+            grafana_container = container
+            break
+    assert grafana_container is not None
+    assert len(grafana_container["env"]) == 3
+
+    docs = render_chart(
+        kube_version=kube_version,
+        values={
+            "global": {"ssl": {"enabled": True}},
+            "grafana": {
+                "extraEnvVars": [
+                    {"name": "GF_SMTP_ENABLED", "value": "true"},
+                    {"name": "GF_SMTP_HOST", "value": "smtp.astronomer.io"},
+                ]
+            },
+        },
+        show_only=[DEPLOYMENT_FILE],
+    )
+
+    assert len(docs) == 1
+    doc = docs[0]
+    grafana_container = None
+    for container in doc["spec"]["template"]["spec"]["containers"]:
+        if container["name"] == "grafana":
+            grafana_container = container
+            break
+    assert grafana_container is not None
+    assert len(grafana_container["env"]) == 5

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -13,6 +13,7 @@ DEPLOYMENT_FILE = "charts/grafana/templates/grafana-deployment.yaml"
     supported_k8s_versions,
 )
 def test_deployment_renders(kube_version):
+    """Test that the grafana-deployment renders without error."""
     docs = render_chart(
         kube_version=kube_version,
         show_only=[DEPLOYMENT_FILE],
@@ -25,7 +26,7 @@ def test_deployment_renders(kube_version):
     supported_k8s_versions,
 )
 def test_deployment_should_render_extra_env(kube_version):
-    """Test that helm renders a good ClusterRoleBinding template for fluentd when rbacEnabled=True."""
+    """Test that helm renders extra environment variables to the grafana-deployment resource when provided."""
     docs = render_chart(
         kube_version=kube_version,
         values={"global": {"ssl": {"enabled": True}}},

--- a/values.yaml
+++ b/values.yaml
@@ -326,7 +326,7 @@ grafana:
   extraEnvVars:
     []
     # - name: GF_SMTP_ENABLED
-    #   value: true
+    #   value: "true"
     # - name: GF_SMTP_HOST
     #   value: smtp.astronomer.io
     # - name: GF_SMTP_USER

--- a/values.yaml
+++ b/values.yaml
@@ -322,6 +322,22 @@ grafana:
     #   velero:
     #     file: dashboards/velero.json
 
+  # provide extra configurations to grafana via environment variables
+  extraEnvVars:
+    []
+    # - name: GF_SMTP_ENABLED
+    #   value: true
+    # - name: GF_SMTP_HOST
+    #   value: smtp.astronomer.io
+    # - name: GF_SMTP_USER
+    #   value: grafana
+    # - name: GF_SMTP_PASSWORD
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: grafana-smtp-secret
+    #       key: smtp_password
+
+
 #################################
 ## Prometheus configuration
 #################################


### PR DESCRIPTION
## Description

Add extra environment variables to the `grafana-deployment` resource in order to set configuration settings in Grafana.

## Related Issues

- [#1308](https://github.com/astronomer/astronomer/issues/1308)

## Testing

Verified that extra environment variables are rendered when provided as a list to the `grafana` section of helm values, and no side effect occurs when not provided.
