### PR TITLE
updated images includes libexpat fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.28.0
+    tag: 0.28.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-2
+    tag: 3.15.0-3
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-9
+    tag: 5.8.4-10
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-2
+    tag: 3.15.0-3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
## Description
**updated images includes libexpat fixes**
* ap-db-bootstrapper 0.26.3 -> 0.26.4
* ap-base 3.15.0-2 -> 3.15.0-3
* ap-curator 5.8.4-9 -> 5.8.4-10
* ap-commander 0.28.0 -> 0.28.1
## Related Issues

GH Issue Link: https://github.com/astronomer/issues/issues/4318

## Testing

Qa team should able to deploy astronomer platform without issues and trivy image should not display critical vulnerabilites

trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-db-bootstrapper:0.26.4
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-curator:5.8.4-10
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-base:3.15.0-3
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-commander:0.28.1

