### PR TITLE
Back port CVE fixes for release-0.29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,31 +284,31 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.29.13
-                - quay.io/astronomer/ap-auth-sidecar:1.23.0
-                - quay.io/astronomer/ap-awsesproxy:1.3-5
-                - quay.io/astronomer/ap-base:3.16.0
-                - quay.io/astronomer/ap-blackbox-exporter:0.21.1
-                - quay.io/astronomer/ap-cli-install:0.26.6
+                - quay.io/astronomer/ap-astro-ui:0.29.11
+                - quay.io/astronomer/ap-auth-sidecar:1.23.1
+                - quay.io/astronomer/ap-awsesproxy:1.3-6
+                - quay.io/astronomer/ap-base:3.16.1
+                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-1
+                - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
-                - quay.io/astronomer/ap-curator:5.8.4-17
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.7
-                - quay.io/astronomer/ap-default-backend:0.28.7
+                - quay.io/astronomer/ap-curator:5.8.4-16
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.8
+                - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.0
                 - quay.io/astronomer/ap-grafana:8.5.5
                 - quay.io/astronomer/ap-houston-api:0.29.33
                 - quay.io/astronomer/ap-kibana:7.17.5
-                - quay.io/astronomer/ap-kube-state:1.9.7
-                - quay.io/astronomer/ap-nats-exporter:0.9.3
-                - quay.io/astronomer/ap-nats-server:2.8.1
-                - quay.io/astronomer/ap-nats-streaming:0.24.5
-                - quay.io/astronomer/ap-nginx-es:1.23.0
+                - quay.io/astronomer/ap-kube-state:2.5.0
+                - quay.io/astronomer/ap-nats-exporter:0.9.3-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-1
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-1
+                - quay.io/astronomer/ap-nginx-es:1.23.1
                 - quay.io/astronomer/ap-nginx:1.3.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.21.4
+                - quay.io/astronomer/ap-openresty:1.21.4-1
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.7
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.14.6-1
+                - quay.io/astronomer/ap-fluentd:1.15.0
                 - quay.io/astronomer/ap-grafana:8.5.5
                 - quay.io/astronomer/ap-houston-api:0.29.33
                 - quay.io/astronomer/ap-kibana:7.17.5
@@ -312,7 +312,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0
                 - quay.io/astronomer/ap-prometheus:2.34.0
-                - quay.io/astronomer/ap-registry:3.15.4-1
+                - quay.io/astronomer/ap-registry:3.16.1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.29.11
+                - quay.io/astronomer/ap-astro-ui:0.29.13
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-6
                 - quay.io/astronomer/ap-base:3.16.1
@@ -292,7 +292,7 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.29.5
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
-                - quay.io/astronomer/ap-curator:5.8.4-16
+                - quay.io/astronomer/ap-curator:5.8.4-17
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.8
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.1
                 - quay.io/astronomer/ap-nats-streaming:0.24.5
                 - quay.io/astronomer/ap-nginx-es:1.23.0
-                - quay.io/astronomer/ap-nginx:1.2.1
+                - quay.io/astronomer/ap-nginx:1.3.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -1,3 +1,5 @@
 # We are not using SSH as per this comment.
 # https://github.com/astronomer/astronomer/pull/1522#issuecomment-1128470766
 CVE-2022-27191
+# more info for CVE-2022-1996 available in https://github.com/kubernetes/ingress-nginx/issues/8745
+CVE-2022-1996

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,11 +32,11 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.6
+    tag: 0.26.7
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.15.4-1
+    tag: 3.16.1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,11 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-<<<<<<< HEAD
     tag: 5.8.4-17
