### PR TITLE
turn on GRPC logs for houston

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -113,6 +113,10 @@ spec:
             failureThreshold: {{ .Values.houston.readinessProbe.failureThreshold }}
           env:
             {{- include "houston_environment" . | indent 12 }}
+            - name: GRPC_VERBOSITY
+              value: "INFO"
+            - name: GRPC_TRACE
+              value: "all"
             - name: APOLLO_SERVER_ID
               valueFrom:
                 fieldRef:

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -90,6 +90,10 @@ spec:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}
           env:
+            - name: GRPC_VERBOSITY
+              value: "INFO"
+            - name: GRPC_TRACE
+              value: "all"
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Description

Log grpc requests logs

## Related Issues

Related https://github.com/astronomer/issues/issues/4329

related pr: https://github.com/astronomer/houston-api/pull/1055
## Testing

locally test in kind

when i set to debug level at the astro/astro level logs look like:
```
astronomer-houston-worker-8487b64497-jlnvr houston D 2022-04-20T20:15:17.178Z | index | Loading @grpc/grpc-js version 1.4.2
astronomer-houston-worker-8487b64497-jlnvr houston {"level":"DEBUG","message":"2022-04-20T20:15:17.606Z | resolving_load_balancer | dns:astronomer-commander:50051 IDLE -> IDLE","timestamp":"2022-04-20T20:15:17.610"}
astronomer-houston-worker-8487b64497-jlnvr houston {"level":"DEBUG","message":"2022-04-20T20:15:17.616Z | connectivity_state | (1) dns:astronomer-commander:50051 IDLE -> IDLE","timestamp":"2022-04-20T20:15:17.616"}
astronomer-houston-worker-8487b64497-jlnvr houston {"level":"DEBUG","message":"2022-04-20T20:15:17.617Z | dns_resolver | Resolver constructed for target dns:astronomer-commander:50051","timestamp":"2022-04-20T20:15:17.617"}
astronomer-houston-worker-8487b64497-jlnvr houston {"level":"DEBUG","message":"2022-04-20T20:15:17.622Z | channel | (1) dns:astronomer-commander:50051 Channel constructed with options {}","timestamp":"2022-04-20T20:15:17.622"}
though there is too many logs so setting it as info instead
```

## Merging

0.29