### PR TITLE
Feature/ap 4510

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.3
+    tag: 7.17.3-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.3.7-1
+    tag: 8.3.7-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.3
+    tag: 7.17.3-1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -34,5 +34,8 @@ def test_container_non_root(request, container):
         f"kubectl://{container['pod_name']}?container={container['_name']}&namespace={container['namespace']}"
     )
 
-    user = pod_client.check_output("whoami")
-    assert user != "root"
+    user_info = pod_client.user()
+    assert user_info.name != "root"
+    assert user_info.group != "root"
+    assert user_info.gid != 0
+    assert user_info.uid != 0


### PR DESCRIPTION
## Description

Updating docker image for below services. This change update the docker container to run as non-root user.

- ap-grafana
- ap-kibana
- ap-elasticsearch

Change PR: https://github.com/astronomer/ap-vendor/pull/294

Other change: Updating non-root functional test case to test `gid` and `uid`.

## Related Issues

https://github.com/astronomer/issues/issues/4510
https://github.com/astronomer/issues/issues/4511
https://github.com/astronomer/issues/issues/4512

## Testing

- Non-root check was tested in change PR.
- Image availability is checked by the unit-test (test_docker_images.py).

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
