### PR TITLE
fix security issues

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.3
+    tag: 0.26.4
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.3.7
+    tag: 8.3.7-1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.5
+    tag: 0.26.6
     pullPolicy: IfNotPresent
 
 backendSecretName: ~


### PR DESCRIPTION


## Description
some security fix enhancements 

* bump ap-grafana 8.3.7 -> 8.3.7-1
* bump ap-db-bootstrapper 0.26.5 -> 0.26.6
* bump ap-cli-install 0.26.3 -> 0.26.4

## Related Issues

NA

## Testing

export img_list=("quay.io/astronomer/ap-grafana:8.3.7-1" "quay.io/astronomer/ap-db-bootstrapper:0.26.6" "quay.io/astronomer/ap-cli-install:0.26.4")
for images in "${img_list[@]}"; do trivy image -f table -s CRITICAL,HIGH $images | grep -Ev 'INFO|WARN'; done

## Merging

cherry-pick to release-27,28,29
