### PR TITLE
update platform images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,12 +317,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.4
+                - quay.io/astronomer/ap-cli-install:0.26.5
                 - quay.io/astronomer/ap-commander:0.29.2
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.6
-                - quay.io/astronomer/ap-default-backend:0.28.4
+                - quay.io/astronomer/ap-default-backend:0.28.6
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
@@ -353,12 +353,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.4
+                - quay.io/astronomer/ap-cli-install:0.26.5
                 - quay.io/astronomer/ap-commander:0.29.2
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.6
-                - quay.io/astronomer/ap-default-backend:0.28.4
+                - quay.io/astronomer/ap-default-backend:0.28.6
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.4
+    tag: 0.26.5
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.4
+    tag: 0.28.6
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION
## Description

Fix freetype CRITICAL VULNERABILITY triggered by trivy scanner 

* bump ap-cli-install 0.26.4 -> 0.26.5
* bump ap-default-backend 0.28.4 -> 0.28.6

## Related Issues

https://github.com/astronomer/issues/issues/4662
https://github.com/astronomer/issues/issues/4664

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

backport to release-0.29,0.27,0.26,0.25
