### PR TITLE
bump astro ui to 0.29.3 from 0.29.2- runtime ui bug fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.29.2
+    tag: 0.29.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update astro ui with fixes for runtime ui for migrate button to be consitent

## Related Issues

Related https://github.com/astronomer/issues/issues/4475

## Testing

tested in dev

## Merging

0.39