### PR TITLE
Bump houston to 0.29.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.4
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-3
-                - quay.io/astronomer/ap-houston-api:0.29.26
+                - quay.io/astronomer/ap-houston-api:0.29.28
                 - quay.io/astronomer/ap-kibana:7.17.4
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1
@@ -364,7 +364,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.4
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.4.5-3
-                - quay.io/astronomer/ap-houston-api:0.29.26
+                - quay.io/astronomer/ap-houston-api:0.29.28
                 - quay.io/astronomer/ap-kibana:7.17.4
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.2-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.26
+    tag: 0.29.28
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description
Changes:
- Bumped Houston to 0.29.28

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-picked into `release-0.29`
