### PR TITLE
make prometheus livenessProbe and readinessProbe configurable

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -116,14 +116,16 @@ spec:
             httpGet:
               path: /-/healthy
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /-/ready
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
       securityContext:
         fsGroup: 65534
         runAsNonRoot: true

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -34,6 +34,16 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+# probe configurations for prometheus container
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 3
+
 configMapReloader:
   resources: {}
     # limits:

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -48,3 +48,44 @@ class TestPrometheusStatefulset:
             {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
             {"mountPath": "/prometheus", "name": "data"},
         ]
+        # check default liveness probe values
+        assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10
+        assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 5
+        assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 3
+        # check default readiness probe values
+        assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 10
+        assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 5
+        assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 3
+
+    def test_prometheus_sts_override_probes(self, kube_version):
+        """Test override of probe values."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "prometheus": {
+                    "livenessProbe": {
+                        "initialDelaySeconds": 20,
+                        "periodSeconds": 21,
+                        "failureThreshold": 22,
+                    },
+                    "readinessProbe": {
+                        "initialDelaySeconds": 30,
+                        "periodSeconds": 31,
+                        "failureThreshold": 32,
+                    },
+                }
+            },
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc)
+        # check modified liveness probe values
+        assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 20
+        assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 21
+        assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 22
+        # check modified readiness probe values
+        assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 30
+        assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 31
+        assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 32


### PR DESCRIPTION
## Description

Make livenessProbe and readinessProbe configurable

## Related Issues

https://github.com/astronomer/issues/issues/5050

## Testing

Unit-tested + manual diff of helm template pre and post, no organic testing.
n.b. 3 is the default kubernetes failureThreshold and is thus a no-op from the status-quo
``` 
    spec:
       nodeSelector:
         {}
@@ -7662,12 +7662,14 @@
               port: 9090
             initialDelaySeconds: 10
             periodSeconds: 5
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /-/ready
               port: 9090
             initialDelaySeconds: 10
             periodSeconds: 5
+            failureThreshold: 3
```

## Merging

Please cherry-pick to 0.29.x and 0.30.x