### PR TITLE
grafana 8.4.5-1

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.3.7-1
+    tag: 8.4.5-1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

grafana 8.4.5-1

## Related Issues

https://github.com/astronomer/issues/issues/4452

## Testing

I have manually tested this version in prod.

## Merging

This should be merged to anywhere that we are using grafana 8. Definitely into 0.29, but probably also 0.28.