### PR TITLE
update airflow chart version to 0.20.2

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 0.20.1
+airflowChartVersion: 0.20.2
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION


## Description

update airflow chart version to 0.20.2

release link: https://github.com/astronomer/airflow-chart/releases/tag/v0.20.2

## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/4123


## Testing

QA team should be able to deploy airflow without any issues
