### PR TITLE
updated images includes libexpat fixes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.26.7-rc2
-appVersion: 0.26.7-rc2
+version: 0.26.7-rc3
+appVersion: 0.26.7-rc3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.26.7-rc2
+version: 0.26.7-rc3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.26.6
+    tag: 0.26.7
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-2
+    tag: 3.15.0-3
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-9
+    tag: 5.8.4-10
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-2
+    tag: 3.15.0-3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION

## Description

* ap-commander 0.26.6 -> 0.26.7
* ap-db-bootstrapper 0.26.3 -> 0.26.4
* ap-base 3.15.0-2 -> 3.15.0-3
* ap-curator 5.8.4-9 -> 5.8.4-10


## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/4318

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
