### PR TITLE
fixPrometheusForNamespaceFreeForm

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -57,6 +57,7 @@ data:
 
     # Airflow deployment configuration
     deployments:
+      namespaceFreeFormEntry: {{ .Values.global.namespaceFreeFormEntry }}
       # Airflow chart settings
       # Static helm configurations for this chart are found below.
       chart:

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -30,7 +30,7 @@ data:
         {{- tpl .Values.additionalAlerts.airflow $ | nindent 8 }}
         {{- end }}
         - alert: AirflowDeploymentUnhealthy
-          expr: sum by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) - count by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) < 0
+          expr: sum by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)"}) - count by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)"}) < 0
           for: 15m # Rough number but should be enough to clear deployments with a reasonable amount of workers
           labels:
             tier: airflow
@@ -96,8 +96,8 @@ data:
 
         - alert: ContainerMemoryNearTheLimitInDeployment
           expr: |
-            (container_memory_working_set_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)", container_name!~"POD|istio-proxy"} /
-            container_spec_memory_limit_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)", container_name!~"POD|istio-proxy"}) * 100 > 95 < +Inf
+            (container_memory_working_set_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)", container_name!~"POD|istio-proxy"} /
+            container_spec_memory_limit_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)", container_name!~"POD|istio-proxy"}) * 100 > 95 < +Inf
           for: 1h
           labels:
             tier: airflow

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -271,6 +271,7 @@ data:
           # Required for multi-namespace mode
           - source_labels: [namespace]
             {{- if .Values.global.namespaceFreeFormEntry }}
+            # use default regex pattern (.*) when namespaceFreeFormEntry is enabled
             {{- else}}
             regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -270,8 +270,11 @@ data:
             action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
+            {{- if (((.Values.houston.config).deployments).namespaceFreeFormEntry) }}
+            {{- else}}
             regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"
+            {{- end}}
             target_label: release
         {{- else}}
         # this drops node metrics that we want in the cloud, but maybe shouldn't be scraping

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -270,7 +270,7 @@ data:
             action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
-            {{- if (((.Values.houston.config).deployments).namespaceFreeFormEntry) }}
+            {{- if ((((.Values.houston).config).deployments).namespaceFreeFormEntry) }}
             {{- else}}
             regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -270,7 +270,7 @@ data:
             action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
-            {{- if ((((.Values.houston).config).deployments).namespaceFreeFormEntry) }}
+            {{- if .Values.global.namespaceFreeFormEntry }}
             {{- else}}
             regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -21,7 +21,6 @@ def common_test_cases(docs):
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-
     airflow_local_settings = prod["deployments"]["helm"]["airflow"][
         "airflowLocalSettings"
     ]
@@ -47,6 +46,25 @@ def test_houston_configmap():
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
         assert prod["deployments"]["helm"]["sccEnabled"] is False
+
+
+def test_houston_configmap_with_namespaceFreeFormEntry():
+    """Validate the houston configmap and its embedded data with regard to namespaceFreeFormEntry."""
+    docs = render_chart(
+        values={"global": {"namespaceFreeFormEntry": True}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is True
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
 
 def test_houston_configmap_with_customlogging_enabled():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -48,22 +48,23 @@ def test_houston_configmap():
         assert prod["deployments"]["helm"]["sccEnabled"] is False
 
 
-def test_houston_configmap_with_namespaceFreeFormEntry():
-    """Validate the houston configmap and its embedded data with regard to namespaceFreeFormEntry."""
+def test_houston_configmap_with_namespaceFreeFormEntry_true():
+    """Validate the houston configmap's embedded data with namespaceFreeFormEntry=True."""
+
     docs = render_chart(
         values={"global": {"namespaceFreeFormEntry": True}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
-
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     assert prod["deployments"]["namespaceFreeFormEntry"] is True
+
+
+def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
+    """Validate the houston configmap's embedded data with namespaceFreeFormEntry defaults."""
     docs = render_chart(
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
-
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -198,11 +198,7 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             values={
-                "astronomer": {
-                    "houston": {
-                        "config": {"deployments": {"namespaceFreeFormEntry": True}},
-                    },
-                },
+                "global": {"namespaceFreeFormEntry": True},
             },
         )[0]
 
@@ -214,5 +210,5 @@ class TestPrometheusConfigConfigmap:
             "metric_relabel_configs[?target_label == 'release']",
             scrape_config_search_result[0],
         )
-        assert not metric_relabel_config_search_result[0]["regex"]
-        assert not metric_relabel_config_search_result[0]["replacement"]
+        assert "regex" not in metric_relabel_config_search_result[0]
+        assert "replacement" not in metric_relabel_config_search_result[0]

--- a/values.yaml
+++ b/values.yaml
@@ -37,7 +37,7 @@ global:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false
         names: []
-
+  namespaceFreeFormEntry: false
   # Use kube-lego
   acme: false
 


### PR DESCRIPTION
## Description

- makes namespaceFreeFormEntry a global helm value
- when enabled it fixes the prometheus regex for release name
- fixes some prometheus alerts that were missing triggerer

## Related Issues
Related https://github.com/astronomer/issues/issues/5039
## Testing

tested in my aws

## Merging

0.31.0