### PR TITLE
Skip check when airflowChartVersion is an rc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,14 @@
 ---
 exclude: '(venv|\.vscode)' # regex
 repos:
+  - repo: local
+    hooks:
+      - id: circle-config-yaml
+        name: Checks for consistency between config.yml and config.yml.j2
+        language: python
+        files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
+        entry: .circleci/generate_circleci_config.py
+        additional_dependencies: ["jinja2"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
@@ -57,11 +65,3 @@ repos:
     rev: v0.8.0.4
     hooks:
       - id: shellcheck
-  - repo: local
-    hooks:
-      - id: circle-config-yaml
-        name: Checks for consistency between config.yml and config.yml.j2
-        language: python
-        files: "config.yml$|config.yml.j2|generate_circleci_config.py$"
-        entry: .circleci/generate_circleci_config.py
-        additional_dependencies: ["jinja2"]

--- a/bin/validate_commander_airflow_version
+++ b/bin/validate_commander_airflow_version
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if grep -E 'airflowChartVersion: [0-9.]+-rc[0-9]+' charts/astronomer/values.yaml ; then
+    echo "Skipping check because airflowChartVersion is an rc"
+    exit 0
+fi
+
 if ! docker version ; then
     echo "ABORT: Something is wrong with docker."
     exit 1


### PR DESCRIPTION
## Description

Skip check when airflowChartVersion is an rc, which breaks us out of a hard dependency loop that and eases testing of rc airflow releases in astronomer release branches.

CI was failing on release-0.29 branch version 0.29.0-rc5 where airflowChartVersion was set to 1.5.0-rc1 because commander did not match the same version. AFAIK this match is not necessary except in airgapped situations, so it should definitely be checked on release branches, but not when we're in an airflow-chart rc phase.

## Related Issues

N/A

## Testing

I manually tested this by changing the `airflowChartVersion` in `charts/astronomer/values.yaml`. The grep syntax works with both bsd and gnu grep.

## Merging

This should be merged to any branches that this check exists in.