### PR TITLE
update elastic package 7.17.5 -> 7.17.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,11 +296,11 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
-                - quay.io/astronomer/ap-kibana:7.17.5
+                - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.9.3-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-2

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"


### PR DESCRIPTION
## Description

updates elastic package to 7.17.6

ES  release notes https://www.elastic.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.6.html
KB  release notes https://www.elastic.co/guide/en/kibana/7.17/release-notes-7.17.6.html

## Related Issues

https://github.com/astronomer/issues/issues/5061

## Testing

QA should able to make elasticsearch and kibana deployments without any issues

## Merging

merge to release-0.25,0.28,0.29,0.30
