### PR TITLE
Fix helm 3.8 compatibility in release 0.26 tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-*            @danielhoherd @andriisoldatenko
-values.yaml  @danielhoherd @andriisoldatenko @astronomer/docs
-*.md         @danielhoherd @andriisoldatenko @astronomer/docs
+*            @astronomer/maintainers-astronomer
+values.yaml  @astronomer/maintainers-astronomer @astronomer/docs
+*.md         @astronomer/maintainers-astronomer @astronomer/docs

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,15 +27,15 @@ The above command will render the full chart for kubernetes version 1.18.0, but 
 kind: Ingress
 apiVersion: networking.k8s.io/v1beta1
 metadata:
-  name: RELEASE-NAME-public-ingress
+  name: release-name-public-ingress
   labels:
     component: public-ingress
     tier: astronomer
-    release: RELEASE-NAME
+    release: release-name
     chart: "astronomer-0.25.2"
     heritage: Helm
   annotations:
-    kubernetes.io/ingress.class: "RELEASE-NAME-nginx"
+    kubernetes.io/ingress.class: "release-name-nginx"
     kubernetes.io/tls-acme: "false"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -57,7 +57,7 @@ spec:
       paths:
         - path: /
           backend:
-            serviceName: RELEASE-NAME-astro-ui
+            serviceName: release-name-astro-ui
             servicePort: astro-ui-http
 ```
 
@@ -290,7 +290,7 @@ This is a normal python repl that we can type python code into:
 >>> pp = pprint.PrettyPrinter(indent=4).pprint
 >>> pp(docs[0]["spec"]["rules"][0])
 {   'host': 'example.com',
-    'http': {   'paths': [   {   'backend': {   'serviceName': 'RELEASE-NAME-astro-ui',
+    'http': {   'paths': [   {   'backend': {   'serviceName': 'release-name-astro-ui',
                                                 'servicePort': 'astro-ui-http'},
                                  'path': '/'}]}}
 >>> import yaml
@@ -299,7 +299,7 @@ host: example.com
 http:
   paths:
   - backend:
-      serviceName: RELEASE-NAME-astro-ui
+      serviceName: release-name-astro-ui
       servicePort: astro-ui-http
     path: /
 ```

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -66,7 +66,7 @@ def validate_k8s_object(instance, kube_version="1.21.0"):
 
 
 def render_chart(
-    name: str = "RELEASE-NAME",
+    name: str = "release-name",
     values: Optional[dict] = None,
     show_only: Optional[list] = None,
     chart_dir: Optional[str] = None,

--- a/tests/test_alertmanager.py
+++ b/tests/test_alertmanager.py
@@ -12,7 +12,7 @@ def test_alertmanager_defaults():
 
     assert doc["kind"] == "StatefulSet"
     assert doc["apiVersion"] == "apps/v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-alertmanager"
+    assert doc["metadata"]["name"] == "release-name-alertmanager"
     assert doc["spec"]["template"]["spec"]["securityContext"]["fsGroup"] == 65534
 
     # rfc1918 configs should be absent from default settings
@@ -45,7 +45,7 @@ def test_alertmanager_rfc1918():
 
     assert doc["kind"] == "StatefulSet"
     assert doc["apiVersion"] == "apps/v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-alertmanager"
+    assert doc["metadata"]["name"] == "release-name-alertmanager"
     assert doc["spec"]["template"]["spec"]["securityContext"]["fsGroup"] == 65534
 
     assert any(

--- a/tests/test_astro_ui_deployment.py
+++ b/tests/test_astro_ui_deployment.py
@@ -26,7 +26,7 @@ class TestIngress:
         )
 
         assert "Deployment" == jmespath.search("kind", docs[0])
-        assert "RELEASE-NAME-astro-ui" == jmespath.search("metadata.name", docs[0])
+        assert "release-name-astro-ui" == jmespath.search("metadata.name", docs[0])
         assert "astro-ui" == jmespath.search(
             "spec.template.spec.containers[0].name", docs[0]
         )

--- a/tests/test_astronomer_commander.py
+++ b/tests/test_astronomer_commander.py
@@ -19,7 +19,7 @@ def test_astronomer_commander_deployment(kube_version):
     doc = docs[0]
     assert doc["kind"] == "Deployment"
     assert doc["apiVersion"] == "apps/v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
+    assert doc["metadata"]["name"] == "release-name-commander"
     assert any(
         image_name.startswith("quay.io/astronomer/ap-commander:")
         for image_name in jmespath.search("spec.template.spec.containers[*].image", doc)
@@ -48,7 +48,7 @@ def test_astronomer_commander_deployment_upgrade_timeout(kube_version):
     doc = docs[0]
     assert doc["kind"] == "Deployment"
     assert doc["apiVersion"] == "apps/v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-commander"
+    assert doc["metadata"]["name"] == "release-name-commander"
     assert any(
         image_name.startswith("quay.io/astronomer/ap-commander:")
         for image_name in jmespath.search("spec.template.spec.containers[*].image", doc)

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -48,7 +48,7 @@ def test_fluentd_clusterrolebinding(kube_version):
     doc = docs[0]
     assert doc["kind"] == "ClusterRoleBinding"
     assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-fluentd"
+    assert doc["metadata"]["name"] == "release-name-fluentd"
     assert len(doc["roleRef"]) > 0
     assert len(doc["subjects"]) > 0
 

--- a/tests/test_houston_configmap.py
+++ b/tests/test_houston_configmap.py
@@ -13,7 +13,7 @@ def common_test_cases(docs):
 
     assert doc["kind"] == "ConfigMap"
     assert doc["apiVersion"] == "v1"
-    assert doc["metadata"]["name"] == "RELEASE-NAME-houston-config"
+    assert doc["metadata"]["name"] == "release-name-houston-config"
 
     local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
 

--- a/tests/test_houston_ingress.py
+++ b/tests/test_houston_ingress.py
@@ -22,13 +22,13 @@ class TestIngress:
 
         annotations = jmespath.search("metadata.annotations", doc)
         assert len(annotations) > 1
-        assert annotations["kubernetes.io/ingress.class"] == "RELEASE-NAME-nginx"
+        assert annotations["kubernetes.io/ingress.class"] == "release-name-nginx"
 
         _, minor, _ = (int(x) for x in kube_version.split("."))
 
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
-            assert "RELEASE-NAME-houston" in [
+            assert "release-name-houston" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.service.name", doc
@@ -43,7 +43,7 @@ class TestIngress:
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
-            assert "RELEASE-NAME-houston" in [
+            assert "release-name-houston" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.serviceName", doc

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -22,13 +22,13 @@ class TestIngress:
 
         annotations = jmespath.search("metadata.annotations", doc)
         assert len(annotations) > 1
-        assert annotations["kubernetes.io/ingress.class"] == "RELEASE-NAME-nginx"
+        assert annotations["kubernetes.io/ingress.class"] == "release-name-nginx"
 
         _, minor, _ = (int(x) for x in kube_version.split("."))
 
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
-            assert "RELEASE-NAME-astro-ui" in [
+            assert "release-name-astro-ui" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.service.name", doc
@@ -43,7 +43,7 @@ class TestIngress:
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
-            assert "RELEASE-NAME-astro-ui" in [
+            assert "release-name-astro-ui" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.serviceName", doc

--- a/tests/test_kubed_clusterrolebinding.py
+++ b/tests/test_kubed_clusterrolebinding.py
@@ -19,16 +19,16 @@ class TestKubedClusterrolebinding:
         assert len(docs) == 1
         doc = docs[0]
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-kubed"
+        assert doc["metadata"]["name"] == "release-name-kubed"
         assert doc["roleRef"] == {
             "apiGroup": "rbac.authorization.k8s.io",
             "kind": "ClusterRole",
-            "name": "RELEASE-NAME-kubed",
+            "name": "release-name-kubed",
         }
         assert doc["subjects"] == [
             {
                 "kind": "ServiceAccount",
-                "name": "RELEASE-NAME-kubed",
+                "name": "release-name-kubed",
                 "namespace": "default",
             }
         ]
@@ -45,7 +45,7 @@ class TestKubedClusterrolebinding:
         doc = docs[0]
         assert doc["kind"] == "ClusterRoleBinding"
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-kubed"
+        assert doc["metadata"]["name"] == "release-name-kubed"
         assert len(doc["roleRef"]) > 0
         assert len(doc["subjects"]) > 0
 

--- a/tests/test_nginx_service.py
+++ b/tests/test_nginx_service.py
@@ -14,7 +14,7 @@ class TestNginx:
 
         assert doc["kind"] == "Service"
         assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-nginx"
+        assert doc["metadata"]["name"] == "release-name-nginx"
 
     def test_nginx_type_loadbalancer(self):
         # sourcery skip: extract-duplicate-method

--- a/tests/test_privateca.py
+++ b/tests/test_privateca.py
@@ -14,7 +14,7 @@ class TestDaemonset:
     def common_tests_daemonset(doc):
         """Test things common to all daemonsets"""
         assert "DaemonSet" == jmespath.search("kind", doc)
-        assert "RELEASE-NAME-private-ca" == jmespath.search("metadata.name", doc)
+        assert "release-name-private-ca" == jmespath.search("metadata.name", doc)
         assert "cert-copy" == jmespath.search(
             "spec.template.spec.containers[0].name", doc
         )
@@ -154,4 +154,4 @@ class TestPSP:
         assert len(docs) == 1
         doc = docs[0]
         assert "PodSecurityPolicy" == jmespath.search("kind", doc)
-        assert "RELEASE-NAME-private-ca" == jmespath.search("metadata.name", doc)
+        assert "release-name-private-ca" == jmespath.search("metadata.name", doc)

--- a/tests/test_prometheus_alerts_configmap.py
+++ b/tests/test_prometheus_alerts_configmap.py
@@ -49,7 +49,7 @@ class TestPrometheusAlertConfigmap:
 
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus-alerts"
+        assert doc["metadata"]["name"] == "release-name-prometheus-alerts"
 
         # Validate the contents of an embedded yaml doc
         groups = yaml.safe_load(doc["data"]["alerts"])["groups"]
@@ -65,17 +65,17 @@ class TestPrometheusAlertConfigmap:
     def test_prometheus_alerts_configmap_with_different_name_and_ns(self, kube_version):
         """Validate the prometheus alerts configmap does not conflate helm deployment name and namespace."""
         docs = render_chart(
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             kube_version=kube_version,
             show_only=self.show_only,
         )
 
         config_yaml = docs[0]["data"]["alerts"]
-        assert re.search(r'job="FOO-NAME', config_yaml)
-        assert not re.search(r'job="BAR-NS', config_yaml)
-        assert re.search(r'namespace="BAR-NS"', config_yaml)
-        assert not re.search(r'namespace="FOO-NAME"', config_yaml)
+        assert re.search(r'job="foo-name', config_yaml)
+        assert not re.search(r'job="bar-ns', config_yaml)
+        assert re.search(r'namespace="bar-ns"', config_yaml)
+        assert not re.search(r'namespace="foo-name"', config_yaml)
 
     def test_prometheus_alerts_configmap_with_addition_alerts(self, kube_version):
         """Validate the prometheus alerts configmap renders additional alerts."""
@@ -88,14 +88,14 @@ class TestPrometheusAlertConfigmap:
         docs = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             values={"prometheus": {"additionalAlerts": additional_alerts}},
         )
 
         config_yaml = docs[0]["data"]["alerts"]
         assert re.search(
-            r'.*The Astronomer Helm release FOO-NAME is failing task instances "{{ printf \\"%.2f\\" \$value }}\%" of the time over the past 30 minutes.*',
+            r'.*The Astronomer Helm release foo-name is failing task instances "{{ printf \\"%.2f\\" \$value }}\%" of the time over the past 30 minutes.*',
             config_yaml,
         )
         assert re.search(

--- a/tests/test_prometheus_config_configmap.py
+++ b/tests/test_prometheus_config_configmap.py
@@ -24,13 +24,13 @@ class TestPrometheusConfigConfigmap:
 
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus-config"
+        assert doc["metadata"]["name"] == "release-name-prometheus-config"
 
     def test_prometheus_config_configmap_with_different_name_and_ns(self, kube_version):
         """Validate the prometheus config configmap does not conflate deployment name and namespace."""
         docs = render_chart(
-            name="FOO-NAME",
-            namespace="BAR-NS",
+            name="foo-name",
+            namespace="bar-ns",
             kube_version=kube_version,
             show_only=self.show_only,
             values={
@@ -47,7 +47,7 @@ class TestPrometheusConfigConfigmap:
         assert len(docs) == 1
 
         config_yaml = docs[0]["data"]["config"]
-        assert re.search(r"http://FOO-NAME", config_yaml)
-        assert not re.search(r"http://BAR-NS", config_yaml)
-        assert re.search(r"\.BAR-NS:", config_yaml)
-        assert not re.search(r"\.FOO-NAME:", config_yaml)
+        assert re.search(r"http://foo-name", config_yaml)
+        assert not re.search(r"http://bar-ns", config_yaml)
+        assert re.search(r"\.bar-ns:", config_yaml)
+        assert not re.search(r"\.foo-name:", config_yaml)

--- a/tests/test_prometheus_ingress.py
+++ b/tests/test_prometheus_ingress.py
@@ -22,13 +22,13 @@ class TestIngress:
 
         annotations = jmespath.search("metadata.annotations", doc)
         assert len(annotations) > 1
-        assert annotations["kubernetes.io/ingress.class"] == "RELEASE-NAME-nginx"
+        assert annotations["kubernetes.io/ingress.class"] == "release-name-nginx"
 
         _, minor, _ = (int(x) for x in kube_version.split("."))
 
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
-            assert "RELEASE-NAME-prometheus" in [
+            assert "release-name-prometheus" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.service.name", doc
@@ -43,7 +43,7 @@ class TestIngress:
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
-            assert "RELEASE-NAME-prometheus" in [
+            assert "release-name-prometheus" in [
                 name[0]
                 for name in jmespath.search(
                     "spec.rules[*].http.paths[*].backend.serviceName", doc

--- a/tests/test_prometheus_statefulset.py
+++ b/tests/test_prometheus_statefulset.py
@@ -21,7 +21,7 @@ class TestPrometheusStatefulset:
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-prometheus"
+        assert doc["metadata"]["name"] == "release-name-prometheus"
         assert len(doc["spec"]["template"]["spec"]["containers"]) == 2
 
         sc = doc["spec"]["template"]["spec"]["securityContext"]

--- a/tests/test_psp.py
+++ b/tests/test_psp.py
@@ -12,27 +12,27 @@ class TestPspEnabled:
     psp_docs = [
         {
             "template": "charts/elasticsearch/templates/es-psp.yaml",
-            "name": "RELEASE-NAME-elasticsearch",
+            "name": "release-name-elasticsearch",
         },
         {
             "template": "charts/fluentd/templates/fluentd-psp.yaml",
-            "name": "RELEASE-NAME-fluentd",
+            "name": "release-name-fluentd",
         },
         {
             "template": "charts/nginx/templates/nginx-psp.yaml",
-            "name": "RELEASE-NAME-ingress-nginx",
+            "name": "release-name-ingress-nginx",
         },
         {
             "template": "charts/prometheus-node-exporter/templates/psp.yaml",
-            "name": "RELEASE-NAME-prometheus-node-exporter",
+            "name": "release-name-prometheus-node-exporter",
         },
         {
             "template": "templates/psp/permissive-psp.yaml",
-            "name": "RELEASE-NAME-permissive",
+            "name": "release-name-permissive",
         },
         {
             "template": "templates/psp/restrictive-psp.yaml",
-            "name": "RELEASE-NAME-restrictive",
+            "name": "release-name-restrictive",
         },
     ]
 
@@ -64,27 +64,27 @@ class TestPspEnabled:
     clusterrole_docs = [
         {
             "template": "charts/elasticsearch/templates/es-psp-clusterrole.yaml",
-            "name": "RELEASE-NAME-psp-elasticsearch",
+            "name": "release-name-psp-elasticsearch",
         },
         {
             "template": "charts/fluentd/templates/fluentd-psp-clusterrole.yaml",
-            "name": "RELEASE-NAME-psp-fluentd",
+            "name": "release-name-psp-fluentd",
         },
         {
             "template": "charts/nginx/templates/nginx-psp-clusterrole.yaml",
-            "name": "RELEASE-NAME-psp-ingress-nginx",
+            "name": "release-name-psp-ingress-nginx",
         },
         {
             "template": "charts/prometheus-node-exporter/templates/psp-clusterrole.yaml",
-            "name": "psp-RELEASE-NAME-prometheus-node-exporter",
+            "name": "psp-release-name-prometheus-node-exporter",
         },
         {
             "template": "templates/psp/permissive-clusterrole.yaml",
-            "name": "RELEASE-NAME-psp-permissive",
+            "name": "release-name-psp-permissive",
         },
         {
             "template": "templates/psp/restrictive-clusterrole.yaml",
-            "name": "RELEASE-NAME-psp-restrictive",
+            "name": "release-name-psp-restrictive",
         },
     ]
 
@@ -122,11 +122,11 @@ class TestPspEnabled:
     clusterrolebinding_docs = [
         {
             "template": "charts/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml",
-            "name": "psp-RELEASE-NAME-prometheus-node-exporter",
+            "name": "psp-release-name-prometheus-node-exporter",
         },
         {
             "template": "templates/psp/restrictive-cluserrolebinding.yaml",
-            "name": "RELEASE-NAME-psp-restrictive",
+            "name": "release-name-psp-restrictive",
         },
     ]
 
@@ -163,19 +163,19 @@ class TestPspEnabled:
     rolebinding_docs = [
         {
             "template": "charts/elasticsearch/templates/es-psp-rolebinding.yaml",
-            "name": "RELEASE-NAME-psp-elasticsearch",
+            "name": "release-name-psp-elasticsearch",
         },
         {
             "template": "charts/fluentd/templates/fluentd-psp-rolebinding.yaml",
-            "name": "RELEASE-NAME-psp-fluentd",
+            "name": "release-name-psp-fluentd",
         },
         {
             "template": "charts/nginx/templates/nginx-psp-rolebinding.yaml",
-            "name": "RELEASE-NAME-psp-ingress-nginx",
+            "name": "release-name-psp-ingress-nginx",
         },
         {
             "template": "templates/psp/permissive-clusterrolebinding.yaml",
-            "name": "RELEASE-NAME-psp-permissive",
+            "name": "release-name-psp-permissive",
         },
     ]
 

--- a/tests/test_registry_statefulset.py
+++ b/tests/test_registry_statefulset.py
@@ -22,12 +22,12 @@ class TestRegistryStatefulset:
 
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "RELEASE-NAME-registry"
+        assert doc["metadata"]["name"] == "release-name-registry"
         expected_env = {
             "name": "REGISTRY_NOTIFICATIONS_ENDPOINTS_0_HEADERS",
             "valueFrom": {
                 "secretKeyRef": {
-                    "name": "RELEASE-NAME-registry-auth-key",
+                    "name": "release-name-registry-auth-key",
                     "key": "authHeaders",
                 }
             },


### PR DESCRIPTION
## Description

Fix helm 3.8 compatibility in release-0.26 tests.

## Related Issues

<https://github.com/astronomer/issues/issues/4124>

## Testing

CI tests passing is enough since only test files were modified.

Also I tested on helm 3.8 locally and tests passed.