### PR TITLE
0.27 branding refactor bump astro-ui 0.27.16 to and houston 0.27.18 and bump platform version 0.27.4-rc3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.27.4-rc2
-appVersion: 0.27.4-rc2
+version: 0.27.4-rc3
+appVersion: 0.27.4-rc3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.27.4-rc2
+version: 0.27.4-rc3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.27.15
+    tag: 0.27.16
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.27.17
+    tag: 0.27.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Rebrand the logo in astro ui and allow ability to change app name in config 

## Related Issues

astronomer/issues#4265

## Testing

Tested in dev and have pr ready for prod changes in google env https://github.com/astronomer/google-environments/pull/674
