### PR TITLE
update default backend nginx to 0.28.0

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.25.4
+    tag: 0.28.0
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION
## Description

update default backend for nginx

## Related Issues

NA

## Testing

NA
