### PR TITLE
vendor images includes fix for zlib

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.1
+    tag: 3.15.3
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-11
+    tag: 5.8.4-12
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.6
+    tag: 1.21.6-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.7.2-1
+    tag: 2.7.2-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1-1
+    tag: 0.9.1-2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.19.0-6
+  tag: 0.19.0-7
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.1
+    tag: 0.24.1-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter


### PR DESCRIPTION


## Description

* update ap-registry 3.15.1 -> 3.15.3
* update ap-curator 5.8.4-11 -> 5.8.4-12
* update ap-nginx-es 1.12.6 -> 1.21.6-1
* update ap-nats-server 2.7.2-1 -> 2.7.2-2
* update ap-nats-exporter 0.9.1-1 -> 0.9.1-2
* update ap-blackbox-exporter 0.19.0-6 -> 0.19.0-7
* update ap-nats-streaming  0.24.1 ->  0.24.1-1

## Related Issues

NA

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
