### PR TITLE
Adding Slack notifications for Image Scan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
 
 orbs:
   snyk: snyk/snyk@1.1.2
+  slack: circleci/slack@4.10.1
 
 parameters:
   scan-docker-images:
@@ -23,6 +24,9 @@ jobs:
     parameters:
       docker_image:
         type: string
+    environment:
+      SCAN_IMAGE: << parameters.docker_image >>
+      SCAN_TOOL: Snyk
     steps:
       - setup_remote_docker:
           version: 20.10.14
@@ -32,12 +36,28 @@ jobs:
           command: docker pull << parameters.docker_image >>
       - snyk-docker-test:
           docker_image: << parameters.docker_image >>
+      - run:
+          name: Slack Init
+          command: |
+            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+            source $BASH_ENV
+          when: always
+      - slack/notify:
+          event: fail
+          template: SLACK_MSG_TEMPLATE
+          channel: C03HS1H9G1E
+
   trivy-scan-docker:
     docker:
       - image: docker:20.10.14-git
+    shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
         type: string
+    environment:
+      SCAN_IMAGE: << parameters.docker_image >>
+      SCAN_TOOL: Trivy
+      BASH_ENV: /etc/profile
     steps:
       - setup_remote_docker:
           version: 20.10.14
@@ -57,10 +77,21 @@ jobs:
       - run:
           name: Scan the local image with trivy
           command: bin/trivy-scan.sh "<< parameters.docker_image >>" ".circleci/trivyignore"
+      - run:
+          name: Slack Init
+          command: |
+            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+            source $BASH_ENV
+          when: on_fail
+      - slack/notify:
+          event: fail
+          template: SLACK_MSG_TEMPLATE
+          channel: C03HS1H9G1E
       - save_cache:
           key: trivy-cache-{{ checksum "date" }}
           paths:
             - /tmp/workspace/trivy-cache
+
   run_pre_commit:
     docker:
       - image: quay.io/astronomer/ci-pre-commit:2022-05
@@ -130,6 +161,7 @@ jobs:
             venv/bin/python -m pytest -v --junitxml=test-results/junit.xml -n auto $TEST_FILES
       - store_test_results:
           path: test-results
+
   build-artifact:
     docker:
       - image: quay.io/astronomer/ap-build:0.2.0
@@ -309,6 +341,8 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
+          context:
+            - slack_team-software-infra-bot
       - trivy-scan-docker:
           matrix:
             parameters:
@@ -343,6 +377,9 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
+          context:
+            - slack_team-software-infra-bot
+
   build-and-release-helm-chart:
     unless:
       and:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,6 +8,7 @@ executors:
 
 orbs:
   snyk: snyk/snyk@1.1.2
+  slack: circleci/slack@4.10.1
 
 parameters:
   scan-docker-images:
@@ -21,6 +22,9 @@ jobs:
     parameters:
       docker_image:
         type: string
+    environment:
+      SCAN_IMAGE: << parameters.docker_image >>
+      SCAN_TOOL: Snyk
     steps:
       - setup_remote_docker:
           version: {{ remote_docker_version }}
@@ -30,12 +34,28 @@ jobs:
           command: docker pull << parameters.docker_image >>
       - snyk-docker-test:
           docker_image: << parameters.docker_image >>
+      - run:
+          name: Slack Init
+          command: |
+            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+            source $BASH_ENV
+          when: always
+      - slack/notify:
+          event: fail
+          template: SLACK_MSG_TEMPLATE
+          channel: C03HS1H9G1E
+
   trivy-scan-docker:
     docker:
       - image: docker:{{ remote_docker_version }}-git
+    shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
         type: string
+    environment:
+      SCAN_IMAGE: << parameters.docker_image >>
+      SCAN_TOOL: Trivy
+      BASH_ENV: /etc/profile
     steps:
       - setup_remote_docker:
           version: {{ remote_docker_version }}
@@ -55,10 +75,21 @@ jobs:
       - run:
           name: Scan the local image with trivy
           command: bin/trivy-scan.sh "<< parameters.docker_image >>" ".circleci/trivyignore"
+      - run:
+          name: Slack Init
+          command: |
+            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+            source $BASH_ENV
+          when: on_fail
+      - slack/notify:
+          event: fail
+          template: SLACK_MSG_TEMPLATE
+          channel: C03HS1H9G1E
       - save_cache:
           {% raw %}key: trivy-cache-{{ checksum "date" }}{% endraw %}
           paths:
             - /tmp/workspace/trivy-cache
+
   run_pre_commit:
     docker:
       - image: quay.io/astronomer/ci-pre-commit:2022-05
@@ -128,6 +159,7 @@ jobs:
             venv/bin/python -m pytest -v --junitxml=test-results/junit.xml -n auto $TEST_FILES
       - store_test_results:
           path: test-results
+
   build-artifact:
     docker:
       - image: quay.io/astronomer/ap-build:0.2.0
@@ -217,6 +249,8 @@ workflows:
 {%- for image in docker_images %}
                 - {{ image }}
 {%- endfor %}
+          context:
+            - slack_team-software-infra-bot
       - trivy-scan-docker:
           matrix:
             parameters:
@@ -224,6 +258,9 @@ workflows:
 {%- for image in docker_images %}
                 - {{ image }}
 {%- endfor %}
+          context:
+            - slack_team-software-infra-bot
+
   build-and-release-helm-chart:
     unless:
       and:

--- a/.circleci/slack_message_templates/security_scan_fail.json
+++ b/.circleci/slack_message_templates/security_scan_fail.json
@@ -1,0 +1,41 @@
+{
+  "blocks": [
+    {
+      "type": "header",
+      "text": {
+        "type": "plain_text",
+        "emoji": true,
+        "text": ":red_circle: ${SCAN_TOOL} Vulnerability Scan Result"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Image*: ${SCAN_IMAGE} \n\n *Project*: ${CIRCLE_PROJECT_REPONAME} \n *Branch*: ${CIRCLE_BRANCH} \n *Job*: ${CIRCLE_JOB} \n *Author*: ${CIRCLE_USERNAME}"
+      },
+      "accessory": {
+        "type": "image",
+        "image_url": "https://assets.brandfolder.com/otz5mn-bw4j2w-6jzqo8/original/circle-logo-badge-black.png",
+        "alt_text": "CircleCI logo"
+      }
+    },
+    {
+      "type": "actions",
+      "elements": [
+        {
+          "type": "button",
+          "text": {
+            "type": "plain_text",
+            "text": "View Build",
+            "emoji": true
+          },
+          "url": "${CIRCLE_BUILD_URL}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This PR adds the scan notifications to Slack (#team-software-infra-bot) on fail. It will only report the fail scan (that found vulnerabilities).

## Related Issues

<https://github.com/astronomer/issues/issues/4620>

## Testing

This change is adding CI capability.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.