### PR TITLE
update ingress controller

### DIFF
--- a/charts/nginx/templates/nginx-role.yaml
+++ b/charts/nginx/templates/nginx-role.yaml
@@ -16,7 +16,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmaps
       - endpoints
       - pods
       - secrets
@@ -26,6 +25,14 @@ rules:
     verbs:
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - list
+      - watch
+      - update
   {{- if not $singleNamespace }}
   - apiGroups:
       - ""
@@ -55,6 +62,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 0.50.0
+    tag: 1.1.2
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

*  We are in progress in supporting k8s >= 1.22, this PR upgrades the current ingress controller to latest version      (0.50.0 -> 1.1.2) includes enhancements and security fixes. 

* current role is not sufficient to run ingress controller , we have updated necessary privileges to run the service.

## Related Issues

https://github.com/astronomer/issues/issues/3889

## Testing

QA should able to deploy and run astronomer platform without any issues due to ingress controller.

