### PR TITLE
update platform  images for security fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.0
+    tag: 3.15.1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.1
+    tag: 0.26.2
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-3
+    tag: 3.15.1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-10
+    tag: 5.8.4-11
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.4
+    tag: 1.21.6
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-1
+    tag: 1.3-3
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -173,7 +173,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.9.1
+  image: quay.io/astronomer/ap-nats-exporter:0.9.1-1
   pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.0
+    tag: 0.28.1
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-5
+  tag: 0.19.0-6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-3
+    tag: 3.15.1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
## Description

update  ap-base  3.15.0-3 ->  3.15.1
update ap-curator 5.8.4-10 -> 5.8.4-11
update ap-nginx-es 1.21.4 -> 1.21.6
update ap-cli-install 0.26.1 -> 0.26.2
update ap-registry  3.15.0 -> 3.15.1
update nats-exporter 0.9.1 -> 0.9.1-1
update  ap-blackbox-exporter 0.19.0-5 -> 0.19.0-6
update ap-awsesproxy  1.3-1 -> 1.3-3 
update ap-default-backend 0.28.0 -> 0.28.1

## Related Issues
Not Yet Created 

## Testing

Yet to update
