### PR TITLE
Add Prometheus config file global.external_labels, remote_write

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2022-01
+      - image: quay.io/astronomer/ci-pre-commit:2022-03
     steps:
       - checkout
       - run:
@@ -45,7 +45,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-01
+      - image: quay.io/astronomer/ci-helm-release:2022-03
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,7 +8,7 @@ executors:
 jobs:
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2022-01
+      - image: quay.io/astronomer/ci-pre-commit:2022-03
     steps:
       - checkout
       - run:
@@ -43,7 +43,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2022-01
+      - image: quay.io/astronomer/ci-helm-release:2022-03
     steps:
       - checkout
       - run:

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -13,9 +13,14 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config: |-
+    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/
     global:
       scrape_interval: 30s
       evaluation_interval: 30s
+      {{ if .Values.external_labels }}external_labels: {{ .Values.external_labels | toYaml | nindent 8 }}{{ end }}
+
+    # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+    {{ if .Values.remote_write }}remote_write: {{ .Values.remote_write | toYaml | nindent 6 }}{{ end }}
 
     # Configure Alertmanager
     alerting:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,6 @@ images:
     tag: 0.5.0-1
     pullPolicy: IfNotPresent
 
-
 resources: {}
 #  limits:
 #   cpu: 100m
@@ -112,3 +111,11 @@ additionalAlerts:
 #     annotations:
 #       summary: "The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf \"%.2f\" $value }}% of the time over the past 30 minutes"
 #       description: Task instances failing above threshold
+
+# Prometheus config file remote_write stanza
+# https://prometheus.io/docs/prometheus/latest/configuration/configuration/
+# remote_write: {}
+
+# Prometheus config file global.external_labels stanza
+# https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
+# external_labels: {}


### PR DESCRIPTION
## Description

Add the ability to specify helm values to be passed into the prometheus config file's remote_write and global.external_labels sections.

## Itemized changes

- Add .Values.external_labels and .Values.remote_write sections to prometheus config file template
- Add tests for Values.external_labels, and .Values.remote_write
- Add commented out sections in charts/prometheus/values.yaml which indicate these available options, and links to prometheus documentation on how to use them
- Refactor adjacent config test test_prometheus_config_configmap_with_different_name_and_ns to not use regex, and instead do string comparisons against loaded prometheus config. This was mainly done for consistency.

## Related Issues

- https://github.com/astronomer/issues/issues/4186

## Testing

I have written unit tests that capture my understanding of the original request made by @fhoda.

Prometheus is tested in CI too, so if prometheus works there we know that the defaults didn't break anything, but I have not implemented a functional test for this feature. Doing so is not a trivial process with our current test process.