### PR TITLE
update to postgresql image 14.4.0-debian-11-r4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
-                - quay.io/astronomer/ap-postgresql:11.15.0
+                - quay.io/astronomer/ap-postgresql:14.4.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,7 +339,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
-                - quay.io/astronomer/ap-postgresql:11.15.0
+                - quay.io/astronomer/ap-postgresql:14.4.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
           context:
@@ -375,7 +375,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
-                - quay.io/astronomer/ap-postgresql:11.15.0
+                - quay.io/astronomer/ap-postgresql:14.4.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
-                - quay.io/astronomer/ap-postgresql:14.4.0
+                - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.15.4-1
           context:

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -1,3 +1,9 @@
 # We are not using SSH as per this comment.
 # https://github.com/astronomer/astronomer/pull/1522#issuecomment-1128470766
 CVE-2022-27191
+# https://github.com/astronomer/issues/issues/4658#issuecomment-1171799477
+CVE-2021-22945
+CVE-2019-8457
+CVE-2022-1586
+CVE-2022-1587
+CVE-2022-29162

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -2,8 +2,4 @@
 # https://github.com/astronomer/astronomer/pull/1522#issuecomment-1128470766
 CVE-2022-27191
 # https://github.com/astronomer/issues/issues/4658#issuecomment-1171799477
-CVE-2021-22945
-CVE-2019-8457
-CVE-2022-1586
-CVE-2022-1587
 CVE-2022-29162

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.15.0
+  tag: 14.4.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description
Update the postgressql image to 4.4.0-debian-11-r4 to address few vulnerabilities, But there are still few which have been added to the trivy ignore for which the upstream fix is not yet available.
The change addressess [issue](https://github.com/astronomer/issues/issues/4658)

## Related Issues

NA

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
