### PR TITLE
update nats exporter service (#1453)

### DIFF
--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1-2
+    tag: 0.9.2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.1
+    tag: 0.9.2
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION
## Description

resolves CVE-2022-24450 cve

![image](https://user-images.githubusercontent.com/81585115/162244593-a60fb03a-792c-4d6c-abb0-c522908aafbe.png)



* bump ap-nats-exporter 0.9.1 -> 0.9.2
* bump ap-nats-exporter 0.9.1-2 -> 0.9.2


## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick commit id dfece8556f555535c095a17304ab2c0b160aa6dd to release-28 branch

