### PR TITLE
bump astro ui to 0.28.10 from 0.28.9

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.9
+    tag: 0.28.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

release 0.28.4 components for astro ui


## Related Issues

- https://github.com/astronomer/issues/issues/4167
- https://github.com/astronomer/issues/issues/4168
- https://github.com/astronomer/issues/issues/4348
- https://github.com/astronomer/issues/issues/4021
- https://github.com/astronomer/issues/issues/4398


## Testing

tested in dev
