### PR TITLE
release 0.28 update nginx ingress controller image to 1.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,7 +292,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.1-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-2
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
-                - quay.io/astronomer/ap-nginx:1.3.0-1
+                - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.3.1
                 - quay.io/astronomer/ap-prometheus:2.37.0
           context:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.0-1
+    tag: 1.3.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION


## Description
fixes all CVE's
bump 1.3.0-1 -> 1.3.1


## Related Issues

https://github.com/astronomer/issues/issues/5010
https://github.com/astronomer/issues/issues/4938

## Testing

Ingress controller should come up without any issues 

## Merging

merge to release-0.28
