### PR TITLE
Reduce Commander Permissions and fix namespace pools Houston config

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -150,7 +150,7 @@ rules:
 # Helm doesn't allow to check if values and sub-values are defined in a "clean" way, we have to do this cascading IF statements
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles"]
-  verbs: ["create", "delete", "get", "patch", "list", "watch", "escalate"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch", "escalate", "bind"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterrolebindings"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -32,9 +32,6 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
 rules:
-- apiGroups: ["*"]
-  resources: ["*"]
-  verbs: ["list", "watch"]
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
@@ -46,13 +43,10 @@ rules:
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["serviceaccounts"]
-  verbs: ["create", "delete", "get", "patch"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["clusterroles"]
-  verbs: ["create", "delete", "get", "patch"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles"]
-  verbs: ["*"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
@@ -70,7 +64,7 @@ rules:
   verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["nodes/proxy"]
-  verbs: ["get"]
+  verbs: ["get", "list", "watch"]
 - apiGroups: [""]
   resources: ["persistentvolumes"]
   verbs: ["create", "delete", "get", "list", "watch", "patch"]
@@ -109,48 +103,64 @@ rules:
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["events"]
-  verbs: ["create", "delete", "patch"]
+  verbs: ["create", "delete", "patch", "list", "watch"]
 - apiGroups: ["extensions"]
   resources: ["ingresses"]
-  verbs: ["create", "delete", "get", "patch"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
 - apiGroups: ["extensions"]
   resources: ["ingresses/status"]
-  verbs: ["update"]
+  verbs: ["update", "list", "watch"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses"]
-  verbs: ["get", "create", "delete", "patch"]
+  verbs: ["get", "create", "delete", "patch", "list", "watch"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["ingresses/status"]
-  verbs: ["update"]
+  verbs: ["update", "list", "watch"]
 - apiGroups: ["networking.k8s.io"]
   resources: ["networkpolicies"]
-  verbs: ["create", "delete", "get", "patch"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["rolebindings"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["tokenreviews"]
+  verbs: ["create", "delete", "list", "watch"]
+- apiGroups: ["authorization.k8s.io"]
+  resources: ["subjectaccessreviews"]
+  verbs: ["create", "delete", "list", "watch"]
+- apiGroups: ["kubed.appscode.com"]
+  resources: ["searchresults"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["create", "delete", "get", "list", "watch"]
 {{- if $useClusterRoles }}
+# permissions for "nonResourceURLs" can only be applied on ClusterRoles
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
 {{- end }}
+{{- if $.Values.houston.config.deployments }}
+{{- if $.Values.houston.config.deployments.helm }}
+{{- if $.Values.houston.config.deployments.helm.airflow }}
+{{- if $.Values.houston.config.deployments.helm.airflow.multiNamespaceMode }}
+# Commander creates ClusterRoles and ClusterRoleBindings only if user enables multiNamespaceMode on the Airflow Helm Chart
+# However, commander will only create ClusterRole and ClusterRoleBinding resources if the multinamespaceMode is enabled
+# in an Airflow helm deployment.
+# Helm doesn't allow to check if values and sub-values are defined in a "clean" way, we have to do this cascading IF statements
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterrolebindings"]
-  verbs: ["create", "delete", "get", "patch"]
-- apiGroups: ["rbac.authorization.k8s.io"]
-  resources: ["rolebindings"]
-  verbs: ["create", "delete", "get", "patch"]
-- apiGroups: ["authentication.k8s.io"]
-  resources: ["tokenreviews"]
-  verbs: ["create", "delete"]
-- apiGroups: ["authorization.k8s.io"]
-  resources: ["subjectaccessreviews"]
-  verbs: ["create", "delete"]
-- apiGroups: ["kubed.appscode.com"]
-  resources: ["searchresults"]
-  verbs: ["get"]
-- apiGroups: ["policy"]
-  resources: ["poddisruptionbudgets"]
-  verbs: ["create", "delete", "get"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if $.Values.global.sccEnabled }}
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  verbs: ["create", "delete"]
+  verbs: ["create", "delete", "list", "watch"]
 {{ end }}
 {{ end }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -44,9 +44,10 @@ rules:
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]
+# Important to understand: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#privilege-escalation-prevention-and-bootstrapping
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles"]
-  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch", "escalate", "bind"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "update", "watch", "patch"]
@@ -149,7 +150,7 @@ rules:
 # Helm doesn't allow to check if values and sub-values are defined in a "clean" way, we have to do this cascading IF statements
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterroles"]
-  verbs: ["create", "delete", "get", "patch", "list", "watch"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch", "escalate"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["clusterrolebindings"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -74,7 +74,10 @@ data:
       {{ if .Values.global.features.namespacePools.enabled }}
       hardDeleteDeployment: true
       manualNamespaceNames: true
-      preCreatedNamespaces:{{ printf "\n" }}{{ toYaml .Values.global.features.namespacePools.namespaces.names | indent 6 }}
+      preCreatedNamespaces:
+      {{- range $i, $namespaceName := .Values.global.features.namespacePools.namespaces.names }}
+        - name: {{ $namespaceName }}
+      {{- end }}
       {{ end }}
 
       {{- if .Values.global.authSidecar.enabled }}

--- a/tests/test_astronomer_commander.py
+++ b/tests/test_astronomer_commander.py
@@ -184,3 +184,98 @@ def test_astronomer_commander_rbac_cluster_role_disabled(kube_version):
         ],
     )
     assert len(docs) == 0
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_astronomer_commander_rbac_multinamespace_mode_disabled(kube_version):
+    """Test that if Houston's Airflow chart sub-configuration has multiNamespaceMode disabled, the rendered commander role doesn't have permissions to manage Cluster-level RBAC resources"""
+    doc = render_chart(
+        kube_version=kube_version,
+        values={
+            "astronomer": {
+                "houston": {
+                    "config": {
+                        "deployments": {
+                            "helm": {"airflow": {"multiNamespaceMode": False}}
+                        }
+                    }
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
+    )[0]
+
+    cluster_resources = ["clusterrolebindings", "clusterroles"]
+
+    # check that there is no rules regarding ClusterRoles and ClusterRolesBinding
+    generated_resources = [
+        resource
+        for rule in doc["rules"]
+        if "resources" in rule
+        for resource in rule["resources"]
+    ]
+    for resource in generated_resources:
+        assert resource not in cluster_resources
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_astronomer_commander_rbac_multinamespace_mode_undefined(kube_version):
+    """Test that if Houston's configuration for Airflow chart is not defined, the rendered commander role doesn't have permissions to manage Cluster-level RBAC resources"""
+    doc = render_chart(
+        kube_version=kube_version,
+        values={},
+        show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
+    )[0]
+
+    cluster_resources = ["clusterrolebindings", "clusterroles"]
+
+    # check that there is no rules regarding ClusterRoles and ClusterRolesBinding
+    generated_resources = [
+        resource
+        for rule in doc["rules"]
+        if "resources" in rule
+        for resource in rule["resources"]
+    ]
+    for resource in generated_resources:
+        assert resource not in cluster_resources
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_astronomer_commander_rbac_multinamespace_mode_enabled(kube_version):
+    """Test that if Houston's Airflow chart sub-configuration has multiNamespaceMode enabled, the rendered commander role has permissions to manage Cluster-level RBAC resources"""
+    doc = render_chart(
+        kube_version=kube_version,
+        values={
+            "astronomer": {
+                "houston": {
+                    "config": {
+                        "deployments": {
+                            "helm": {"airflow": {"multiNamespaceMode": True}}
+                        }
+                    }
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
+    )[0]
+
+    cluster_resources = ["clusterrolebindings", "clusterroles"]
+
+    # check that there are rules for cluterroles and clusterrolebindings
+    generated_resources = [
+        resource
+        for rule in doc["rules"]
+        if "resources" in rule
+        for resource in rule["resources"]
+    ]
+    for resource in cluster_resources:
+        assert resource in generated_resources

--- a/tests/test_astronomer_namespace_pools.py
+++ b/tests/test_astronomer_namespace_pools.py
@@ -216,7 +216,9 @@ def test_astronomer_namespace_pools_houston_configmap(kube_version):
 
     assert deployments_config["deployments"]["hardDeleteDeployment"]
     assert deployments_config["deployments"]["manualNamespaceNames"]
-    assert deployments_config["deployments"]["preCreatedNamespaces"] == [{"name": namespace} for namespace in namespaces]
+    assert deployments_config["deployments"]["preCreatedNamespaces"] == [
+        {"name": namespace} for namespace in namespaces
+    ]
 
     # test configuration when namespacePools is disabled -> should not add configuration parameters
     doc = render_chart(

--- a/tests/test_astronomer_namespace_pools.py
+++ b/tests/test_astronomer_namespace_pools.py
@@ -216,7 +216,7 @@ def test_astronomer_namespace_pools_houston_configmap(kube_version):
 
     assert deployments_config["deployments"]["hardDeleteDeployment"]
     assert deployments_config["deployments"]["manualNamespaceNames"]
-    assert deployments_config["deployments"]["preCreatedNamespaces"] == namespaces
+    assert deployments_config["deployments"]["preCreatedNamespaces"] == [{"name": namespace} for namespace in namespaces]
 
     # test configuration when namespacePools is disabled -> should not add configuration parameters
     doc = render_chart(

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -17,7 +17,7 @@ show_only = [
 commander_expected_result = {
     "apiGroups": ["security.openshift.io"],
     "resources": ["securitycontextconstraints"],
-    "verbs": ["create", "delete"],
+    "verbs": ["create", "delete", "list", "watch"],
 }
 
 
@@ -31,7 +31,12 @@ def test_scc_disabled(kube_version):
     """
     docs = render_chart(
         kube_version=kube_version,
-        values={"global": {"sccEnabled": False}},
+        values={
+            "global": {
+                "sccEnabled": False,
+                "features": {"namespacePools": {"enabled": False}},
+            }
+        },
         show_only=show_only,
     )
     houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
@@ -56,7 +61,9 @@ def test_scc_enabled(kube_version):
             "global": {
                 "sccEnabled": True,
                 "clusterRoles": True,
-                "namespacePools": {"enabled": False},
+                "features": {
+                    "namespacePools": {"enabled": False},
+                },
             }
         },
         show_only=show_only,


### PR DESCRIPTION
## Description

This PR contains:
- Reduce permissions for Commander
- Fix a bug, when using the new global.features.namespacePools value, the rendered configmap for Houston to use these preCreatedNamespaces was not formatted properly: I rendered a list of string, instead of a list of object with the form {"name": "namespace-name"}.

At the moment, users do not like the permissions we give to Commander:
- `*` values in permissions can be risky
- Permissions to manage ClusterRoles and ClusterRoleBindings is too dangerous, if someones steals commander's Service Account, he can just create an admin ClusterRole + binding and gain access to the whole cluster.

The only scenario in which we want to give Commander the permissions to manage Cluster* RBAC resources is if the user uses the Airflow multinamespace mode, see the official [Airflow chart](https://github.com/apache/airflow/blob/77d4e725c639efa68748e0ae51ddf1e11b2fd163/chart/templates/rbac/pod-launcher-role.yaml#L22).

So, in order to fix these problems, I removed `*` permissions (and added these permissions to each resource required by Commander instead), and only create the rules for commander to manage Cluster* RBAC resources if the option (multinamespace mode) is enabled in Airflow (users can customize Airflow chart values by providing these values when deploying this Astronomer chart in the [houston configuration](https://github.com/astronomer/houston-api/blob/5238c5e1ad3a87df8acc43f2b6ec07413a4b560b/config/default.yaml#L697)).

## Related Issues

- https://github.com/astronomer/issues/issues/4382 (Fix a bug I introduced in the PR https://github.com/astronomer/astronomer/pull/1407)
- https://github.com/astronomer/issues/issues/4332

## Testing

I'll add details on how to test this fix
