### PR TITLE
update nginx default backend

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.3
+    tag: 0.28.4
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION

## Description

* bump 0.28.3 -> 0.28.4

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA team should able to see the 404, 503, 403 error pages properly

## Merging

merge to release-29 and release-28 
