### PR TITLE
Update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,12 +329,12 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.4.5-3
                 - quay.io/astronomer/ap-houston-api:0.29.26
                 - quay.io/astronomer/ap-kibana:7.17.4
-                - quay.io/astronomer/ap-kube-state:1.7.2
+                - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
                 - quay.io/astronomer/ap-nginx-es:1.22.0
-                - quay.io/astronomer/ap-nginx:1.2.0
+                - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.19.9-2
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
@@ -365,12 +365,12 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.4.5-3
                 - quay.io/astronomer/ap-houston-api:0.29.26
                 - quay.io/astronomer/ap-kibana:7.17.4
-                - quay.io/astronomer/ap-kube-state:1.7.2
+                - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
                 - quay.io/astronomer/ap-nginx-es:1.22.0
-                - quay.io/astronomer/ap-nginx:1.2.0
+                - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.19.9-2
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1

--- a/charts/kube-state/templates/kube-state-role.yaml
+++ b/charts/kube-state/templates/kube-state-role.yaml
@@ -92,6 +92,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingresses
   verbs:
   - list
   - watch

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 1.7.2
+    tag: 2.5.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.2.0
+    tag: 1.2.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

update vendor packages 
* bump ap-nginx 1.2.0 -> 1.2.1
* bump kube-state 1.7.2 -> 2.5.0
* added ingress resource in apigroup networking.k8s.io for kube state

## Related Issues
Yet to create 

## Testing

Yet to update

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
