### PR TITLE
Sync release28 branch

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.0
+    tag: 3.15.1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.1
+    tag: 0.26.2
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.4
+    tag: 0.26.5
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.1
+    tag: 3.15.3
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-11
+    tag: 5.8.4-12
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.6
+    tag: 1.21.6-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,11 +10,11 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.16.3
+    tag: 7.17.1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-3
+    tag: 3.15.3
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-10
+    tag: 5.8.4-11
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.4
+    tag: 1.21.6
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.19.9
+    tag: 1.19.9-1
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-1
+    tag: 1.3-3
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.3-1
+    tag: 1.14.5
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.5
+    tag: 1.14.5-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.4
+    tag: 0.26.5
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.3.3-1
+    tag: 8.3.7
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.16.3
+    tag: 7.17.1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kubed/values.yaml
+++ b/charts/kubed/values.yaml
@@ -5,7 +5,7 @@
 images:
   kubed:
     repository: quay.io/astronomer/ap-kubed
-    tag: 0.13.0
+    tag: 0.13.2
     pullPolicy: IfNotPresent
 
 # Declare variables to be passed into your templates.

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1
+    tag: 0.9.1-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.7.2
+    tag: 2.7.2-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.7.2-1
+    tag: 2.7.2-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1-1
+    tag: 0.9.1-2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.2
+    tag: 0.28.3
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.1
+    tag: 0.28.2
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.0
+    tag: 0.28.1
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-6
+  tag: 0.19.0-7
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-5
+  tag: 0.19.0-6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.32.1
+    tag: 2.34.0
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.1
+    tag: 0.24.1-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.0-3
+    tag: 3.15.3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
## Description

This PR cherry-picks the commits from master to sync platform and vendor images which includes cve fixes


## Related Issues

NA

## Testing

QA should able to perform upgrade from existing installation and new installation of platform should not cause issues

**Overview of changes for QA view**

   quay.io/astronomer/ap-registry:3.15.3
   quay.io/astronomer/ap-cli-install:0.26.2
   quay.io/astronomer/ap-elasticsearch:7.17.1
   quay.io/astronomer/ap-kibana:7.17.1
   quay.io/astronomer/ap-base:3.15.3
   quay.io/astronomer/ap-curator:5.8.4-12
   quay.io/astronomer/ap-nginx-es:1.21.6-1
   quay.io/astronomer/ap-openresty:1.19.9-1
   quay.io/astronomer/ap-awsesproxy:1.3-3
   quay.io/astronomer/ap-fluentd:1.14.5-1 
   quay.io/astronomer/ap-grafana:8.3.7
   quay.io/astronomer/ap-kubed:0.13.2
   quay.io/astronomer/ap-nats-server:2.7.2-2
   quay.io/astronomer/ap-nats-exporter:0.9.1-2
   quay.io/astronomer/ap-nats-exporter:0.24.1-1
   quay.io/astronomer/ap-default-backend:0.28.3
   quay.io/astronomer/ap-blackbox-exporter:0.19.0-7
   quay.io/astronomer/ap-prometheus:2.34.0
   quay.io/astronomer/ap-db-bootstrapper:0.26.5
