### PR TITLE
Fix nats, stan, and prometheus image names for private registry

### DIFF
--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -22,6 +22,14 @@ Return the NATS cluster routes.
 {{- end -}}
 {{- end }}
 
+{{ define "nats-exporter.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-exporter:{{ .Values.images.exporter.tag }}
+{{- else -}}
+{{ .Values.images.exporter.repository }}:{{ .Values.images.exporter.tag }}
+{{- end }}
+{{- end }}
+
 {{ define "nats.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-nats-server:{{ .Values.images.nats.tag }}

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -24,7 +24,7 @@ Return the NATS cluster routes.
 
 {{ define "nats.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-nats:{{ .Values.images.nats.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-server:{{ .Values.images.nats.tag }}
 {{- else -}}
 {{ .Values.images.nats.repository }}:{{ .Values.images.nats.tag }}
 {{- end }}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -279,7 +279,7 @@ spec:
       ##############################
       {{ if .Values.exporter.enabled }}
       - name: metrics
-        image: {{ .Values.exporter.image }}
+        image: {{ template "nats-exporter.image" . }}
         imagePullPolicy: {{ .Values.exporter.pullPolicy }}
         args:
         - -connz

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -8,6 +8,10 @@ images:
     repository: quay.io/astronomer/ap-nats-server
     tag: 2.3.2-3
     pullPolicy: IfNotPresent
+  exporter:
+    repository: quay.io/astronomer/ap-nats-exporter
+    tag: 0.9.0
+    pullPolicy: IfNotPresent
 
 nats:
   # In case both external access and advertise are enabled
@@ -173,8 +177,6 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.9.0
-  pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}
   #  limits:

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -65,3 +65,14 @@ Allow the release namespace to be overridden for multi-namespace deployments in 
     {{- .Release.Namespace -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Docker repository name
+*/}}
+{{ define "image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/node-exporter:{{ .Values.image.tag }}
+{{- else -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -33,7 +33,7 @@ spec:
 {{- end }}
       containers:
         - name: node-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ template "image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --path.procfs=/host/proc

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/prometheus/node-exporter
+  repository: quay.io/astronomer/node-exporter
   tag: v1.3.0
   pullPolicy: IfNotPresent
 

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/astronomer/node-exporter
+  repository: quay.io/prometheus/node-exporter
   tag: v1.3.0
   pullPolicy: IfNotPresent
 

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -33,7 +33,7 @@ Create chart name and version as used by the chart label.
 
 {{ define "configReloader.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-config-reloader:{{ .Values.images.configReloader.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-configmap-reloader:{{ .Values.images.configReloader.tag }}
 {{- else -}}
 {{ .Values.images.configReloader.repository }}:{{ .Values.images.configReloader.tag }}
 {{- end }}

--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -23,6 +23,14 @@ Return the list of peers in a NATS Streaming cluster.
 {{ print $replicas }}
 {{- end -}}
 
+{{ define "stan-exporter.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-exporter:{{ .Values.images.exporter.tag }}
+{{- else -}}
+{{ .Values.images.exporter.repository }}:{{ .Values.images.exporter.tag }}
+{{- end }}
+{{- end }}
+
 {{ define "stan.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-nats-streaming:{{ .Values.images.stan.tag }}

--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -25,7 +25,7 @@ Return the list of peers in a NATS Streaming cluster.
 
 {{ define "stan.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-stan:{{ .Values.images.stan.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-nats-streaming:{{ .Values.images.stan.tag }}
 {{- else -}}
 {{ .Values.images.stan.repository }}:{{ .Values.images.stan.tag }}
 {{- end }}

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -142,7 +142,7 @@ spec:
           {{- end }}
         {{ if .Values.exporter.enabled }}
         - name: metrics
-          image: {{ .Values.exporter.image }}
+          image: {{ template "stan-exporter.image" . }}
           resources:
 {{ toYaml .Values.exporter.resources | indent 12 }}
           args:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -12,6 +12,10 @@ images:
     repository: quay.io/astronomer/ap-nats-streaming
     tag: 0.22.0-2
     pullPolicy: IfNotPresent
+  exporter:
+    repository: quay.io/astronomer/ap-nats-exporter
+    tag: 0.9.0
+    pullPolicy: IfNotPresent
 
 stan:
   resources: {}
@@ -147,8 +151,6 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.9.0
-  pullPolicy: IfNotPresent
   resources: {}
   #  limits:
   #   cpu: 100m

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -1,7 +1,5 @@
 from tests.helm_template_generator import render_chart
 import jmespath
-import pytest
-from . import supported_k8s_versions
 
 
 def test_private_repository_image_names_the_same_as_public_ones():

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -1,0 +1,59 @@
+from tests.helm_template_generator import render_chart
+import jmespath
+import pytest
+from . import supported_k8s_versions
+
+
+def test_private_repository_image_names_the_same_as_public_ones():
+    """test that image names dont change when using a custom repo because that breaks
+    pull-through caching proxies in use by various customers"""
+    repository = "quay.io/astronomer"
+    public_repo_docs = render_chart()
+    private_repo_docs = render_chart(
+        values={
+            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
+        },
+    )
+    # should be same number of images regardless of where they come from
+    assert len(public_repo_docs) == len(private_repo_docs)
+    search_string = "spec.template.spec.containers[*].image"
+    differtly_named_images = []
+    for public_repo_doc, private_repo_doc in zip(public_repo_docs, private_repo_docs):
+        public_repo_images = jmespath.search(search_string, public_repo_doc)
+        private_repo_images = jmespath.search(search_string, private_repo_doc)
+        if public_repo_images is not None or private_repo_images is not None:
+            assert len(public_repo_images) == len(private_repo_images)
+            for public_repo_image, private_repo_image in zip(
+                public_repo_images, private_repo_images
+            ):
+                if public_repo_image != private_repo_image:
+                    print(
+                        f"image name differs when using a private repo named same as public - {public_repo_image} vs {private_repo_image}"
+                    )
+                    differtly_named_images.append(
+                        (private_repo_image, public_repo_image)
+                    )
+    assert len(differtly_named_images) == 0
+
+
+def test_repository_overrides_work():
+    """image names should always contain the new repository is specified"""
+    repository = "bob-the-registry"
+    docs = render_chart(
+        values={
+            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
+        },
+    )
+    # there should be lots of image hits
+    assert len(docs) > 50
+    differtly_named_images = []
+    for doc in docs:
+        documentImages = jmespath.search("spec.template.spec.containers[*].image", doc)
+        if documentImages is not None:
+            for image in documentImages:
+                if not image.startswith(repository):
+                    print(
+                        f"{image} did not begin with specified repository - {repository}"
+                    )
+                    differtly_named_images.append(image)
+    assert len(differtly_named_images) == 0

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -21,7 +21,9 @@ def test_private_repository_image_names_the_same_as_public_ones():
         private_repo_images = jmespath.search(search_string, private_repo_doc)
         if public_repo_images is not None or private_repo_images is not None:
             assert len(public_repo_images) == len(private_repo_images)
-            for public_repo_image, private_repo_image in zip(public_repo_images, private_repo_images):
+            for public_repo_image, private_repo_image in zip(
+                public_repo_images, private_repo_images
+            ):
                 public_repo_image = public_repo_image.split("/")[-1]
                 private_repo_image = private_repo_image.split("/")[-1]
                 if public_repo_image != private_repo_image:

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -9,25 +9,19 @@ def test_private_repository_image_names_the_same_as_public_ones():
     public_repo_docs = render_chart()
     private_repo_docs = render_chart(
         values={
-            "global": {
-                "privateRegistry": {"enabled": True, "repository": repository}
-            }
+            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
         },
     )
     # should be same number of images regardless of where they come from
     assert len(public_repo_docs) == len(private_repo_docs)
     search_string = "spec.template.spec.containers[*].image"
     differently_named_images = []
-    for public_repo_doc, private_repo_doc in zip(
-        public_repo_docs, private_repo_docs
-    ):
+    for public_repo_doc, private_repo_doc in zip(public_repo_docs, private_repo_docs):
         public_repo_images = jmespath.search(search_string, public_repo_doc)
         private_repo_images = jmespath.search(search_string, private_repo_doc)
         if public_repo_images is not None or private_repo_images is not None:
             assert len(public_repo_images) == len(private_repo_images)
-            for public_repo_image, private_repo_image in zip(
-                public_repo_images, private_repo_images
-            ):
+            for public_repo_image, private_repo_image in zip(public_repo_images, private_repo_images):
                 public_repo_image = public_repo_image.split("/")[-1]
                 private_repo_image = private_repo_image.split("/")[-1]
                 if public_repo_image != private_repo_image:
@@ -45,18 +39,14 @@ def test_repository_overrides_work():
     repository = "bob-the-registry"
     docs = render_chart(
         values={
-            "global": {
-                "privateRegistry": {"enabled": True, "repository": repository}
-            }
+            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
         },
     )
     # there should be lots of image hits
     assert len(docs) > 50
     differently_named_images = []
     for doc in docs:
-        doc_images = jmespath.search(
-            "spec.template.spec.containers[*].image", doc
-        )
+        doc_images = jmespath.search("spec.template.spec.containers[*].image", doc)
         if doc_images is not None:
             for image in doc_images:
                 if not image.startswith(repository):

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -37,7 +37,7 @@ def test_private_repository_image_names_the_same_as_public_ones():
                     differently_named_images.append(
                         (public_repo_image, private_repo_image)
                     )
-    assert (len(differently_named_images) == 0, differently_named_images)
+    assert len(differently_named_images) == 0, differently_named_images
 
 
 def test_repository_overrides_work():
@@ -64,4 +64,4 @@ def test_repository_overrides_work():
                         f"{image} did not begin with specified repository - {repository}"
                     )
                     differently_named_images.append(image)
-    assert (len(differently_named_images) == 0, differently_named_images)
+    assert len(differently_named_images) == 0, differently_named_images

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -9,14 +9,18 @@ def test_private_repository_image_names_the_same_as_public_ones():
     public_repo_docs = render_chart()
     private_repo_docs = render_chart(
         values={
-            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
+            "global": {
+                "privateRegistry": {"enabled": True, "repository": repository}
+            }
         },
     )
     # should be same number of images regardless of where they come from
     assert len(public_repo_docs) == len(private_repo_docs)
     search_string = "spec.template.spec.containers[*].image"
-    differtly_named_images = []
-    for public_repo_doc, private_repo_doc in zip(public_repo_docs, private_repo_docs):
+    differently_named_images = []
+    for public_repo_doc, private_repo_doc in zip(
+        public_repo_docs, private_repo_docs
+    ):
         public_repo_images = jmespath.search(search_string, public_repo_doc)
         private_repo_images = jmespath.search(search_string, private_repo_doc)
         if public_repo_images is not None or private_repo_images is not None:
@@ -30,10 +34,10 @@ def test_private_repository_image_names_the_same_as_public_ones():
                     print(
                         f"image name differs when using a private repo named same as public - {public_repo_image} vs {private_repo_image}"
                     )
-                    differtly_named_images.append(
+                    differently_named_images.append(
                         (public_repo_image, private_repo_image)
                     )
-    assert len(differtly_named_images) == 0
+    assert (len(differently_named_images) == 0, differently_named_images)
 
 
 def test_repository_overrides_work():
@@ -41,19 +45,23 @@ def test_repository_overrides_work():
     repository = "bob-the-registry"
     docs = render_chart(
         values={
-            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
+            "global": {
+                "privateRegistry": {"enabled": True, "repository": repository}
+            }
         },
     )
     # there should be lots of image hits
     assert len(docs) > 50
-    differtly_named_images = []
+    differently_named_images = []
     for doc in docs:
-        doc_images = jmespath.search("spec.template.spec.containers[*].image", doc)
+        doc_images = jmespath.search(
+            "spec.template.spec.containers[*].image", doc
+        )
         if doc_images is not None:
             for image in doc_images:
                 if not image.startswith(repository):
                     print(
                         f"{image} did not begin with specified repository - {repository}"
                     )
-                    differtly_named_images.append(image)
-    assert len(differtly_named_images) == 0
+                    differently_named_images.append(image)
+    assert (len(differently_named_images) == 0, differently_named_images)

--- a/tests/test_private_registry.py
+++ b/tests/test_private_registry.py
@@ -24,12 +24,14 @@ def test_private_repository_image_names_the_same_as_public_ones():
             for public_repo_image, private_repo_image in zip(
                 public_repo_images, private_repo_images
             ):
+                public_repo_image = public_repo_image.split("/")[-1]
+                private_repo_image = private_repo_image.split("/")[-1]
                 if public_repo_image != private_repo_image:
                     print(
                         f"image name differs when using a private repo named same as public - {public_repo_image} vs {private_repo_image}"
                     )
                     differtly_named_images.append(
-                        (private_repo_image, public_repo_image)
+                        (public_repo_image, private_repo_image)
                     )
     assert len(differtly_named_images) == 0
 
@@ -46,9 +48,9 @@ def test_repository_overrides_work():
     assert len(docs) > 50
     differtly_named_images = []
     for doc in docs:
-        documentImages = jmespath.search("spec.template.spec.containers[*].image", doc)
-        if documentImages is not None:
-            for image in documentImages:
+        doc_images = jmespath.search("spec.template.spec.containers[*].image", doc)
+        if doc_images is not None:
+            for image in doc_images:
                 if not image.startswith(repository):
                     print(
                         f"{image} did not begin with specified repository - {repository}"


### PR DESCRIPTION
## Description

NATS, STAN, and Prometheus have wrong image names when `privateRegistry` is enabled. Normally, customers using private registry will mirror our public names. Having different names for only few of the images causes confusion and should be fixed. Should also be merged to 0.26, 0.25 and 0.23 releases.

## Related Issues

https://github.com/astronomer/issues/issues/3893

## Testing
Manual testing has been done to show that the configs do work in run time. It uses the same image names as the public images, should not need additional testing.