### PR TITLE
Fix openshift RBAC permissions with namespace pools

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -158,7 +158,7 @@ rules:
 {{- end }}
 {{- end }}
 # Only grant OpenShift permissions if using cluster Roles.
-# Commander needs Cluster-level permissions to manage securitycontextconstraints
+# Commander needs Cluster-level permissions to manage SecurityContextConstraints
 {{- if and $useClusterRoles $.Values.global.sccEnabled }}
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
@@ -168,7 +168,7 @@ rules:
 {{- end }}
 
 # If users run Openshift, and are using namespace pools, we also need to provide commander
-# with CLUSTER permissions for the securitycontextconstraints resource from Openshift.
+# with CLUSTER permissions for the SecurityContextConstraints resource from Openshift.
 {{- if and .Values.global.rbacEnabled .Values.global.sccEnabled (not $useClusterRoles) }}
 ---
 kind: ClusterRole

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -157,10 +157,35 @@ rules:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- if $.Values.global.sccEnabled }}
+# Only grant OpenShift permissions if using cluster Roles.
+# Commander needs Cluster-level permissions to manage securitycontextconstraints
+{{- if and $useClusterRoles $.Values.global.sccEnabled }}
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
   verbs: ["create", "delete", "list", "watch"]
 {{ end }}
 {{ end }}
+{{- end }}
+
+# If users run Openshift, and are using namespace pools, we also need to provide commander
+# with CLUSTER permissions for the securitycontextconstraints resource from Openshift.
+{{- if and .Values.global.rbacEnabled .Values.global.sccEnabled (not $useClusterRoles) }}
+---
+kind: ClusterRole
+apiVersion: {{ template "apiVersion.rbac" . }}
+metadata:
+  name: {{ $.Release.Name }}-commander
+  labels:
+    tier: houston
+    release: {{ $.Release.Name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    heritage: {{ $.Release.Service }}
+  {{- if $.Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
+rules:
+- apiGroups: ["security.openshift.io"]
+  resources: ["securitycontextconstraints"]
+  verbs: ["create", "delete", "list", "watch"]
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -38,3 +38,25 @@ subjects:
     namespace: {{ $.Release.Namespace }}
 {{ end }}
 {{- end }}
+
+# If user runs Openshift and uses the namespace pools feature, we need to provide
+# cluster level permissions to manage some Openshift resources.
+{{- if and .Values.global.rbacEnabled .Values.global.sccEnabled (not $useClusterRoles) }}
+---
+apiVersion: {{ template "apiVersion.rbac" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $.Release.Name }}-commander
+  {{- if $.Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ $.Release.Name }}-commander
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Release.Name }}-commander
+    namespace: {{ $.Release.Namespace }}
+{{- end }}


### PR DESCRIPTION
## Description

With recent re-work on the namespace pools feature, we have removed the use of ClusterRoles and ClusterRoleBindings for `commander`.

On Openshift, commander needs permissions to manage `securitycontextconstraints` resources, set at the **CLUSTER** Level (through ClusterRole and ClusterRoleBinding).

So in this PR, I simply added a Cluster and ClusterRoleBinding if `namespacePools` is enabled, and `sccEnabled` is true, to only create Cluster-RBAC permissions in this scenario.

## Related Issues

https://github.com/astronomer/issues/issues/4613
