### PR TITLE
bump vendor images

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.2
+    tag: 0.26.3
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-8
+    tag: 5.8.4-9
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
## Description

bump vendor images to fix critical cve

## Related Issues

https://github.com/astronomer/issues/issues/4089

## Testing

trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-curator:5.8.4-9
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-db-bootstrapper:0.26.3