### PR TITLE
bump houston to 0.29.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-2
-                - quay.io/astronomer/ap-houston-api:0.29.18
+                - quay.io/astronomer/ap-houston-api:0.29.19
                 - quay.io/astronomer/ap-kibana:7.17.3-1
                 - quay.io/astronomer/ap-kube-state:1.7.2
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
@@ -329,7 +329,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-2
-                - quay.io/astronomer/ap-houston-api:0.29.18
+                - quay.io/astronomer/ap-houston-api:0.29.19
                 - quay.io/astronomer/ap-kibana:7.17.3-1
                 - quay.io/astronomer/ap-kube-state:1.7.2
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.18
+    tag: 0.29.19
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

bump houston to 0.29.19
## Related Issues

Related https://github.com/astronomer/issues/issues/4622

## Testing

On dev

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
0.29