### PR TITLE
update vendor packages for astronomer/astronomer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,13 +287,13 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.30.3
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-7
-                - quay.io/astronomer/ap-base:3.16.2
-                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
+                - quay.io/astronomer/ap-base:3.16.2-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
-                - quay.io/astronomer/ap-curator:5.8.4-18
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.9
+                - quay.io/astronomer/ap-curator:5.8.4-19
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
@@ -302,19 +302,19 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.31.0
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0
-                - quay.io/astronomer/ap-nats-server:2.8.1-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-2
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
-                - quay.io/astronomer/ap-node-exporter:1.3.1
+                - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.21.4-2
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-1
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.0
+                - quay.io/astronomer/ap-prometheus:2.37.1
                 - quay.io/astronomer/ap-registry:3.16.2
-                - quay.io/astronomer/ap-vector:0.23.0
+                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.31.0
                 - quay.io/astronomer/ap-kibana:7.17.6
-                - quay.io/astronomer/ap-kube-state:2.5.0
+                - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1
                 - quay.io/astronomer/ap-nats-server:2.8.1-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-3
@@ -313,7 +313,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.1
-                - quay.io/astronomer/ap-registry:3.16.2
+                - quay.io/astronomer/ap-registry:3.16.2-1
                 - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,7 +286,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.30.3
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
-                - quay.io/astronomer/ap-awsesproxy:1.3-7
+                - quay.io/astronomer/ap-awsesproxy:1.3-8
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -3,3 +3,5 @@
 CVE-2022-27191
 # more info for CVE-2022-1996 available in https://github.com/kubernetes/ingress-nginx/issues/8745
 CVE-2022-1996
+# golang.org/x/net CVE
+CVE-2022-27664

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-18
+    tag: 5.8.4-19
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-7
+    tag: 1.3-8
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-2
+    tag: 2.8.1-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-1
+  tag: 1.17.0-3
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-2
+  tag: 0.22.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.3.1
+  tag: 1.4.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.0
+    tag: 2.37.1
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-2
+    tag: 0.24.5-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.23.0
+    image: quay.io/astronomer/ap-vector:0.23.3-1
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
 


### PR DESCRIPTION
## Description

image | old | new
--    | --  | --
ap-base | 3.16.2  | 3.16.2-1
ap-db-bootstrapper | 0.26.9 |  0.26.11
ap-nats-server | 2.8.1-2 | 2.8.1-3
ap-nats-exporter | 0.10.0 | 0.10.0-1
ap-pgbouncer-krb | 1.17.0-1 | 1.17.0-3
ap-blackbox-exporter | 0.21.1-2 | 0.22.0 
ap-node-exporter  | 1.3.1 | 1.4.0
ap-prometheus | 2.37.0 | 2.37.1
ap-nats-streaming | 0.24.5-2 | 0.24.5-3
ap-vector | 0.23.0 | 0.23.3-1
ap-kube-state | 2.5.0 | 2.6.0
ap-registry |  3.16.2 | 3.16.2-1
ap-awsesproxy | 1.3-7 | 1.3-8
## Related Issues

related to https://github.com/astronomer/issues/issues/5065
## Testing

QA should see all updated services should function normally without causing any new issues 

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
