### PR TITLE
bump houston-api: hotfix upgrade-deployments hook

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.16
+    tag: 0.29.17
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

hotfix: upgrade deployments when airflow version is null #1096

## Related Issues

https://github.com/astronomer/issues/issues/4578

## Testing

via unit tests and practical tests

## Merging

0.29.0
