### PR TITLE
Fix bundled Nginx Ingress contoller role

### DIFF
--- a/charts/nginx/Chart.yaml
+++ b/charts/nginx/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: nginx
-version: 0.12.0
+version: 0.12.1
 description: Helm chart to deploy the Astronomer Platform NGINX module
 keywords:
   - astronomer

--- a/charts/nginx/templates/nginx-role.yaml
+++ b/charts/nginx/templates/nginx-role.yaml
@@ -59,7 +59,6 @@ rules:
       - get
       - list
       - watch
-  {{- if not $singleNamespace }}
   - apiGroups:
       - ""
     resources:
@@ -79,5 +78,4 @@ rules:
       - ingresses/status
     verbs:
       - update
-  {{- end }}
 {{- end }}

--- a/tests/test_nginx_role.py
+++ b/tests/test_nginx_role.py
@@ -1,0 +1,32 @@
+from tests.helm_template_generator import render_chart
+
+
+class TestNginxRole:
+    def test_nginx_role(self):
+        # sourcery skip: extract-duplicate-method
+        docs = render_chart(
+            show_only=["charts/nginx/templates/nginx-role.yaml"],
+        )
+
+        assert len(docs) == 1
+
+        doc = docs[0]
+
+        assert doc["kind"] == "Role"
+        assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
+
+    def test_nginx_role_verbs_ingresses_status(self):
+        # sourcery skip: extract-duplicate-method
+        docs = render_chart(
+            values={"global": {"singleNamespace": "true"}},
+            show_only=["charts/nginx/templates/nginx-role.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["kind"] == "Role"
+        assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
+        assert doc["rules"] == any('ingresses/status' in val for val in doc.values())

--- a/tests/test_nginx_role.py
+++ b/tests/test_nginx_role.py
@@ -29,4 +29,4 @@ class TestNginxRole:
         assert doc["kind"] == "Role"
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
-        assert doc["rules"] == any('ingresses/status' in val for val in doc.values())
+        assert doc["rules"] == any("ingresses/status" in val for val in doc.values())

--- a/tests/test_nginx_role.py
+++ b/tests/test_nginx_role.py
@@ -12,7 +12,7 @@ class TestNginxRole:
 
         doc = docs[0]
 
-        assert doc["kind"] == "Role"
+        assert doc["kind"] == "ClusterRole"
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
 


### PR DESCRIPTION
## Description

If `singleNamespace: true`, Nginx SA don't have needed privileges to update Ingress object with assigned LB IP:
```
W0131 23:50:52.478747       7 status.go:301] error updating ingress rule: ingresses.networking.k8s.io "astronomer-prometheus-ingress" is forbidden: User "system:serviceaccount:astronomer:astronomer-nginx" cannot update resource "ingresses/status" in API group "networking.k8s.io" in the namespace "astronomer"
```

## Related Issues

---

## Testing

1. Provision Astronomer Helm chart with `global.singleNamespace: true`
2. Wait for Nginx Ingress to start updating Ingress objects with LB IP
3. See that no LB IP was assigned
4. Check Nginx Ingress controller logs:
```
W0131 23:50:52.478747       7 status.go:301] error updating ingress rule: ingresses.networking.k8s.io "astronomer-prometheus-ingress" is forbidden: User "system:serviceaccount:astronomer:astronomer-nginx" cannot update resource "ingresses/status" in API group "networking.k8s.io" in the namespace "astronomer"
```
5. Manually update `astronomer-nginx` with missed verbs
6. Ingress objects get LB IP assigned
