### PR TITLE
update nats exporter 0.9.3-2 -> 0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -302,7 +302,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.9.3-2
+                - quay.io/astronomer/ap-nats-exporter:0.10.0
                 - quay.io/astronomer/ap-nats-server:2.8.1-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-2
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-2
+    tag: 0.10.0
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.9.3-2
+    tag: 0.10.0
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION


## Description

* bump 0.9.3-2 -> 0.10.0
* Fixes
   CVE-2022-21698
   CVE-2022-40674 

## Related Issues

https://github.com/astronomer/issues/issues/5020

## Testing
NA

## Merging

Yet to verify which we have not updated the nats images
