### PR TITLE
add ap-awsesproxy and ap-openresty to make show-docker-images output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,8 @@ show-docker-images: ## Show all docker images and versions used in the helm char
 		--set global.baseDomain=foo.com \
 		--set global.authSidecar.enabled=True \
 		--set global.blackboxExporterEnabled=True \
+		--set global.customLogging.awsSecretName=dummy \
+		--set global.customLogging.enabled=True \
 		--set global.postgresqlEnabled=True \
 		--set global.postgresqlEnabled=True \
 		--set global.prometheusPostgresExporterEnabled=True \

--- a/Makefile
+++ b/Makefile
@@ -65,29 +65,15 @@ update-requirements: ## Update all requirements.txt files
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
 	@helm template . \
-		--set global.baseDomain=foo.com \
-		--set global.authSidecar.enabled=True \
-		--set global.blackboxExporterEnabled=True \
-		--set global.customLogging.awsSecretName=dummy \
-		--set global.customLogging.enabled=True \
-		--set global.postgresqlEnabled=True \
-		--set global.postgresqlEnabled=True \
-		--set global.prometheusPostgresExporterEnabled=True \
-		--set global.pspEnabled=True \
-		--set global.veleroEnabled=True \
+		-f tests/enable_all_features.yaml \
 		2>/dev/null \
 		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
 
 .PHONY: show-docker-images
 show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
 	@helm template . \
+		-f tests/enable_all_features.yaml \
 		--set global.privateRegistry.enabled=True \
 		--set global.privateRegistry.repository=example.com/the-private-registry \
-		--set global.baseDomain=foo.com \
-		--set global.blackboxExporterEnabled=True \
-		--set global.postgresqlEnabled=True \
-		--set global.prometheusPostgresExporterEnabled=True \
-		--set global.pspEnabled=True \
-		--set global.veleroEnabled=True \
 		2>/dev/null \
 		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -1,0 +1,12 @@
+global:
+  authSidecar:
+    enabled: true
+  baseDomain: foo.com
+  blackboxExporterEnabled: true
+  customLogging:
+    awsSecretName: dummy
+    enabled: true
+  postgresqlEnabled: true
+  prometheusPostgresExporterEnabled: true
+  pspEnabled: true
+  veleroEnabled: true


### PR DESCRIPTION
## Description

We have two images not showing up on make show-docker-images. This sets the options needed for ap-awsesproxy and ap-openresty to show.

## Related Issues

https://github.com/astronomer/issues/issues/4508

## Testing

Ran make show-docker-images before and after, here's the diff of the results before and after this change.

```
rob@Robs-MacBook-Pro astronomer % diff -u /tmp/old /tmp/new
--- /tmp/old	2022-04-12 08:48:55.000000000 -0400
+++ /tmp/new	2022-04-12 08:52:34.000000000 -0400
@@ -1,6 +1,7 @@
 https://nginxinc/nginx-unprivileged                   nginxinc/nginx-unprivileged:stable
 https://quay.io/astronomer/ap-alertmanager            quay.io/astronomer/ap-alertmanager:0.23.0
 https://quay.io/astronomer/ap-astro-ui                quay.io/astronomer/ap-astro-ui:0.28.12
+https://quay.io/astronomer/ap-awsesproxy              quay.io/astronomer/ap-awsesproxy:1.3-3
 https://quay.io/astronomer/ap-base                    quay.io/astronomer/ap-base:3.15.3
 https://quay.io/astronomer/ap-blackbox-exporter       quay.io/astronomer/ap-blackbox-exporter:0.19.0-7
 https://quay.io/astronomer/ap-cli-install             quay.io/astronomer/ap-cli-install:0.26.3
@@ -23,6 +24,7 @@
 https://quay.io/astronomer/ap-nginx                   quay.io/astronomer/ap-nginx:0.50.0
 https://quay.io/astronomer/ap-nginx-es                quay.io/astronomer/ap-nginx-es:1.21.6-1
 https://quay.io/astronomer/ap-node-exporter           quay.io/astronomer/ap-node-exporter:1.3.1
+https://quay.io/astronomer/ap-openresty               quay.io/astronomer/ap-openresty:1.19.9-1
 https://quay.io/astronomer/ap-postgres-exporter       quay.io/astronomer/ap-postgres-exporter:0.10.1
 https://quay.io/astronomer/ap-postgresql              quay.io/astronomer/ap-postgresql:11.13.0
 https://quay.io/astronomer/ap-prometheus              quay.io/astronomer/ap-prometheus:2.34.0
```

## Merging

Please cherry-pick into all currently supported release branches as we may use the output of make show-docker-images for security scanning in the future.
