### PR TITLE
Bump versions for houston 0.28.18 and astro-ui 0.28.12

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.10
+    tag: 0.28.12
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.17
+    tag: 0.28.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

bump versions for houston 0.28.18 and astro-ui 0.28.12

## Related Issues

ui:
Relates https://github.com/astronomer/issues/issues/4457
Relates https://github.com/astronomer/issues/issues/4409
Relates https://github.com/astronomer/issues/issues/4146

houston:
Related https://github.com/astronomer/issues/issues/4457
related https://github.com/astronomer/issues/issues/4488

## Testing

tested by dev

## Merging

release-0.28 - 0.28.4
