### PR TITLE
add support for multiple receivers in alertmanager

### DIFF
--- a/charts/alertmanager/templates/alertmanager-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-configmap.yaml
@@ -59,3 +59,6 @@ data:
     - name: airflow-receiver
 {{ toYaml .Values.receivers.airflow | trim | indent 6 }}
 {{- end }}
+{{ if .Values.customReceiver }}
+{{ toYaml .Values.customReceiver | trim | indent 4 }}
+{{ end }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -59,4 +59,15 @@ customRoutes: []
 #     tier: platform
 #     namespace: ^(test-ns.*)
 
+customReceiver: []
+# Example
+#  - name: sns-receiver
+#    sns_configs:
+#      - api_url: <SNS ENDPOINT>
+#        subject: '[Alert: {{ .GroupLabels.alertname }} - {{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]'
+#        topic_arn: <SNS-TOPIC>
+#        sigv4:
+#          region: <REGION>
+#          role_arn: <SNS-ROLE>
+
 enableNonRFC1918: false

--- a/tests/chart_tests/test_alertmanager.py
+++ b/tests/chart_tests/test_alertmanager.py
@@ -1,5 +1,7 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import jmespath
+import textwrap
+import yaml
 
 
 def test_alertmanager_defaults():
@@ -61,3 +63,28 @@ def test_alertmanager_rfc1918():
         )
         for value in item
     )
+
+
+def test_alertmanager_customReceiver():
+    """Test  alertmanager customer receiver configuration"""
+    test_custom_receiver_config = textwrap.dedent(
+        """
+        alertmanager:
+          customReceiver:
+          - name: sns-receiver
+            sns_configs:
+              - api_url: <SNS ENDPOINT>
+                subject: '[Alert: {{ .GroupLabels.alertname }} - {{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}]'
+                topic_arn: <SNS-TOPIC>
+                sigv4:
+                  region: <REGION>
+                  role_arn: <SNS-ROLE>
+            """
+    )
+    values = yaml.safe_load(test_custom_receiver_config)
+    docs = render_chart(
+        values=values,
+        show_only=["charts/alertmanager/templates/alertmanager-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    assert "sns-receiver" in docs[0]["data"]["alertmanager.yaml"]


### PR DESCRIPTION
## Description

Option to configure multiple receivers in addition to defaults.
This Allows customers to bring in multiple  custom receivers and allows them to define their own rules , based on their needs instead of depending on astronomer platform configured ones.

## Related Issues

Issue Link: https://github.com/astronomer/issues/issues/3114

## Testing

QA should able to define multiple  custom receivers and able to get alerts though the custome ones.

## Merging

release-0.29,0.30
