### PR TITLE
update vendor images for security fixes and enhancements

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.0
+    tag: 3.15.1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.1
+    tag: 0.26.2
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-10
+    tag: 5.8.4-11
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.4
+    tag: 1.21.6
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.19.9
+    tag: 1.19.9-1
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-1
+    tag: 1.3-3
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.3-1
+    tag: 1.14.5
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/kubed/values.yaml
+++ b/charts/kubed/values.yaml
@@ -5,7 +5,7 @@
 images:
   kubed:
     repository: quay.io/astronomer/ap-kubed
-    tag: 0.13.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
 
 # Declare variables to be passed into your templates.

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1
+    tag: 0.9.1-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.0
+    tag: 0.28.1
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-5
+  tag: 0.19.0-6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION

## Description

* update ap-base 3.15.0-3 -> 3.15.1
* update ap-curator 5.8.4-10 -> 5.8.4-11
* update ap-nginx-es 1.21.4 -> 1.21.6
* update ap-cli-install 0.26.1 -> 0.26.2
* update ap-registry 3.15.0 -> 3.15.1
* update nats-exporter 0.9.1 -> 0.9.1-1
* update ap-blackbox-exporter 0.19.0-5 -> 0.19.0-6
* update ap-awsesproxy 1.3-1 -> 1.3-3
* update ap-default-backend 0.28.0 -> 0.28.1
* update ap-openresty 1.19.9 1.19.9-1
* update ap-fluentd 1.14.3-1 1.14.5
* update ap-kubed 0.13.0 -> 0.13.2


## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA should be able to install platform without any issues 
