### PR TITLE
Adding header for Helm templates - 0.28

### DIFF
--- a/charts/elasticsearch/templates/es-psp-clusterrole.yaml
+++ b/charts/elasticsearch/templates/es-psp-clusterrole.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP ClusterRole
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:

--- a/charts/elasticsearch/templates/es-psp-rolebinding.yaml
+++ b/charts/elasticsearch/templates/es-psp-rolebinding.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP Rolebinding
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: RoleBinding
 metadata:

--- a/charts/elasticsearch/templates/es-psp.yaml
+++ b/charts/elasticsearch/templates/es-psp.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Elasticsearch PSP
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
+++ b/charts/fluentd/templates/fluentd-psp-clusterrole.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP ClusterRole
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:

--- a/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
+++ b/charts/fluentd/templates/fluentd-psp-rolebinding.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP RoleBinding
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: RoleBinding
 metadata:

--- a/charts/fluentd/templates/fluentd-psp.yaml
+++ b/charts/fluentd/templates/fluentd-psp.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Fluentd PSP
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/nginx/templates/nginx-psp-clusterrole.yaml
+++ b/charts/nginx/templates/nginx-psp-clusterrole.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Nginx PSP ClusterRole
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:
@@ -15,4 +15,4 @@ rules:
   - {{ .Release.Name }}-ingress-nginx
   verbs:
   - use
-  {{- end -}}
+{{- end -}}

--- a/charts/nginx/templates/nginx-psp-rolebinding.yaml
+++ b/charts/nginx/templates/nginx-psp-rolebinding.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.global.pspEnabled }}
 ################################
 ## Nginx PSP RoleBinding
