### PR TITLE
update nginx ingress controller image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.1-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-2
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
-                - quay.io/astronomer/ap-nginx:1.3.0-1
+                - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-openresty:1.21.4-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-1

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.0-1
+    tag: 1.3.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION


## Description

* update ap-nginx 1.3.0-1 -> 1.3.1

## Related Issues

https://github.com/astronomer/issues/issues/5010

## Testing

QA should able to see access all exposed platform components without any issues. or errors in nginx console

## Merging

cherry-pick to release-0.29,0.30
