### PR TITLE
bump various image

### DIFF
--- a/bin/functional-tests/test_config.py
+++ b/bin/functional-tests/test_config.py
@@ -244,29 +244,20 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
 
 def test_cve_2021_44228_es_client(es_client):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
-    assert (
-        es_client.check_output(
-            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
-        )
-        == "-Dlog4j2.formatMsgNoLookups=true"
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_client.check_output(
+        "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
 
 def test_cve_2021_44228_es_data(es_data):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
-    assert (
-        es_data.check_output(
-            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
-        )
-        == "-Dlog4j2.formatMsgNoLookups=true"
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_data.check_output(
+        "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
 
 def test_cve_2021_44228_es_master(es_master):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
-    assert (
-        es_master.check_output(
-            "/usr/share/elasticsearch/jdk/bin/jps -lv | grep -o '[^ ]*MsgNoLookups[^ ]*'"
-        )
-        == "-Dlog4j2.formatMsgNoLookups=true"
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_master.check_output(
+        "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.15.2
+    tag: 7.16.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.15.2
+    tag: 7.16.2
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kubed/values.yaml
+++ b/charts/kubed/values.yaml
@@ -5,7 +5,7 @@
 images:
   kubed:
     repository: quay.io/astronomer/ap-kubed
-    tag: 0.12.0
+    tag: 0.13.0
     pullPolicy: IfNotPresent
 
 # Declare variables to be passed into your templates.

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -71,7 +71,7 @@ Docker repository name
 */}}
 {{ define "image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/node-exporter:{{ .Values.image.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-node-exporter:{{ .Values.image.tag }}
 {{- else -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag }}
 {{- end }}

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/prometheus/node-exporter
-  tag: v1.3.1
+  repository: quay.io/astronomer/ap-node-exporter
+  tag: 1.3.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Description

* elasticsearch version update to 7.16.2
* kibana version update to 7.16.2
* kubed version update to 0.13.0
* node exporter move to astronomer quay

Also

* Improve cve_2021_44228 test cases by string matching in python instead of grep

## Related Issues

https://github.com/astronomer/issues/issues/3945
https://github.com/astronomer/issues/issues/3942
https://github.com/astronomer/issues/issues/3833

## Testing

NA
