### PR TITLE
createRootAdminJob

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-houston-api:0.31.0
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0

--- a/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
@@ -1,0 +1,16 @@
+################################
+## Houston Bootstrap Secrets
+#################################
+kind: Secret
+apiVersion: v1
+metadata:
+  name: astronomer-root-admin-credentials
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+    component: astronomer-root-admin-credentials
+type: Opaque
+data:
+  username: {{ print "root@root.com" | b64enc | quote }}
+  password: {{ randAlphaNum 20 | b64enc | quote }}

--- a/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
@@ -12,5 +12,5 @@ metadata:
     component: astronomer-root-admin-credentials
 type: Opaque
 data:
-  username: {{ print "root@root.com" | b64enc | quote }}
+  username: {{ .Values.global.rootAdmin.username | b64enc | quote }}
   password: {{ randAlphaNum 20 | b64enc | quote }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-rotate-root-admin-credentials.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-rotate-root-admin-credentials.yaml
@@ -1,0 +1,65 @@
+#######################################
+## Create Root Admin Job
+#######################################
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-rotate-root-admin-crednetial-cronjob
+  labels:
+    tier: astronomer
+    component: houston-rotate-root-admin-crednetial-cronjob
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  # this cronjob is only intended for manually triggering
+  suspend: true
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-rotate-root-admin-crednetial-cronjob
+            release: {{ .Release.Name }}
+            app: houston-rotate-root-admin-crednetial-cronjob
+            version: {{ .Chart.Version }}
+          {{- if .Values.global.istio.enabled }}
+          annotations:
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+        spec:
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          containers:
+            - name: rotate-root-admin-credential-job
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              volumeMounts:
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ template "houston.backendSecret" . }}
+                      key: connection
+                - name: ROOT_ADMIN_USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: astronomer-root-admin-credentials
+                      key: username
+                - name: ROOT_ADMIN_PASSWORD
+                  value: {{ randAlphaNum 20 | b64enc | quote }}
+              command: ["yarn"]
+              # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
+              args: ["rotate-root-admin-password", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
+          volumes:
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-rotate-root-admin-credentials.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-rotate-root-admin-credentials.yaml
@@ -4,10 +4,10 @@
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-rotate-root-admin-crednetial-cronjob
+  name: {{ .Release.Name }}-update-root-admin-password-cronjob
   labels:
     tier: astronomer
-    component: houston-rotate-root-admin-crednetial-cronjob
+    component: houston-update-root-admin-password-cronjob
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -20,9 +20,9 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston-rotate-root-admin-crednetial-cronjob
+            component: houston-update-root-admin-password-cronjob
             release: {{ .Release.Name }}
-            app: houston-rotate-root-admin-crednetial-cronjob
+            app: houston-update-root-admin-password-cronjob
             version: {{ .Chart.Version }}
           {{- if .Values.global.istio.enabled }}
           annotations:
@@ -38,7 +38,7 @@ spec:
           restartPolicy: Never
 {{- include "astronomer.imagePullSecrets" . | indent 10 }}
           containers:
-            - name: rotate-root-admin-credential-job
+            - name: update-root-admin-password-job
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               volumeMounts:
@@ -59,7 +59,7 @@ spec:
                   value: {{ randAlphaNum 20 | b64enc | quote }}
               command: ["yarn"]
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-              args: ["rotate-root-admin-password", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
+              args: ["update-root-admin-password", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "0 5 31 2 0"
+  schedule: "0 5 31 2 *" # https://crontab.guru/#0_5_31_2_*  At 05:00 on day-of-month 31 in February.
   # this cronjob is only intended for manually triggering
   suspend: true
   jobTemplate:

--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -12,6 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  schedule: "0 5 31 2 0"
   # this cronjob is only intended for manually triggering
   suspend: true
   jobTemplate:

--- a/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
@@ -1,0 +1,75 @@
+#######################################
+## Create Root Admin Job
+#######################################
+apiVersion: {{ include "apiVersion.batch" . }}
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-create-root-admin-job
+  labels:
+    tier: astronomer
+    component: houston-create-root-admin-job
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-upgrade,post-install
+    # since weight is larger than db migration job we should not need the wait for db init container
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 1
+  template:
+    metadata:
+      labels:
+        tier: astronomer
+        component: houston-create-root-admin-job
+        release: {{ .Release.Name }}
+        app: houston-create-root-admin-job
+        version: {{ .Chart.Version }}
+      {{- if .Values.global.istio.enabled }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "houston.bootstrapperServiceAccount" . }}
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 6 }}
+      containers:
+        - name: post-upgrade-create-admin-job
+          image: {{ template "houston.image" . }}
+          imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+          command: ["yarn"]
+          # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
+          args: ["create-root-admin", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
+          volumeMounts:
+            {{- include "houston_volume_mounts" . | indent 12 }}
+            {{- include "custom_ca_volume_mounts" . | indent 12 }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "houston.backendSecret" . }}
+                  key: connection
+            - name: ROOT_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: root-admin-credentials
+                  key: username
+            - name: ROOT_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: root-admin-credentials
+                  key: password
+      volumes:
+        {{- include "houston_volumes" . | indent 8 }}
+        {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
@@ -63,12 +63,12 @@ spec:
             - name: ROOT_ADMIN_USERNAME
               valueFrom:
                 secretKeyRef:
-                  name: root-admin-credentials
+                  name: astronomer-root-admin-credentials
                   key: username
             - name: ROOT_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: root-admin-credentials
+                  name: astronomer-root-admin-credentials
                   key: password
       volumes:
         {{- include "houston_volumes" . | indent 8 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.19
+    tag: 0.31.0
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/tests/chart_tests/test_cronjob_update_root_admin_password.py
+++ b/tests/chart_tests/test_cronjob_update_root_admin_password.py
@@ -1,0 +1,24 @@
+from tests.chart_tests.helm_template_generator import render_chart
+import pytest
+from tests import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestHoustonCronJobUpdateRootAdminPassword:
+    def test_cronjob_update_root_admin_password(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {}}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["kind"] == "CronJob"
+        assert doc["spec"]["suspend"] is True

--- a/tests/chart_tests/test_houston_root_admin_secret.py
+++ b/tests/chart_tests/test_houston_root_admin_secret.py
@@ -1,0 +1,28 @@
+from tests.chart_tests.helm_template_generator import render_chart
+import pytest
+import base64
+from tests import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestHoustonSecretHoustonRootAdminCredentials:
+    def test_secret_root_admin_credentials_default_values(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {}}},
+            show_only=[
+                "charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["kind"] == "Secret"
+        username = base64.b64decode(doc["data"]["username"])
+
+        assert username == b"root@root.com"
+        assert len(base64.b64decode(doc["data"]["password"])) == 20

--- a/tests/chart_tests/test_houston_root_admin_secret.py
+++ b/tests/chart_tests/test_houston_root_admin_secret.py
@@ -24,5 +24,5 @@ class TestHoustonSecretHoustonRootAdminCredentials:
         assert doc["kind"] == "Secret"
         username = base64.b64decode(doc["data"]["username"])
 
-        assert username == b"root@root.com"
+        assert username == b"root@example.com"
         assert len(base64.b64decode(doc["data"]["password"])) == 20

--- a/tests/chart_tests/test_job_create_root_admin.py
+++ b/tests/chart_tests/test_job_create_root_admin.py
@@ -1,0 +1,23 @@
+from tests.chart_tests.helm_template_generator import render_chart
+import pytest
+from tests import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestHoustonJobCreateRootAdmin:
+    def test_job_create_root_admin(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {}}},
+            show_only=[
+                "charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        assert doc["kind"] == "Job"

--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,7 @@ global:
   networkNSLabels: false
 
   rootAdmin:
-    username: root@root.com
+    username: root@example.com
 
   # Sidecar Logging
   loggingSidecar:

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,9 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
+  rootAdmin:
+    username: root@root.com
+
   # Sidecar Logging
   loggingSidecar:
     enabled: false


### PR DESCRIPTION
## Description

Adds a post install post upgrade webhook that creates a root admin user.
Adds a cronjob that users can use to rotate the root admin credential.

## Related Issues

astronomer/issues#4951
astronomer/issues#4910

## Testing

Tested locally in kind 

See demo https://user-images.githubusercontent.com/8050013/185661641-661ab0b7-63fc-47c0-a24a-d9b7a83ae634.mov


## Merging

0.31.0