### PR TITLE
Add fluentd config buffer flush_at_shutdown true

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -202,6 +202,7 @@ data:
           @type file
           path "/var/log/fluentd-buffers/#{ENV['RELEASE']}-kubernetes.system.buffer"
           flush_mode interval
+          flush_at_shutdown true
           retry_type exponential_backoff
           flush_thread_count 2
           flush_interval 5s


### PR DESCRIPTION
## Description

Force fluentd to flush buffers at shutdown. This [defaults to false on file backed buffers](https://docs.fluentd.org/configuration/buffer-section#flushing-parameters) which is likely the wrong configuration for our environment.

## Related Issues

https://github.com/astronomer/astronomer/issues/1349

## Testing

This one would be a bit difficult to test to confirm that the function is working, though that is a bit beyond the scope of what we should be testing. Making sure fluentd continues to function should be enough, so as long as logs are coming in we should be good.