### PR TITLE
bump grafana chart security fixes

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 7.5.10
+    tag: 7.5.12
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.25.1
+    tag: 0.26.3
     pullPolicy: IfNotPresent
 
 backendSecretName: ~


### PR DESCRIPTION
## Description

* update grafana image 7.5.10 -> 7.5.12
* grafana db-bootstrapper 0.25.1 -> 0.26.3

## Related Issues

Issue Link : https://github.com/astronomer/issues/issues/4123

## Testing

trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-grafana:7.5.12
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-db-bootstrapper:0.26.3
