### PR TITLE
Allow nodeSelector, affinity, and tolerations configuration for Stan and Nats

### DIFF
--- a/charts/fluentd/templates/fluentd-serviceaccount.yaml
+++ b/charts/fluentd/templates/fluentd-serviceaccount.yaml
@@ -12,4 +12,6 @@ metadata:
     chart: {{ template "fluentd.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+{{ toYaml (.Values.serviceAccountAnnotations) | indent 4 }}
 {{- end -}}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -47,10 +47,12 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.affinity }}
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
-{{- toYaml  . | nindent 8 }}
-{{- end }}
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       # Common volumes for the containers.
       volumes:
       - name: config-volume

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -82,6 +82,16 @@ securityContext: null
 #   runAsUser: 1000
 #   runAsNonRoot: true
 
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
 # Affinity for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -51,10 +51,12 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       terminationGracePeriodSeconds: 90
-{{- with .Values.affinity }}
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
-{{- toYaml  . | nindent 8 }}
-{{- end }}
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       volumes:
       - configMap:
           name: {{ template "stan.name".  }}-config

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -66,6 +66,16 @@ securityContext:
   runAsGroup: 1000
   runAsUser: 1000
 
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
 # Affinity for pod assignment
 # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -82,7 +82,7 @@ def render_chart(
         tmp_file.write(content.encode())
         tmp_file.flush()
         command = [
-            "helm",
+            "helm-3.7.2",
             "template",
             "--kube-version",
             kube_version,

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -82,7 +82,7 @@ def render_chart(
         tmp_file.write(content.encode())
         tmp_file.flush()
         command = [
-            "helm-3.7.2",
+            "helm",
             "template",
             "--kube-version",
             kube_version,

--- a/tests/test_nats_sts.py
+++ b/tests/test_nats_sts.py
@@ -30,12 +30,12 @@ class TestNatsStatefulSet:
             "quay.io/astronomer/ap-nats-server:"
         )
         assert c_by_name["nats"]["livenessProbe"] == {
-            "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
+            "httpGet": {"path": "/", "port": 8222},
             "initialDelaySeconds": 10,
             "timeoutSeconds": 5,
         }
         assert c_by_name["nats"]["readinessProbe"] == {
-            "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
+            "httpGet": {"path": "/", "port": 8222},
             "initialDelaySeconds": 10,
             "timeoutSeconds": 5,
         }

--- a/tests/test_nats_sts.py
+++ b/tests/test_nats_sts.py
@@ -69,11 +69,62 @@ class TestNatsStatefulSet:
 
     def test_nats_statefulset_with_affinity_and_tolerations(self, kube_version):
         """Test that nats statefulset renders proper nodeSelector, affinity, and tolerations"""
+        values = {
+            "nats": {
+                "nodeSelector": {"role": "astro"},
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "astronomer.io/multi-tenant",
+                                            "operator": "In",
+                                            "values": ["false"],
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "astronomer",
+                        "operator": "Exists",
+                    }
+                ],
+            },
+        }
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/nats/templates/statefulset.yaml"],
-            values={
-                "nats": {
+            values=values,
+        )
+
+        assert len(docs) == 1
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] != {}
+        assert spec["nodeSelector"]["role"] == "astro"
+        assert spec["affinity"] != {}
+        assert (
+            len(
+                spec["affinity"]["nodeAffinity"][
+                    "requiredDuringSchedulingIgnoredDuringExecution"
+                ]["nodeSelectorTerms"]
+            )
+            == 1
+        )
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["nats"]["tolerations"]
+
+    def test_nats_statefulset_with_global_affinity_and_tolerations(self, kube_version):
+        """Test that nats statefulset renders proper nodeSelector, affinity, and tolerations with global config"""
+        values = {
+            "global": {
+                "platformNodePool": {
                     "nodeSelector": {"role": "astro"},
                     "affinity": {
                         "nodeAffinity": {
@@ -100,7 +151,12 @@ class TestNatsStatefulSet:
                         }
                     ],
                 },
-            },
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/nats/templates/statefulset.yaml"],
+            values=values,
         )
 
         assert len(docs) == 1
@@ -117,3 +173,6 @@ class TestNatsStatefulSet:
             == 1
         )
         assert len(spec["tolerations"]) > 0
+        assert (
+            spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
+        )

--- a/tests/test_nats_sts.py
+++ b/tests/test_nats_sts.py
@@ -7,12 +7,12 @@ from . import supported_k8s_versions
     "kube_version",
     supported_k8s_versions,
 )
