### PR TITLE
update nats exporter service

### DIFF
--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1-2
+    tag: 0.9.2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1
+    tag: 0.9.2
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION
## Description

* bump ap-nats-exporter 0.9.1 -> 0.9.2
* bump ap-nats-exporter 0.9.1-2 -> 0.9.2


## Related Issues
Fixes  CVE-2022-24450 vulnerability

![image](https://user-images.githubusercontent.com/81585115/162173921-dbf132d8-96f7-46f1-a39a-b29124c32201.png)

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
