### PR TITLE
FIX FluentD retrieve logs from namespaces in ns pool even if disabled

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -101,14 +101,18 @@ data:
     <filter kubernetes.**>
       @type grep
       <regexp>
-        key $.kubernetes.namespace_name
         {{- if and .Values.global.features.namespacePools.enabled (gt (len .Values.global.features.namespacePools.namespaces.names) 0) }}
+        key $.kubernetes.namespace_name
         pattern ^({{ join "|" .Values.global.features.namespacePools.namespaces.names }})$
         {{- else if .Values.global.manualNamespaceNamesEnabled }}
+        key $.kubernetes.namespace_name
         # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled
         pattern "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
         {{ else }}
-        pattern "^#{ENV['NAMESPACE']}(?:-.*)?$"
+        # only retrieve logs from namespaces containing the label "platform", which is added to all namespaces used to host Airflow Deployments.
+        # this makes sure that if customers enable namespaces pools, then disable it, we can still get the logs from these deployments.
+        key $.kubernetes.namespace_labels.platform
+        pattern "{{ .Release.Name }}"
         {{ end }}
       </regexp>
       <regexp>

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -108,6 +108,6 @@ def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_ve
     )[0]
 
     expected_rule = (
-        "key $.kubernetes.namespace_name\n    pattern \"^#{ENV['NAMESPACE']}(?:-.*)?$\""
+        'key $.kubernetes.namespace_labels.platform\n    pattern "release-name"'
     )
     assert expected_rule in doc["data"]["output.conf"]


### PR DESCRIPTION
## Description

With the new Namespace Pool update, we updated the Fluentd Configuration to only retrieve logs from namespaces in the Pool.

The problem is that if a user then disables the NS pool feature, logs from the namespaces in the pool are not collected anymore.

In this PR, I updated FluentD's configuration to collect logs for all namespaces containing the label `platform` (automatically added to all namespaces running Airflow deployments by the Control Plane). This allows us to still capture logs from deployments inside namespace in NS pool even if disabled.

## Related Issues

https://github.com/astronomer/issues/issues/4646

## Testing

See Issue for detailed steps on how to test this update.
