### PR TITLE
Fix nats, stan and prometheus image names for environments using private registry

### DIFF
--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -24,7 +24,7 @@ Return the NATS cluster routes.
 
 {{ define "nats.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-nats:{{ .Values.images.nats.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-server:{{ .Values.images.nats.tag }}
 {{- else -}}
 {{ .Values.images.nats.repository }}:{{ .Values.images.nats.tag }}
 {{- end }}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{ define "configReloader.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-config-reloader:{{ .Values.images.configReloader.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-configmap-reloader:{{ .Values.images.configReloader.tag }}
 {{- else -}}
 {{ .Values.images.configReloader.repository }}:{{ .Values.images.configReloader.tag }}
 {{- end }}

--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -25,7 +25,7 @@ Return the list of peers in a NATS Streaming cluster.
 
 {{ define "stan.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-stan:{{ .Values.images.stan.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-streaming:{{ .Values.images.stan.tag }}
 {{- else -}}
 {{ .Values.images.stan.repository }}:{{ .Values.images.stan.tag }}
 {{- end }}


### PR DESCRIPTION
## Description

NATS, STAN, and Prometheus have wrong image names when `privateRegistry` is enabled. Normally, customers using private registry will mirror our public names. Having different names for only few of the images causes confusion and should be fixed.

## Related Issues

https://github.com/astronomer/issues/issues/3893
