### PR TITLE
Allow show-only of dependencies

### DIFF
--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -18,7 +18,6 @@
 import subprocess
 import sys
 from functools import cache
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Tuple
 from typing import Optional
@@ -99,10 +98,10 @@ def render_chart(
         ]
         if namespace:
             command.extend(["--namespace", namespace])
-        for i in show_only:
-            if not Path(i).exists():
-                raise FileNotFoundError(f"ERROR: {i} not found")
-            else:
+        if show_only:
+            if isinstance(show_only, str):
+                show_only = [show_only]
+            for i in show_only:
                 command.extend(["--show-only", i])
         try:
             templates = subprocess.check_output(command, stderr=subprocess.PIPE)


### PR DESCRIPTION
## Description

We had been checking for the existence of files in python, rather than passing them through to helm. This was preventing helm from using `--show-only` in non-expanded dependent sub-charts.

See this thread where the issue was discovered for more details: <https://github.com/astronomer/airflow-chart/pull/337#discussion_r915331497>

🌯 to @jedcunningham for spotting the issue!

## Related Issues

N/A

## Testing

I've manually tested this.

## Merging

This should be merged into all supported branches.
