### PR TITLE
release 0.29 cve fixes

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -28,15 +28,15 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.29.14
+    tag: 0.29.15
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.8
+    tag: 0.26.9
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.7
+    tag: 0.26.8
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-17
+    tag: 5.8.4-18
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.1
+    tag: 1.23.1-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-1
+    tag: 1.21.4-2
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-6
+    tag: 1.3-7
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.5
+    tag: 8.5.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.8
+    tag: 0.26.9
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-1
+    tag: 2.8.1-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-1
+    tag: 0.10.0
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,11 +9,11 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.0
+    tag: 1.3.0-1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.8
+    tag: 0.28.9
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-1
+  tag: 0.21.1-2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.10.1
+  tag: 0.11.1
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -36,12 +36,12 @@ postgresqlExporter:
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.34.0
+    tag: 2.37.0
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.5.0-1
+    tag: 0.7.1
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.1
+    tag: 3.16.2
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-1
+    tag: 0.10.0
     pullPolicy: IfNotPresent
 
 stan:

--- a/values.yaml
+++ b/values.yaml
@@ -113,7 +113,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.1
+    tag: 1.23.1-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

image | old | new
-- | -- | --
ap-registry   |  3.16.1 | 3.16.2 
ap-astro-ui   | 0.29.14 | 0.29.15
ap-db-bootstrapper |  0.26.8 |  0.26.9 
 ap-cli-install | 0.26.7 | 0.26.8
ap-curator |  5.8.4-17 |  5.8.4-18
ap-nginx-es  |  1.23.1 | 1.23.1-1 
ap-base |  3.16.1 |  3.16.2
ap-openresty |  1.21.4-1 | 1.21.4-2
 ap-awsesproxy | 1.3-6 | 1.3-7
ap-grafana |  8.5.5 | 8.5.10
ap-db-bootstrapper | 0.26.8 | 0.26.9
ap-nats-server |  2.8.1-1 |  2.8.1-2
ap-nats-exporter |  0.9.3-1 | 0.10.0
ap-nginx | 1.3.0 | 1.3.0-1
ap-default-backend | 0.28.8 | 0.28.9
ap-blackbox-exporter |   0.21.1-1 |  0.21.1-2
ap-postgres-exporter | 0.10.1 | 0.11.1
ap-prometheus | 2.34.0 | 2.37.0
ap-config-reloader  | 0.5.0-1 |  0.7.1  
ap-auth-sidecar | 1.23.1 | 1.23.1-1

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
