### PR TITLE
fix loadBalancerIPs to loadBalancerIP

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -47,7 +47,7 @@ ingressAnnotations: {}
 antiAffinity: "soft"
 
 # String IP address the nginx ingress should bind to
-loadBalancerIPs: ~
+loadBalancerIP: ~
 
 # String IP address that the service should list as an external IP. Currently only 1 address is supported
 externalIPs: ~


### PR DESCRIPTION
## Description

Update values typo introduced in pull #1160

## Related Issues

closes https://github.com/astronomer/issues/issues/4522

## Testing

Verified that  loadBalancerIP was used in the code but incorrectly identified in the values file


