### PR TITLE
change logging sidecar values to global

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -94,12 +94,13 @@ data:
           {{- end }}
         }
       {{- end }}
-      {{- if .Values.houston.loggingSidecar.enabled }}
+
+      {{- if .Values.global.loggingSidecar.enabled }}
       # enables sidecar logging for airflow deployments
       loggingSidecar:
         enabled: true
-        name: {{ .Values.houston.loggingSidecar.name }}
-        terminationEndpoint: {{ .Values.houston.loggingSidecar.terminationEndpoint }}
+        name: {{ .Values.global.loggingSidecar.name }}
+        terminationEndpoint: {{ .Values.global.loggingSidecar.terminationEndpoint }}
       {{- end }}
 
       # These values get passed directly into the airflow helm deployments
@@ -243,16 +244,16 @@ data:
                       container.args = container.command + container.args
                   container.command = ["tini", "--", "/entrypoint"]
                   pod.spec.containers[0] = container
-      {{ if .Values.houston.loggingSidecar.enabled }}
+      {{ if .Values.global.loggingSidecar.enabled }}
                   # For sidecar logging we override the default entrypoint to redirect
                   # logs to files that are consumed by the sidecar container. The command
-                  # ends with a POST to {{ .Values.houston.loggingSidecar.terminationEndpoint }}, which signals the
+                  # ends with a POST to {{ .Values.global.loggingSidecar.terminationEndpoint }}, which signals the
                   # sidecar log consumer to exit.
-                  log_cmd = "1> >( tee -a /var/log/{{ .Values.houston.loggingSidecar.name }}/out.log ) 2> >( tee -a /var/log/{{ .Values.houston.loggingSidecar.name }}/err.log >&2 )"
+                  log_cmd = "1> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/out.log ) 2> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/err.log >&2 )"
                   if container.args[0:3] == ["airflow", "tasks", "run"]:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
-                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.houston.loggingSidecar.terminationEndpoint }}"
+                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"
                       new_args.append(command_str)
                       container.args = new_args
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -53,10 +53,6 @@ astroUI:
   #   memory: 128Mi
 
 houston:
-  loggingSidecar:
-    enabled: false
-    name: sidecar-log-consumer
-    terminationEndpoint: http://localhost:8000/quitquitquit
   prismaConnectionLimit: 5
   replicas: 2
   # This only applies when replicas > 3

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -43,7 +43,11 @@ data:
         location = /_search {
           # This combined with disabling explicit index searching downstream
           # prevents any deployment from being able to query any other indexes.
+          {{- if .Values.global.loggingSidecar.enabled }}
+          rewrite ^/(.*) /vector.$remote_user.*/$1 break;
+          {{- else }}
           rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;
+          {{- end }}
           proxy_pass http://elasticsearch;
         }
 

--- a/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
@@ -28,6 +28,7 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
         matchLabels:
@@ -43,6 +44,7 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.common.ports.http }}

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -27,6 +27,7 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
         matchLabels:
@@ -42,6 +43,7 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.service.securehttp }}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -148,7 +148,7 @@ class TestElasticSearch:
         """Test Nginx ES Service with NetworkPolicies."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"astronomer": {"houston": {"loggingSidecar": {"enabled": True}}}},
+            values={"global": {"loggingSidecar": {"enabled": True}}},
             show_only=[
                 "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
             ],

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -142,6 +142,28 @@ class TestElasticSearch:
             assert pod_data["securityContext"]["runAsNonRoot"] is True
             assert pod_data["securityContext"]["runAsUser"] == 1001
 
+    def test_nginx_es_client_network_selector_defaults(self, kube_version):
+        """Test Nginx ES Service with NetworkPolicy defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "NetworkPolicy" == doc["kind"]
+        assert [
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]
+
     def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
         self, kube_version
     ):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -271,8 +271,8 @@ class TestExternalElasticSearch:
                         "host": "esdemo.example.com",
                         "awsServiceAccountAnnotation": "arn:aws:iam::xxxxxxxx:role/customrole",
                     },
-                    "astronomer": {"houston": {"loggingSidecar": {"enabled": True}}},
-                }
+                    "loggingSidecar": {"enabled": True},
+                },
             },
             show_only=[
                 "charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml",

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -257,10 +257,41 @@ class TestExternalElasticSearch:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["kibanaUIEnabled"] is False
 
+    def test_external_es_network_selector_defaults(self, kube_version):
+        """Test External Elasticsearch Service with NetworkPolicies."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "customLogging": {
+                        "enabled": True,
+                        "scheme": "https",
+                        "host": "esdemo.example.com",
+                        "awsServiceAccountAnnotation": "arn:aws:iam::xxxxxxxx:role/customrole",
+                    },
+                },
+            },
+            show_only=[
+                "charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "NetworkPolicy"
+        assert [
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]
+
     def test_external_es_network_selector_with_logging_sidecar_enabled(
         self, kube_version
     ):
-        """Test External Elasticsearch Service with NetworkPolicies."""
+        """Test External Elasticsearch Service with NetworkPolicy Defaults."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -129,7 +129,7 @@ def test_houston_configmapwith_loggingsidecar_enabled():
     """Validate the houston configmap and its embedded data with loggingSidecar."""
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
-        values={"astronomer": {"houston": {"loggingSidecar": {"enabled": True}}}},
+        values={"global": {"loggingSidecar": {"enabled": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
 
@@ -157,10 +157,8 @@ def test_houston_configmapwith_loggingsidecar_enabled_with_overrides():
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
         values={
-            "astronomer": {
-                "houston": {
-                    "loggingSidecar": {"enabled": True, "name": sidecar_container_name}
-                }
+            "global": {
+                "loggingSidecar": {"enabled": True, "name": sidecar_container_name}
             }
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,12 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
+  # Sidecar Logging
+  loggingSidecar:
+    enabled: false
+    name: sidecar-log-consumer
+    terminationEndpoint: http://localhost:8000/quitquitquit
+
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false


### PR DESCRIPTION
## Description

**Move loggingsidecar config to globals**

This change moves logging sidecar values to global , so that additional conditions can be implemented if needed for other components
updates to nginx es client to allow vector indexes to be allowed for search if logging sidecar is enabled
Allow multiple airflow components to communicate nginx es when sidecar is enabled

## Related Issues

Yet to be updated

## Testing

QA team will see below changes
**- when sidecar logging is disabled** 
* only webserver network policies are activated in elasticsearch nginx 
* only webserver network policies are activated in external es proxy 
* index will be pointing to fluent.*

**- when sidecar logging is enabled**
* all airlfow components( triggerer, worker, scheduler, webserver)  will be activated in elasticsearch nginx network policies
* elasticsearch nginx will switch to vector.* index 
* all airlfow components( triggerer, worker, scheduler, webserver)  network policies are activated in external es proxy 


## Merging

should be cherry-picked into release 0.29 release branch
