### PR TITLE
bump houston to 0.29.6 from 0.29.5

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.5
+    tag: 0.29.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

various runtime issues for release 0.29 

## Related Issues
Related https://github.com/astronomer/issues/issues/4574
Related https://github.com/astronomer/issues/issues/4566
https://github.com/astronomer/issues/issues/4584
Related https://github.com/astronomer/issues/issues/4557
https://github.com/astronomer/issues/issues/4557

## Testing

in dev and locally

## Merging

0.29