### PR TITLE
bump airflow-chart to 1.2.0

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.1.1
+airflowChartVersion: 1.2.0
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
we want to include most recent airflow OSS chart so, we need to bump astronomer airflow-chart to 1.2.0

release notes https://github.com/apache/airflow/releases/tag/helm-chart%2F1.4.0 

https://github.com/apache/airflow/pull/20266/files
