### PR TITLE
Bump image versions in nats and stan

### DIFF
--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.3.2-4
+    tag: 2.7.2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.0-1
+    tag: 0.9.1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0
+    tag: 3.15.0-2
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.22.0-3
+    tag: 0.24.1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.0-1
+    tag: 0.9.1
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION
## Description

Bump image versions in nats and stan. This is partly to solve CVEs, and partly to stay up on the latest updates.

These changes should be merged into all supported branches.

## Related Issues

https://github.com/astronomer/issues/issues/4202

## Testing

Normal testing should cover these changes AFAIK.