### PR TITLE
update vendor images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,10 +301,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.21.6-2
+                - quay.io/astronomer/ap-nginx-es:1.21.6-3
                 - quay.io/astronomer/ap-nginx:1.2.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.19.9-1
+                - quay.io/astronomer/ap-openresty:1.19.9-2
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
@@ -335,10 +335,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.21.6-2
+                - quay.io/astronomer/ap-nginx-es:1.21.6-3
                 - quay.io/astronomer/ap-nginx:1.2.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.19.9-1
+                - quay.io/astronomer/ap-openresty:1.19.9-2
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.21.6-2
+    tag: 1.21.6-3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.19.9-1
+    tag: 1.19.9-2
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy


### PR DESCRIPTION


## Description

* update ap-openresty:1.19.9-1 -> 1.19.9-2
* ap-nginx-es:1.21.6-2 -> ap-nginx-es:1.21.6-3

## Related Issues

NA

## Testing

output should  not show any  CRITICAL/HIGH CVE's  
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-openresty:1.19.9-2
trivy image -s CRITICAL,HIGH quay.io/astronomer/ap-nginx-es:1.21.6-3


## Merging

backport to all release branches 
