### PR TITLE
Added astronomer-nginx-metrics-policy global flag

### DIFF
--- a/charts/nginx/templates/nginx-metrics-networkpolicy.yaml
+++ b/charts/nginx/templates/nginx-metrics-networkpolicy.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Nginx controller metrics pods NetworkPolicy
 #################################
+{{- if .Values.global.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -29,3 +30,4 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.ports.metrics }}
+{{- end }}


### PR DESCRIPTION
## Description

Disable all the network policies from global configuration.Fixed this in regression testing cc @pgvishnuram 

## Related Issues

https://github.com/astronomer/issues/issues/4386

