### PR TITLE
bump platform image for various security fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,11 +15,11 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.25.3
+    tag: 0.25.4
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.14.2-2
+    tag: 3.15.0
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION


## Description

* ap-commander 0.25.3 -> 0.25.4
* ap-registry 3.14.2-2 -> 3.15.0

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Qa team should able to deploy platform without any issues , and able to deploy airflow.
