### PR TITLE
bump ap-cli-install

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.2
+    tag: 0.26.3
     pullPolicy: IfNotPresent
 
 astroUI:


### PR DESCRIPTION
## Description

Fixes zlib vulnerability
bump ap-cli-install 0.26.2 -> 0.26.3

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
