### PR TITLE
CVE fix new es client

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -345,7 +345,7 @@ data:
     elasticsearch:
       enabled: true
       client:
-        node: {{ printf "http://%s-external-es-proxy:9201" .Release.Name }}
+        node: {{ printf "https://%s-external-es-proxy:9201" .Release.Name }}
         log: error
     {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -345,7 +345,7 @@ data:
     elasticsearch:
       enabled: true
       client:
-        host: {{ printf "http://%s-external-es-proxy:9201" .Release.Name }}
+        node: {{ printf "http://%s-external-es-proxy:9201" .Release.Name }}
         log: error
     {{- end }}
 
@@ -359,7 +359,7 @@ data:
     elasticsearch:
       enabled: true
       client:
-        host: {{ printf "http://%s-elasticsearch:9200" .Release.Name }}
+        node: {{ printf "http://%s-elasticsearch:9200" .Release.Name }}
         log: error
     {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -345,7 +345,7 @@ data:
     elasticsearch:
       enabled: true
       client:
-        host: {{ printf "%s-external-es-proxy:9201" .Release.Name }}
+        host: {{ printf "http://%s-external-es-proxy:9201" .Release.Name }}
         log: error
     {{- end }}
 
@@ -359,7 +359,7 @@ data:
     elasticsearch:
       enabled: true
       client:
-        host: {{ printf "%s-elasticsearch:9200" .Release.Name }}
+        host: {{ printf "http://%s-elasticsearch:9200" .Release.Name }}
         log: error
     {{- end }}
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -42,8 +42,8 @@ def test_houston_configmap():
     # Ensure airflow elasticsearch param is at correct location
     assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
     # Ensure elasticsearch client param is at the correct location and contains http://
-    assert ('node' in prod["elasticsearch"]["client"]) is True
-    assert ('http://' in prod["elasticsearch"]["client"]["node"]) is True
+    assert ("node" in prod["elasticsearch"]["client"]) is True
+    assert ("http://" in prod["elasticsearch"]["client"]["node"]) is True
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
         assert prod["deployments"]["helm"]["sccEnabled"] is False

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -43,10 +43,25 @@ def test_houston_configmap():
     assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
     # Ensure elasticsearch client param is at the correct location and contains http://
     assert ("node" in prod["elasticsearch"]["client"]) is True
-    assert ("http://" in prod["elasticsearch"]["client"]["node"]) is True
+    assert prod["elasticsearch"]["client"]["node"].startswith("http://")
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
         assert prod["deployments"]["helm"]["sccEnabled"] is False
+
+
+def test_houston_configmap_with_customlogging_enabled():
+    """Validate the houston configmap and its embedded data with customLogging."""
+    docs = render_chart(
+        values={"global": {"customLogging": {"enabled": True}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+    assert ("node" in prod["elasticsearch"]["client"]) is True
+    assert prod["elasticsearch"]["client"]["node"].startswith("https://") is True
 
 
 def test_houston_configmapwith_scc_enabled():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -41,7 +41,8 @@ def test_houston_configmap():
     prod = yaml.safe_load(doc["data"]["production.yaml"])
     # Ensure airflow elasticsearch param is at correct location
     assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
-
+    # Ensure elasticsearch client param is at the correct location
+    assert ('http://' in prod["elasticsearch"]["client"]["node"]) is True
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
         assert prod["deployments"]["helm"]["sccEnabled"] is False

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -41,7 +41,8 @@ def test_houston_configmap():
     prod = yaml.safe_load(doc["data"]["production.yaml"])
     # Ensure airflow elasticsearch param is at correct location
     assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
-    # Ensure elasticsearch client param is at the correct location
+    # Ensure elasticsearch client param is at the correct location and contains http://
+    assert ('node' in prod["elasticsearch"]["client"]) is True
     assert ('http://' in prod["elasticsearch"]["client"]["node"]) is True
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default


### PR DESCRIPTION
## Description

Refactoring ES config params upon migrating to the new elasticsearch client in houston, required to fix an ansi-regex snyk vulnerability

## Related Issues

Related https://github.com/astronomer/issues/issues/4624
astronomer/issues#4660

## Related Houston PR

https://github.com/astronomer/houston-api/pull/1134

## Testing
Tested on kind cluster

## Merging

0.29.2