### PR TITLE
update ap-default backend

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.1
+    tag: 0.28.2
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION


## Description

* bump default-backend 0.28.1 -> 0.28.2

## Related Issues

https://github.com/astronomer/issues/issues/4428
## Testing

Qa should able to deploy and see proper error pages
