### PR TITLE
update db bootstrapper: fix CVEs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.7
                 - quay.io/astronomer/ap-default-backend:0.28.6
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.4
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.7
                 - quay.io/astronomer/ap-default-backend:0.28.6
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.6
+    tag: 0.26.7
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.6
+    tag: 0.26.7
     pullPolicy: IfNotPresent
 
 backendSecretName: ~


### PR DESCRIPTION


## Description

* fixes critical CVE found by trivy
* bump db-boostrapper 0.26.6 -> 0.26.7

## Related Issues

https://github.com/astronomer/issues/issues/4663

## Testing

NA

## Merging

cherry-pick to all release branches
