### PR TITLE
disable postgres init container

### DIFF
--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -46,7 +46,7 @@ image:
 ## volumePermissions: Change the owner of the persist volume mountpoint to RunAsUser:fsGroup
 ##
 volumePermissions:
-  enabled: true
+  enabled: false
   image:
     ## ref: https://hub.docker.com/r/bitnami/minideb/tags/
     registry: docker.io

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -18,11 +18,10 @@ class TestPostgresql:
 
         assert len(docs) == 1
         doc = docs[0]
-        print(doc["spec"]["template"]["spec"]["containers"])
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-postgresql"
-        assert "initContainers" in doc["spec"]["template"]["spec"]
+        assert "initContainers" not in doc["spec"]["template"]["spec"]
 
     def test_postgresql_statefulset_with_volumePermissions_enabled(self, kube_version):
         """Test postgresql statefulset when volumePermissions init container is enabled."""
@@ -30,14 +29,16 @@ class TestPostgresql:
             kube_version=kube_version,
             values={
                 "global": {"postgresqlEnabled": True},
-                "postgresql.volumePermissions.enabled": True,
+                "postgresql": {
+                    "volumePermissions": {"enabled": True},
+                    "persistence": {"enabled": True},
+                },
             },
             show_only=["charts/postgresql/templates/statefulset.yaml"],
         )
 
         assert len(docs) == 1
         doc = docs[0]
-        print(doc["spec"]["template"]["spec"]["containers"])
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-postgresql"

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,0 +1,44 @@
+from tests.helm_template_generator import render_chart
+import pytest
+from . import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestPostgresql:
+    def test_postgresql_statefulset_defaults(self, kube_version):
+        """Test postgresql statefulset is good with defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"postgresqlEnabled": True}},
+            show_only=["charts/postgresql/templates/statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        print(doc["spec"]["template"]["spec"]["containers"])
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-postgresql"
+        assert "initContainers" in doc["spec"]["template"]["spec"]
+
+    def test_postgresql_statefulset_with_volumePermissions_enabled(self, kube_version):
+        """Test postgresql statefulset when volumePermissions init container is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"postgresqlEnabled": True},
+                "postgresql.volumePermissions.enabled": True,
+            },
+            show_only=["charts/postgresql/templates/statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        print(doc["spec"]["template"]["spec"]["containers"])
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-postgresql"
+        assert "initContainers" in doc["spec"]["template"]["spec"]


### PR DESCRIPTION
## Description

we no longer need to run init container with root privileges for in cluster postgres , we have already migrated our postgres image to run as non root. we can disable this in astronomer/astronomer postgres chart helm values

## Related Issues

https://github.com/astronomer/issues/issues/4087

## Testing

NA
