### PR TITLE
bump houston to 0.29.26 from 0.29.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-3
-                - quay.io/astronomer/ap-houston-api:0.29.24
+                - quay.io/astronomer/ap-houston-api:0.29.26
                 - quay.io/astronomer/ap-kibana:7.17.3-1
                 - quay.io/astronomer/ap-kube-state:1.7.2
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.3-1
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-3
-                - quay.io/astronomer/ap-houston-api:0.29.24
+                - quay.io/astronomer/ap-houston-api:0.29.26
                 - quay.io/astronomer/ap-kibana:7.17.3-1
                 - quay.io/astronomer/ap-kube-state:1.7.2
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.24
+    tag: 0.29.26
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

updating houston for 0.29 with hotfix for graphql issue and ad azure filter 

## Related Issues

https://github.com/astronomer/houston-api/issues/1104
https://github.com/astronomer/issues/issues/4675
Related https://github.com/astronomer/issues/issues/4693

## Testing

dev and customer cluster for display name filter

## Merging

0.29.1