-#################################
+################################
+{{- if .Values.global.pspEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: RoleBinding
 metadata:

--- a/charts/nginx/templates/nginx-psp.yaml
+++ b/charts/nginx/templates/nginx-psp.yaml
@@ -1,7 +1,7 @@
+######################
+##    Nginx PSP     ##
+######################
 {{- if .Values.global.pspEnabled }}
-################################
-## Nginx PSP
-#################################
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/prometheus-node-exporter/templates/psp-clusterrole.yaml
+++ b/charts/prometheus-node-exporter/templates/psp-clusterrole.yaml
@@ -1,3 +1,6 @@
+#############################################
+##   Prometheus Node Exporter ClusterRole  ##
+#############################################
 {{- if .Values.rbac.create }}
 {{- if .Values.global.pspEnabled }}
 kind: ClusterRole

--- a/charts/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
+++ b/charts/prometheus-node-exporter/templates/psp-clusterrolebinding.yaml
@@ -1,3 +1,6 @@
+##################################################
+## Prometheus Node Exporter ClusterRoleBinding  ##
+##################################################
 {{- if .Values.rbac.create }}
 {{- if .Values.global.pspEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/prometheus-node-exporter/templates/psp.yaml
+++ b/charts/prometheus-node-exporter/templates/psp.yaml
@@ -1,3 +1,6 @@
+#############################################
+##    Prometheus Node Exporter PSP         ##
+#############################################
 {{- if .Values.rbac.create }}
 {{- if .Values.global.pspEnabled }}
 apiVersion: policy/v1beta1

--- a/templates/psp/permissive-clusterrole.yaml
+++ b/templates/psp/permissive-clusterrole.yaml
@@ -1,3 +1,6 @@
+#################################
+##    PSP ClusterRole          ##
+#################################
 {{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/templates/psp/permissive-clusterrolebinding.yaml
+++ b/templates/psp/permissive-clusterrolebinding.yaml
@@ -1,3 +1,6 @@
+#################################
+##    PSP RoleBinding          ##
+#################################
 {{- if .Values.global.pspEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: RoleBinding

--- a/templates/psp/permissive-psp.yaml
+++ b/templates/psp/permissive-psp.yaml
@@ -1,3 +1,6 @@
+#################################
+##    PSP                      ##
+#################################
 {{- if .Values.global.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy

--- a/templates/psp/restrictive-cluserrolebinding.yaml
+++ b/templates/psp/restrictive-cluserrolebinding.yaml
@@ -1,3 +1,6 @@
+#################################
+##    Cluster Role Binding     ##
+#################################
 {{- if .Values.global.pspEnabled }}
 kind: ClusterRoleBinding
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/templates/psp/restrictive-clusterrole.yaml
+++ b/templates/psp/restrictive-clusterrole.yaml
@@ -1,3 +1,6 @@
+#################################
+##    Cluster Role             ##
+#################################
 {{- if .Values.global.pspEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/templates/psp/restrictive-psp.yaml
+++ b/templates/psp/restrictive-psp.yaml
@@ -1,6 +1,6 @@
-{{- if .Values.global.pspEnabled }}
 # All purpose catch all restrictive policy
 # If a specific policy is not applied this one will be
+{{- if .Values.global.pspEnabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/tests/test_psp.py
+++ b/tests/test_psp.py
@@ -1,7 +1,7 @@
-from tests.helm_template_generator import render_chart
 import pytest
+
+from tests.helm_template_generator import render_chart
 from . import supported_k8s_versions
-from subprocess import CalledProcessError
 
 
 @pytest.mark.parametrize(
@@ -41,12 +41,14 @@ class TestPspEnabled:
     @pytest.mark.parametrize("psp_docs", psp_docs, ids=psp_doc_ids)
     def test_psp(self, kube_version, psp_docs):
         """Test that helm errors when pspEnabled=False, and renders a good PodSecurityPolicy template when pspEnabled=True."""
-        with pytest.raises(CalledProcessError):
-            docs = render_chart(
-                kube_version=kube_version,
-                values={"global": {"pspEnabled": False}},
-                show_only=[psp_docs["template"]],
-            )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"pspEnabled": False}},
+            show_only=[psp_docs["template"]],
+        )
+
+        assert len(docs) == 0
 
         docs = render_chart(
             kube_version=kube_version,
@@ -95,12 +97,12 @@ class TestPspEnabled:
     )
     def test_clusterrole(self, kube_version, clusterrole_docs):
         """Test that helm errors when pspEnabled=False, and renders a good ClusterRole template when pspEnabled=True."""
-        with pytest.raises(CalledProcessError):
-            docs = render_chart(
-                kube_version=kube_version,
-                values={"global": {"pspEnabled": False}},
-                show_only=[clusterrole_docs["template"]],
-            )
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"pspEnabled": False}},
+            show_only=[clusterrole_docs["template"]],
+        )
+        assert len(docs) == 0
 
         docs = render_chart(
             kube_version=kube_version,
@@ -139,12 +141,14 @@ class TestPspEnabled:
     )
     def test_clusterrolebinding(self, kube_version, clusterrolebinding_docs):
         """Test that helm errors when pspEnabled=False, and renders a good ClusterRoleBinding template when pspEnabled=True."""
-        with pytest.raises(CalledProcessError):
-            docs = render_chart(
-                kube_version=kube_version,
-                values={"global": {"pspEnabled": False}},
-                show_only=[clusterrolebinding_docs["template"]],
-            )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"pspEnabled": False}},
+            show_only=[clusterrolebinding_docs["template"]],
+        )
+
+        assert len(docs) == 0
 
         docs = render_chart(
             kube_version=kube_version,
@@ -188,12 +192,14 @@ class TestPspEnabled:
     )
     def test_rolebinding(self, kube_version, rolebinding_docs):
         """Test that helm errors when pspEnabled=False, and renders a good RoleBinding template when pspEnabled=True."""
-        with pytest.raises(CalledProcessError):
-            docs = render_chart(
-                kube_version=kube_version,
-                values={"global": {"pspEnabled": False}},
-                show_only=[rolebinding_docs["template"]],
-            )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"pspEnabled": False}},
+            show_only=[rolebinding_docs["template"]],
+        )
+
+        assert len(docs) == 0
 
         docs = render_chart(
             kube_version=kube_version,


### PR DESCRIPTION
## Description

Many helm templates were missing headers and that caused errors in rendering. Adding headers to those templates.

Master PR: https://github.com/astronomer/astronomer/pull/1644

## Related Issues

https://github.com/astronomer/issues/issues/4230

## Testing

The test was present and updated.

## Merging

- 0.25: https://github.com/astronomer/astronomer/pull/1663
- 0.29: https://github.com/astronomer/astronomer/pull/1664
- 0.30: Already updated