### PR TITLE
Add update check confs to houston conf

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -371,6 +371,10 @@ data:
     prometheus:
       enabled: true
       host: {{ printf "%s-prometheus" .Release.Name }}
+    updateAirflowCheck: |
+    {{ toYaml .Values.houston.updateAirflowCheck | indent 4 }}
+    updateRuntimeCheck: |
+    {{ toYaml .Values.houston.updateRuntimeCheck | indent 4 }}
 
   # These are any user-specified config overrides.
   local-production.yaml: |

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -371,10 +371,8 @@ data:
     prometheus:
       enabled: true
       host: {{ printf "%s-prometheus" .Release.Name }}
-    updateAirflowCheck: |
-    {{ toYaml .Values.houston.updateAirflowCheck | indent 4 }}
-    updateRuntimeCheck: |
-    {{ toYaml .Values.houston.updateRuntimeCheck | indent 4 }}
+    updateAirflowCheckEnabled: {{ .Values.houston.updateAirflowCheck.enabled }}
+    updateRuntimeCheckEnabled: {{ .Values.houston.updateRuntimeCheck.enabled }}
 
   # These are any user-specified config overrides.
   local-production.yaml: |

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -299,3 +299,47 @@ def test_cron_splay(test_data):
     assert (
         str(test_data[1]) == cron_minute
     ), f'test_data should be: ("{test_data[0]}", {cron_minute}),'
+
+
+def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
+    """Validate the houston configmap and its embedded data with updateAirflowCheck and updateRuntimeCheck."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "updateAirflowCheck": {"enabled": True},
+                    "updateRuntimeCheck": {"enabled": True},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+    assert prod["updateAirflowCheckEnabled"] is True
+    assert prod["updateRuntimeCheckEnabled"] is True
+
+
+def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
+    """Validate the houston configmap and its embedded data with updateAirflowCheck and updateRuntimeCheck."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "updateAirflowCheck": {"enabled": False},
+                    "updateRuntimeCheck": {"enabled": False},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    print(prod)
+    assert prod["updateAirflowCheckEnabled"] is False
+    assert prod["updateRuntimeCheckEnabled"] is False


### PR DESCRIPTION
## Description

Passes down the feature flags controlling whether update airflow and update runtime features are enabled.

Related PR https://github.com/astronomer/houston-api/pull/1176 in which these flags are used by houston.

## Related Issues

Related https://github.com/astronomer/issues/issues/4831
Related https://github.com/astronomer/issues/issues/4830

## Testing

unit tested

## Merging

0.30.0