### PR TITLE
fluentd 1.15.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.15.0
+                - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.5
                 - quay.io/astronomer/ap-houston-api:0.30.7
                 - quay.io/astronomer/ap-kibana:7.17.5

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.0
+    tag: 1.15.1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
## Description

fluentd version 1.15.1 (which uses ubuntu 22.04 as base image instead of 20.04)

## Related Issues

https://github.com/astronomer/issues/issues/4908

## Testing

None so far. Normal fluentd tests should be fine: just making sure logs are shipping, no unexpected output it seen in the fluentd logs.

## Merging

Merge everywhere.