### PR TITLE
bump platform image for docker image security fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,11 +15,11 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.26.5
+    tag: 0.26.6
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.14.2-2
+    tag: 3.15.0
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION
## Description

Update astronomer's helm chart to use latest commander docker image.

We found a few security vulnerabilities in the previous base docker image (which we extend in commander). In order to fix these vulnerabilities, I updated the base image to a newer version.

## Related Issues

- https://github.com/astronomer/issues/issues/4215
- https://github.com/astronomer/commander/pull/80 the PR containing the fix.
