### PR TITLE
bump houston-api yarn migrate hotfix

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.27.4
+    tag: 0.28.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.3
+    tag: 0.28.5
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
- [x] Platform fails with houston db migrations error in an airgap cluster #4232 https://github.com/astronomer/issues/issues/4232 
- [x] bump commander to include latest airflow-chart 1.3.0 (pre-cached)