### PR TITLE
Fix lots of privateRegistry images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: help
 help: ## Print Makefile help.
-	@grep -Eh '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'
+	@grep -Eh '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-41s\033[0m %s\n", $$1, $$2}'
 
 # List of charts to build
 CHARTS := astronomer nginx grafana prometheus alertmanager elasticsearch kibana fluentd kube-state postgresql
@@ -69,6 +69,22 @@ update-requirements: ## Update all requirements.txt files
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
 	@helm template . \
+		--set global.baseDomain=foo.com \
+		--set global.blackboxExporterEnabled=True \
+		--set global.kedaEnabled=True \
+		--set global.postgresqlEnabled=True \
+		--set global.postgresqlEnabled=True \
+		--set global.prometheusPostgresExporterEnabled=True \
+		--set global.pspEnabled=True \
+		--set global.veleroEnabled=True \
+		2>/dev/null \
+		| awk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
+
+.PHONY: show-docker-images
+show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
+	@helm template . \
+		--set global.privateRegistry.enabled=True \
+		--set global.privateRegistry.repository=example.com/the-private-registry \
 		--set global.baseDomain=foo.com \
 		--set global.blackboxExporterEnabled=True \
 		--set global.kedaEnabled=True \

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -79,9 +79,7 @@ spec:
       {{- end }}
 
       #################
-      #               #
       #  TLS Volumes  #
-      #               #
       #################
       {{- with .Values.nats.tls }}
       {{ $secretName := .secret.name }}
@@ -126,15 +124,13 @@ spec:
       shareProcessNamespace: true
 
       #################
-      #               #
       #  NATS Server  #
-      #               #
       #################
       terminationGracePeriodSeconds: 60
       containers:
       - name: nats
         image: {{ include "nats.image" . }}
-        imagePullPolicy: {{ .Values.nats.pullPolicy }}
+        imagePullPolicy: {{ .Values.images.nats.pullPolicy }}
         ports:
         - containerPort: 4222
           name: client
@@ -186,9 +182,7 @@ spec:
           {{- end }}
 
           #######################
-          #                     #
           #  TLS Volumes Mounts #
-          #                     #
           #######################
           {{- with .Values.nats.tls }}
           {{ $secretName := .secret.name }}
@@ -251,9 +245,7 @@ spec:
               command: ["/bin/sh", "-c", "nats-server -sl=ldm=/var/run/nats/nats.pid && /bin/sleep 60"]
 
       #################################
-      #                               #
       #  NATS Configuration Reloader  #
-      #                               #
       #################################
       {{ if .Values.reloader.enabled }}
       - name: reloader
@@ -275,9 +267,7 @@ spec:
       {{ end }}
 
       ##############################
-      #                            #
       #  NATS Prometheus Exporter  #
-      #                            #
       ##############################
       {{ if .Values.exporter.enabled }}
       - name: metrics

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -272,7 +272,7 @@ spec:
       {{ if .Values.exporter.enabled }}
       - name: metrics
         image: {{ template "nats-exporter.image" . }}
-        imagePullPolicy: {{ .Values.exporter.pullPolicy }}
+        imagePullPolicy: {{ .Values.images.exporter.pullPolicy }}
         args:
         - -connz
         - -routez

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -38,6 +38,7 @@ spec:
           securityContext:
             runAsUser: 101
           image: {{ template "nginx.image" . }}
+          imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           args:

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -22,6 +22,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
@@ -54,24 +55,13 @@ Create chart name and version as used by the chart label.
 Return the proper PostgreSQL image name
 */}}
 {{- define "postgresql.image" -}}
