### PR TITLE
add nats cluster name

### DIFF
--- a/charts/nats/templates/configmap.yaml
+++ b/charts/nats/templates/configmap.yaml
@@ -76,6 +76,12 @@ data:
     cluster {
       port: 6222
 
+      {{- if .Values.cluster.name}}
+
+      name: {{ .Release.Name }}-{{ .Values.cluster.name }}
+
+      {{- end }}
+
       {{- with .Values.cluster.tls }}
       {{ $secretName := .secret.name }}
       tls {

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -103,6 +103,7 @@ podAnnotations: {}
 
 cluster:
   enabled: true
+  name: nats
 
 # Leafnode connections to extend a cluster:
 #

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -185,8 +185,7 @@ class TestNatsStatefulSet:
             values=values,
         )
 
-        doc = docs[0]
-        nats_cm = doc["data"]["nats.conf"]
+        nats_cm = doc[0]["data"]["nats.conf"]
         assert "release-name-nats" in nats_cm
 
     def test_nats_statefulset_with_default_cluster_name_overrides(self, kube_version):

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -185,7 +185,7 @@ class TestNatsStatefulSet:
             values=values,
         )
 
-        nats_cm = doc[0]["data"]["nats.conf"]
+        nats_cm = docs[0]["data"]["nats.conf"]
         assert "release-name-nats" in nats_cm
 
     def test_nats_statefulset_with_default_cluster_name_overrides(self, kube_version):
@@ -199,5 +199,5 @@ class TestNatsStatefulSet:
             values=values,
         )
 
-        nats_cm = doc[0]["data"]["nats.conf"]
+        nats_cm = docs[0]["data"]["nats.conf"]
         assert "release-name-astronats" in nats_cm

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -1,10 +1,6 @@
-import json
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 from tests import supported_k8s_versions, get_containers_by_name
-import yaml
-import jmespath
-import sys
 
 
 @pytest.mark.parametrize(

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -199,6 +199,5 @@ class TestNatsStatefulSet:
             values=values,
         )
 
-        doc = docs[0]
-        nats_cm = doc["data"]["nats.conf"]
+        nats_cm = doc[0]["data"]["nats.conf"]
         assert "release-name-astronats" in nats_cm


### PR DESCRIPTION
## Description

Nats server on every restart/upgrades picks a dynamic cluster name which increases the delay in startup, this changes fixes that issue and adds a cluster name based on release name

## Related Issues

Related Issue: https://github.com/astronomer/issues/issues/4978

## Testing

QA should see result similar to below screen shot
<img width="974" alt="image" src="https://user-images.githubusercontent.com/81585115/189701924-d90ed0e4-befb-45b5-88ac-bb467a5268f0.png">


## Merging

Not yet confirmed 
