### PR TITLE
bump houston to 0.29.18

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.17
+    tag: 0.29.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Made the token refresh error logs more descriptive

## Related Issues

[Do not merge this PR until this text is replaced with links to related issues.
](https://app.zenhub.com/workspaces/team-platform-apps-61d5f7ef8de56e0014840a75/issues/astronomer/issues/4628)
## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
0.29.0
