### PR TITLE
kubestate metrics adding extra args

### DIFF
--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -36,9 +36,12 @@ spec:
 {{- include "kube-state.imagePullSecrets" . | indent 6 }}
       containers:
       - name: kube-state
-      {{- if .Values.global.singleNamespace }}
         args:
+      {{- if .Values.global.singleNamespace }}
           - --namespace={{ .Release.Namespace }}
+      {{- end }}
+      {{- if .Values.extraArgs }}
+          {{- .Values.extraArgs | toYaml | nindent 8 }}
       {{- end }}
         image: {{ include "kube-state.image" . }}
         imagePullPolicy: {{ .Values.images.kubeState.pullPolicy }}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -28,4 +28,4 @@ ports:
 replicas: 1
 
 extraArgs:
-- --metric-labels-allowlist=namespaces=[*]
+- "--metric-labels-allowlist=namespaces=[*]"

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -27,4 +27,5 @@ ports:
 
 replicas: 1
 
-extraArgs: []
+extraArgs:
+- --metric-labels-allowlist=namespaces=[*]

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -26,3 +26,5 @@ ports:
   telemetry: 8081
 
 replicas: 1
+
+extraArgs: []

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -54,3 +54,21 @@ class TestKubeStateDeployment:
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }
+
+    def test_kube_state_deployment_with_default_args(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "kube-state": {},
+            },
+            show_only=["charts/kube-state/templates/kube-state-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc)
+        assert (
+            "--metric-labels-allowlist=namespaces=[*]"
+            in c_by_name["kube-state"]["args"]
+        )


### PR DESCRIPTION
## Description

* current kube state config does not allow us to provide extra args to allow additional flags, this change allow that option
* post 2.0.x kube-state version not all metrics are exposed by default to reduce load , this allow us to define args needed for platform to work

## Related Issues

- https://github.com/astronomer/issues/issues/4828
- https://github.com/astronomer/issues/issues/4754

## Testing

Yet to update

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
