### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,10 +291,10 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.30.4
-                - quay.io/astronomer/ap-configmap-reloader:0.5.0-1
+                - quay.io/astronomer/ap-configmap-reloader:0.7.1
                 - quay.io/astronomer/ap-curator:5.8.4-18
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
-                - quay.io/astronomer/ap-default-backend:0.28.8
+                - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.1
@@ -310,9 +310,9 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-1
-                - quay.io/astronomer/ap-postgres-exporter:0.10.1
+                - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.34.0
+                - quay.io/astronomer/ap-prometheus:2.37.0
                 - quay.io/astronomer/ap-registry:3.16.2
           context:
             - slack_team-software-infra-bot

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.8
+    tag: 0.28.9
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.10.1
+  tag: 0.11.1
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -34,12 +34,12 @@ postgresqlExporter:
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.34.0
+    tag: 2.37.0
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.5.0-1
+    tag: 0.7.1
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
## Description

* bump ap-prometheus 2.34.0 -> 2.37.0
* bump ap-config-reloader 0.5.0-1 -> 0.7.1
* bump ap-postgres-exporter 0.10.1 -> 0.11.1

## Related Issues

https://github.com/astronomer/issues/issues/4200
https://github.com/astronomer/issues/issues/4932
https://github.com/astronomer/issues/issues/4986
## Testing
NA

## Merging

Yet to update
