### PR TITLE
Update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,16 +285,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.29.11
-                - quay.io/astronomer/ap-auth-sidecar:1.23.0
+                - quay.io/astronomer/ap-auth-sidecar:1.23.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-5
-                - quay.io/astronomer/ap-base:3.16.0
-                - quay.io/astronomer/ap-blackbox-exporter:0.21.1
-                - quay.io/astronomer/ap-cli-install:0.26.6
+                - quay.io/astronomer/ap-base:3.16.1
+                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-1
+                - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-15
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.7
-                - quay.io/astronomer/ap-default-backend:0.28.7
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.8
+                - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
@@ -302,13 +302,13 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.29.30
                 - quay.io/astronomer/ap-kibana:7.17.5
                 - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.9.3
+                - quay.io/astronomer/ap-nats-exporter:0.9.3-1
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.23.0
+                - quay.io/astronomer/ap-nginx-es:1.23.1
                 - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.21.4
+                - quay.io/astronomer/ap-openresty:1.21.4-1
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,8 +303,8 @@ workflows:
                 - quay.io/astronomer/ap-kibana:7.17.5
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.3-1
-                - quay.io/astronomer/ap-nats-server:2.8.1
-                - quay.io/astronomer/ap-nats-streaming:0.24.5
+                - quay.io/astronomer/ap-nats-server:2.8.1-1
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-1
                 - quay.io/astronomer/ap-nginx-es:1.23.1
                 - quay.io/astronomer/ap-nginx:1.2.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,13 +286,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.29.11
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1
-                - quay.io/astronomer/ap-awsesproxy:1.3-5
+                - quay.io/astronomer/ap-awsesproxy:1.3-6
                 - quay.io/astronomer/ap-base:3.16.1
                 - quay.io/astronomer/ap-blackbox-exporter:0.21.1-1
                 - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
-                - quay.io/astronomer/ap-curator:5.8.4-15
+                - quay.io/astronomer/ap-curator:5.8.4-16
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.8
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,11 +32,11 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.6
+    tag: 0.26.7
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-15
+    tag: 5.8.4-16
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.0
+    tag: 3.16.1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.0
+    tag: 1.23.1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4
+    tag: 1.21.4-1
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-5
+    tag: 1.3-6
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1
+    tag: 2.8.1-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3
+    tag: 0.9.3-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.7
+    tag: 0.28.8
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1
+  tag: 0.21.1-1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.0
+    tag: 3.16.1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3
+    tag: 0.9.3-1
     pullPolicy: IfNotPresent
 
 stan:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5
+    tag: 0.24.5-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/values.yaml
+++ b/values.yaml
@@ -113,7 +113,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.0
+    tag: 1.23.1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

**Update Vendor packages for CVE fixes and enhacements** 

image | old | new
-- | -- | --
ap-db-bootstrapper | 0.26.7 | 0.26.8
ap-cli-install | 0.26.6 | 0.26.7
ap-base | 3.16.0 | 3.16.1
ap-nginx-es | 1.23.0 | 1.23.1
ap-openresty | 1.21.4 |  1.21.4-1
ap-nats-exporter | 0.9.3 | 0.9.3-1
ap-default-backend | 0.28.7 | 0.28.8
ap-blackbox-exporter | 0.21.1 | 0.21.1-1
ap-auth-sidecar | 1.23.0 |  1.23.1 
ap-awsesproxy  | 1.3-5 |  1.3-6
ap-curator| 5.8.4-15 |  5.8.4-16 
ap-nats-server| 2.8.1 | 2.8.1-1
ap-nats-streaming| 0.24.5 | 0.24.5-1

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