-{{- $registryName := .Values.image.registry -}}
-{{- $repositoryName := .Values.image.repository -}}
-{{- $tag := .Values.image.tag | toString -}}
-{{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 doesn't support it, so we need to implement this if-else logic.
-Also, we can't use a single if because lazy evaluation is not an option
-*/}}
-{{- if .Values.global }}
-    {{- if .Values.global.imageRegistry }}
-        {{- printf "%s/%s:%s" .Values.global.imageRegistry $repositoryName $tag -}}
-    {{- else -}}
-        {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-    {{- end -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
 {{- else -}}
-    {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
-{{- end -}}
-{{- end -}}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end }}
+{{- end }}
+
 
 {{/*
 Return PostgreSQL password

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -56,12 +56,11 @@ Return the proper PostgreSQL image name
 */}}
 {{- define "postgresql.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-postgresql:{{ .Values.image.tag }}
 {{- else -}}
 {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
 {{- end }}
 {{- end }}
-
 
 {{/*
 Return PostgreSQL password

--- a/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-blackbox-exporter/templates/_helpers.tpl
@@ -29,3 +29,14 @@ Create chart name and version as used by the chart label.
 {{- define "prometheus-blackbox-exporter.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-blackbox-exporter.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-blackbox-exporter:{{ .Values.image.tag }}
+{{- else -}}
+{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+{{- end }}
+{{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
       {{- end }}
       containers:
         - name: blackbox-exporter
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: {{ template "prometheus-blackbox-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -76,13 +76,14 @@ spec:
             - "-timeout"
             - "1m"
           image: {{ include "stan.init.image" . }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.images.init.pullPolicy }}
           env:
             - name: NATS__URL
               value: "nats://{{ .Release.Name }}-nats:4222"
       containers:
         - name: stan
           image: {{ include "stan.image" . }}
+          imagePullPolicy: {{ .Values.images.stan.pullPolicy }}
           args:
           - -sc
           - /etc/stan-config/stan.conf
@@ -145,6 +146,7 @@ spec:
         {{ if .Values.exporter.enabled }}
         - name: metrics
           image: {{ template "stan-exporter.image" . }}
+          imagePullPolicy: {{ .Values.images.stan.pullPolicy }}
           resources:
 {{ toYaml .Values.exporter.resources | indent 12 }}
           args:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,7 +22,10 @@ def get_containers_by_name(doc, include_init_containers=False):
         "initContainers"
     ):
         c_by_name.update(
-            {c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")}
+            {
+                c["name"]: c
+                for c in doc["spec"]["template"]["spec"].get("initContainers")
+            }
         )
 
     return c_by_name

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -8,3 +8,21 @@ git_root_dir = Path(git_repo.git.rev_parse("--show-toplevel"))
 # This should match the major.minor version list in .circleci/generate_circleci_config.py
 # Patch version should always be 0
 supported_k8s_versions = ["1.19.0", "1.20.0", "1.21.0"]
+
+
+def get_containers_by_name(doc, include_init_containers=False):
+    """Given a single doc, return all the containers by name.
+
+    doc must be a valid spec for a pod manager. (EG: ds, sts)
+    """
+
+    c_by_name = {c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]}
+
+    if include_init_containers and doc["spec"]["template"]["spec"].get(
+        "initContainers"
+    ):
+        c_by_name.update(
+            {c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")}
+        )
+
+    return c_by_name

--- a/tests/test_authsidecar.py
+++ b/tests/test_authsidecar.py
@@ -135,13 +135,11 @@ class TestAuthSidecar:
         assert len(docs) == 1
         doc = docs[0]
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        print(prod["deployments"]["authSideCar"])
-
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-houston-config"
 
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
         expected_output = {
             "enabled": True,
             "repository": "nginxinc/nginx-unprivileged",

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -33,8 +33,11 @@ class TestAllCharts:
                     "imagePullPolicy"
                 ], f"container {name} does not have an imagePullPolicy: {doc}"
 
-    def test_all_charts_with_private_registry(self, template):
-        """Test that each chart uses the privateRegistry."""
+    def test_all_default_charts_with_private_registry(self, template):
+        """Test that each chart uses the privateRegistry.
+
+        This only finds default images, not the many which are hidden behind feature flags.
+        """
         private_repo = "example.com/the-private-registry-repository"
         docs = render_chart(
             show_only=[template["name"]],

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -17,3 +17,22 @@ def test_default_chart_with_basedomain(template):
         show_only=[template["name"]],
     )
     assert len(docs) == template["length"]
+
+    pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
+
+    pod_manger_docs = [doc for doc in docs if doc["kind"] in pod_managers]
+    for doc in pod_manger_docs:
+        c_by_name = {
+            c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
+        }
+        if doc["spec"]["template"]["spec"].get("initContainers"):
+            c_by_name.update(
+                {
+                    c["name"]: c
+                    for c in doc["spec"]["template"]["spec"].get("containers")
+                }
+            )
+        for name, container in c_by_name.items():
+            assert container[
+                "imagePullPolicy"
+            ], f"container {name} does not have an imagePullPolicy: {doc}"

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -31,7 +31,7 @@ class TestAllCharts:
                 ], f"container {name} does not have an image: {doc}"
                 assert container[
                     "imagePullPolicy"
-                ], f"container {name} does not have an imagePullPolicy: {doc}"
+                ], f"Template filename: {template['name']}\nContainer name '{name}' does not have an imagePullPolicy\ndoc: {doc}"
 
     def test_all_default_charts_with_private_registry(self, template):
         """Test that each chart uses the privateRegistry.

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -2,6 +2,7 @@ from tests.helm_template_generator import render_chart
 import pytest
 import yaml
 from . import git_root_dir
+from . import get_containers_by_name
 
 
 with open(f"{git_root_dir}/tests/default_chart_data.yaml") as file:
@@ -23,16 +24,7 @@ class TestAllCharts:
 
         pod_manger_docs = [doc for doc in docs if doc["kind"] in self.pod_managers]
         for doc in pod_manger_docs:
-            c_by_name = {
-                c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
-            }
-            if doc["spec"]["template"]["spec"].get("initContainers"):
-                c_by_name.update(
-                    {
-                        c["name"]: c
-                        for c in doc["spec"]["template"]["spec"].get("containers")
-                    }
-                )
+            c_by_name = get_containers_by_name(doc, include_init_containers=True)
             for name, container in c_by_name.items():
                 assert container[
                     "image"
@@ -58,16 +50,7 @@ class TestAllCharts:
 
         pod_manger_docs = [doc for doc in docs if doc["kind"] in self.pod_managers]
         for doc in pod_manger_docs:
-            c_by_name = {
-                c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
-            }
-            if doc["spec"]["template"]["spec"].get("initContainers"):
-                c_by_name.update(
-                    {
-                        c["name"]: c
-                        for c in doc["spec"]["template"]["spec"].get("containers")
-                    }
-                )
+            c_by_name = get_containers_by_name(doc)
 
             for name, container in c_by_name.items():
                 assert container["image"].startswith(

--- a/tests/test_default_chart.py
+++ b/tests/test_default_chart.py
@@ -11,28 +11,65 @@ template_ids = [template["name"] for template in default_chart_data]
 
 
 @pytest.mark.parametrize("template", default_chart_data, ids=template_ids)
-def test_default_chart_with_basedomain(template):
-    """Test that each template used with just baseDomain set renders."""
-    docs = render_chart(
-        show_only=[template["name"]],
-    )
-    assert len(docs) == template["length"]
-
+class TestAllCharts:
     pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 
-    pod_manger_docs = [doc for doc in docs if doc["kind"] in pod_managers]
-    for doc in pod_manger_docs:
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
-        }
-        if doc["spec"]["template"]["spec"].get("initContainers"):
-            c_by_name.update(
-                {
-                    c["name"]: c
-                    for c in doc["spec"]["template"]["spec"].get("containers")
+    def test_default_chart_with_basedomain(self, template):
+        """Test that each template used with just baseDomain set renders."""
+        docs = render_chart(
+            show_only=[template["name"]],
+        )
+        assert len(docs) == template["length"]
+
+        pod_manger_docs = [doc for doc in docs if doc["kind"] in self.pod_managers]
+        for doc in pod_manger_docs:
+            c_by_name = {
+                c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
+            }
+            if doc["spec"]["template"]["spec"].get("initContainers"):
+                c_by_name.update(
+                    {
+                        c["name"]: c
+                        for c in doc["spec"]["template"]["spec"].get("containers")
+                    }
+                )
+            for name, container in c_by_name.items():
+                assert container[
+                    "image"
+                ], f"container {name} does not have an image: {doc}"
+                assert container[
+                    "imagePullPolicy"
+                ], f"container {name} does not have an imagePullPolicy: {doc}"
+
+    def test_all_charts_with_private_registry(self, template):
+        """Test that each chart uses the privateRegistry."""
+        private_repo = "example.com/the-private-registry-repository"
+        docs = render_chart(
+            show_only=[template["name"]],
+            values={
+                "global": {
+                    "privateRegistry": {
+                        "enabled": True,
+                        "repository": private_repo,
+                    }
                 }
-            )
-        for name, container in c_by_name.items():
-            assert container[
-                "imagePullPolicy"
-            ], f"container {name} does not have an imagePullPolicy: {doc}"
+            },
+        )
+
+        pod_manger_docs = [doc for doc in docs if doc["kind"] in self.pod_managers]
+        for doc in pod_manger_docs:
+            c_by_name = {
+                c["name"]: c for c in doc["spec"]["template"]["spec"].get("containers")
+            }
+            if doc["spec"]["template"]["spec"].get("initContainers"):
+                c_by_name.update(
+                    {
+                        c["name"]: c
+                        for c in doc["spec"]["template"]["spec"].get("containers")
+                    }
+                )
+
+            for name, container in c_by_name.items():
+                assert container["image"].startswith(
+                    private_repo
+                ), f"The container '{name}' does not use the privateRegistry repo '{private_repo}': {container}"

--- a/tests/test_kube_state_deployment.py
+++ b/tests/test_kube_state_deployment.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,7 @@ class TestKubeStateDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "RELEASE-NAME-kube-state"
 
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert c_by_name["kube-state"]
         assert c_by_name["kube-state"]["resources"] == {
             "limits": {"cpu": "500m", "memory": "1024Mi"},
@@ -50,9 +48,7 @@ class TestKubeStateDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "RELEASE-NAME-kube-state"
 
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert c_by_name["kube-state"]
         assert c_by_name["kube-state"]["resources"] == {
             "limits": {"cpu": "777m", "memory": "999Mi"},

--- a/tests/test_kubed_clusterrolebinding.py
+++ b/tests/test_kubed_clusterrolebinding.py
@@ -49,6 +49,8 @@ class TestKubedClusterrolebinding:
         assert len(doc["roleRef"]) > 0
         assert len(doc["subjects"]) > 0
 
+    def test_kubed_clusterrolebinding_rbac_disabled(self, kube_version):
+        """Test that helm renders no ClusterRoleBinding template for kubed when rbacEnabled=False."""
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"rbacEnabled": False}},

--- a/tests/test_nats_sts.py
+++ b/tests/test_nats_sts.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -17,9 +17,7 @@ class TestNatsStatefulSet:
 
         assert len(docs) == 1
         doc = docs[0]
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-nats"
@@ -61,9 +59,8 @@ class TestNatsStatefulSet:
         )
 
         assert len(docs) == 1
-        containers = docs[0]["spec"]["template"]["spec"]["containers"]
-        assert len(containers) == 2
-        c_by_name = {c["name"]: c for c in containers}
+        c_by_name = get_containers_by_name(docs[0])
+        assert len(c_by_name) == 2
         assert c_by_name["nats"]["resources"]["requests"]["cpu"] == "123m"
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 

--- a/tests/test_postgres.py
+++ b/tests/test_postgres.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -43,3 +43,29 @@ class TestPostgresql:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-postgresql"
         assert "initContainers" in doc["spec"]["template"]["spec"]
+
+    def test_postgresql_statefulset_with_private_registry_enabled(self, kube_version):
+        """Test postgresql with privateRegistry=True."""
+        repostiory = "private-repository.example.com"
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "privateRegistry": {
+                        "enabled": True,
+                        "repository": repostiory,
+                    },
+                    "postgresqlEnabled": True,
+                },
+            },
+            show_only=[
+                "charts/postgresql/templates/statefulset.yaml",
+            ],
+        )
+
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc=doc, include_init_containers=True)
+            for name, container in c_by_name.items():
+                assert container["image"].startswith(
+                    repostiory
+                ), f"Container named '{name}' does not use registry '{repostiory}': {container}"

--- a/tests/test_prometheus_node_exporter.py
+++ b/tests/test_prometheus_node_exporter.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -21,9 +21,7 @@ class TestPrometheusNodeExporterDaemonset:
         assert doc["kind"] == "DaemonSet"
         assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus-node-exporter"
 
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert c_by_name["node-exporter"]
         assert c_by_name["node-exporter"]["resources"] == {
             "limits": {"cpu": "100m", "memory": "128Mi"},
@@ -50,9 +48,7 @@ class TestPrometheusNodeExporterDaemonset:
         assert doc["kind"] == "DaemonSet"
         assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus-node-exporter"
 
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert c_by_name["node-exporter"]
         assert c_by_name["node-exporter"]["resources"] == {
             "limits": {"cpu": "777m", "memory": "999Mi"},

--- a/tests/test_prometheus_statefulset.py
+++ b/tests/test_prometheus_statefulset.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -29,9 +29,7 @@ class TestPrometheusStatefulset:
         assert sc["runAsUser"] == 65534
         assert sc["runAsNonRoot"] is True
 
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert c_by_name["configmap-reloader"]["image"].startswith(
             "quay.io/astronomer/ap-configmap-reloader:"
         )

--- a/tests/test_stan_sts.py
+++ b/tests/test_stan_sts.py
@@ -1,6 +1,6 @@
 from tests.helm_template_generator import render_chart
 import pytest
-from . import supported_k8s_versions
+from . import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -17,9 +17,7 @@ class TestStanStatefulSet:
 
         assert len(docs) == 1
         doc = docs[0]
-        c_by_name = {
-            c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]
-        }
+        c_by_name = get_containers_by_name(doc)
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "RELEASE-NAME-stan"
@@ -61,9 +59,8 @@ class TestStanStatefulSet:
         )
 
         assert len(docs) == 1
-        containers = docs[0]["spec"]["template"]["spec"]["containers"]
-        assert len(containers) == 2
-        c_by_name = {c["name"]: c for c in containers}
+        c_by_name = get_containers_by_name(docs[0])
+        assert len(c_by_name) == 2
         assert c_by_name["stan"]["resources"]["requests"]["cpu"] == "123m"
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 
@@ -202,11 +199,7 @@ class TestStanStatefulSet:
 
         assert len(docs) == 1
         doc = docs[0]
-        c_by_name = {
-            c["name"]: c
-            for c in doc["spec"]["template"]["spec"]["containers"]
-            + doc["spec"]["template"]["spec"]["initContainers"]
-        }
+        c_by_name = get_containers_by_name(doc, include_init_containers=True)
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
@@ -224,7 +217,7 @@ class TestStanStatefulSet:
 
     def test_stan_statefulset_with_private_registry(self, kube_version):
         """Test that stan statefulset properly uses the private registry images."""
-        private_repo = "example.com/the-private-registry-repository"
+        private_registry = "private-registry.example.com"
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/stan/templates/statefulset.yaml"],
@@ -232,7 +225,7 @@ class TestStanStatefulSet:
                 "global": {
                     "privateRegistry": {
                         "enabled": True,
-                        "repository": private_repo,
+                        "repository": private_registry,
                     }
                 }
             },
@@ -241,16 +234,12 @@ class TestStanStatefulSet:
         assert len(docs) == 1
         doc = docs[0]
 
-        c_by_name = {
-            c["name"]: c
-            for c in doc["spec"]["template"]["spec"]["containers"]
-            + doc["spec"]["template"]["spec"]["initContainers"]
-        }
+        c_by_name = get_containers_by_name(doc, include_init_containers=True)
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
 
         for name, container in c_by_name.items():
             assert container["image"].startswith(
-                private_repo
-            ), f"The container '{name}' does not use the privateRegistry repo '{private_repo}': {container}"
+                private_registry
+            ), f"Container named '{name}' does not use registry '{private_registry}': {container}"


### PR DESCRIPTION
## Description

Lots of our images were not using the privateRegistry when it was enabled. Most of these do not appear to be supported production things, but some of them are.

The only images I have found that do not support privateRegistry are:

- quay.io/astronomer/ap-keda:1.3.0
- quay.io/astronomer/ap-keda-metrics-adapter:1.3.0
- quay.io/astronomer/ap-postgres-exporter:0.10.1

## Itemized changes

- Add make target: `show-docker-images-with-private-registry`.
- Fix or add missing imagePullPolicy on several images.
- Templatize some postgres stuff to be modern and support privateRegstry.
- Add test function `get_containers_by_name` and use it wherever `c_by_name` was done long-form.
- Slight refactor in test_authsidecar: remove print, move definition closer to use.
- Add `test_all_charts_with_private_registry` that tests images not hidden behind a feature flag.
- Break `test_kubed_clusterrolebinding_rbac_disabled` into its own test.
- Add `test_postgresql_statefulset_with_private_registry_enabled` since it is hidden behind a feature flag.
- Add some stan tests.

## Related Issues

https://github.com/astronomer/issues/issues/4229

## Testing

Nothin' but tests™ (not actually true, but basically.)

Also:
```
$ make show-docker-images-with-private-registry
2022-02-10T19:11:55-0800
https://example.com/the-private-registry/ap-alertmanager            example.com/the-private-registry/ap-alertmanager:0.23.0
https://example.com/the-private-registry/ap-astro-ui                example.com/the-private-registry/ap-astro-ui:0.28.5
https://example.com/the-private-registry/ap-base                    example.com/the-private-registry/ap-base:3.15.0
https://example.com/the-private-registry/ap-base                    example.com/the-private-registry/ap-base:3.15.0-2
https://example.com/the-private-registry/ap-blackbox-exporter       example.com/the-private-registry/ap-blackbox-exporter:0.19.0-5
https://example.com/the-private-registry/ap-cli-install             example.com/the-private-registry/ap-cli-install:0.26.1
https://example.com/the-private-registry/ap-commander               example.com/the-private-registry/ap-commander:0.27.4
https://example.com/the-private-registry/ap-configmap-reloader      example.com/the-private-registry/ap-configmap-reloader:0.5.0-1
https://example.com/the-private-registry/ap-curator                 example.com/the-private-registry/ap-curator:5.8.4-9
https://example.com/the-private-registry/ap-db-bootstrapper         example.com/the-private-registry/ap-db-bootstrapper:0.26.1
https://example.com/the-private-registry/ap-db-bootstrapper         example.com/the-private-registry/ap-db-bootstrapper:0.26.3
https://example.com/the-private-registry/ap-default-backend         example.com/the-private-registry/ap-default-backend:0.28.0
https://example.com/the-private-registry/ap-elasticsearch           example.com/the-private-registry/ap-elasticsearch:7.16.2
https://example.com/the-private-registry/ap-elasticsearch-exporter  example.com/the-private-registry/ap-elasticsearch-exporter:1.3.0
https://example.com/the-private-registry/ap-fluentd                 example.com/the-private-registry/ap-fluentd:1.14.3-1
https://example.com/the-private-registry/ap-grafana                 example.com/the-private-registry/ap-grafana:8.3.3-1
https://example.com/the-private-registry/ap-houston-api             example.com/the-private-registry/ap-houston-api:0.28.3
https://example.com/the-private-registry/ap-kibana                  example.com/the-private-registry/ap-kibana:7.16.2
https://example.com/the-private-registry/ap-kube-state              example.com/the-private-registry/ap-kube-state:1.7.2
https://example.com/the-private-registry/ap-kubed                   example.com/the-private-registry/ap-kubed:0.13.0
https://example.com/the-private-registry/ap-nats-exporter           example.com/the-private-registry/ap-nats-exporter:0.9.1
https://example.com/the-private-registry/ap-nats-server             example.com/the-private-registry/ap-nats-server:2.7.2
https://example.com/the-private-registry/ap-nats-streaming          example.com/the-private-registry/ap-nats-streaming:0.24.1
https://example.com/the-private-registry/ap-nginx                   example.com/the-private-registry/ap-nginx:0.50.0
https://example.com/the-private-registry/ap-nginx-es                example.com/the-private-registry/ap-nginx-es:1.21.4
https://example.com/the-private-registry/ap-node-exporter           example.com/the-private-registry/ap-node-exporter:1.3.1
https://example.com/the-private-registry/ap-postgresql              example.com/the-private-registry/ap-postgresql:11.13.0
https://example.com/the-private-registry/ap-prometheus              example.com/the-private-registry/ap-prometheus:2.32.1
https://example.com/the-private-registry/ap-registry                example.com/the-private-registry/ap-registry:3.15.0
https://quay.io/astronomer/ap-keda                                  quay.io/astronomer/ap-keda:1.3.0
https://quay.io/astronomer/ap-keda-metrics-adapter                  quay.io/astronomer/ap-keda-metrics-adapter:1.3.0
https://quay.io/astronomer/ap-postgres-exporter                     quay.io/astronomer/ap-postgres-exporter:0.10.1
```