### PR TITLE
bump houston to 0.29.13

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.12
+    tag: 0.29.13
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

bump Houston to 0.29.13

## Related Issues

Related https://github.com/astronomer/issues/issues/4586

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.
Tested google direct sign in in kind cluster

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
release-0.29