### PR TITLE
Add tests for stan

### DIFF
--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -132,7 +132,7 @@ spec:
       containers:
       - name: nats
         image: {{ include "nats.image" . }}
-        imagePullPolicy: {{ .Values.nats.pullPolicy }}
+        imagePullPolicy: {{ .Values.images.nats.pullPolicy }}
         ports:
         - containerPort: 4222
           name: client

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -38,6 +38,7 @@ spec:
           securityContext:
             runAsUser: 101
           image: {{ template "nginx.image" . }}
+          imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           args:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -144,6 +144,7 @@ spec:
         {{ if .Values.exporter.enabled }}
         - name: metrics
           image: {{ .Values.exporter.image }}
+          imagePullPolicy: {{ .Values.images.stan.pullPolicy }}
           resources:
 {{ toYaml .Values.exporter.resources | indent 12 }}
           args:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -74,13 +74,14 @@ spec:
             - "-timeout"
             - "1m"
           image: {{ include "stan.init.image" . }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.images.init.pullPolicy }}
           env:
             - name: NATS__URL
               value: "nats://{{ .Release.Name }}-nats:4222"
       containers:
         - name: stan
           image: {{ include "stan.image" . }}
+          imagePullPolicy: {{ .Values.images.stan.pullPolicy }}
           args:
           - -sc
           - /etc/stan-config/stan.conf

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -3,7 +3,8 @@ import pytest
 import yaml
 from . import git_root_dir
 
-
+# TODO: find a way to easily update this default_chart_data.yaml EG when new files are added
+# TODO: add more checks that should apply to all manifests of a given type like how we check that all pod_managers have imagePullPolicy
 with open(f"{git_root_dir}/tests/default_chart_data.yaml") as file:
     default_chart_data = yaml.load(file, Loader=yaml.SafeLoader)
 
@@ -12,8 +13,32 @@ template_ids = [template["name"] for template in default_chart_data]
 
 @pytest.mark.parametrize("template", default_chart_data, ids=template_ids)
 def test_default_chart_with_basedomain(template):
-    """Test that each template used with just baseDomain set renders."""
+    """Test that each template used with just baseDomain set renders and all standard properties are present."""
     docs = render_chart(
         show_only=[template["name"]],
     )
     assert len(docs) == template["length"]
+
+    pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
+
+    pod_manger_docs = [doc for doc in docs if doc["kind"] in pod_managers]
+
+    for doc in pod_manger_docs:
+        c_by_name = {
+            c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
+        }
+
+        if doc["spec"]["template"]["spec"].get("initContainers"):
+            c_by_name.update(
+                {
+                    c["name"]: c
+                    for c in doc["spec"]["template"]["spec"].get("containers")
+                }
+            )
+
+        for name, container in c_by_name.items():
+            assert container[
+                "imagePullPolicy"
+            ], f"container {name} does not have an imagePullPolicy: {doc}"
+
+        # breakpoint()

--- a/tests/test_stan_sts.py
+++ b/tests/test_stan_sts.py
@@ -90,10 +90,11 @@ class TestStanStatefulSet:
         assert len(docs) == 1
         doc = docs[0]
         c_by_name = {
-            c["name"]: c
-            for c in doc["spec"]["template"]["spec"]["containers"]
-            + doc["spec"]["template"]["spec"]["initContainers"]
+            c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
         }
+
+        if doc["spec"]["template"]["spec"].get("initContainers"):
+            c_by_name.update(doc["spec"]["template"]["spec"].get("initContainers"))
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"

