### PR TITLE
Use houston-bootstrapper SA in upgrade-deployment hook job

### DIFF
--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -33,6 +33,7 @@ spec:
         sidecar.istio.io/inject: "false"
       {{- end }}
     spec:
+      serviceAccountName: {{ template "houston.bootstrapperServiceAccount" . }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:


### PR DESCRIPTION
## Description

We had an issue where the job houston-upgrade-deployment (triggered when Helm release is upgraded for Astronomer Platform) failed due to insufficient K8s permissions.

The `initContainer` houston-bootstrapper tried to read and create/patch a k8s secret. This k8s job was configured with `default` service account, with 0 permissions, so it failed.

To fix this, I simply made the houston-upgrade-deployment job use an already-created houston-bootstrapper SA which seems to be used for this very specific purpose.

## Related Issues

https://github.com/astronomer/issues/issues/4618
