### PR TITLE
enable namespace labels to platform

### DIFF
--- a/charts/astronomer/templates/add-labels-to-namespace.yaml
+++ b/charts/astronomer/templates/add-labels-to-namespace.yaml
@@ -1,0 +1,78 @@
+########################################################
+## Astronomer Platform Namespace label configure Hook ##
+########################################################
+{{- if .Values.global.networkNSLabels }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-labeller
+rules:
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["patch", "update", "get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "-2"
+  name: {{ .Release.Name }}-labeller
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Release.Name }}-labeller
+  namespace: {{ .Release.Namespace }}
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-labeller
+  apiGroup: ""
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-weight": "3"
+  name: {{ .Release.Name }}-labeller
+  labels:
+    tier: platform
+    component: labeller
+    release: {{ .Release.Name }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-platform-labeller
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook-weight": "5"
+  labels:
+    tier: platform
+    component: labeller
+    release: {{ .Release.Name }}
+spec:
+  template:
+    metadata:
+      labels:
+        tier: platform
+        component: labeller
+        release: {{ .Release.Name }}
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-labeller
+      containers:
+      - name: label-platform-namespace
+        image: {{ template "dbBootstrapper.image" . }}
+        imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
+        command: ["/bin/sh", "-c"]
+        args:
+          - data=`kubectl get ns {{ .Release.Namespace }} -o=jsonpath='{.metadata.labels.platform}'` ;if [[ "$data" = "" ]]  ; then kubectl label namespace {{ .Release.Namespace }} platform={{ .Release.Name }} ;else echo "Label Already exists" ;fi
+{{ end }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -95,6 +95,11 @@ data:
         # If security context constraints are enabled, enable SCCs for airflow-chart
         sccEnabled: true
       {{- end }}
+
+      {{- if .Values.global.networkNSLabels }}
+        networkNSLabels: true
+      {{- end }}
+
         airflow:
           useAstroSecurityManager: true
           webserver:

--- a/charts/postgresql/templates/networkpolicy.yaml
+++ b/charts/postgresql/templates/networkpolicy.yaml
@@ -34,7 +34,13 @@ spec:
       - podSelector:
           matchLabels:
             component: pgbouncer
-        namespaceSelector: {}
+        {{- if .Values.global.networkNSLabels }}
+        namespaceSelector:
+          matchLabels:
+            platform: {{ .Release.Name }}
+        {{ else }}
+          namespaceSelector: {}
+        {{- end }}
       - podSelector:
           matchLabels:
             release: {{ .Release.Name }}

--- a/charts/postgresql/templates/networkpolicy.yaml
+++ b/charts/postgresql/templates/networkpolicy.yaml
@@ -31,16 +31,19 @@ spec:
           matchLabels:
             release: {{ .Release.Name }}
             component: grafana
+      {{- if .Values.global.networkNSLabels  }}
+      - namespaceSelector:
+          matchLabels:
+            platform: {{ .Release.Name }}
+        podSelector:
+          matchLabels:
+            component: pgbouncer
+      {{- else }}
       - podSelector:
           matchLabels:
             component: pgbouncer
-        {{- if .Values.global.networkNSLabels }}
-        namespaceSelector:
-          matchLabels:
-            platform: {{ .Release.Name }}
-        {{ else }}
-          namespaceSelector: {}
-        {{- end }}
+        namespaceSelector: {}
+      {{- end }}
       - podSelector:
           matchLabels:
             release: {{ .Release.Name }}

--- a/tests/test_network_ns_labels.py
+++ b/tests/test_network_ns_labels.py
@@ -1,0 +1,48 @@
+from tests.helm_template_generator import render_chart
+import pytest
+from . import supported_k8s_versions
+import yaml
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestNSSelectorNetworkPolicies:
+    def test_networkNSLabels_houston_configmap_with_feature_enabled(self, kube_version):
+        """Test Houston Configmap with networkNSLabels."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"networkNSLabels": True}},
+            show_only=[
+                "charts/astronomer/templates/houston/houston-configmap.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-houston-config"
+        assert prod["deployments"]["helm"]["networkNSLabels"] is True
+
+    def test_networknsselector_with_postgresql(self, kube_version):
+        """Test postgresql Service with namespace selector labels."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"networkNSLabels": True, "postgresqlEnabled": True}},
+            show_only=[
+                "charts/postgresql/templates/networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "NetworkPolicy" == doc["kind"]
+        assert [
+            {
+                "namespaceSelector": {"matchLabels": {"platform": "RELEASE-NAME"}},
+                "podSelector": {"matchLabels": {"component": "pgbouncer"}},
+            }
+        ] == [doc["spec"]["ingress"][0]["from"][2]]

--- a/values.yaml
+++ b/values.yaml
@@ -91,6 +91,9 @@ global:
   # Enable security context constraints required for OpenShift
   sccEnabled: false
 
+  # Enables namespace labels for network policies
+  networkNSLabels: false
+
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false


### PR DESCRIPTION
## Description

This PR allows to set platform label to be used along with network policies , additionally locks down communication which is not  part of astronomer platform 

## Related Issues

Related astronomer/issues#3278 

## Testing

Yet to be added 
