### PR TITLE
Update components for CVE-2022-37434 fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,27 +284,27 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.30.2
+                - quay.io/astronomer/ap-astro-ui:0.30.3
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1
-                - quay.io/astronomer/ap-awsesproxy:1.3-6
+                - quay.io/astronomer/ap-awsesproxy:1.3-7
                 - quay.io/astronomer/ap-base:3.16.1
-                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
                 - quay.io/astronomer/ap-cli-install:0.26.7
-                - quay.io/astronomer/ap-commander:0.30.0
+                - quay.io/astronomer/ap-commander:0.30.1
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
-                - quay.io/astronomer/ap-curator:5.8.4-17
+                - quay.io/astronomer/ap-curator:5.8.4-18
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.8
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.13
+                - quay.io/astronomer/ap-houston-api:0.30.14
                 - quay.io/astronomer/ap-kibana:7.17.5
                 - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.9.3-1
-                - quay.io/astronomer/ap-nats-server:2.8.1-1
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-1
+                - quay.io/astronomer/ap-nats-exporter:0.9.3-2
+                - quay.io/astronomer/ap-nats-server:2.8.1-2
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-2
                 - quay.io/astronomer/ap-nginx-es:1.23.1
                 - quay.io/astronomer/ap-nginx:1.3.0
                 - quay.io/astronomer/ap-node-exporter:1.3.1
@@ -313,7 +313,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.34.0
-                - quay.io/astronomer/ap-registry:3.16.1
+                - quay.io/astronomer/ap-registry:3.16.2
           context:
             - slack_team-software-infra-bot
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,20 +15,20 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.30.0
+    tag: 0.30.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.13
+    tag: 0.30.14
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.30.2
+    tag: 0.30.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-17
+    tag: 5.8.4-18
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-6
+    tag: 1.3-7
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-1
+    tag: 2.8.1-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-1
+    tag: 0.9.3-2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-1
+  tag: 0.21.1-2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-1
+    tag: 0.24.5-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-1
+    tag: 0.9.3-2
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION
## Description

Update all components affected by CVE-2022-37434

## Related Issues

https://github.com/astronomer/issues/issues/4928

## Testing

The only changes here are the base image, so minimal testing will suffice.

## Merging

This is only meant for the release-0.30 branch. Changes could be cherry-picked to master too if needed for future releases.