### PR TITLE
Use the long URL since git.io is shutting down.

### DIFF
--- a/bin/build-helm-chart.sh
+++ b/bin/build-helm-chart.sh
@@ -18,7 +18,7 @@ if [[ ! "${CIRCLE_BRANCH}" =~ release-[0-9]+\.[0-9]+ ]] ; then
   version=$(awk '$1 ~ /^version/ {printf "%s-build%s\n", $2, ENVIRON["CIRCLE_BUILD_NUM"]}' "${TEMPDIR}/astronomer/Chart.yaml")
   echo "Building helm chart for CIRCLE_BUILD_NUM $CIRCLE_BUILD_NUM version ${version}"
   sed -Ei "/(^version|appVersion): /s/^(version|appVersion): .*/\1: $version/" "${TEMPDIR}/astronomer/Chart.yaml" "${TEMPDIR}/astronomer/charts/astronomer/Chart.yaml"
-  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL} tps://github.com/astronomer/astronomer/commits/${CIRCLE_SHA1}#" "${TEMPDIR}/astronomer/Chart.yaml"
+  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL} https://github.com/astronomer/astronomer/commits/${CIRCLE_SHA1}#" "${TEMPDIR}/astronomer/Chart.yaml"
 fi
 
 helm package "${TEMPDIR}/astronomer"

--- a/bin/build-helm-chart.sh
+++ b/bin/build-helm-chart.sh
@@ -18,8 +18,7 @@ if [[ ! "${CIRCLE_BRANCH}" =~ release-[0-9]+\.[0-9]+ ]] ; then
   version=$(awk '$1 ~ /^version/ {printf "%s-build%s\n", $2, ENVIRON["CIRCLE_BUILD_NUM"]}' "${TEMPDIR}/astronomer/Chart.yaml")
   echo "Building helm chart for CIRCLE_BUILD_NUM $CIRCLE_BUILD_NUM version ${version}"
   sed -Ei "/(^version|appVersion): /s/^(version|appVersion): .*/\1: $version/" "${TEMPDIR}/astronomer/Chart.yaml" "${TEMPDIR}/astronomer/charts/astronomer/Chart.yaml"
-  short_git_url=$(curl -sS -i https://git.io -F "url=https://github.com/astronomer/astronomer/commits/${CIRCLE_SHA1}" | awk '$1 == "Location:" {printf "%s", $2}')
-  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${short_git_url} ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL}#" "${TEMPDIR}/astronomer/Chart.yaml"
+  sed -i "s#^description: .*#description: $(date "+%FT%T%z") ${CIRCLE_BRANCH} ${CIRCLE_BUILD_URL} tps://github.com/astronomer/astronomer/commits/${CIRCLE_SHA1}#" "${TEMPDIR}/astronomer/Chart.yaml"
 fi
 
 helm package "${TEMPDIR}/astronomer"


### PR DESCRIPTION
## Description

[git.io is shutting down on Friday](https://github.blog/changelog/2022-04-25-git-io-deprecation/). This change removes the short URL and just uses the long URL. 

## Related Issues

https://github.com/astronomer/issues/issues/4564

## Testing

This is a very small change that is only related to CI. No testing is needed if CI passes.

## Merging

This change should be merged to every branch we support.