### PR TITLE
allowAirflowDbToBeSeperateFromHoustonDb

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -205,11 +205,13 @@ s3:
     secretKeyRef:
       name: {{ template "houston.backendSecret" . }}
       key: connection
+{{- if not (((.Values.houston.config.deployments).database).connection) }}
 - name: DEPLOYMENTS__DATABASE__CONNECTION
   valueFrom:
     secretKeyRef:
       name: {{ template "houston.airflowBackendSecret" . }}
       key: connection
+{{- end}}
   # These are set here for Houston's entrypoint script
 - name: COMMANDER__HOST
   value: {{ .Release.Name }}-commander


### PR DESCRIPTION
## Description

Previously our chart was ignoring if someone set the deployment db connection via helm because the env var set here overwrit the connection. By blocking the env var when the user sets the deployment db connection we enable them to use a seperate db for the airflow deployments than the db used by houston.

## Related Issues

astronomer/issues#4738

## Testing

Tested this change in aws and kind

## Merging

0.30.0