### PR TITLE
Deprecate 1.18. Use 1.21 as default in chart tests and comments.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,22 +117,6 @@ jobs:
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 
-  platform-1-18-19:
-    machine:
-      image: ubuntu-2004:202107-02
-      resource_class: xlarge
-    environment:
-      KUBE_VERSION: v1.18.19
-    steps:
-      - helm-install:
-          astronomer-tags: "platform postgresql monitoring logging kubed keda"
-      - run:
-          name: Check chart for k8s 1.18.19 compatibility with kubent
-          command: |
-            set -o pipefail
-            helm template --kube-version=v1.18.19 -f values.yaml --set global.baseDomain=example.com . |
-            kubent --cluster=false --helm2=false --helm3=false --filename -
-          when: always
   platform-1-19-11:
     machine:
       image: ubuntu-2004:202107-02
@@ -197,14 +181,9 @@ workflows:
       - approve-test-all-platforms:
           type: approval
 
-      - platform-1-18-19:
-          requires:
-            - build-artifact
       - platform-1-19-11:
           requires:
-            - approve-test-all-platforms
             - build-artifact
-
       - platform-1-20-7:
           requires:
             - approve-test-all-platforms
@@ -220,13 +199,12 @@ workflows:
             - gcp-astronomer-prod
           requires:
             - approve-internal-release
-            - platform-1-18-19
+            - platform-1-19-11
             - platform-1-21-2
       - approve-public-release:
           type: approval
           requires:
             - release-to-internal
-            - platform-1-19-11
             - platform-1-20-7
           filters:
             branches:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,7 +11,7 @@ from jinja2 import Template
 # recent patch version on Dockerhub
 # https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-KUBE_VERSIONS = ["1.18.19", "1.19.11", "1.20.7", "1.21.2"]
+KUBE_VERSIONS = ["1.19.11", "1.20.7", "1.21.2"]
 
 
 def main():

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ kubectl edit deployment -n astronomer <your deployment>
 #### Change Kubernetes version:
 
 ```sh
-bin/reset-local-dev -K 1.18.15
+bin/reset-local-dev -K 1.21.2
 ```
 
 #### Locally test HA configurations:

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -14,7 +14,7 @@ Options:
   -h    Print this help text
   -H    Use HA
   -k    List recent kubernetes versions to use with -K (not all will be available to KIND)
-  -K    Kubernetes version to use (eg: 1.18.8) https://github.com/kubernetes/kubernetes/releases/
+  -K    Kubernetes version to use (eg: 1.21.2) https://github.com/kubernetes/kubernetes/releases/
   -M    Enable multi-node kind cluster
 
 "

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,4 +7,4 @@ git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 
 # This should match the major.minor version list in .circleci/generate_circleci_config.py
 # Patch version should always be 0
-supported_k8s_versions = ["1.18.0", "1.19.0", "1.20.0", "1.21.0"]
+supported_k8s_versions = ["1.19.0", "1.20.0", "1.21.0"]

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -32,7 +32,7 @@ api_client = ApiClient()
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master"
 
 
-def get_schema_k8s(api_version, kind, kube_version="1.18.0"):
+def get_schema_k8s(api_version, kind, kube_version="1.21.0"):
     """Return a k8s schema for use in validation."""
     api_version = api_version.lower()
     kind = kind.lower()
@@ -49,14 +49,14 @@ def get_schema_k8s(api_version, kind, kube_version="1.18.0"):
 
 
 @lru_cache(maxsize=None)
-def create_validator(api_version, kind, kube_version="1.18.0"):
+def create_validator(api_version, kind, kube_version="1.21.0"):
     """Create a k8s validator for the given inputs."""
     schema = get_schema_k8s(api_version, kind, kube_version=kube_version)
     jsonschema.Draft7Validator.check_schema(schema)
     return jsonschema.Draft7Validator(schema)
 
 
-def validate_k8s_object(instance, kube_version="1.18.0"):
+def validate_k8s_object(instance, kube_version="1.21.0"):
     """Validate the k8s object."""
     validate = create_validator(
         instance.get("apiVersion"), instance.get("kind"), kube_version=kube_version
@@ -69,7 +69,7 @@ def render_chart(
     values=None,
     show_only=None,
     chart_dir=None,
-    kube_version="1.18.0",
+    kube_version="1.21.0",
     baseDomain="example.com",
 ):
     """


### PR DESCRIPTION
## Description

Stop testing and suggesting k8s 1.18. k8s 1.18 will be deprecated by all cloud providers within 2 months. We will not be writing any new features for it and will not support it going forward.

We can hold off to merge this until we're ready to deprecate it, or just merge early since we're not going to support 1.18 long anyway and all our feature development is targeting 1.21 and soon 1.22.

## Related Issues

https://github.com/astronomer/issues/issues/3890

## Testing

Nothing beyond CI. We're removing features and defaulting to 1.21, so there's not much to test. 1.21 already works, so using it as a default is not a huge change.