### PR TITLE
fix platform dashboard failure

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.4.5-2
+    tag: 8.4.5-3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

After migrating grafana to latest version platform dashboard started failing due to missing plugins. This change fixes that issue and make platform dashboard viewable

## Related Issues

https://github.com/astronomer/issues/issues/4519

## Testing

QA team now able to load platform dashboard without any issues

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
