### PR TITLE
Fix airflow chart version in commander

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.27.5
+    tag: 0.27.6
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

Recently incorrect airflow chart versions are shipped inside commander image due to an issue observed in ci pipeline, which affected airgapped installs.  

This PR fixes those issues and ships with correct airflow chart version

## Related Issues

GH Issue: https://github.com/astronomer/issues/issues/4396

## Testing

QA can run below command to verify the chart version 
docker run -it --rm --entrypoint=/bin/sh quay.io/astronomer/ap-commander:release-0.27.6 -c 'ls -l astronomer-ee'

output
```
docker run -it --rm --entrypoint=/bin/sh quay.io/astronomer/ap-commander:release-0.27 -c 'ls -l astronomer-ee'
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
total 136
-rw-r--r-- 1 commander commander 135766 Mar 21 11:34 airflow-1.1.2.tgz
```