### PR TITLE
update airflow chart version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.0
                 - quay.io/astronomer/ap-blackbox-exporter:0.21.1
                 - quay.io/astronomer/ap-cli-install:0.26.6
-                - quay.io/astronomer/ap-commander:0.29.3
+                - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-15
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.7

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.6.0
+airflowChartVersion: 1.6.1
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.29.3
+    tag: 0.29.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION


## Description

* set airflowchartversion to 1.6.1
* include commander image that has airflowchart 1.6.1

## Related Issues

https://github.com/astronomer/issues/issues/4819

## Testing

QA should see 1.6.1 airflowchart 

## Merging
merge to release-0.29
