### PR TITLE
fix: remove prisma obsolete code

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -354,4 +354,3 @@ ports:
   registryHTTP: 5000
   registryScrape: 5001
   installHTTP: 8080
-  prismaHTTP: 4466

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -627,7 +627,7 @@ data:
             runbook_url:
             summary: '{{`{{ $labels.pod }}`}} Pod is CrashLooping'
           expr: |
-            rate(kube_pod_container_status_restarts_total{container=~"astro-ui|commander|registry|houston|prisma|prometheus|sqlproxy"}[15m]) * 60 * 5 > 0
+            rate(kube_pod_container_status_restarts_total{container=~"astro-ui|commander|registry|houston|prometheus|sqlproxy"}[15m]) * 60 * 5 > 0
           for: 15m
           labels:
             severity: critical

--- a/values.yaml
+++ b/values.yaml
@@ -196,7 +196,7 @@ global:
 
   # Set nodeSelector, affinity, and tolerations values for platform and deployment related pods.
   # This allows for separation of platform and airflow pods between kubernetes node pools.
-  # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui, prisma,
+  # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui,
   # registry, es-client, es-data, es-exporter, es-master, nginx-es, grafana, kibana, kube-state, nginx, nginx-default, prometheus.
   # nodeSelector, affinity, and tolerations values for airflow deployment pods are assigned via houston config.
   # See more information on pod / node assignment here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
## Description

Code cleanup: remove prisma related PORT and update comments, since we don't rely on prisma seperatly. It's backed into houston currently. 

## Merging

release-0.30