### PR TITLE
Remove docs from YAML review

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 *            @astronomer/maintainers-astronomer
-values.yaml  @astronomer/maintainers-astronomer @astronomer/docs
+values.yaml  @astronomer/maintainers-astronomer
 *.md         @astronomer/maintainers-astronomer @astronomer/docs


### PR DESCRIPTION
## Description

Now that @cmarteepants is a product manager on Software, I'm much more in tune with what's happening on `astronomer/astronomer` for a given release. Without context, the PRs alone don't provide enough information to warrant a writer being a reviewer on every one. I'll still keep us on `.md` in case there's any internal documentation that needs review. 