### PR TITLE
add extraLogStores config to fluentd configmap

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -240,4 +240,7 @@ data:
         </buffer>
       </store>
       {{- end }}
+      {{- if .Values.extraLogStores }}
+{{ .Values.extraLogStores | indent 6}}
+      {{- end }}
     </match>

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -139,5 +139,5 @@ def test_fluentd_configmap_configure_extra_log_stores(kube_version):
         },
         show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
     )[0]
-    expected_store = "<store>\n    @type newrelic\n    @log_level info\n    base_uri https://log-api.newrelic.com/log/v1\n    license_key <LICENSE_KEY>"
+    expected_store = "  <store>\n    @type newrelic\n    @log_level info\n    base_uri https://log-api.newrelic.com/log/v1\n    license_key <LICENSE_KEY>"
     assert expected_store in doc["data"]["output.conf"]


### PR DESCRIPTION
## Description

Add customization for fluentd log stores.

## Related Issues

[Issue 4863](https://github.com/astronomer/issues/issues/4863)

## Testing

Add the following configuration in the `fluentd` section of the astronomer helm values:

```
fluentd:
  extraLogStores: |
    <store>
      @type newrelic
      @log_level info
      base_uri https://log-api.newrelic.com/log/v1
      license_key <LICENSE_KEY>
      <buffer>
        @type memory
        flush_interval 5s
      </buffer>
    </store>
```

This is just an example of an extra store, but you could also configure this with an S3 store outside of using the built-in chart configuration to test if logs show up.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
