### PR TITLE
Fix bug deployments get deleted when namespace pools is disabled

### DIFF
--- a/charts/astronomer/templates/namespaces.yaml
+++ b/charts/astronomer/templates/namespaces.yaml
@@ -6,5 +6,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ $namespaceName }}
+  annotations:
+    # Keep namespaces if user disable namespace pools later on
+    "helm.sh/resource-policy": keep
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## Description

Fix a bug where existing deployments in namespaces from namespace pools get deleted when a user redeploys a new version of the Astronomer Platform with Namespace Pools feature disabled.

bug was that Helm deletes Namespace Resources since they are not part of the release anymore. When k8s deletes namespaces, it also deletes all resources inside it. In this case, the Airflow deployments.

## Related Issues

https://github.com/astronomer/issues/issues/4621

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
