### PR TITLE
fix kubed performance in large clusters: scope to release ns

### DIFF
--- a/charts/kubed/templates/kubed-deployment.yaml
+++ b/charts/kubed/templates/kubed-deployment.yaml
@@ -59,6 +59,7 @@ spec:
         - --tls-private-key-file=/var/serving-cert/tls.key
         - --use-kubeapiserver-fqdn-for-aks={{ .Values.apiserver.useKubeapiserverFqdnForAks }}
         - --enable-analytics={{ .Values.enableAnalytics }}
+        - --config-source-namespace={{ .Release.Namespace }}
         ports:
         - containerPort: 8443
 {{- if .Values.apiserver.healthcheck.enabled }}

--- a/tests/test_kubed.py
+++ b/tests/test_kubed.py
@@ -39,3 +39,16 @@ class TestKubed:
                 values={"global": {"kubedEnabled": False}},
                 show_only=self.show_only,
             )
+
+    def test_kubed_config_source_namespace(self, kube_version):
+        """Test that the KubeD deployment is rendered with the right configuration to scope configuration source to release namespace."""
+
+        namespace = "my-namespace"
+        doc = render_chart(
+            namespace=namespace,
+            kube_version=kube_version,
+            show_only=["charts/kubed/templates/kubed-deployment.yaml"],
+        )[0]
+
+        container = doc["spec"]["template"]["spec"]["containers"][0]
+        assert f"--config-source-namespace={namespace}" in container["args"]


### PR DESCRIPTION
## Description

Use a configuration flag on KubeD Deployment to scope it to Astronomer release namespace. Should fix performance issues and latency before synchronizing secrets.

## Related Issues

https://github.com/astronomer/issues/issues/4546