### PR TITLE
update nginx ingress controller image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
                 - quay.io/astronomer/ap-nginx-es:1.23.0
-                - quay.io/astronomer/ap-nginx:1.2.1
+                - quay.io/astronomer/ap-nginx:1.3.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1

--- a/charts/nginx/templates/nginx-config-role.yaml
+++ b/charts/nginx/templates/nginx-config-role.yaml
@@ -44,4 +44,26 @@ rules:
       - get
       - create
       - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - ingress-controller-leader-{{ template "nginx.fullname" . }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.2.1
+    tag: 1.3.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION

## Description

* CVE fixes and upstream enhancements
**release_notes:** 
* https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.3.0

**Points to note:**
* This release removes support for Kubernetes v1.19.0
* permissions on the coordination.k8s.io/leases resource for leaderelection lock added 



## Related Issues

Yet to create

## Testing

Yet to add

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
