### PR TITLE
bump houston to 0.29.12 from 0.29.11

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.11
+    tag: 0.29.12
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

add email tempates for runtime errors

## Related Issues

related https://github.com/astronomer/issues/issues/4526

## Testing

local/dev

## Merging

0.29
