### PR TITLE
Feature/4472 Adding Extra Object Capability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,8 @@ jobs:
   unittest-charts:
     docker:
       - image: quay.io/astronomer/ci-helm-release:2022-05
-    parallelism: 6
+    parallelism: 8
+    resource_class: xlarge
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -128,7 +128,8 @@ jobs:
   unittest-charts:
     docker:
       - image: quay.io/astronomer/ci-helm-release:2022-05
-    parallelism: 6
+    parallelism: 8
+    resource_class: xlarge
     steps:
       - setup_remote_docker:
           docker_layer_caching: true

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -38,6 +38,14 @@ spec:
           imagePullPolicy: {{ .Values.images.astroUI.pullPolicy }}
           resources:
 {{ toYaml .Values.astroUI.resources | indent 12 }}
+          {{- if .Values.astroUI.command }}
+          command:
+            {{- toYaml .Values.astroUI.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.astroUI.args }}
+          args:
+            {{- toYaml .Values.astroUI.args | nindent 12 }}
+          {{- end }}
           ports:
             - name: astro-ui-http
               containerPort: {{ .Values.ports.astroUIHTTP }}
@@ -64,3 +72,14 @@ spec:
             - name: APP_API_LOC_WSS
               value: "wss://houston.{{ .Values.global.baseDomain }}/ws"
             {{- end }}
