### PR TITLE
allow vector index search for external elasic service

### DIFF
--- a/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
@@ -44,7 +44,11 @@ data:
         location = /_search {
           # This combined with disabling explicit index searching downstream
           # prevents any deployment from being able to query any other indexes.
+          {{- if .Values.global.loggingSidecar.enabled }}
+          rewrite ^/(.*) /vector.$remote_user.*/$1 break;
+          {{- else }}
           rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;
+          {{- end }}
           {{- if  or .Values.global.customLogging.awsSecretName  .Values.global.customLogging.awsServiceAccountAnnotation .Values.global.customLogging.awsIAMRole }}
           proxy_pass http://localhost:{{ .Values.service.awsproxy }};
           {{- else }}

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -339,3 +339,54 @@ class TestExternalElasticSearch:
                 },
             },
         ] == doc["spec"]["ingress"][0]["from"]
+
+    def test_external_es_index_pattern_defaults(self, kube_version):
+        """Test External Elasticsearch Service Index Pattern Search defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "customLogging": {
+                        "enabled": True,
+                        "scheme": "https",
+                        "host": "esdemo.example.com",
+                        "awsServiceAccountAnnotation": "arn:aws:iam::xxxxxxxx:role/customrole",
+                    },
+                },
+            },
+            show_only=[
+                "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        es_index = doc["data"]["nginx.conf"]
+        assert doc["kind"] == "ConfigMap"
+        assert "fluentd.$remote_user.*/$1" in es_index
+
+    def test_external_es_index_pattern_with_sidecar_logging_enabled(self, kube_version):
+        """Test External Elasticsearch Service Index Pattern Search with sidecar logging."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "customLogging": {
+                        "enabled": True,
+                        "scheme": "https",
+                        "host": "esdemo.example.com",
+                        "awsServiceAccountAnnotation": "arn:aws:iam::xxxxxxxx:role/customrole",
+                    },
+                    "loggingSidecar": {"enabled": True},
+                },
+            },
+            show_only=[
+                "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        es_index = doc["data"]["nginx.conf"]
+        assert doc["kind"] == "ConfigMap"
+        assert "vector.$remote_user.*/$1" in es_index


### PR DESCRIPTION
## Description

Allow vector index pattern search from airflow when  external elasicsearch  service is configured.

## Related Issues

NA

## Testing

QA should able to see logs in airflow UI. 

## Merging

merge to release-0.29