--- a/tests/test_stan_sts.py
+++ b/tests/test_stan_sts.py
@@ -1,0 +1,110 @@
+from tests.helm_template_generator import render_chart
+import pytest
+from . import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestStanStatefulSet:
+    def test_stan_statefulset_defaults(self, kube_version):
+        """Test that stan statefulset is good with defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/stan/templates/statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = {
+            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
+        }
+
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "RELEASE-NAME-stan"
+        assert c_by_name["metrics"]["image"].startswith(
+            "quay.io/astronomer/ap-nats-exporter:"
+        )
+        assert c_by_name["stan"]["image"].startswith(
+            "quay.io/astronomer/ap-nats-streaming:"
+        )
+        assert c_by_name["stan"]["livenessProbe"] == {
+            "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+        }
+        assert c_by_name["stan"]["readinessProbe"] == {
+            "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+        }
+
+    def test_stan_statefulset_with_metrics_and_resources(self, kube_version):
+        """Test that stan statefulset renders good metrics exporter."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/stan/templates/statefulset.yaml"],
+            values={
+                "stan": {
+                    "exporter": {
+                        "enabled": True,
+                        "resources": {"requests": {"cpu": "234m"}},
+                    },
+                    "stan": {"resources": {"requests": {"cpu": "123m"}}},
+                },
+            },
+        )
+
+        assert len(docs) == 1
+        containers = docs[0]["spec"]["template"]["spec"]["containers"]
+        assert len(containers) == 2
+        c_by_name = {c["name"]: c for c in containers}
+        assert c_by_name["stan"]["resources"]["requests"]["cpu"] == "123m"
+        assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
+
+    def test_stan_statefulset_with_custom_images(self, kube_version):
+        """Test we can customize the stan images."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/stan/templates/statefulset.yaml"],
+            values={
+                "stan": {
+                    "images": {
+                        "init": {
+                            "repository": "example.com/custom/image/the-init-image",
+                            "tag": "the-custom-init-tag",
+                            "pullPolicy": "Always",
+                        },
+                        "stan": {
+                            "repository": "example.com/custom/image/the-stan-image",
+                            "tag": "the-custom-stan-tag",
+                            "pullPolicy": "Always",
+                        },
+                    },
+                },
+            },
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        c_by_name = {
+            c["name"]: c
+            for c in doc["spec"]["template"]["spec"]["containers"]
+            + doc["spec"]["template"]["spec"]["initContainers"]
+        }
+
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+
+        assert (
+            c_by_name["stan"]["image"]
+            == "example.com/custom/image/the-stan-image:the-custom-stan-tag"
+        )
+        assert c_by_name["stan"]["imagePullPolicy"] == "Always"
+        assert (
+            c_by_name["wait-for-nats-server"]["image"]
+            == "example.com/custom/image/the-init-image:the-custom-init-tag"
+        )
+        assert c_by_name["stan"]["imagePullPolicy"] == "Always"

--- a/tests/test_stan_sts.py
+++ b/tests/test_stan_sts.py
@@ -94,7 +94,12 @@ class TestStanStatefulSet:
         }
 
         if doc["spec"]["template"]["spec"].get("initContainers"):
-            c_by_name.update(doc["spec"]["template"]["spec"].get("initContainers"))
+            c_by_name.update(
+                {
+                    c["name"]: c
+                    for c in doc["spec"]["template"]["spec"].get("initContainers")
+                }
+            )
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"


### PR DESCRIPTION
## Description

release-0.27 did not have tests for stan, and we ran into some problems with some release-0.28 in airgapped environments. This adds tests to make sure release-0.27 image customization works. The boilerplate tests were taken from release-0.28, but `test_stan_statefulset_with_custom_images` is not in release-0.28 and should be ported and updated for those changes.

Part of the problem here included imagePullPolicy being absent from a pod manager manifest. To check for this everywhere I wrote a test that checks all pod managers for imagePullPolicy. This test found 3 other places where it was missing, along with at least one other place where it would be missing if a feature that appears to be broken (but apparently quite unused) was enabled. I have fixed those three instances so those changes appear in this change set, and have [opened an issue for the broken feature](https://github.com/astronomer/issues/issues/4228).

## Itemized changes

- Add test for all pod managers to have imagePullPolicy
- Fix or add imagePullPolicy in nats, nginx, stan (total 4 containers)
- Add tests for nats statefulset

## Related Issues

https://github.com/astronomer/issues/issues/4229

## Testing

Testing is the name of the game here.