### PR TITLE
drop all capabilities from elastic service

### DIFF
--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -84,14 +84,6 @@ spec:
       - name: es-data
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
-          capabilities:
-            add:
-              {{- if .Values.common.persistence.enabled }}
-              - IPC_LOCK
-              {{- else }}
-              - IPC_LOCK
-              - SYS_RESOURCE
-              {{- end }}
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.images.es.pullPolicy }}
         env:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -83,14 +83,6 @@ spec:
       - name: es-master
         securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
-          capabilities:
-            add:
-              {{- if .Values.common.persistence.enabled }}
-              - IPC_LOCK
-              {{- else }}
-              - IPC_LOCK
-              - SYS_RESOURCE
-              {{- end }}
         image: {{ template "elasticsearch.image" . }}
         imagePullPolicy: {{ .Values.images.es.pullPolicy }}
         env:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -218,5 +218,8 @@ podSecurityContext:
   fsGroup: 1000
 
 securityContext:
+  capabilities:
+    drop:
+      - ALL
   runAsNonRoot: true
   runAsUser: 1000

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -100,13 +100,6 @@ class TestElasticSearch:
                 "fsGroup": 1000
             }
 
-            assert doc["spec"]["template"]["spec"]["securityContext"] == {
-                "runAsNonRoot": True
-            }
-            assert doc["spec"]["template"]["spec"]["securityContext"] == {
-                "runAsUser": 1000
-            }
-
     def test_elasticsearch_securitycontext_defaults(self, kube_version):
         """Test  ElasticSearch master, data with securitycontext default values"""
         docs = render_chart(

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -11,7 +11,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 )
 class TestElasticSearch:
     def test_elasticsearch_with_sysctl_defaults(self, kube_version):
-        """Test  ElasticSearch with sysctl config/values.yaml."""
+        """Test ElasticSearch with sysctl config/values.yaml."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -83,8 +83,8 @@ class TestElasticSearch:
         for doc in docs:
             assert not doc["spec"]["template"]["spec"]["initContainers"]
 
-    def test_elasticsearch_securitycontext_defaults(self, kube_version):
-        """Test  ElasticSearch master, data and client with securitycontext default values"""
+    def test_elasticsearch_fsgroup_defaults(self, kube_version):
+        """Test  ElasticSearch master, data and client with FsGroup default values"""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -99,3 +99,52 @@ class TestElasticSearch:
             assert doc["spec"]["template"]["spec"]["securityContext"] == {
                 "fsGroup": 1000
             }
+
+            assert doc["spec"]["template"]["spec"]["securityContext"] == {
+                "runAsNonRoot": True
+            }
+            assert doc["spec"]["template"]["spec"]["securityContext"] == {
+                "runAsUser": 1000
+            }
+
+    def test_elasticsearch_securitycontext_defaults(self, kube_version):
+        """Test  ElasticSearch master, data with securitycontext default values"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+                "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+            ],
+        )
+        assert len(docs) == 2
+        for doc in docs:
+            pod_data = doc["spec"]["template"]["spec"]["containers"][0]
+            assert pod_data["securityContext"]["capabilities"]["drop"] == ["ALL"]
+            assert pod_data["securityContext"]["runAsNonRoot"] is True
+            assert pod_data["securityContext"]["runAsUser"] == 1000
+
+    def test_elasticsearch_securitycontext_overrides(self, kube_version):
+        """Test  ElasticSearch master, data  with securitycontext custom values"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "elasticsearch": {
+                    "securityContext": {
+                        "capabilities": {"drop": ["IPC_LOCK"]},
+                        "runAsNonRoot": True,
+                        "runAsUser": 1001,
+                    }
+                }
+            },
+            show_only=[
+                "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+                "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+            ],
+        )
+        assert len(docs) == 2
+        for doc in docs:
+            pod_data = doc["spec"]["template"]["spec"]["containers"][0]
+            assert pod_data["securityContext"]["capabilities"]["drop"] == ["IPC_LOCK"]
+            assert pod_data["securityContext"]["runAsNonRoot"] is True
+            assert pod_data["securityContext"]["runAsUser"] == 1001

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -84,7 +84,7 @@ class TestElasticSearch:
             assert not doc["spec"]["template"]["spec"]["initContainers"]
 
     def test_elasticsearch_fsgroup_defaults(self, kube_version):
-        """Test  ElasticSearch master, data and client with FsGroup default values"""
+        """Test ElasticSearch master, data and client with fsGroup default values"""
         docs = render_chart(
             kube_version=kube_version,
             values={},

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -118,7 +118,7 @@ class TestElasticSearch:
             assert pod_data["securityContext"]["runAsUser"] == 1000
 
     def test_elasticsearch_securitycontext_overrides(self, kube_version):
-        """Test  ElasticSearch master, data  with securitycontext custom values"""
+        """Test ElasticSearch master, data with securityContext custom values"""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -131,7 +131,7 @@ class TestElasticSearch:
             values={
                 "elasticsearch": {
                     "securityContext": {
-                        "capabilities": {"drop": ["IPC_LOCK"]},
+                        "capabilities": {"add": ["IPC_LOCK"]},
                         "runAsNonRoot": True,
                         "runAsUser": 1001,
                     }
@@ -145,6 +145,6 @@ class TestElasticSearch:
         assert len(docs) == 2
         for doc in docs:
             pod_data = doc["spec"]["template"]["spec"]["containers"][0]
-            assert pod_data["securityContext"]["capabilities"]["drop"] == ["IPC_LOCK"]
+            assert pod_data["securityContext"]["capabilities"]["add"] == ["IPC_LOCK"]
             assert pod_data["securityContext"]["runAsNonRoot"] is True
             assert pod_data["securityContext"]["runAsUser"] == 1001

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -101,7 +101,7 @@ class TestElasticSearch:
             }
 
     def test_elasticsearch_securitycontext_defaults(self, kube_version):
-        """Test  ElasticSearch master, data with securitycontext default values"""
+        """Test ElasticSearch master, data with securityContext default values"""
         docs = render_chart(
             kube_version=kube_version,
             values={},


### PR DESCRIPTION
## Description

Dropping all capabilities from elasticsearch, this will allow enterprise customer to install elasticsearch with no extra privileges 

## Related Issues

https://github.com/astronomer/issues/issues/4226

## Testing

Yet to update

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
