### PR TITLE
enhanced security fixes

### DIFF
--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.5
+    tag: 1.14.5-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.32.1
+    tag: 2.34.0
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader


### PR DESCRIPTION

## Description

fluentd kubernetes meta plugin had a vulnerable kube_client plugin that has been updated in the new version of fluentd image 
minor enhancements to prometheus image 

Image update details below:

update ap-fluentd 1.14.5 -> 1.14.5-1

update ap-prometheus  2.32.1 -> 2.34.0


## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA should able to deploy / upgrade platform without any issues
