### PR TITLE
bump astro ui to 0.29.4 from 0.29.3

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.29.3
+    tag: 0.29.4
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

fix astro ui runtime triggerer and scheduler slider not showing up problem

## Related Issues

https://github.com/astronomer/issues/issues/4574

## Testing

tested locally and in dev

## Merging

0.29
