### PR TITLE
Bump airflowChartVersion

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.3.0
+airflowChartVersion: 1.4.0
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

Bump airflowChartVersion to 1.4.0.

airflow-chart 1.4.0 added k8s 1.22 and 1.23 support. It also does not work with k8s 1.18 or lower.

## Related Issues

<https://github.com/astronomer/issues/issues/4377>

## Testing

Manual testing has been done. There are no automated tests that can verify this change because it requires doing an `astro deploy` and we still don't have the ability to do such a thing in an automated way.