### PR TITLE
CI: check commander's airflow chart version matches astronomer/astronomer's

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,16 @@ jobs:
             kubent --cluster=false --helm2=false --helm3=false --filename -
           when: always
 
+  check-commander-airflow-version:
+    docker:
+      - image: cimg/base:2022.03
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Check that commander image uses same Airflow chart version
+          command: make validate-commander-airflow-version
+
 workflows:
   version: 2.1
   build-and-release-helm-chart:
@@ -171,6 +181,7 @@ workflows:
       - lint
       - run_pre_commit
       - unittest-charts
+      - check-commander-airflow-version
       - build-artifact:
           requires:
             - lint

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -131,6 +131,16 @@ jobs:
           when: always
 {%- endfor %}
 
+  check-commander-airflow-version:
+    docker:
+      - image: cimg/base:2022.03
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Check that commander image uses same Airflow chart version
+          command: make validate-commander-airflow-version
+
 workflows:
   version: 2.1
   build-and-release-helm-chart:
@@ -138,6 +148,7 @@ workflows:
       - lint
       - run_pre_commit
       - unittest-charts
+      - check-commander-airflow-version
       - build-artifact:
           requires:
             - lint

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ unittest-requirements: .unittest-requirements ## Setup venv required for unit te
 unittest-charts: .unittest-requirements ## Unittest the Astronomer helm chart
 	venv/bin/python -m pytest -n auto tests
 
+.PHONY: validate-commander-airflow-version
+validate-commander-airflow-version:
+	./bin/validate_commander_airflow_version
+
 .PHONY: lint-charts
 lint-charts: lint-prep ## Lint Astronomer sub-charts
 	# Check that nothing accidentally is using release name instead of namespace for metadata.namespace

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ unittest-charts: .unittest-requirements ## Unittest the Astronomer helm chart
 validate-commander-airflow-version:
 	./bin/validate_commander_airflow_version
 
+.PHONY: test
+test: validate-commander-airflow-version unittest-charts
+
 .PHONY: lint-charts
 lint-charts: lint-prep ## Lint Astronomer sub-charts
 	# Check that nothing accidentally is using release name instead of namespace for metadata.namespace

--- a/bin/validate_commander_airflow_version
+++ b/bin/validate_commander_airflow_version
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+GIT_ROOT="$(git -C "${0%/*}" rev-parse --show-toplevel)"
+
+commander_image=quay.io/astronomer/ap-commander
+# Get commander's version from astronomer subchart values.yaml
+commander_version=$(grep -A1 -E "$commander_image" "$GIT_ROOT/charts/astronomer/values.yaml" | grep -o -E '[0-9]+.[0-9]+.[0-9]+')
+commander_image_full="$commander_image:$commander_version"
+
+# Retrieve the value for the airflow chart version label on commander's docker image
+docker pull "$commander_image_full"
+
+commander_airflow_chart_version=$(docker inspect "$commander_image_full" | jq -r '.[0].Config.Labels."io.astronomer.build.airflow.chart.version"')
+
+# Check if it matches with astronomer/astronomer chart's default value for Airflow chart version
+if [[ "$commander_airflow_chart_version" != "null" ]]; then
+    astronomer_airflow_chart_version=$(grep -E "airflowChartVersion" "$GIT_ROOT/charts/astronomer/values.yaml" | grep -o -E '[0-9]+.[0-9]+.[0-9]+')
+    if [[ "$astronomer_airflow_chart_version" != "$commander_airflow_chart_version" ]]; then
+        echo "Error: Airflow Chart version mismatch between Commander (release $commander_version): $commander_airflow_chart_version and astronomer/astronomer: $astronomer_airflow_chart_version"
+        exit 1
+    fi
+
+    echo "Success: Airflow Chart version matches in both Commander and astronomer/astronomer Helm Chart."
+else
+    echo "Commander's docker image (release $commander_version) does not have the associated label 'io.astronomer.build.airflow.chart.version', skipping this check..."
+fi


### PR DESCRIPTION
## Description

We want to check the Airflow Chart version used in Commander when making changes to astronomer/astronomer (see the issue for more details).

In this PR, I added the job in CI that inspects commander's image to retrieve the airflow chart version used, and compare it with the default version set in astronomer/astronomer.

This will allow us to get notified when there's a mismatch of Airflow Chart Version between Commander and astronomer/astronomer before shipping a release.

## Related Issues

https://github.com/astronomer/issues/issues/4369
