### PR TITLE
bump houston from 0.29.28 to 0.29.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.5.5
-                - quay.io/astronomer/ap-houston-api:0.29.28
+                - quay.io/astronomer/ap-houston-api:0.29.30
                 - quay.io/astronomer/ap-kibana:7.17.5
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.3

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.28
+    tag: 0.29.30
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description
Changes:
- Bumped Houston image from 0.29.28 to 0.29.30

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

To be cherry-picked in `release-0.29`
