### PR TITLE
bump astro ui to 0.28.9 from 0.28.8 fix zlib CVE

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.8
+    tag: 0.28.9
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

fix astro ui zlib CVE

## Related Issues

related: https://github.com/astronomer/astro-ui/pull/1400

## Testing

passes CI