### PR TITLE
setting proxy buffer size to 16k to avoid payload issues

### DIFF
--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -26,6 +26,7 @@ metadata:
         deny all;
         return 403;
       }
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}


### PR DESCRIPTION
## Description

Due to payload size exceeds the default value end up in 502 error, this change fixes that issue by increasing 16k

## Related Issues

https://github.com/astronomer/issues/issues/3974

## Testing

NA
