### PR TITLE
increase-cronjob-frequency for airflow check

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -191,7 +191,7 @@ houston:
     url: https://updates.astronomer.io/astronomer-certified
 
     # Default here is to run at midnight every night
-    schedule: "0 0 * * *"
+    schedule: "57 * * * *"
 
   # Check for Astronomer Runtime Updates
   # This runs as a CronJob

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -190,7 +190,7 @@ houston:
     # url for update service
     url: https://updates.astronomer.io/astronomer-certified
 
-    # Default here is to run at midnight every night
+    # Run at minute 57 every hour https://crontab.guru/#57_*_*_*_*
     schedule: "57 * * * *"
 
   # Check for Astronomer Runtime Updates


### PR DESCRIPTION
## Description

Run cronjob/astronomer-houston-update-airflow-check more frequently by default from 24hrs to hourly at the 57 min mark in every hour as suggested by @danielhoherd 

## Related Issues

https://github.com/astronomer/issues/issues/4633

## Merging

Can be cherry-picked into any releases. Not mandatory, not high priority.
