### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,16 +313,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.29.9
-                - quay.io/astronomer/ap-auth-sidecar:1.22.0
+                - quay.io/astronomer/ap-auth-sidecar:1.23.0
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.16.0
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.5
+                - quay.io/astronomer/ap-cli-install:0.26.6
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.7
-                - quay.io/astronomer/ap-default-backend:0.28.6
+                - quay.io/astronomer/ap-default-backend:0.28.7
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.4
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
@@ -333,10 +333,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.22.0
+                - quay.io/astronomer/ap-nginx-es:1.23.0
                 - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.19.9-2
+                - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
@@ -349,16 +349,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.29.9
-                - quay.io/astronomer/ap-auth-sidecar:1.22.0
+                - quay.io/astronomer/ap-auth-sidecar:1.23.0
                 - quay.io/astronomer/ap-awsesproxy:1.3-4
                 - quay.io/astronomer/ap-base:3.16.0
                 - quay.io/astronomer/ap-blackbox-exporter:0.20.0
-                - quay.io/astronomer/ap-cli-install:0.26.5
+                - quay.io/astronomer/ap-cli-install:0.26.6
                 - quay.io/astronomer/ap-commander:0.29.3
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-14
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.7
-                - quay.io/astronomer/ap-default-backend:0.28.6
+                - quay.io/astronomer/ap-default-backend:0.28.7
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.4
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
@@ -369,10 +369,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.22.0
+                - quay.io/astronomer/ap-nginx-es:1.23.0
                 - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.19.9-2
+                - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.5
+    tag: 0.26.6
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.22.0
+    tag: 1.23.0
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.19.9-2
+    tag: 1.21.4
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.6
+    tag: 0.28.7
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.22.0
+    tag: 1.23.0
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION

## Description

* bump ap-cli-install 0.26.5 -> 0.26.6
* bump ap-nginx-es 1.22.0 -> 1.23.0
* ap-openresty  1.19.9-2 -> 1.21.4
* ap-default-backend 0.28.6 -> 0.28.7
* ap-auth-sidecar 1.22.0 -> 1.23.0

## Related Issues

https://github.com/astronomer/issues/issues/4783

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
