### PR TITLE
Bump several components in bin/reset-local-dev

### DIFF
--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-KIND_VERSION="0.11.1"
-HELM_VERSION="3.8.1"
-GCLOUD_VERSION="345.0.0"
-MKCERT_VERSION="1.4.3"
-KUBENT_VERSION="0.4.0"
+KIND_VERSION="0.14.0"
+HELM_VERSION="3.9.0"
+GCLOUD_VERSION="392.0.0"
+MKCERT_VERSION="1.4.4"
+KUBENT_VERSION="0.5.1"
 
 OS=$(uname | tr '[:upper:]' '[:lower:]')
 


### PR DESCRIPTION
## Description

Just keeping `bin/reset-local-dev` up to date with the latest component versions.

## Related Issues

N/A, but slack discussion is here: <https://astronomer.slack.com/archives/C02J8JT58CC/p1657653587089449>

## Testing

As long as CI is passing we're good.

## Merging

This should be merged into every supported branch: 0.29, 0.28, 0.25
