### PR TITLE
adding sidecar houston config overrides

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -94,6 +94,13 @@ data:
           {{- end }}
         }
       {{- end }}
+      {{- if .Values.houston.loggingSidecar.enabled }}
+      # enables sidecar logging for airflow deployments
+      loggingSidecar:
+        enabled: true
+        name: {{ .Values.houston.loggingSidecar.name }}
+        terminationEndpoint: {{ .Values.houston.loggingSidecar.terminationEndpoint }}
+      {{- end }}
 
       # These values get passed directly into the airflow helm deployments
       helm:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -252,7 +252,7 @@ data:
                   if container.args[0:3] == ["airflow", "tasks", "run"]:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
-                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL {{ .Values.houston.loggingSidecar.terminationEndpoint }}"
+                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.houston.loggingSidecar.terminationEndpoint }}"
                       new_args.append(command_str)
                       container.args = new_args
 


### PR DESCRIPTION
## Description

- Add houston loggingSidecar flag overrides
- Fix curl call to kill container by adding missing http post method
- Improve logging sidecar tests

## Related Issues

- https://github.com/astronomer/issues/issues/4577
- https://github.com/astronomer/issues/issues/4576

## Testing

Verified in an AWS test cluster that these changes solve the original issue.

## Merging

This should only go to 0.29