### PR TITLE
lowercase some test data for helm 3.8 compatibility.

### DIFF
--- a/tests/test_prometheus_alerts_configmap.py
+++ b/tests/test_prometheus_alerts_configmap.py
@@ -65,17 +65,17 @@ class TestPrometheusAlertConfigmap:
     def test_prometheus_alerts_configmap_with_different_name_and_ns(self, kube_version):
         """Validate the prometheus alerts configmap does not conflate helm deployment name and namespace."""
         docs = render_chart(
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             kube_version=kube_version,
             show_only=self.show_only,
         )
 
         config_yaml = docs[0]["data"]["alerts"]
-        assert re.search(r'job="FOO-NAME', config_yaml)
-        assert not re.search(r'job="BAR-NS', config_yaml)
-        assert re.search(r'namespace="BAR-NS"', config_yaml)
-        assert not re.search(r'namespace="FOO-NAME"', config_yaml)
+        assert re.search(r'job="foo-name', config_yaml)
+        assert not re.search(r'job="bar-ns', config_yaml)
+        assert re.search(r'namespace="bar-ns"', config_yaml)
+        assert not re.search(r'namespace="foo-name"', config_yaml)
 
     def test_prometheus_alerts_configmap_with_addition_alerts(self, kube_version):
         """Validate the prometheus alerts configmap renders additional alerts."""
@@ -88,14 +88,14 @@ class TestPrometheusAlertConfigmap:
         docs = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             values={"prometheus": {"additionalAlerts": additional_alerts}},
         )
 
         config_yaml = docs[0]["data"]["alerts"]
         assert re.search(
-            r'.*The Astronomer Helm release FOO-NAME is failing task instances "{{ printf \\"%.2f\\" \$value }}\%" of the time over the past 30 minutes.*',
+            r'.*The Astronomer Helm release foo-name is failing task instances "{{ printf \\"%.2f\\" \$value }}\%" of the time over the past 30 minutes.*',
             config_yaml,
         )
         assert re.search(

--- a/tests/test_prometheus_config_configmap.py
+++ b/tests/test_prometheus_config_configmap.py
@@ -29,8 +29,8 @@ class TestPrometheusConfigConfigmap:
     def test_prometheus_config_configmap_with_different_name_and_ns(self, kube_version):
         """Validate the prometheus config configmap does not conflate deployment name and namespace."""
         doc = render_chart(
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             kube_version=kube_version,
             show_only=self.show_only,
             values={
@@ -53,13 +53,13 @@ class TestPrometheusConfigConfigmap:
         ][0]
 
         target_checks = [
-            "http://FOO-NAME-cli-install.BAR-NS",
-            "http://FOO-NAME-commander.BAR-NS:8880/healthz",
-            "http://FOO-NAME-elasticsearch.BAR-NS:9200/_cluster/health?local=true",
-            "http://FOO-NAME-grafana.BAR-NS:3000/api/health",
-            "http://FOO-NAME-houston.BAR-NS:8871/v1/healthz",
-            "http://FOO-NAME-kibana.BAR-NS:5601",
-            "http://FOO-NAME-registry.BAR-NS:5000",
+            "http://foo-name-cli-install.bar-ns",
+            "http://foo-name-commander.bar-ns:8880/healthz",
+            "http://foo-name-elasticsearch.bar-ns:9200/_cluster/health?local=true",
+            "http://foo-name-grafana.bar-ns:3000/api/health",
+            "http://foo-name-houston.bar-ns:8871/v1/healthz",
+            "http://foo-name-kibana.bar-ns:5601",
+            "http://foo-name-registry.bar-ns:5000",
             "https://app.example.com",
             "https://houston.example.com/v1/healthz",
             "https://install.example.com",


### PR DESCRIPTION
## Description

Lowercase some test data that is breaking on helm 3.8. This is part 2 of <https://github.com/astronomer/astronomer/pull/1362>

## Related Issues

https://github.com/astronomer/issues/issues/4124

## Testing

Chart unit tests are passing with helm 3.8 on my machine now when previously they were not.