### PR TITLE
removeAccidentallyAddedFeatureFlagDefaults

### DIFF
--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -69,10 +69,6 @@ astronomer:
         cpu: "0m"
         memory: "0Mi"
     config:
-      registry:
-        protectedCustomRegistryEnabled: true
-      deployments:
-        enableUpdateDeploymentImageEndpoint: true
       emailConfirmation: false
       auth:
         local:


### PR DESCRIPTION
Issue: https://app.zenhub.com/workspaces/team-platform-apps-61d5f7ef8de56e0014840a75/issues/astronomer/issues/4395

Description: these were added by accident and should not be set. having them set won't cause any issues atm its just not our desired default state.