### PR TITLE
update grafana image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.1
-                - quay.io/astronomer/ap-grafana:8.5.5
+                - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.7
                 - quay.io/astronomer/ap-kibana:7.17.5
                 - quay.io/astronomer/ap-kube-state:2.5.0

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.5
+    tag: 8.5.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION


## Description

* bump 8.5.5 -> 8.5.10
* release notes: https://github.com/grafana/grafana/releases/tag/v8.5.10


## Related Issues

https://github.com/astronomer/issues/issues/4914

## Testing

NA

## Merging

cherry-pick into 0.28,0.29,0.30
