### PR TITLE
updated the CLI version in chart values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.29.0
+                - quay.io/astronomer/ap-cli-install:0.26.5
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
@@ -353,7 +353,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.29.0
+                - quay.io/astronomer/ap-cli-install:0.26.5
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.5
+                - quay.io/astronomer/ap-cli-install:0.29.0
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
@@ -353,7 +353,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.15.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.5
+                - quay.io/astronomer/ap-cli-install:0.29.0
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.5
+    tag: 0.29
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.29
+    tag: 0.26.5
     pullPolicy: IfNotPresent
 
 astroUI:
@@ -332,7 +332,7 @@ registry:
 
 install:
   resources: {}
-  cliVersion: 0.27.0
+  cliVersion: 0.29
   #  limits:
   #   cpu: 100m
   #   memory: 128Mi


### PR DESCRIPTION
## Description
Updated the CLI install version to the latest one, i.e. `0.29`

The bash script present in `astro-cli` repo, used by the install CLI pod, now supports not mentioning the patch number, in which case it will pull the latest patch of that minor version
Ex:
<img width="1391" alt="Screenshot 2022-06-06 at 7 05 18 PM" src="https://user-images.githubusercontent.com/92356010/172171109-2c3bd04a-724a-4ec3-9aa6-371567f34810.png">

This will help us not to update the chart value for each patch release

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
