### PR TITLE
bump airflow chart to 1.1.1 to add 1.3.1 of the oss chart

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.1.0
+airflowChartVersion: 1.1.1
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

bump airflow chart to 1.1.1 to add 1.3.1 of the oss chart

## Related Issues

https://github.com/astronomer/airflow-chart/pull/277
https://github.com/astronomer/issues/issues/3923

## Testing

@ernest-kr how was this tested?
Tested in a air gap environment where external access is completely cut down.