### PR TITLE
ap-curator 5.8.4-17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
-                - quay.io/astronomer/ap-curator:5.8.4-16
+                - quay.io/astronomer/ap-curator:5.8.4-17
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.8
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-16
+    tag: 5.8.4-17
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
## Description

Fix urllib3 CVE.

## Related Issues

- https://github.com/astronomer/issues/issues/4427
- https://github.com/elastic/curator/issues/1622

## Testing

This version of ap-curator is a rebuild of the prior version, just with a new version of urllib3. Testing isn't necessary for this.

## Merging

This can be merged into all supported branches.