### PR TITLE
master: update vendor image in astronomer/astronomer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,15 +285,15 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.30.3
-                - quay.io/astronomer/ap-auth-sidecar:1.23.1
+                - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-7
-                - quay.io/astronomer/ap-base:3.16.1
+                - quay.io/astronomer/ap-base:3.16.2
                 - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
                 - quay.io/astronomer/ap-cli-install:0.26.7
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-18
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.8
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.8
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
@@ -305,10 +305,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.9.3-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-2
-                - quay.io/astronomer/ap-nginx-es:1.23.1
-                - quay.io/astronomer/ap-nginx:1.3.0
+                - quay.io/astronomer/ap-nginx-es:1.23.1-1
+                - quay.io/astronomer/ap-nginx:1.3.0-1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-openresty:1.21.4-1
+                - quay.io/astronomer/ap-openresty:1.21.4-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-1
                 - quay.io/astronomer/ap-postgres-exporter:0.10.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-7
                 - quay.io/astronomer/ap-base:3.16.2
                 - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
-                - quay.io/astronomer/ap-cli-install:0.26.7
+                - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
                 - quay.io/astronomer/ap-curator:5.8.4-18

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.8
+    tag: 0.26.9
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.1
+    tag: 1.23.1-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-1
+    tag: 1.21.4-2
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.8
+    tag: 0.26.9
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.0
+    tag: 1.3.0-1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming

--- a/values.yaml
+++ b/values.yaml
@@ -116,7 +116,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.1
+    tag: 1.23.1-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION


## Description

List of images being updated in this PR 

image | old | new
-- | -- | --
ap-base            | 3.16.1     | 3.16.2
ap-nginx           | 1.3.0 |  1.3.0-1
ap-db-bootstrapper |  0.26.8 |  0.26.9
ap-nginx-es |  1.23.1 |  1.23.1-1
ap-auth-sidecar |  1.23.1 |  1.23.1-1
ap-openresty |  1.21.4-1 |  1.21.4-2 
ap-cli-install  |  0.26.7    | 0.26.8

## Related Issues

https://github.com/astronomer/issues/issues/4987

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick release-0.29, 0.30
