### PR TITLE
bump nginx ingress controller image

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 0.49.3
+    tag: 0.50.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

updates nginx ingress controller image to 0.50.0 for base image cve fixes

## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/3930
