### PR TITLE
add support for configuring securityContexts on fluentd

### DIFF
--- a/charts/fluentd/templates/fluentd-daemonset.yaml
+++ b/charts/fluentd/templates/fluentd-daemonset.yaml
@@ -35,9 +35,13 @@ spec:
       tolerations:
 {{ toYaml (.Values.tolerations) | indent 8 }}
       serviceAccountName: {{ template "fluentd.fullname" . }}
+      securityContext:
+{{ toYaml .Values.pod.securityContext | indent 8 }}
       containers:
       - name: fluentd
         image: {{ template "fluentd.image" . }}
+        securityContext:
+{{ toYaml .Values.container.securityContext | indent 10 }}
         {{- if .Values.global.istioEnabled }}
         command:
           - "/bin/bash"

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -2,6 +2,10 @@ nodeSelector: {}
 affinity: {}
 tolerations: []
 
+pod:
+  securityContext: {}
+container:
+  securityContext: {}
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -3,6 +3,7 @@ import pytest
 from tests import supported_k8s_versions
 import jmespath
 
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
@@ -121,15 +122,7 @@ def test_fluentd_pod_securityContextOverride(kube_version):
 
     docs = render_chart(
         kube_version=kube_version,
-        values={
-            "fluentd": {
-                "pod": {
-                    "securityContext": {
-                        "runAsUser": 9999
-                    }
-                }
-            }
-        },
+        values={"fluentd": {"pod": {"securityContext": {"runAsUser": 9999}}}},
         show_only=["charts/fluentd/templates/fluentd-daemonset.yaml"],
     )
 
@@ -155,9 +148,7 @@ def test_fluentd_container_securityContextOverride(kube_version):
                 "container": {
                     "securityContext": {
                         "runAsUser": 8888,
-                        "seLinuxOptions": {
-                            "type": "spc_t"
-                        }
+                        "seLinuxOptions": {"type": "spc_t"},
                     }
                 }
             }


### PR DESCRIPTION
## Description

Adds a configurable securityContextConstraint for fluentd

## Related Issues

[Github issue #4989](https://github.com/astronomer/issues/issues/4989)

## Testing

Added new unit tests
Tested against a real prod cluster pre-and-post and made sure, when set, the securityContext in pod and container was set appropriately. 

## Merging

Please cherry-pick to main and 0.30.x