### PR TITLE
fix cert issues with bumping houston-api to 0.28.17

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.14
+    tag: 0.28.17
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

fix cert issues for aws in houston-api

## Related Issues

no issue is created for issue

## Testing

vishnu tested 

## Merging

release-0.28
