### PR TITLE
Revert prometheus scrape inverval configuration feature additions.

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -15,8 +15,8 @@ data:
   config: |-
     # https://prometheus.io/docs/prometheus/latest/configuration/configuration/
     global:
-      scrape_interval: {{ .Values.scrape_interval }}
-      evaluation_interval: {{ .Values.evaluation_interval }}
+      scrape_interval: 30s
+      evaluation_interval: 30s
       {{ if .Values.external_labels }}external_labels: {{ .Values.external_labels | toYaml | nindent 8 }}{{ end }}
 
     # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
@@ -153,7 +153,7 @@ data:
 
       {{- if .Values.global.veleroEnabled }}
       - job_name: velero
-        scrape_interval: {{ .Values.velero.scrape_interval }}
+        scrape_interval: 30s
         kubernetes_sd_configs:
           - role: service
             namespaces:
@@ -172,8 +172,8 @@ data:
 
       {{- if .Values.global.prometheusPostgresExporterEnabled }}
       - job_name: postgresql-exporter
-        scrape_interval: {{ .Values.postgresqlExporter.scrape_interval }}
-        scrape_timeout: {{ .Values.postgresqlExporter.scrape_timeout }}
+        scrape_interval: 60s
+        scrape_timeout: 30s
         kubernetes_sd_configs:
           - role: service
             namespaces:
@@ -195,7 +195,7 @@ data:
 
 
       - job_name: kube-state
-        scrape_interval: {{ .Values.kubeState.scrape_interval }} # Faster scrape to power dashboards
+        scrape_interval: 10s # Faster scrape to power dashboards
         kubernetes_sd_configs:
           - role: service
             namespaces:
@@ -293,7 +293,7 @@ data:
           {{- end}}
 
       - job_name: fluentd
-        scrape_interval: {{ .Values.fluentd.scrape_interval }}
+        scrape_interval: 30s
         kubernetes_sd_configs:
           - role: pod
             namespaces:
@@ -318,7 +318,7 @@ data:
 
       {{- if .Values.global.nodeExporterEnabled }}
       - job_name: node-exporter
-        scrape_interval: {{ .Values.nodeExporter.scrape_interval }}
+        scrape_interval: 30s
         kubernetes_sd_configs:
           - role: pod
             namespaces:
@@ -349,7 +349,7 @@ data:
       {{- end }}
 
       - job_name: airflow
-        scrape_interval: {{ .Values.airflow.scrape_interval }} # Faster scrape to power dashboards
+        scrape_interval: 10s # Faster scrape to power dashboards
         kubernetes_sd_configs:
           - role: service
           {{- if .Values.global.singleNamespace }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -15,22 +15,6 @@ podLabels: {}
 # such that only one is replaced at a time.
 replicas: 1
 
-scrape_interval: 30s
-evaluation_interval: 30s
-velero:
-  scrape_interval: 30s
-kubeState:
-  scrape_interval: 10s
-fluentd:
-  scrape_interval: 30s
-nodeExporter:
-  scrape_interval: 30s
-airflow:
-  scrape_interval: 10s
-postgresqlExporter:
-  scrape_interval: 60s
-  scrape_timeout: 30s
-
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -125,46 +125,6 @@ class TestPrometheusConfigConfigmap:
             }
         ]
 
-    def test_prometheus_config_configmap_scrape_interval(self, kube_version):
-        """Prometheus should have configurable scrape interval duration which can be defined as helm value"""
-        doc = render_chart(
-            kube_version=kube_version,
-            show_only=self.show_only,
-            values={
-                "prometheus": {
-                    "scrape_interval": "30s",
-                    "evaluation_interval": "foo",
-                    "velero": {"scrape_interval": "velero"},
-                    "fluentd": {"scrape_interval": "fluentd"},
-                    "airflow": {"scrape_interval": "airflow"},
-                    "nodeExporter": {"scrape_interval": "node-exp"},
-                    "kubeState": {"scrape_interval": "kube-state"},
-                    "postgresqlExporter": {
-                        "scrape_interval": "foo",
-                        "scrape_timeout": "bar",
-                    },
-                }
-            },
-        )[0]
-        # few jobs have scrape timeout, that's why dirty if-else
-        config_yaml = yaml.safe_load(doc["data"]["config"])
-        assert config_yaml["global"]["scrape_interval"] == "30s"
-        assert config_yaml["global"]["evaluation_interval"] == "foo"
-        for job in config_yaml["scrape_configs"]:
-            if job["job_name"] == "velero":
-                assert job["scrape_interval"] == "velero"
-            elif job["job_name"] == "fluentd":
-                assert job["scrape_interval"] == "fluentd"
-            elif job["job_name"] == "airflow":
-                assert job["scrape_interval"] == "airflow"
-            elif job["job_name"] == "node-exporter":
-                assert job["scrape_interval"] == "node-exp"
-            elif job["job_name"] == "kube-state":
-                assert job["scrape_interval"] == "kube-state"
-            if job["job_name"] == "postgresql-exporter":
-                assert job["scrape_interval"] == "foo"
-                assert job["scrape_timeout"] == "bar"
-
     def test_prometheus_config_configmap_with_node_exporter(self, kube_version):
         """Validate the prometheus config configmap has the node-exporter enabled with params."""
         doc = render_chart(
@@ -176,9 +136,6 @@ class TestPrometheusConfigConfigmap:
                 "global": {
                     "nodeExporterEnabled": True,
                 },
-                "prometheus": {
-                    "nodeExporter": {"scrape_interval": "333s"},
-                },
             },
         )[0]
 
@@ -187,7 +144,7 @@ class TestPrometheusConfigConfigmap:
             for x in yaml.safe_load(doc["data"]["config"])["scrape_configs"]
             if x["job_name"] == "node-exporter"
         ]
-        assert nodeExporterConfigs[0]["scrape_interval"] == "333s"
+        assert nodeExporterConfigs[0]["job_name"] == "node-exporter"
 
     def test_prometheus_config_configmap_without_node_exporter(self, kube_version):
         """Validate the prometheus config configmap does not have node-exporter when it is not enabled."""


### PR DESCRIPTION
## Description

Revert https://github.com/astronomer/astronomer/pull/1578 due to the implementation breaking other things. Will revisit this later.

## Related Issues

https://github.com/astronomer/issues/issues/4782

## Testing

The changes in the original PR had a test case added that referenced the feature, so I have fixed that test and opened this PR rather than doing a direct revert, which caused conflicts. Tests are passing now. QA has already validated that unsetting these parameters fixes the problem, but it's worth validating once more.

## Merging

Merge to 0.30 and 0.29