### PR TITLE
fixes CVE-2022-28391

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.3
+    tag: 3.15.4
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.5
+    tag: 0.26.6
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.3
+    tag: 3.15.4
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-12
+    tag: 5.8.4-13
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.6-1
+    tag: 1.21.6-2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-3
+    tag: 1.3-4
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.7.2-2
+    tag: 2.7.2-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.2
+    tag: 0.9.2-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.15.3
+    tag: 3.15.4
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.1-1
+    tag: 0.24.1-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.2
+    tag: 0.9.2-1
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION

## Description
fixes CVE-2022-28391
* bump ap-registry 3.15.3 -> 3.15.4
* bump ap-db-bootstraper 0.26.5 -> 0.26.6
* bump  ap-base 3.15.3 -> 3.15.4
* bump ap-curator 5.8.4-12 -> 5.8.4-13
* bump nginx-es 1.21.6-1 1.21.6-2
* bump ap-awsesproxy 1.3-3 -> 1.3-4
* bump ap-nats-exporter 0.9.2 -> 0.9.2-1
* bump ap-nats-streaming 0.24.1-1 0.24.1-2
* bump ap-nats-exporter 0.9.2 -> 0.9.2-1
* bump ap-nats-server 2.7.2-2 -> 2.7.2-3

## Related Issues

https://github.com/astronomer/issues/issues/4538

## Testing

NA

## Merging

should go in release-29 and release-28
