### PR TITLE
add the image used by global.authSidecar.repository to make show-docker-images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ update-requirements: ## Update all requirements.txt files
 show-docker-images: ## Show all docker images and versions used in the helm chart
 	@helm template . \
 		--set global.baseDomain=foo.com \
+		--set global.authSidecar.enabled=True \
 		--set global.blackboxExporterEnabled=True \
 		--set global.postgresqlEnabled=True \
 		--set global.postgresqlEnabled=True \


### PR DESCRIPTION
## Description

Adds the image used by global.authSidecar.repository to the list of images listed by make show-docker-images

## Related Issues

https://github.com/astronomer/issues/issues/4502

## Testing

Ran make show-docker-images and now it shows up as expected. Note that this image is currently named nginxinc/nginx-unprivileged:stable but is anticipated to be renamed shortly.

## Merging

Please cherry-pick into all currently supported release branches as we may wish to use these values in automated image scanning in the future.