-class TestStanStatefulSet:
-    def test_stan_statefulset_defaults(self, kube_version):
-        """Test that stan statefulset is good with defaults."""
+class TestNatsStatefulSet:
+    def test_nats_statefulset_defaults(self, kube_version):
+        """Test that nats statefulset is good with defaults."""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=["charts/stan/templates/statefulset.yaml"],
+            show_only=["charts/nats/templates/statefulset.yaml"],
         )
 
         assert len(docs) == 1
@@ -22,19 +22,19 @@ class TestStanStatefulSet:
         }
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-stan"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-nats"
         assert c_by_name["metrics"]["image"].startswith(
             "quay.io/astronomer/ap-nats-exporter:"
         )
-        assert c_by_name["stan"]["image"].startswith(
-            "quay.io/astronomer/ap-nats-streaming:"
+        assert c_by_name["nats"]["image"].startswith(
+            "quay.io/astronomer/ap-nats-server:"
         )
-        assert c_by_name["stan"]["livenessProbe"] == {
+        assert c_by_name["nats"]["livenessProbe"] == {
             "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
             "initialDelaySeconds": 10,
             "timeoutSeconds": 5,
         }
-        assert c_by_name["stan"]["readinessProbe"] == {
+        assert c_by_name["nats"]["readinessProbe"] == {
             "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
             "initialDelaySeconds": 10,
             "timeoutSeconds": 5,
@@ -44,18 +44,18 @@ class TestStanStatefulSet:
         assert doc["spec"]["template"]["spec"]["affinity"] == {}
         assert doc["spec"]["template"]["spec"]["tolerations"] == []
 
-    def test_stan_statefulset_with_metrics_and_resources(self, kube_version):
-        """Test that stan statefulset renders good metrics exporter."""
+    def test_nats_statefulset_with_metrics_and_resources(self, kube_version):
+        """Test that nats statefulset renders good metrics exporter."""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=["charts/stan/templates/statefulset.yaml"],
+            show_only=["charts/nats/templates/statefulset.yaml"],
             values={
-                "stan": {
+                "nats": {
                     "exporter": {
                         "enabled": True,
                         "resources": {"requests": {"cpu": "234m"}},
                     },
-                    "stan": {"resources": {"requests": {"cpu": "123m"}}},
+                    "nats": {"resources": {"requests": {"cpu": "123m"}}},
                 },
             },
         )
@@ -64,16 +64,16 @@ class TestStanStatefulSet:
         containers = docs[0]["spec"]["template"]["spec"]["containers"]
         assert len(containers) == 2
         c_by_name = {c["name"]: c for c in containers}
-        assert c_by_name["stan"]["resources"]["requests"]["cpu"] == "123m"
+        assert c_by_name["nats"]["resources"]["requests"]["cpu"] == "123m"
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 
-    def test_stan_statefulset_with_affinity_and_tolerations(self, kube_version):
-        """Test that stan statefulset renders proper nodeSelector, affinity, and tolerations"""
+    def test_nats_statefulset_with_affinity_and_tolerations(self, kube_version):
+        """Test that nats statefulset renders proper nodeSelector, affinity, and tolerations"""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=["charts/stan/templates/statefulset.yaml"],
+            show_only=["charts/nats/templates/statefulset.yaml"],
             values={
-                "stan": {
+                "nats": {
                     "nodeSelector": {"role": "astro"},
                     "affinity": {
                         "nodeAffinity": {

--- a/values.yaml
+++ b/values.yaml
@@ -383,9 +383,9 @@ keda:
 nats:
   nodeSelector:
     <<: *platformNodeSelector
-    affinity:
-      <<: *platformAffinity
-    tolerations: *platformTolerations
+  affinity:
+    <<: *platformAffinity
+  tolerations: *platformTolerations
   resources:
     requests:
       cpu: "75m"
@@ -397,9 +397,9 @@ nats:
 stan:
   nodeSelector:
     <<: *platformNodeSelector
-    affinity:
-      <<: *platformAffinity
-    tolerations: *platformTolerations
+  affinity:
+    <<: *platformAffinity
+  tolerations: *platformTolerations
   resources:
     requests:
       cpu: "75m"


### PR DESCRIPTION
## Description
Allow the ability to configure nodeSelector, affinity, and tolerations for Nats and Stan in order to restrict the Kubernetes nodes the Pods are scheduled on.

## Related Issues
https://github.com/astronomer/issues/issues/4137

## Testing
- Added `test_nats_sts.py` to validate generation of the statefulset yaml and nodeSelector, affinity, and tolerations are configured correctly
- Added test in `test_stan_sts.py` to validate nodeSelector, affinity, and tolerations are configured correctly
