### PR TITLE
sync master to release 0.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4-1
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
-                - quay.io/astronomer/ap-postgresql:11.15.0
+                - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.34.0
                 - quay.io/astronomer/ap-registry:3.16.1
           context:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.30.0-rc2
-appVersion: 0.30.0-rc2
+version: 0.30.0-rc3
+appVersion: 0.30.0-rc3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.30.0-rc2
+version: 0.30.0-rc3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.0-rc1
+airflowChartVersion: 1.7.0-rc2
 
 nodeSelector: {}
 affinity: {}
@@ -354,4 +354,3 @@ ports:
   registryHTTP: 5000
   registryScrape: 5001
   installHTTP: 8080
-  prismaHTTP: 4466

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.15.0
+  tag: 11.15.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -627,7 +627,7 @@ data:
             runbook_url:
             summary: '{{`{{ $labels.pod }}`}} Pod is CrashLooping'
           expr: |
-            rate(kube_pod_container_status_restarts_total{container=~"astro-ui|commander|registry|houston|prisma|prometheus|sqlproxy"}[15m]) * 60 * 5 > 0
+            rate(kube_pod_container_status_restarts_total{container=~"astro-ui|commander|registry|houston|prometheus|sqlproxy"}[15m]) * 60 * 5 > 0
           for: 15m
           labels:
             severity: critical

--- a/values.yaml
+++ b/values.yaml
@@ -196,7 +196,7 @@ global:
 
   # Set nodeSelector, affinity, and tolerations values for platform and deployment related pods.
   # This allows for separation of platform and airflow pods between kubernetes node pools.
-  # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui, prisma,
+  # Pods in the platformNodePool include alertmanager, cli-install, commander, houston, kube-replicator, astro-ui,
   # registry, es-client, es-data, es-exporter, es-master, nginx-es, grafana, kibana, kube-state, nginx, nginx-default, prometheus.
   # nodeSelector, affinity, and tolerations values for airflow deployment pods are assigned via houston config.
   # See more information on pod / node assignment here: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/


### PR DESCRIPTION
## Description
This PR is to sync master branch to release 0.30 

* includes update airflowChartVersion 1.7.0-rc1 -> 1.7.0-rc2
* Code cleanup: remove prisma related PORT and update comments, since we don't rely on prisma seperatly. It's backed into houston currently.

## Related Issues

This is a sync PR from master again re-linking issues not needed


## Testing

NA

## Merging

git merge master to release-0.30
