### PR TITLE
bump prometheus image to 2.32.1

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.30.3
+    tag: 2.32.1
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader


### PR DESCRIPTION
## Description

Includes CVE fixes and enhancements for prometheus service

## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/3946

## Testing

No testing done, but this should be tested as part of QA before the next release.
