### PR TITLE
update elasticsearch exporter package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,7 +295,7 @@ workflows:
                 - quay.io/astronomer/ap-curator:5.8.4-18
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.9
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.3.0
+    tag: 1.5.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es


### PR DESCRIPTION


## Description

* update es exporter 1.3.0 -> 1.5.0
* fix CVE-2022-21698

## Related Issues

https://github.com/astronomer/issues/issues/5003

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to release-0.28,0.29,0.30
