### PR TITLE
Feature/AP-4510 Updating images with non root users

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.1
+    tag: 7.17.3-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.3.7
+    tag: 8.3.7-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.1
+    tag: 7.17.3-1
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"


### PR DESCRIPTION
## Description

Updating docker image for below services. This change update the docker container to run as non-root user. This PR is to check the backward support.

- ap-grafana
- ap-kibana
- ap-elasticsearch


- PR to `master`: https://github.com/astronomer/astronomer/pull/1503
- Change PR: https://github.com/astronomer/ap-vendor/pull/294

## Related Issues

https://github.com/astronomer/issues/issues/4510
https://github.com/astronomer/issues/issues/4511
https://github.com/astronomer/issues/issues/4512

## Testing

Non-root check was tested in change PR.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
