### PR TITLE
Improve helmignore

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -21,15 +21,17 @@
 *.tmproj
 
 # Astronomer helm repository directory
-repository
-certs
-tiller-rbac
-
+/.circleci
+/.github
 /bin/
 /configs/
 /docs/
 /secrets/
 /test/
 /venv/
-tests
-charts/*/tests
+/LICENSE
+/certs
+/repository
+/requirements
+/tests
+/tiller-rbac


### PR DESCRIPTION
## Description

A lot of extra files are being included in our helm chart. These additions keep the helm chart more tidy and a bit smaller file size.

```
$ k -n astronomer get secret "sh.helm.release.v1.astronomer.v170" -o jsonpath='{.data.release}' | base64 -d | base64 -d | gzip -d | jq '.chart.files[].name'
2022-06-17T14:50:19-0700
".circleci/config.yml"
".circleci/config.yml.j2"
".circleci/generate_circleci_config.py"
".circleci/slack_message_templates/security_scan_fail.json"
".circleci/tiller-rbac.yaml"
".circleci/trivyignore"
".github/pull_request_template.md"
".helmignore"
".pre-commit-config.yaml"
"CODEOWNERS"
"LICENSE"
"Makefile"
"README.md"
"requirements/chart-tests.in"
"requirements/chart-tests.txt"
"requirements/functional-tests.in"
"requirements/functional-tests.txt"
"values.schema.json.example"
```
## Related Issues

Found while debugging some elusive pgbouncer restart stuff. Opened a similar PR in airflow-chart: <https://github.com/astronomer/airflow-chart/pull/330>

## Testing

As long as tests are passing that should be enough.

## Merging

This should be merged into every supported branch.