### PR TITLE
Bump ap-default-backend to 0.28.0

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.25.4
+    tag: 0.28.0
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION
## Description

Bump to [ap-default-backend 0.28.0](https://github.com/astronomer/default-backend/releases/tag/v0.28.0) to solve several issues. This version also [moves from Redhat ubi8 to nginx](https://github.com/astronomer/default-backend/commit/e9ca08d09b01512ae7b2a690c2cd91266b40629f).

## Related Issues

https://github.com/astronomer/issues/issues/3953

## Testing

N/A