### PR TITLE
Namespace Pools: Optimize fluentd's configuration

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -102,8 +102,10 @@ data:
       @type grep
       <regexp>
         key $.kubernetes.namespace_name
+        {{- if and .Values.global.features.namespacePools.enabled (gt (len .Values.global.features.namespacePools.namespaces.names) 0) }}
+        pattern ^({{ join "|" .Values.global.features.namespacePools.namespaces.names }})$
+        {{- else if .Values.global.manualNamespaceNamesEnabled }}
         # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled
-        {{- if or .Values.global.manualNamespaceNamesEnabled .Values.global.features.namespacePools.enabled }}
         pattern "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         {{ else }}
         pattern "^#{ENV['NAMESPACE']}(?:-.*)?$"

--- a/tests/test_astronomer_namespace_pools.py
+++ b/tests/test_astronomer_namespace_pools.py
@@ -239,3 +239,28 @@ def test_astronomer_namespace_pools_houston_configmap(kube_version):
     assert "hardDeleteDeployment" not in deployments_config["deployments"]
     assert "manualNamespaceNames" not in deployments_config["deployments"]
     assert "preCreatedNamespaces" not in deployments_config["deployments"]
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_astronomer_namespace_pools_fluentd_configmap(kube_version):
+    """Test that when namespace Pools is enabled, and a list of namespaces is provided, helm render fluentd configmap correctly, with a regex targeting pods in the provided namespaces only."""
+    namespaces = ["my-namespace-1", "my-namespace-2"]
+    doc = render_chart(
+        kube_version=kube_version,
+        values={
+            "global": {
+                "features": {
+                    "namespacePools": {
+                        "enabled": True,
+                        "namespaces": {"create": True, "names": namespaces},
+                    }
+                }
+            }
+        },
+        show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
+    )[0]
+
+    expected_rule = "key $.kubernetes.namespace_name\n    pattern ^({}|{})$".format(namespaces[0], namespaces[1])
+    assert expected_rule in doc["data"]["output.conf"]

--- a/tests/test_astronomer_namespace_pools.py
+++ b/tests/test_astronomer_namespace_pools.py
@@ -240,6 +240,7 @@ def test_astronomer_namespace_pools_houston_configmap(kube_version):
     assert "manualNamespaceNames" not in deployments_config["deployments"]
     assert "preCreatedNamespaces" not in deployments_config["deployments"]
 
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
@@ -262,5 +263,7 @@ def test_astronomer_namespace_pools_fluentd_configmap(kube_version):
         show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
     )[0]
 
-    expected_rule = "key $.kubernetes.namespace_name\n    pattern ^({}|{})$".format(namespaces[0], namespaces[1])
+    expected_rule = "key $.kubernetes.namespace_name\n    pattern ^({}|{})$".format(
+        namespaces[0], namespaces[1]
+    )
     assert expected_rule in doc["data"]["output.conf"]

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -60,6 +60,7 @@ def test_fluentd_clusterrolebinding(kube_version):
 
     assert len(docs) == 0
 
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
@@ -75,7 +76,7 @@ def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
                     "namespacePools": {
                         "enabled": False,
                     }
-                }
+                },
             }
         },
         show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
@@ -83,6 +84,7 @@ def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
 
     expected_rule = "key $.kubernetes.namespace_name\n    # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled"
     assert expected_rule in doc["data"]["output.conf"]
+
 
 @pytest.mark.parametrize(
     "kube_version",
@@ -99,11 +101,13 @@ def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_ve
                     "namespacePools": {
                         "enabled": False,
                     }
-                }
+                },
             }
         },
         show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
     )[0]
 
