### PR TITLE
bump astro ui from 0.28.7 to 0.28.8

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.7
+    tag: 0.28.8
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

fix cve issues in astro ui
HIGH severity CVE CVE-2022-23308

## Related Issues
https://github.com/astronomer/issues/issues/4426

## Testing
ci is passing

Do not merge this PR until this text is replaced with details about how these changes were tested.
