### PR TITLE
Bump commander to 0.27.4

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.27.3
+    tag: 0.27.4
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description
Bump up the commander image to latest 0.27.4 release

## Related Issues
Changes present in the new release: https://github.com/astronomer/commander/pull/77

## Testing
Have tested locally and on circle-ci that the commander while building was able to pick up the latest airflow chart version