-    expected_rule = "key $.kubernetes.namespace_name\n    pattern \"^#{ENV['NAMESPACE']}(?:-.*)?$\""
+    expected_rule = (
+        "key $.kubernetes.namespace_name\n    pattern \"^#{ENV['NAMESPACE']}(?:-.*)?$\""
+    )
     assert expected_rule in doc["data"]["output.conf"]

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -59,3 +59,51 @@ def test_fluentd_clusterrolebinding(kube_version):
     )
 
     assert len(docs) == 0
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
+    """Test that when namespace Pools is disabled, and manualNamespaces is enabled, helm renders fluentd configmap targeting all namespaces."""
+    doc = render_chart(
+        kube_version=kube_version,
+        values={
+            "global": {
+                "manualNamespaceNamesEnabled": True,
+                "features": {
+                    "namespacePools": {
+                        "enabled": False,
+                    }
+                }
+            }
+        },
+        show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
+    )[0]
+
+    expected_rule = "key $.kubernetes.namespace_name\n    # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled"
+    assert expected_rule in doc["data"]["output.conf"]
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_version):
+    """Test that when namespace Pools and manualNamespaceNamesEnabled aredisabled, helm renders a default fluentd configmap looking at an environment variable"""
+    doc = render_chart(
+        kube_version=kube_version,
+        values={
+            "global": {
+                "manualNamespaceNamesEnabled": False,
+                "features": {
+                    "namespacePools": {
+                        "enabled": False,
+                    }
+                }
+            }
+        },
+        show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
+    )[0]
+
+    expected_rule = "key $.kubernetes.namespace_name\n    pattern \"^#{ENV['NAMESPACE']}(?:-.*)?$\""
+    assert expected_rule in doc["data"]["output.conf"]

--- a/tests/test_fluentd.py
+++ b/tests/test_fluentd.py
@@ -91,7 +91,7 @@ def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_version):
-    """Test that when namespace Pools and manualNamespaceNamesEnabled aredisabled, helm renders a default fluentd configmap looking at an environment variable"""
+    """Test that when namespace Pools and manualNamespaceNamesEnabled are disabled, helm renders a default fluentd configmap looking at an environment variable"""
     doc = render_chart(
         kube_version=kube_version,
         values={


### PR DESCRIPTION
## Description

When using the Namespace Pools feature, we want to optimize fluentd to only retrieve Airflow logs from the namespaces provided in the pool, since Airflow deployments will ONLY be deployed in these namespaces.

I have also added tests to look for this configuration under the different scenarios.

## Related Issues

https://github.com/astronomer/issues/issues/4322

## Testing

To test this PR, we want to render the helm chart and check that the fluentd configuration is set properly according to our global values.


We want to make sure that fluentd is still working as expected, we are going to create a helm release with namespace pool enabled, and provide a list of namespaces to use and to create, and then we will need to make sure that fluentd does collect the logs from our Airflow deployments created in these namespaces:
- First step: create the release, you need to set the following values (here, we're enabling the namespacePools feature, and want helm to create 2 namespaces to be used in the pool: `my-ns-1` and `my-ns-2`)
```yaml
global:
  features:
    namespacePools:
      enabled: true
      namespaces:
        create: true
        names:
          - my-ns-1
          - my-ns-2
```
- Wait for the release to be deployed
- Check that the fluentd configmap is configured properly, by reading the rendered configuration inside the cluster:
  ```bash
  kubectl get cm -n <release-namespace> fluentd-configmap -o yaml
  ```
  You should be looking for the following content inside the output of the previous command:
  ```
  <filter kubernetes.**>
      @type grep
      <regexp>
        key $.kubernetes.namespace_name
        pattern ^(my-ns-1|my-ns-2)$
      </regexp>
      <regexp>
        key $.kubernetes.labels.component
        pattern ^(scheduler|webserver|worker|triggerer)$
      </regexp>
    </filter>
  ```
- Create Airflow deployments in your Astronomer platform inside these 2 namespaces
- Check that Logs from the airflow components show up in ElasticSearch (or whatever, we need to check that fluentd collects logs from Airflow components in the namespaces of the pool).