-=======
-    tag: 5.8.4-16
->>>>>>> dfece827 (Update vendor packages (#1612))
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.0
+    tag: 3.16.1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.0
+    tag: 1.23.1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,11 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
+<<<<<<< HEAD
     tag: 5.8.4-17
+=======
+    tag: 5.8.4-16
+>>>>>>> dfece827 (Update vendor packages (#1612))
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4
+    tag: 1.21.4-1
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-5
+    tag: 1.3-6
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.6-1
+    tag: 1.15.0
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -35,9 +35,12 @@ spec:
       serviceAccountName: {{ template "kube-state.fullname" . }}
       containers:
       - name: kube-state
-      {{- if .Values.global.singleNamespace }}
         args:
+      {{- if .Values.global.singleNamespace }}
           - --namespace={{ .Release.Namespace }}
+      {{- end }}
+      {{- if .Values.extraArgs }}
+          {{- .Values.extraArgs | toYaml | nindent 8 }}
       {{- end }}
         image: {{ include "kube-state.image" . }}
         imagePullPolicy: {{ .Values.images.kubeState.pullPolicy }}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 1.9.7
+    tag: 2.5.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -26,3 +26,6 @@ ports:
   telemetry: 8081
 
 replicas: 1
+
+extraArgs:
+- "--metric-labels-allowlist=namespaces=[*]"

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1
+    tag: 2.8.1-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3
+    tag: 0.9.3-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/templates/nginx-config-role.yaml
+++ b/charts/nginx/templates/nginx-config-role.yaml
@@ -44,4 +44,26 @@ rules:
       - get
       - create
       - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - ingress-controller-leader-{{ template "nginx.fullname" . }}
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
 {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.2.1
+    tag: 1.3.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.7
+    tag: 0.28.8
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1
+  tag: 0.21.1-1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.0
+    tag: 3.16.1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5
+    tag: 0.24.5-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3
+    tag: 0.9.3-1
     pullPolicy: IfNotPresent
 
 stan:

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -18,7 +18,6 @@
 import subprocess
 import sys
 from functools import cache
-from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Tuple
 from typing import Optional
@@ -99,10 +98,10 @@ def render_chart(
         ]
         if namespace:
             command.extend(["--namespace", namespace])
-        for i in show_only:
-            if not Path(i).exists():
-                raise FileNotFoundError(f"ERROR: {i} not found")
-            else:
+        if show_only:
+            if isinstance(show_only, str):
+                show_only = [show_only]
+            for i in show_only:
                 command.extend(["--show-only", i])
         try:
             templates = subprocess.check_output(command, stderr=subprocess.PIPE)

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -146,7 +146,14 @@ def test_houston_configmap_with_loggingsidecar_enabled():
     """Validate the houston configmap and its embedded data with loggingSidecar."""
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
-        values={"global": {"loggingSidecar": {"enabled": True}}},
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "image": "quay.io/astronomer/ap-vector:0.22.3",
+                }
+            }
+        },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
 
@@ -175,10 +182,15 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
     """Validate the houston configmap and its embedded data with loggingSidecar."""
     sidecar_container_name = "sidecar-log-test"
     terminationEndpoint = "http://localhost:8000/quitquitquit"
+    image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
             "global": {
-                "loggingSidecar": {"enabled": True, "name": sidecar_container_name}
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "image": image_name,
+                }
             }
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -211,6 +223,7 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
     """Validate the houston configmap and its embedded data with loggingSidecar customConfig Enabled."""
     sidecar_container_name = "sidecar-log-test"
     terminationEndpoint = "http://localhost:8000/quitquitquit"
+    image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
             "global": {
@@ -218,6 +231,7 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
                     "enabled": True,
                     "name": sidecar_container_name,
                     "customConfig": True,
+                    "image": image_name,
                 }
             }
         },

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -54,3 +54,21 @@ class TestKubeStateDeployment:
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }
+
+    def test_kube_state_deployment_with_default_args(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "kube-state": {},
+            },
+            show_only=["charts/kube-state/templates/kube-state-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc)
+        assert (
+            "--metric-labels-allowlist=namespaces=[*]"
+            in c_by_name["kube-state"]["args"]
+        )

--- a/values.yaml
+++ b/values.yaml
@@ -113,7 +113,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.0
+    tag: 1.23.1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |

--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.22.3
+    image: quay.io/astronomer/ap-vector:0.23.0
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
 
@@ -512,15 +512,15 @@ kibana:
 #################################
 ## Fluentd configuration
 #################################
-# fluentd:
-#   # Configure resources
-#   resources:
-#     requests:
-#       cpu: "250m"
-#       memory: "512Mi"
-#     limits:
-#       cpu: "500m"
-#       memory: "1024Mi"
+fluentd:
+  # Configure resources
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1000m"
+      memory: "1024Mi"
 
 #################################
 ## Kube State configuration


### PR DESCRIPTION
## Description

**Update Vendor packages for CVE fixes and enhacements** 

image | old | new
-- | -- | --
ap-registry|3.15.4-1|3.16.1
ap-db-bootstrapper | 0.26.7 | 0.26.8
ap-cli-install | 0.26.6 | 0.26.7
ap-base | 3.16.0 | 3.16.1
ap-curator| 5.8.4-15 |  5.8.4-17 
ap-nginx-es | 1.23.0 | 1.23.1
ap-openresty | 1.21.4 |  1.21.4-1
ap-awsesproxy  | 1.3-5 |  1.3-6
ap-fluentd|1.14.6-1|1.15.0
ap-kube-state| 1.9.7 | 2.5.0
ap-nats-server| 2.8.1 | 2.8.1-1
ap-nats-exporter | 0.9.3 | 0.9.3-1
ap-nats-streaming| 0.24.5 | 0.24.5-1
ap-nginx| 1.2.1 | 1.3.0
ap-default-backend | 0.28.7 | 0.28.8
ap-blackbox-exporter | 0.21.1 | 0.21.1-1
ap-auth-sidecar | 1.23.0 |  1.23.1 
ap-vector|0.22.3|0.23.0


## Related Issues

https://github.com/astronomer/issues/issues/4876

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
