### PR TITLE
Bump grafana to 8.3.3

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 7.5.12
+    tag: 8.3.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

This is a major version bump from grafana 7 to grafana 8.

## Related Issues

https://github.com/astronomer/issues/issues/3292

## Testing

No testing done for this specific version yet. We should definitely check this quite a lot before shipping it to customers.

Also it would be possible to write some functional tests for grafana, so maybe we should do that before merging this.