### PR TITLE
make sysctl config configurable for elasticsearch

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -67,12 +67,14 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       initContainers:
+      {{- if (.Values.sysctlInitContainer.enabled) }}
       - name: sysctl
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+      {{- end }}
       serviceAccountName: {{ template "elasticsearch.fullname" . }}
       containers:
       - name: es-client

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -69,12 +69,14 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       initContainers:
+      {{- if (.Values.sysctlInitContainer.enabled) }}
       - name: sysctl
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+      {{- end }}
       - name: chown
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.images.es.pullPolicy }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -68,12 +68,14 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       initContainers:
+      {{- if (.Values.sysctlInitContainer.enabled) }}
       - name: sysctl
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
-        command: ["sysctl", "-w", "vm.max_map_count=262144"]
+        command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+      {{- end }}
       - name: chown
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.images.es.pullPolicy }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -209,6 +209,7 @@ nginx:
   resources: {}
 
 # sysctl init container
+# Warning: sysctl changes affect the kernel, and thus, all containers running on the same node.
 sysctlInitContainer:
   enabled: true
   sysctlVmMaxMapCount: 262144

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -207,3 +207,8 @@ nginx:
   fullnameOverride: ~
   ingressClass: ~
   resources: {}
+
+# sysctl init container
+sysctlInitContainer:
+  enabled: true
+  sysctlVmMaxMapCount: 262144

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -24,15 +24,15 @@ class TestElasticSearch:
             ],
         )
 
+        default_max_map_count = "262144"
         assert len(docs) == 3
         doc = docs[0]
-        print(doc)
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" == jmespath.search(
             "spec.template.spec.initContainers[0].name", docs[0]
         )
         assert any(
-            "262144" in arg
+            default_max_map_count in arg
             for args in jmespath.search(
                 "spec.template.spec.initContainers[*].command", doc
             )
@@ -45,7 +45,7 @@ class TestElasticSearch:
             "spec.template.spec.initContainers[0].name", docs[1]
         )
         assert any(
-            "262144" in arg
+            default_max_map_count in arg
             for args in jmespath.search(
                 "spec.template.spec.initContainers[*].command", doc
             )
@@ -58,7 +58,7 @@ class TestElasticSearch:
             "spec.template.spec.initContainers[0].name", docs[2]
         )
         assert any(
-            "262144" in arg
+            default_max_map_count in arg
             for args in jmespath.search(
                 "spec.template.spec.initContainers[*].command", doc
             )
@@ -79,7 +79,6 @@ class TestElasticSearch:
 
         assert len(docs) == 3
         doc = docs[0]
-        print(doc)
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" not in jmespath.search(
             "spec.template.spec.initContainers[*].name", docs[0]

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,0 +1,96 @@
+from tests.helm_template_generator import render_chart
+import pytest
+from . import supported_k8s_versions
+import jmespath
+import base64
+
+secret = base64.b64encode(b"sample-secret").decode()
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestElasticSearch:
+    def test_elasticsearch_with_sysctl_defaults(self, kube_version):
+        """Test  ElasticSearch with sysctl config/values.yaml."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+                "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+                "charts/elasticsearch/templates/client/es-client-deployment.yaml",
+            ],
+        )
+
+        assert len(docs) == 3
+        doc = docs[0]
+        print(doc)
+        assert doc["kind"] == "StatefulSet"
+        assert "sysctl" == jmespath.search(
+            "spec.template.spec.initContainers[0].name", docs[0]
+        )
+        assert any(
+            "262144" in arg
+            for args in jmespath.search(
+                "spec.template.spec.initContainers[*].command", doc
+            )
+            for arg in args
+        )
+
+        doc = docs[1]
+        assert doc["kind"] == "StatefulSet"
+        assert "sysctl" == jmespath.search(
+            "spec.template.spec.initContainers[0].name", docs[1]
+        )
+        assert any(
+            "262144" in arg
+            for args in jmespath.search(
+                "spec.template.spec.initContainers[*].command", doc
+            )
+            for arg in args
+        )
+
+        doc = docs[2]
+        assert doc["kind"] == "Deployment"
+        assert "sysctl" == jmespath.search(
+            "spec.template.spec.initContainers[0].name", docs[2]
+        )
+        assert any(
+            "262144" in arg
+            for args in jmespath.search(
+                "spec.template.spec.initContainers[*].command", doc
+            )
+            for arg in args
+        )
+
+    def test_elasticsearch_with_sysctl_disabled(self, kube_version):
+        """Test  ElasticSearch with sysctl config/values.yaml."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"elasticsearch": {"sysctlInitContainer": {"enabled": False}}},
+            show_only=[
+                "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+                "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+                "charts/elasticsearch/templates/client/es-client-deployment.yaml",
+            ],
+        )
+
+        assert len(docs) == 3
+        doc = docs[0]
+        print(doc)
+        assert doc["kind"] == "StatefulSet"
+        assert "sysctl" not in jmespath.search(
+            "spec.template.spec.initContainers[*].name", docs[0]
+        )
+
+        doc = docs[1]
+        assert doc["kind"] == "StatefulSet"
+        assert "sysctl" not in jmespath.search(
+            "spec.template.spec.initContainers[*].name", docs[1]
+        )
+
+        doc = docs[2]
+        assert doc["kind"] == "Deployment"
+        assert jmespath.search("spec.template.spec.initContainers", docs[2]) is None

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -23,6 +23,8 @@ class TestElasticSearch:
 
         default_max_map_count = "262144"
         assert len(docs) == 3
+
+        # elasticsearch master
         doc = docs[0]
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" == jmespath.search(
@@ -36,6 +38,7 @@ class TestElasticSearch:
             for arg in args
         )
 
+        # elasticsearch data
         doc = docs[1]
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" == jmespath.search(
@@ -49,6 +52,7 @@ class TestElasticSearch:
             for arg in args
         )
 
+        # elasticsearch client
         doc = docs[2]
         assert doc["kind"] == "Deployment"
         assert "sysctl" == jmespath.search(
@@ -76,17 +80,21 @@ class TestElasticSearch:
 
         assert len(docs) == 3
         doc = docs[0]
+
+        # elasticsearch master
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" not in jmespath.search(
             "spec.template.spec.initContainers[*].name", docs[0]
         )
 
+        # elasticsearch data
         doc = docs[1]
         assert doc["kind"] == "StatefulSet"
         assert "sysctl" not in jmespath.search(
             "spec.template.spec.initContainers[*].name", docs[1]
         )
 
+        # elasticsearch client
         doc = docs[2]
         assert doc["kind"] == "Deployment"
         assert jmespath.search("spec.template.spec.initContainers", docs[2]) is None

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -2,9 +2,6 @@ from tests.helm_template_generator import render_chart
 import pytest
 from . import supported_k8s_versions
 import jmespath
-import base64
-
-secret = base64.b64encode(b"sample-secret").decode()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

* this change enables customer to enable|disable sysctl config option (defaults to true)
* applicable for master,data and client services


## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/4226

## Testing

QA team can set elasticsearch.sysctlInitContainer.enabled=false to see if sysctl containers are not applied anymore.
