### PR TITLE
Add redirect section in registry configmap

### DIFF
--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -35,6 +35,10 @@ data:
       filesystem:
         rootdirectory: /var/lib/registry
     {{- end }}
+    {{- if .Values.registry.redirectDisabled }}
+      redirect:
+        disable: {{ .Values.registry.redirectDisabled }}
+    {{- end }}
       delete:
         enabled: true
     http:

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -35,9 +35,9 @@ data:
       filesystem:
         rootdirectory: /var/lib/registry
     {{- end }}
-    {{- if .Values.registry.redirectDisabled }}
+    {{- if (.Values.registry.redirect).disable }}
       redirect:
-        disable: {{ .Values.registry.redirectDisabled }}
+        disable: {{ .Values.registry.redirect.disable }}
     {{- end }}
       delete:
         enabled: true

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -35,7 +35,7 @@ data:
       filesystem:
         rootdirectory: /var/lib/registry
     {{- end }}
-    {{- if (.Values.registry.redirect).disable }}
+    {{- if .Values.registry.redirect.disable }}
       redirect:
         disable: {{ .Values.registry.redirect.disable }}
     {{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -310,6 +310,8 @@ registry:
   notifications:
     timeout: 30s
 
+  redirectDisabled: false
+
 install:
   resources: {}
   cliVersion: 0.27.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -310,7 +310,8 @@ registry:
   notifications:
     timeout: 30s
 
-  redirectDisabled: false
+  redirect:
+    disable: false
 
 install:
   resources: {}

--- a/tests/test_astronomer_registry_configmap.py
+++ b/tests/test_astronomer_registry_configmap.py
@@ -9,7 +9,7 @@ import re
     "kube_version",
     supported_k8s_versions,
 )
-def test_astronomer_registry_configmap(kube_version):
+def test_astronomer_registry_configmap_defaults(kube_version):
     """Test that helm renders a good configmap template for astronomer registry."""
     docs = render_chart(
         kube_version=kube_version,
@@ -24,14 +24,15 @@ def test_astronomer_registry_configmap(kube_version):
     assert doc["kind"] == "ConfigMap"
     assert doc["apiVersion"] == "v1"
     assert bool(re.match("[+]?\\d+s", timeout))
+    assert "redirect" not in parsed_config_yml["storage"]
 
 
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
 )
-def test_astronomer_registry_redirect(kube_version):
-    """Test that helm renders redirect section in configmap of astronomer registry."""
+def test_astronomer_registry_redirect_disabled(kube_version):
+    """Test that helm renders astronomer registry configmap template with redirect disabled."""
     docs = render_chart(
         kube_version=kube_version,
         values={"astronomer": {"registry": {"redirect": {"disable": True}}}},
@@ -40,8 +41,5 @@ def test_astronomer_registry_redirect(kube_version):
 
     assert len(docs) == 1
     doc = docs[0]
-    config_yml = doc["data"]["config.yml"]
-    parsed_config_yml = yaml.safe_load(config_yml)
-    redirectDisabled = parsed_config_yml["storage"]["redirect"]["disable"]
-    assert doc["kind"] == "ConfigMap"
-    assert redirectDisabled
+    parsed_config_yml = yaml.safe_load(doc["data"]["config.yml"])
+    assert parsed_config_yml["storage"]["redirect"]["disable"]

--- a/tests/test_astronomer_registry_configmap.py
+++ b/tests/test_astronomer_registry_configmap.py
@@ -34,7 +34,7 @@ def test_astronomer_registry_redirect(kube_version):
     """Test that helm renders redirect section in configmap of astronomer registry."""
     docs = render_chart(
         kube_version=kube_version,
-        values={"astronomer": {"registry": {"redirectDisabled": True}}},
+        values={"astronomer": {"registry": {"redirect": {"disable": True}}}},
         show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
     )
 

--- a/tests/test_astronomer_registry_configmap.py
+++ b/tests/test_astronomer_registry_configmap.py
@@ -24,3 +24,24 @@ def test_astronomer_registry_configmap(kube_version):
     assert doc["kind"] == "ConfigMap"
     assert doc["apiVersion"] == "v1"
     assert bool(re.match("[+]?\\d+s", timeout))
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+def test_astronomer_registry_redirect(kube_version):
+    """Test that helm renders redirect section in configmap of astronomer registry."""
+    docs = render_chart(
+        kube_version=kube_version,
+        values={"astronomer": {"registry": {"redirectDisabled": True}}},
+        show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
+    )
+
+    assert len(docs) == 1
+    doc = docs[0]
+    config_yml = doc["data"]["config.yml"]
+    parsed_config_yml = yaml.safe_load(config_yml)
+    redirectDisabled = parsed_config_yml["storage"]["redirect"]["disable"]
+    assert doc["kind"] == "ConfigMap"
+    assert redirectDisabled


### PR DESCRIPTION
## Description
Changes:
- Added redirect section under storage in registry config map (Default value for `redirectDisabled` is set to False, same as what docker registry treats it in case it is not passed)

Currently, the astronomer registry will use redirection whenever the backend of the registry supports it. This PR is to allow users to disable registry redirection and pass all the data through the registry, this use case is useful in a couple of scenarios, one of them is when the backend storage for instance does not allow any other connection to push objects except the registry IP.

Reference: https://docs.docker.com/registry/configuration/#redirect

## Related Issues
https://github.com/astronomer/issues/issues/4183

## Testing
In order to test whether this change fixes the mentioned issue, one has to bring up an Astronomer cluster on AWS with a registry backend configured as an S3 bucket, with a similar bucket policy:

```JSON
{
    "Version": "2012-10-17",
    "Id": "Policy1648101441413",
    "Statement": [
        {
            "Sid": "Stmt1648101431372",
            "Effect": "Deny",
            "Principal": "*",
            "Action": "s3:*",
            "Resource": [
                "arn:aws:s3:::neel-dev-test-registry",
                "arn:aws:s3:::neel-dev-test-registry/*"
            ],
            "Condition": {
                "StringNotLike": {
                    "aws:userid": "AKxxxxxxxxx",
                    "aws:username": "neel"
                },
                "NotIpAddress": {
                    "aws:VpcSourceIp": [
                        "10.10.0.0/16",
                        "10.100.0.0/16"
                    ]
                },
                "StringNotEquals": {
                    "aws:username": "neel"
                }
            }
        }
    ]
}
```

When the platform is brought up without disabling the redirection, then the registry configmap will look something like:
<img width="468" alt="Screenshot 2022-03-30 at 1 19 30 PM" src="https://user-images.githubusercontent.com/92356010/160795011-fd71dc41-fb12-45e2-8d2f-e97b6803a0dc.png">
(AWS user used in this screenshot has already been deleted)

And then when trying to push an image from local via `astro deploy` one will face the following error:
<img width="854" alt="Screenshot 2022-03-30 at 1 19 11 PM" src="https://user-images.githubusercontent.com/92356010/160795125-b6f6e150-e509-40a4-a527-fe76c2a375a1.png">

Same scenario when registry redirection is disabled by setting `redirect.disable` under registry in values.yaml as True and the platform is recreated, i.e.:
```YAML
  registry:
    replicas: 1
    redirect:
      disable: true
    s3:
      enabled: true
      bucket: neel-dev-test-registry
      region: us-east-1
```
Then one should be able to successfully push the image to the registry:
<img width="1269" alt="Screenshot 2022-03-30 at 12 46 47 PM" src="https://user-images.githubusercontent.com/92356010/160795677-5a022e5e-8d22-40af-9c4e-d313d36d89ea.png">

