### PR TITLE
fix: namespace pool add platform label to namespaces for KubeD

### DIFF
--- a/charts/astronomer/templates/namespaces.yaml
+++ b/charts/astronomer/templates/namespaces.yaml
@@ -6,5 +6,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $namespaceName }}
+  labels:
+    # these labels are used by multiple components for example KubeD to synchronize required secrets
+    platform: {{ .Release.Name }}
+    platform-release: {{ .Release.Name }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## Description

After working on the "KubeD deprecation/removal" task for multiple days, I realized that namespaces created in a namespace pool do not have the `platform` label.

This label is used by components such as `KubeD` in order to synchronize K8s secrets to the airflow deployment namespaces. Airflow deployments might need these secrets in multiple use cases:
- Houston JWT signing certificate is exposed via a GraphQL resolver, but if the user uses a private CA with mTLS authentication, Airflow deployments can't access Houston and need to load the signing certificate from K8s secret.
- OpenShift users need SSL certificates to get synchronized to Airflow deployment namespaces.

To avoid breaking changes for these use cases for namespace pool users, I'm simply adding these labels to these namespaces created by this helm chart.

## Testing

To test this fix, we need to:
- Deploy this helm chart, with namespace pools enabled and namespaces creation enabled, see the following values.yaml:
```yaml
global:
  features:
    namespacePools:
      enabled: true
      namespaces:
        create: true
        names:
          - my-ns-1
          - my-ns-2
```
  This will configure Astronomer to use 2 namespaces in the pool my-ns-1 and my-ns-2, these namespaces should be created with the `platform={{ your release name }}` label.
- check if the houston jwt signing certificate secret has been synchronized to these namespaces properly:
```
kubectl get secret -n my-ns-1
# It should display 
{{ your release name}}-houston-jwt-signing-certificate
```
