### PR TITLE
bump postgres exporter to 0.10.1

### DIFF
--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.10.0
+  tag: 0.10.1
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Description

Enhancement for postgres exporter 

for descriptive changelog ref https://github.com/prometheus-community/postgres_exporter/releases/tag/v0.10.1 

## Related Issues

NA

## Testing

NA