+          volumeMounts:
+{{- if .Values.astroUI.volumeMounts }}
+{{- toYaml .Values.astroUI.volumeMounts | nindent 12 }}
+{{- end }}
+{{- if .Values.astroUI.extraContainers }}
+{{- toYaml .Values.astroUI.extraContainers | nindent 8 }}
+{{- end }}
+      volumes:
+{{- if .Values.astroUI.extraVolumes }}
+{{- toYaml .Values.astroUI.extraVolumes | nindent 8 }}
+{{- end }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -74,12 +74,12 @@ spec:
             {{- end }}
           volumeMounts:
 {{- if .Values.astroUI.volumeMounts }}
-{{- toYaml .Values.astroUI.volumeMounts | nindent 12 }}
+{{- tpl (toYaml .Values.astroUI.volumeMounts) $ | nindent 12 }}
 {{- end }}
 {{- if .Values.astroUI.extraContainers }}
-{{- toYaml .Values.astroUI.extraContainers | nindent 8 }}
+{{- tpl (toYaml .Values.astroUI.extraContainers) $ | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.astroUI.extraVolumes }}
-{{- toYaml .Values.astroUI.extraVolumes | nindent 8 }}
+{{- tpl (toYaml .Values.astroUI.extraVolumes) $ | nindent 8 }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -107,12 +107,12 @@ spec:
             {{- end }}
           volumeMounts:
 {{- if .Values.commander.volumeMounts }}
-{{- toYaml .Values.commander.volumeMounts | nindent 12 }}
+{{- tpl (toYaml .Values.commander.volumeMounts) $ | nindent 12 }}
 {{- end }}
 {{- if .Values.commander.extraContainers }}
-{{- toYaml .Values.commander.extraContainers | nindent 8 }}
+{{- tpl (toYaml .Values.commander.extraContainers) $ | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.commander.extraVolumes }}
-{{- toYaml .Values.commander.extraVolumes | nindent 8 }}
+{{- tpl (toYaml .Values.commander.extraVolumes) $ | nindent 8 }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -47,6 +47,10 @@ spec:
           imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
           resources:
 {{ toYaml .Values.commander.resources | indent 12 }}
+          {{- if .Values.commander.command }}
+          command:
+            {{- toYaml .Values.commander.command | nindent 12 }}
+          {{- end }}
           {{- if .Values.commander.args }}
           args:
             {{- toYaml .Values.commander.args | nindent 12 }}

--- a/charts/astronomer/templates/extra-objects.yaml
+++ b/charts/astronomer/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/astronomer/templates/extra-objects.yaml
+++ b/charts/astronomer/templates/extra-objects.yaml
@@ -1,3 +1,6 @@
+#######################################
+## Astronomer Platform Extra Object ##
+#######################################
 {{ range .Values.extraObjects }}
 ---
 {{ tpl (toYaml .) $ }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -114,11 +114,15 @@ spec:
             initialDelaySeconds: {{ .Values.houston.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.houston.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.houston.readinessProbe.failureThreshold }}
+          {{- if .Values.houston.command }}
+          command:
+            {{- toYaml .Values.houston.command | nindent 12 }}
+          {{ else }}
+          command: ["yarn", "serve"]
+          {{- end }}
           {{- if .Values.houston.apiArgs }}
           args:
             {{- toYaml .Values.houston.apiArgs | nindent 12 }}
-          {{ else }}
-          args: ["yarn", "serve"]
           {{- end }}
           env:
             {{- include "houston_environment" . | indent 12 }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -117,8 +117,6 @@ spec:
           {{- if .Values.houston.command }}
           command:
             {{- toYaml .Values.houston.command | nindent 12 }}
-          {{ else }}
-          command: ["yarn", "serve"]
           {{- end }}
           {{- if .Values.houston.apiArgs }}
           args:

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -95,7 +95,7 @@ spec:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}
 {{- if .Values.houston.volumeMounts }}
-{{- toYaml .Values.houston.volumeMounts | nindent 12 }}
+{{- tpl (toYaml .Values.houston.volumeMounts) $ | nindent 12 }}
 {{- end }}
           ports:
             - name: houston-http
@@ -144,11 +144,11 @@ spec:
                   name: {{ template "registry.authHeaderSecret" . }}
                   key: token
 {{- if .Values.houston.extraContainers }}
-{{- toYaml .Values.houston.extraContainers | nindent 8 }}
+{{- tpl (toYaml .Values.houston.extraContainers) $ | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.houston.extraVolumes }}
-{{ toYaml .Values.houston.extraVolumes | indent 8 }}
+{{ tpl (toYaml .Values.houston.extraVolumes) $ | indent 8 }}
 {{- end }}
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -99,7 +99,7 @@ spec:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}
 {{- if .Values.houston.volumeMounts }}
-{{- toYaml .Values.houston.volumeMounts | nindent 12 }}
+{{- tpl (toYaml .Values.houston.volumeMounts) $ | nindent 12 }}
 {{- end }}
           env:
             - name: GRPC_VERBOSITY
@@ -121,11 +121,11 @@ spec:
             - name: APOLLO_SERVER_PLATFORM
               value: "kubernetes/deployment"
 {{- if .Values.houston.extraContainers }}
-{{- toYaml .Values.houston.extraContainers | nindent 8 }}
+{{- tpl (toYaml .Values.houston.extraContainers) $ | nindent 8 }}
 {{- end }}
       volumes:
 {{- if .Values.houston.extraVolumes }}
-{{ toYaml .Values.houston.extraVolumes | indent 8 }}
+{{ tpl (toYaml .Values.houston.extraVolumes) $ | indent 8 }}
 {{- end }}
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -83,23 +83,23 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          {{- if .Values.houston.workerCommand }}
+          {{- if .Values.houston.worker.command }}
           command:
-            {{- toYaml .Values.houston.workerCommand | nindent 12 }}
+            {{- toYaml .Values.houston.worker.command | nindent 12 }}
           {{ else }}
           command: ["yarn", "worker"]
           {{- end }}
-          {{- if .Values.houston.workerArgs }}
+          {{- if .Values.houston.worker.args }}
           args:
-            {{- toYaml .Values.houston.workerArgs | nindent 12 }}
+            {{- toYaml .Values.houston.worker.args | nindent 12 }}
           {{- end }}
           resources:
 {{ toYaml .Values.houston.resources | indent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}
-{{- if .Values.houston.volumeMounts }}
-{{- tpl (toYaml .Values.houston.volumeMounts) $ | nindent 12 }}
+{{- if .Values.houston.worker.volumeMounts }}
+{{- tpl (toYaml .Values.houston.worker.volumeMounts) $ | nindent 12 }}
 {{- end }}
           env:
             - name: GRPC_VERBOSITY
@@ -120,12 +120,12 @@ spec:
               value: {{ template "houston.image" . }}
             - name: APOLLO_SERVER_PLATFORM
               value: "kubernetes/deployment"
-{{- if .Values.houston.extraContainers }}
-{{- tpl (toYaml .Values.houston.extraContainers) $ | nindent 8 }}
+{{- if .Values.houston.worker.extraContainers }}
+{{- tpl (toYaml .Values.houston.worker.extraContainers) $ | nindent 8 }}
 {{- end }}
       volumes:
-{{- if .Values.houston.extraVolumes }}
-{{ tpl (toYaml .Values.houston.extraVolumes) $ | indent 8 }}
+{{- if .Values.houston.worker.extraVolumes }}
+{{ tpl (toYaml .Values.houston.worker.extraVolumes) $ | indent 8 }}
 {{- end }}
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -83,11 +83,15 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+          {{- if .Values.houston.workerCommand }}
+          command:
+            {{- toYaml .Values.houston.workerCommand | nindent 12 }}
+          {{ else }}
+          command: ["yarn", "worker"]
+          {{- end }}
           {{- if .Values.houston.workerArgs }}
           args:
             {{- toYaml .Values.houston.workerArgs | nindent 12 }}
-          {{ else }}
-          args: ["yarn", "worker"]
           {{- end }}
           resources:
 {{ toYaml .Values.houston.resources | indent 12 }}

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -62,26 +62,31 @@ class TestAstronomerFileLogs:
         assert len(container["volumeMounts"]) == 1
 
     def houston_container(self, container, run_type):
+
+        assert container["command"] == ["/bin/sh"]
         assert container["args"] == [
-            "sh",
             "-c",
             "yarn "
             + run_type
-            + " 1> >( tee -a /var/logs/houston/data.out.log ) 2> >( tee -a /var/logs/houston/data.err.log >&2 )",
+            + " 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
         ]
 
         volume_mounts = container["volumeMounts"]
         for volume in volume_mounts:
             if volume["name"] == "logvol":
-                assert volume["mountPath"] == "/var/logs/houston"
+                assert volume["mountPath"] == "/var/log/houston"
 
     def commander_container(self, container):
-        assert container["args"] == ["sh", "-c", "echo hello"]
+        assert container["command"] == ["/bin/sh"]
+        assert container["args"] == [
+            "-c",
+            "commander  1> >( tee -a /var/log/commander/out.log ) 2> >( tee -a /var/log/commander/err.log >&2 )",
+        ]
 
         volume_mounts = container["volumeMounts"]
         for volume in volume_mounts:
             if volume["name"] == "logvol":
-                assert volume["mountPath"] == "/var/logs/commander"
+                assert volume["mountPath"] == "/var/log/commander"
 
     def test_file_logs_config(self, kube_version):
         docs = render_chart(

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -11,11 +11,6 @@ chart_values = {
                 "-c",
                 "yarn serve 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
             ],
-            "workerCommand": ["/bin/sh"],
-            "workerArgs": [
-                "-c",
-                "yarn worker 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
-            ],
             "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/houston"}],
             "extraContainers": [
                 {
@@ -28,6 +23,27 @@ chart_values = {
                 }
             ],
             "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
+            "worker": {
+                "command": ["/bin/sh"],
+                "args": [
+                    "-c",
+                    "yarn worker 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
+                ],
+                "volumeMounts": [
+                    {"name": "logvol", "mountPath": "/var/log/houston_worker"}
+                ],
+                "extraContainers": [
+                    {
+                        "name": "fluentd",
+                        "image": "ap-fluentd:0.5",
+                        "imagePullPolicy": "Never",
+                        "volumeMounts": [
+                            {"name": "logvol", "mountPath": "/var/log/file_logs/"}
+                        ],
+                    }
+                ],
+                "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
+            },
         },
         "commander": {
             "command": ["/bin/sh"],

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -77,7 +77,7 @@ class TestAstronomerFileLogs:
         assert container["image"] == "ap-fluentd:0.5"
         assert len(container["volumeMounts"]) == 1
 
-    def houston_container(self, container, run_type):
+    def houston_container(self, container):
 
         assert container["command"] == ["/bin/sh"]
         assert container["args"] == [

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -6,17 +6,17 @@ from tests.chart_tests.helm_template_generator import render_chart
 chart_values = {
     "astronomer": {
         "houston": {
+            "command": ["/bin/sh"],
             "apiArgs": [
-                "sh",
                 "-c",
-                "yarn serve 1> >( tee -a /var/logs/houston/data.out.log ) 2> >( tee -a /var/logs/houston/data.err.log >&2 )",
+                "yarn serve 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
             ],
+            "workerCommand": ["/bin/sh"],
             "workerArgs": [
-                "sh",
                 "-c",
-                "yarn worker 1> >( tee -a /var/logs/houston/data.out.log ) 2> >( tee -a /var/logs/houston/data.err.log >&2 )",
+                "yarn worker 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
             ],
-            "volumeMounts": [{"name": "logvol", "mountPath": "/var/logs/houston"}],
+            "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/houston"}],
             "extraContainers": [
                 {
                     "name": "fluentd",
@@ -30,8 +30,12 @@ chart_values = {
             "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
         },
         "commander": {
-            "args": ["sh", "-c", "echo hello"],
-            "volumeMounts": [{"name": "logvol", "mountPath": "/var/logs/commander"}],
+            "command": ["/bin/sh"],
+            "args": [
+                "-c",
+                "commander  1> >( tee -a /var/log/commander/out.log ) 2> >( tee -a /var/log/commander/err.log >&2 )",
+            ],
+            "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/commander"}],
             "extraContainers": [
                 {
                     "name": "fluentd",

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -27,7 +27,7 @@ chart_values = {
                 "command": ["/bin/sh"],
                 "args": [
                     "-c",
-                    "yarn worker 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
+                    "yarn worker 1> >( tee -a /var/log/houston_worker/data.out.log ) 2> >( tee -a /var/log/houston_worker/data.err.log >&2 )",
                 ],
                 "volumeMounts": [
                     {"name": "logvol", "mountPath": "/var/log/houston_worker"}
@@ -82,8 +82,7 @@ class TestAstronomerFileLogs:
         assert container["command"] == ["/bin/sh"]
         assert container["args"] == [
             "-c",
-            "yarn "
-            + run_type
+            "yarn serve"
             + " 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
         ]
 
@@ -91,6 +90,20 @@ class TestAstronomerFileLogs:
         for volume in volume_mounts:
             if volume["name"] == "logvol":
                 assert volume["mountPath"] == "/var/log/houston"
+
+    def houston_worker_container(self, container):
+
+        assert container["command"] == ["/bin/sh"]
+        assert container["args"] == [
+            "-c",
+            "yarn worker"
+            + " 1> >( tee -a /var/log/houston_worker/data.out.log ) 2> >( tee -a /var/log/houston_worker/data.err.log >&2 )",
+        ]
+
+        volume_mounts = container["volumeMounts"]
+        for volume in volume_mounts:
+            if volume["name"] == "logvol":
+                assert volume["mountPath"] == "/var/log/houston_worker"
 
     def commander_container(self, container):
         assert container["command"] == ["/bin/sh"]
@@ -131,14 +144,14 @@ class TestAstronomerFileLogs:
                 if name == "astro-file-logs-houston":
 
                     if container["name"] == "houston":
-                        self.houston_container(container=container, run_type="serve")
+                        self.houston_container(container=container)
                     elif container["name"] == "fluentd":
                         self.fleuntd_container(container=container)
 
                 elif name == "astro-file-logs-houston-worker":
 
                     if container["name"] == "houston":
-                        self.houston_container(container, "worker")
+                        self.houston_worker_container(container=container)
                     elif container["name"] == "fluentd":
                         self.fleuntd_container(container)
 

--- a/tests/chart_tests/test_extra_objects.py
+++ b/tests/chart_tests/test_extra_objects.py
@@ -1,5 +1,4 @@
 import json
-from subprocess import CalledProcessError
 
 import pytest
 
@@ -11,12 +10,14 @@ from .. import supported_k8s_versions
 class TestExtraObjects:
     def test_extra_objects_defaults(self, kube_version):
         """Test that extra-objects works as default."""
-        with pytest.raises(CalledProcessError):
-            render_chart(
-                kube_version=kube_version,
-                values={"astronomer": {"extraObjects": []}},
-                show_only=["charts/astronomer/templates/extra-objects.yaml"],
-            )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"extraObjects": []}},
+            show_only=["charts/astronomer/templates/extra-objects.yaml"],
+        )
+
+        assert len(docs) == 0
 
     def test_extra_objects_configured(self, kube_version):
         """Test that extra-objects works as default."""

--- a/tests/chart_tests/test_extra_objects.py
+++ b/tests/chart_tests/test_extra_objects.py
@@ -1,0 +1,44 @@
+import json
+from subprocess import CalledProcessError
+
+import pytest
+
+from tests.chart_tests.helm_template_generator import render_chart
+from .. import supported_k8s_versions
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestExtraObjects:
+    def test_extra_objects_defaults(self, kube_version):
+        """Test that extra-objects works as default."""
+        with pytest.raises(CalledProcessError):
+            render_chart(
+                kube_version=kube_version,
+                values={"astronomer": {"extraObjects": []}},
+                show_only=["charts/astronomer/templates/extra-objects.yaml"],
+            )
+
+    def test_extra_objects_configured(self, kube_version):
+        """Test that extra-objects works as default."""
+
+        eo1 = json.loads(
+            """{"apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "metadata":
+            {"name": "minimal-ingress", "annotations": {"nginx.ingress.kubernetes.io/rewrite-target": "/"}},
+            "spec": {"ingressClassName": "nginx-example", "rules": [{"http": {"paths": [{"path": "/testpath",
+            "pathType": "Prefix", "backend": {"service": {"name": "test", "port": {"number": 80}}}}]}}]}}"""
+        )
+        eo2 = json.loads(
+            """{"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":
+            {"name":"gluster-vol-default"},"provisioner":"kubernetes.io/glusterfs","parameters":
+            {"resturl":"http://192.168.10.100:8080","restuser":"","secretNamespace":"","secretName":""},
+            "allowVolumeExpansion":true}"""
+        )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"extraObjects": [eo1, eo2]}},
+            show_only=["charts/astronomer/templates/extra-objects.yaml"],
+        )
+        assert len(docs) == 2
+        assert eo1 in docs
+        assert eo2 in docs

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -9,6 +9,7 @@ container_ignore_list = [
     "kube-state",
     "houston",
     "fluentd",
+    "metrics-exporter",
 ]
 
 container_list = get_pod_running_containers()

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -9,7 +9,6 @@ container_ignore_list = [
     "kube-state",
     "houston",
     "fluentd",
-    "metrics-exporter",
 ]
 
 container_list = get_pod_running_containers()

--- a/values.yaml
+++ b/values.yaml
@@ -297,6 +297,8 @@ astronomer:
         cpu: "500m"
         memory: "1024Mi"
 
+  extraObjects: []
+
   # podLabels: {}
 
 #################################


### PR DESCRIPTION
## Description

- Adding capability to add any Kubernetes Object from values.
- Adding capability to add extra containers and volumes for `astro-ui` service.
- Improving CircleCI `unittest` execution time by using the larger machine to test.

## Related Issues

[#4472 ](https://github.com/astronomer/issues/issues/4472)

## Testing

- Added test case to test the extra-object input.

## Merging

N/A
