### PR TITLE
nginx chart uses quay.io/astronomer/ap-nginx:1.2.0

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.1.2-1
+    tag: 1.2.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION


## Description

* cherry-pick release-29 branch
* fixes kubernetes/ingress-nginx#8503

## Related Issues

NA

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to release-29 branch
