### PR TITLE
release 0.28 security fixes for elasticsearch exporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
                 - quay.io/astronomer/ap-curator:5.8.4-18
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.9
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.5.10

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.3.0
+    tag: 1.5.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es


### PR DESCRIPTION


## Description

* bump ap-elasticsearch-exporter 1.3.0 -> 1.5.0

## Related Issues

https://github.com/astronomer/issues/issues/5003

## Testing

NA

## Merging

cherry-pick to release-0.28
