### PR TITLE
Sync sidecar changes rel 029

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.29.0-rc21
-appVersion: 0.29.0-rc21
+version: 0.29.0-rc22
+appVersion: 0.29.0-rc22
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.29.0-rc21
+version: 0.29.0-rc22
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -94,12 +94,13 @@ data:
           {{- end }}
         }
       {{- end }}
-      {{- if .Values.houston.loggingSidecar.enabled }}
+
+      {{- if .Values.global.loggingSidecar.enabled }}
       # enables sidecar logging for airflow deployments
       loggingSidecar:
         enabled: true
-        name: {{ .Values.houston.loggingSidecar.name }}
-        terminationEndpoint: {{ .Values.houston.loggingSidecar.terminationEndpoint }}
+        name: {{ .Values.global.loggingSidecar.name }}
+        terminationEndpoint: {{ .Values.global.loggingSidecar.terminationEndpoint }}
       {{- end }}
 
       # These values get passed directly into the airflow helm deployments
@@ -243,16 +244,16 @@ data:
                       container.args = container.command + container.args
                   container.command = ["tini", "--", "/entrypoint"]
                   pod.spec.containers[0] = container
-      {{ if .Values.houston.loggingSidecar.enabled }}
+      {{ if .Values.global.loggingSidecar.enabled }}
                   # For sidecar logging we override the default entrypoint to redirect
                   # logs to files that are consumed by the sidecar container. The command
-                  # ends with a POST to {{ .Values.houston.loggingSidecar.terminationEndpoint }}, which signals the
+                  # ends with a POST to {{ .Values.global.loggingSidecar.terminationEndpoint }}, which signals the
                   # sidecar log consumer to exit.
-                  log_cmd = "1> >( tee -a /var/log/{{ .Values.houston.loggingSidecar.name }}/out.log ) 2> >( tee -a /var/log/{{ .Values.houston.loggingSidecar.name }}/err.log >&2 )"
+                  log_cmd = "1> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/out.log ) 2> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/err.log >&2 )"
                   if container.args[0:3] == ["airflow", "tasks", "run"]:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
-                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.houston.loggingSidecar.terminationEndpoint }}"
+                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"
                       new_args.append(command_str)
                       container.args = new_args
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.5.0-rc2
+airflowChartVersion: 1.5.0-rc4
 
 nodeSelector: {}
 affinity: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -53,10 +53,6 @@ astroUI:
   #   memory: 128Mi
 
 houston:
-  loggingSidecar:
-    enabled: false
-    name: sidecar-log-consumer
-    terminationEndpoint: http://localhost:8000/quitquitquit
   prismaConnectionLimit: 5
   replicas: 2
   # This only applies when replicas > 3

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -43,7 +43,11 @@ data:
         location = /_search {
           # This combined with disabling explicit index searching downstream
           # prevents any deployment from being able to query any other indexes.
+          {{- if .Values.global.loggingSidecar.enabled }}
+          rewrite ^/(.*) /vector.$remote_user.*/$1 break;
+          {{- else }}
           rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;
+          {{- end }}
           proxy_pass http://elasticsearch;
         }
 

--- a/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
@@ -28,6 +28,21 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: scheduler
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: worker
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: triggerer
+          tier: airflow
     ports:
     - protocol: TCP
       port: {{ .Values.common.ports.http }}

--- a/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
@@ -28,6 +28,7 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
         matchLabels:
@@ -43,6 +44,7 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.common.ports.http }}

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -27,6 +27,7 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
         matchLabels:
@@ -42,6 +43,7 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.service.securehttp }}

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -27,6 +27,21 @@ spec:
         matchLabels:
           tier: airflow
           component: webserver
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: scheduler
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: worker
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: triggerer
+          tier: airflow
     ports:
     - protocol: TCP
       port: {{ .Values.service.securehttp }}

--- a/charts/nginx/templates/nginx-metrics-networkpolicy.yaml
+++ b/charts/nginx/templates/nginx-metrics-networkpolicy.yaml
@@ -1,6 +1,7 @@
 ################################
 ## Nginx controller metrics pods NetworkPolicy
 #################################
+{{- if .Values.global.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -29,3 +30,4 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.ports.metrics }}
+{{- end }}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -141,3 +141,45 @@ class TestElasticSearch:
             assert pod_data["securityContext"]["capabilities"]["add"] == ["IPC_LOCK"]
             assert pod_data["securityContext"]["runAsNonRoot"] is True
             assert pod_data["securityContext"]["runAsUser"] == 1001
+
+    def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
+        self, kube_version
+    ):
+        """Test Nginx ES Service with NetworkPolicies."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"loggingSidecar": {"enabled": True}}}},
+            show_only=[
+                "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "NetworkPolicy" == doc["kind"]
+        assert [
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "scheduler", "tier": "airflow"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "worker", "tier": "airflow"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "triggerer", "tier": "airflow"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -142,13 +142,35 @@ class TestElasticSearch:
             assert pod_data["securityContext"]["runAsNonRoot"] is True
             assert pod_data["securityContext"]["runAsUser"] == 1001
 
+    def test_nginx_es_client_network_selector_defaults(self, kube_version):
+        """Test Nginx ES Service with NetworkPolicy defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "NetworkPolicy" == doc["kind"]
+        assert [
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]
+
     def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
         self, kube_version
     ):
         """Test Nginx ES Service with NetworkPolicies."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"astronomer": {"houston": {"loggingSidecar": {"enabled": True}}}},
+            values={"global": {"loggingSidecar": {"enabled": True}}},
             show_only=[
                 "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
             ],

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -129,7 +129,7 @@ def test_houston_configmapwith_loggingsidecar_enabled():
     """Validate the houston configmap and its embedded data with loggingSidecar."""
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
-        values={"astronomer": {"houston": {"loggingSidecar": {"enabled": True}}}},
+        values={"global": {"loggingSidecar": {"enabled": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
 
@@ -157,10 +157,8 @@ def test_houston_configmapwith_loggingsidecar_enabled_with_overrides():
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
         values={
-            "astronomer": {
-                "houston": {
-                    "loggingSidecar": {"enabled": True, "name": sidecar_container_name}
-                }
+            "global": {
+                "loggingSidecar": {"enabled": True, "name": sidecar_container_name}
             }
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],

--- a/tests/test_global_network_policy_flag.py
+++ b/tests/test_global_network_policy_flag.py
@@ -25,7 +25,7 @@ show_only = [
     "charts/prometheus/templates/prometheus-networkpolicy.yaml",
     "charts/kube-state/templates/kube-state-networkpolicy.yaml",
     "charts/elasticsearch/templates/master/es-master-networkpolicy.yaml",
-    "charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml",
+    "charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml",
     "charts/elasticsearch/templates/exporter/es-exporter-networkpolicy.yaml",
     "charts/elasticsearch/templates/data/es-data-networkpolicy.yaml",
     "charts/elasticsearch/templates/client/es-client-networkpolicy.yaml",

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,12 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
+  # Sidecar Logging
+  loggingSidecar:
+    enabled: false
+    name: sidecar-log-consumer
+    terminationEndpoint: http://localhost:8000/quitquitquit
+
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false


### PR DESCRIPTION
## Description

Backport sidecar logging feature changes from master

sideLogging feature now moved to global values 

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA team can set sidecarLogging from global params instead of houston params

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
