### PR TITLE
bump astro ui to 0.29.11 from 0.29.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.29.10
+                - quay.io/astronomer/ap-astro-ui:0.29.11
                 - quay.io/astronomer/ap-auth-sidecar:1.23.0
                 - quay.io/astronomer/ap-awsesproxy:1.3-5
                 - quay.io/astronomer/ap-base:3.16.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.29.10
+    tag: 0.29.11
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

bump astro ui to 0.29.11 from 0.29.10
## Related Issues

https://github.com/astronomer/issues/issues/4808
https://github.com/astronomer/issues/issues/4816

## Testing

dev
## Merging

0.29.2