### PR TITLE
add loggingSidecar to enable_all_features so it shows on image list

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.0
                 - quay.io/astronomer/ap-registry:3.16.2
+                - quay.io/astronomer/ap-vector:0.23.0
           context:
             - slack_team-software-infra-bot
 

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -6,6 +6,8 @@ global:
   customLogging:
     awsSecretName: dummy
     enabled: true
+  loggingSidecar:
+    enabled: true
   pgbouncer:
     enabled: true
   postgresqlEnabled: true


### PR DESCRIPTION
## Description

add loggingSidecar to enable_all_features so it shows on image list

## Issue
https://github.com/astronomer/issues/issues/5036

## Testing

make show-docker-images now includes this image

## Merging

Please cherry-pick to release-0.29 release-0.30 as well as to v0.30.1 v0.29.3 and v0.29.4.