### PR TITLE
Feature-3892 Disabling Security Context from Elasticsearch Exporter

### DIFF
--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -201,9 +201,10 @@ exporter:
     # Path under which to expose metrics.
     path: /metrics
 
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
+#  securityContext:
+#    runAsNonRoot: true
+#    runAsUser: 1000
+#    runAsGroup: 1000
 
 # NGINX Elasticsearch values
 nginx:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -201,11 +201,6 @@ exporter:
     # Path under which to expose metrics.
     path: /metrics
 
-#  securityContext:
-#    runAsNonRoot: true
-#    runAsUser: 1000
-#    runAsGroup: 1000
-
 # NGINX Elasticsearch values
 nginx:
   replicas: 1

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -271,5 +271,4 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
-        assert pod_data["securityContext"]["runAsNonRoot"] is True
-        assert pod_data["securityContext"]["runAsUser"] == 2000
+        assert pod_data["securityContext"]["runAsUser"] == 65534

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -250,8 +250,7 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
-        assert pod_data["securityContext"]["runAsNonRoot"] is True
-        assert pod_data["securityContext"]["runAsUser"] == 1000
+        assert pod_data["securityContext"]["runAsUser"] == 65534
 
     def test_elasticsearch_exporter_securitycontext_overrides(self, kube_version):
         """Test ElasticSearch Exporter with securityContext default values"""
@@ -271,4 +270,5 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
-        assert pod_data["securityContext"]["runAsUser"] == 65534
+        assert pod_data["securityContext"]["runAsNonRoot"] is True
+        assert pod_data["securityContext"]["runAsUser"] == 2000

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -156,16 +156,16 @@ class TestElasticSearch:
         doc = docs[0]
         assert "NetworkPolicy" == doc["kind"]
         assert [
-                   {
-                       "namespaceSelector": {},
-                       "podSelector": {
-                           "matchLabels": {"tier": "airflow", "component": "webserver"}
-                       },
-                   },
-               ] == doc["spec"]["ingress"][0]["from"]
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
-            self, kube_version
+        self, kube_version
     ):
         """Test Nginx ES Service with NetworkPolicies."""
         docs = render_chart(
@@ -180,31 +180,31 @@ class TestElasticSearch:
         doc = docs[0]
         assert "NetworkPolicy" == doc["kind"]
         assert [
-                   {
-                       "namespaceSelector": {},
-                       "podSelector": {
-                           "matchLabels": {"tier": "airflow", "component": "webserver"}
-                       },
-                   },
-                   {
-                       "namespaceSelector": {},
-                       "podSelector": {
-                           "matchLabels": {"component": "scheduler", "tier": "airflow"}
-                       },
-                   },
-                   {
-                       "namespaceSelector": {},
-                       "podSelector": {
-                           "matchLabels": {"component": "worker", "tier": "airflow"}
-                       },
-                   },
-                   {
-                       "namespaceSelector": {},
-                       "podSelector": {
-                           "matchLabels": {"component": "triggerer", "tier": "airflow"}
-                       },
-                   },
-               ] == doc["spec"]["ingress"][0]["from"]
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"tier": "airflow", "component": "webserver"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "scheduler", "tier": "airflow"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "worker", "tier": "airflow"}
+                },
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "triggerer", "tier": "airflow"}
+                },
+            },
+        ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_index_pattern_defaults(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search defaults."""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -156,16 +156,16 @@ class TestElasticSearch:
         doc = docs[0]
         assert "NetworkPolicy" == doc["kind"]
         assert [
-            {
-                "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
-            },
-        ] == doc["spec"]["ingress"][0]["from"]
+                   {
+                       "namespaceSelector": {},
+                       "podSelector": {
+                           "matchLabels": {"tier": "airflow", "component": "webserver"}
+                       },
+                   },
+               ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
-        self, kube_version
+            self, kube_version
     ):
         """Test Nginx ES Service with NetworkPolicies."""
         docs = render_chart(
@@ -180,31 +180,31 @@ class TestElasticSearch:
         doc = docs[0]
         assert "NetworkPolicy" == doc["kind"]
         assert [
-            {
-                "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "scheduler", "tier": "airflow"}
-                },
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "worker", "tier": "airflow"}
-                },
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "triggerer", "tier": "airflow"}
-                },
-            },
-        ] == doc["spec"]["ingress"][0]["from"]
+                   {
+                       "namespaceSelector": {},
+                       "podSelector": {
+                           "matchLabels": {"tier": "airflow", "component": "webserver"}
+                       },
+                   },
+                   {
+                       "namespaceSelector": {},
+                       "podSelector": {
+                           "matchLabels": {"component": "scheduler", "tier": "airflow"}
+                       },
+                   },
+                   {
+                       "namespaceSelector": {},
+                       "podSelector": {
+                           "matchLabels": {"component": "worker", "tier": "airflow"}
+                       },
+                   },
+                   {
+                       "namespaceSelector": {},
+                       "podSelector": {
+                           "matchLabels": {"component": "triggerer", "tier": "airflow"}
+                       },
+                   },
+               ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_index_pattern_defaults(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search defaults."""
@@ -250,7 +250,8 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
-        assert pod_data["securityContext"]["runAsUser"] == 65534
+
+        assert pod_data["securityContext"] is None
 
     def test_elasticsearch_exporter_securitycontext_overrides(self, kube_version):
         """Test ElasticSearch Exporter with securityContext default values"""

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -9,7 +9,6 @@ container_ignore_list = [
     "kube-state",
     "houston",
     "fluentd",
-    "metrics-exporter",
 ]
 
 container_list = get_pod_running_containers()


### PR DESCRIPTION
## Description

The `elasticsearch-exporter` has security-context set on it, making it run as a root group. Disabling setting security-context that will run it as default user `65534`. 

## Related Issues

https://github.com/astronomer/issues/issues/3892

## Testing

The test is already in place. Fixing it to test in case of the default value. 

## Merging

N/A
