### PR TITLE
bump commander to 0.27.2 to include airflow chart 1.1.1 that includes 1.3.1 of the oss chart

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.27.1
+    tag: 0.27.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

bump airflow chart in commander to 1.1.1 to add 1.3.1 of the oss chart


## Related Issues

astronomer/airflow-chart#277
astronomer/issues#3923


## Testing

Tested in a air gap environment where external access is completely cut down.