### PR TITLE
New pre-commit hook: docformatter

### DIFF
--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
-"""
-This script is used to create the circle config file
-so that we can stay DRY.
-"""
+"""This script is used to create the circle config file so that we can stay
+DRY."""
 import os
 import subprocess
 from pathlib import Path
@@ -27,7 +25,7 @@ def list_docker_images(path):
 
 
 def main():
-    """Render the Jinja2 template file"""
+    """Render the Jinja2 template file."""
     project_directory = Path(__file__).parent.parent
     circle_directory = os.path.dirname(os.path.realpath(__file__))
     config_template_path = os.path.join(circle_directory, "config.yml.j2")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,10 @@
 ---
 exclude: '(venv|\.vscode)' # regex
 repos:
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.5.0
+    hooks:
+      - id: docformatter
   - repo: local
     hooks:
       - id: circle-config-yaml

--- a/bin/validate-helm-unittest-templates.py
+++ b/bin/validate-helm-unittest-templates.py
@@ -12,7 +12,8 @@ git_root = this_script.resolve().parent.parent
 
 
 def validate_test_file(file: PosixPath) -> None:
-    """Validate that each template file referenced in the given helm unittest file exists on disk."""
+    """Validate that each template file referenced in the given helm unittest
+    file exists on disk."""
     with open(file) as f:
         try:
             for test_suite in yaml.safe_load_all(f):
@@ -43,7 +44,8 @@ def validate_template_file(file: PosixPath) -> None:
 
 
 def validate_all_unittest_files() -> None:
-    """Find all helm unittest files in the repo and validate all template files found within them."""
+    """Find all helm unittest files in the repo and validate all template files
+    found within them."""
     for test_file in git_root.glob("charts/*/tests/*_test.yaml"):
         validate_test_file(test_file)
 

--- a/tests/chart_tests/conftest.py
+++ b/tests/chart_tests/conftest.py
@@ -26,9 +26,7 @@ from tests import git_root_dir
 
 @pytest.fixture(autouse=True, scope="session")
 def upgrade_helm(tmp_path_factory, worker_id):
-    """
-    Add stable helm repo, upgrade helm repos, and do helm dep upgrade.
-    """
+    """Add stable helm repo, upgrade helm repos, and do helm dep upgrade."""
 
     def _upgrade_helm():
         try:
@@ -67,9 +65,8 @@ def docker_daemon_present():
 
 @pytest.fixture(scope="session")
 def docker_client():
-    """This is a text fixture for the docker client,
-    should it be needed in a test
-    """
+    """This is a text fixture for the docker client, should it be needed in a
+    test."""
     if docker_daemon_present():
         docker.from_env().ping()
         client = docker.from_env()

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -75,8 +75,9 @@ def render_chart(
     baseDomain: str = "example.com",
     namespace: Optional[str] = None,
 ):
-    """
-    Render a helm chart into dictionaries. For helm chart testing only.
+    """Render a helm chart into dictionaries.
+
+    For helm chart testing only.
     """
     values = values or {}
     chart_dir = chart_dir or sys.path[0]
@@ -130,8 +131,8 @@ def render_chart(
 
 
 def prepare_k8s_lookup_dict(k8s_objects) -> Dict[Tuple[str, str], Dict[str, Any]]:
-    """
-    Helper to create a lookup dict from k8s_objects.
+    """Helper to create a lookup dict from k8s_objects.
+
     The keys of the dict are the k8s object's kind and name
     """
     return {
@@ -141,7 +142,8 @@ def prepare_k8s_lookup_dict(k8s_objects) -> Dict[Tuple[str, str], Dict[str, Any]
 
 
 def render_k8s_object(obj, type_to_render):
-    """
-    Function that renders dictionaries into k8s objects. For helm chart testing only.
+    """Function that renders dictionaries into k8s objects.
+
+    For helm chart testing only.
     """
     return api_client._ApiClient__deserialize_model(obj, type_to_render)

--- a/tests/chart_tests/test_alertmanager.py
+++ b/tests/chart_tests/test_alertmanager.py
@@ -5,7 +5,7 @@ import yaml
 
 
 def test_alertmanager_defaults():
-    """Test that alertmanager chart looks sane with defaults"""
+    """Test that alertmanager chart looks sane with defaults."""
     docs = render_chart(
         show_only=["charts/alertmanager/templates/alertmanager-statefulset.yaml"],
     )
@@ -37,7 +37,7 @@ def test_alertmanager_defaults():
 
 
 def test_alertmanager_rfc1918():
-    """Test rfc1918 features of alertmanager template"""
+    """Test rfc1918 features of alertmanager template."""
     docs = render_chart(
         values={"alertmanager": {"enableNonRFC1918": True}},
         show_only=["charts/alertmanager/templates/alertmanager-statefulset.yaml"],
@@ -66,7 +66,7 @@ def test_alertmanager_rfc1918():
 
 
 def test_alertmanager_customReceiver():
-    """Test  alertmanager customer receiver configuration"""
+    """Test  alertmanager customer receiver configuration."""
     test_custom_receiver_config = textwrap.dedent(
         """
         alertmanager:

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -10,7 +10,8 @@ import jmespath
 )
 class TestAstronomerCommander:
     def test_astronomer_commander_deployment(self, kube_version):
-        """Test that helm renders a good deployment template for astronomer/commander."""
+        """Test that helm renders a good deployment template for
+        astronomer/commander."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=[
@@ -37,7 +38,11 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "300"
 
     def test_astronomer_commander_deployment_upgrade_timeout(self, kube_version):
-        """Test that helm renders a good deployment template for astronomer/commander. when upgrade timeout is set"""
+        """Test that helm renders a good deployment template for
+        astronomer/commander.
+
+        when upgrade timeout is set
+        """
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"commander": {"upgradeTimeout": 600}}},
@@ -66,7 +71,9 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
 
     def test_astronomer_commander_rbac_cluster_role_enabled(self, kube_version):
-        """Test that if rbacEnabled and clusterRoles are enabled but namespacePools disabled, helm renders ClusterRole and ClusterRoleBinding resources"""
+        """Test that if rbacEnabled and clusterRoles are enabled but
+        namespacePools disabled, helm renders ClusterRole and
+        ClusterRoleBinding resources."""
 
         # First rbacEnabled and clusterRoles set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
         docs = render_chart(
@@ -112,7 +119,8 @@ class TestAstronomerCommander:
     def test_astronomer_commander_rbac_cluster_roles_disabled_rbac_enabled(
         self, kube_version
     ):
-        """Test that if rbacEnabled set to true, but clusterRoles and namespacePools are disabled, we do not create any RBAC resources"""
+        """Test that if rbacEnabled set to true, but clusterRoles and
+        namespacePools are disabled, we do not create any RBAC resources."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -132,7 +140,8 @@ class TestAstronomerCommander:
         assert len(docs) == 0
 
     def test_astronomer_commander_rbac_all_disabled(self, kube_version):
-        """Test that if rbacEnabled, namespacePools and clusterRoles are disabled, we do not create any RBAC resources"""
+        """Test that if rbacEnabled, namespacePools and clusterRoles are
+        disabled, we do not create any RBAC resources."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -152,7 +161,8 @@ class TestAstronomerCommander:
         assert len(docs) == 0
 
     def test_astronomer_commander_rbac_cluster_role_disabled(self, kube_version):
-        """Test that if clusterRoles and namespacePools are disabled but rbacEnabled is enabled, helm does not render RBAC resources"""
+        """Test that if clusterRoles and namespacePools are disabled but
+        rbacEnabled is enabled, helm does not render RBAC resources."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -172,7 +182,9 @@ class TestAstronomerCommander:
         assert len(docs) == 0
 
     def test_astronomer_commander_rbac_multinamespace_mode_disabled(self, kube_version):
-        """Test that if Houston's Airflow chart sub-configuration has multiNamespaceMode disabled, the rendered commander role doesn't have permissions to manage Cluster-level RBAC resources"""
+        """Test that if Houston's Airflow chart sub-configuration has
+        multiNamespaceMode disabled, the rendered commander role doesn't have
+        permissions to manage Cluster-level RBAC resources."""
         doc = render_chart(
             kube_version=kube_version,
             values={
@@ -204,7 +216,9 @@ class TestAstronomerCommander:
     def test_astronomer_commander_rbac_multinamespace_mode_undefined(
         self, kube_version
     ):
-        """Test that if Houston's configuration for Airflow chart is not defined, the rendered commander role doesn't have permissions to manage Cluster-level RBAC resources"""
+        """Test that if Houston's configuration for Airflow chart is not
+        defined, the rendered commander role doesn't have permissions to manage
+        Cluster-level RBAC resources."""
         doc = render_chart(
             kube_version=kube_version,
             values={},
@@ -224,7 +238,9 @@ class TestAstronomerCommander:
             assert resource not in cluster_resources
 
     def test_astronomer_commander_rbac_multinamespace_mode_enabled(self, kube_version):
-        """Test that if Houston's Airflow chart sub-configuration has multiNamespaceMode enabled, the rendered commander role has permissions to manage Cluster-level RBAC resources"""
+        """Test that if Houston's Airflow chart sub-configuration has
+        multiNamespaceMode enabled, the rendered commander role has permissions
+        to manage Cluster-level RBAC resources."""
         doc = render_chart(
             kube_version=kube_version,
             values={
@@ -254,7 +270,8 @@ class TestAstronomerCommander:
             assert resource in generated_resources
 
     def test_astronomer_commander_rbac_scc_enabled_ns_pools(self, kube_version):
-        """Test that if a sccEnabled and namespacePools are enabled, we add Cluster permissions for scc resources"""
+        """Test that if a sccEnabled and namespacePools are enabled, we add
+        Cluster permissions for scc resources."""
         namespaces = ["test"]
         docs = render_chart(
             kube_version=kube_version,
@@ -328,7 +345,9 @@ class TestAstronomerCommander:
             assert role_binding["subjects"][0] == expected_subject
 
     def test_astronomer_commander_rbac_scc_cluster_roles(self, kube_version):
-        """Test that if scc is enabled but namespace pools is disabled, scc permissions are rendered once in ClusterRole and ClusterRoleBinding objects"""
+        """Test that if scc is enabled but namespace pools is disabled, scc
+        permissions are rendered once in ClusterRole and ClusterRoleBinding
+        objects."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -41,7 +41,8 @@ cron_test_data = [
 )
 class TestAstronomerConfigSyncer:
     def test_astronomer_config_syncer_rbac_namespace_pools_disabled(self, kube_version):
-        """Test that if rbacEnabled but namespacePools disabled, helm renders ClusterRole and ClusterRoleBinding resources for config syncer"""
+        """Test that if rbacEnabled but namespacePools disabled, helm renders
+        ClusterRole and ClusterRoleBinding resources for config syncer."""
 
         # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
         docs = render_chart(
@@ -84,7 +85,8 @@ class TestAstronomerConfigSyncer:
         assert cluster_role_binding["subjects"] == expected_subjects
 
     def test_astronomer_config_syncer_namespace_pools_rbac(self, kube_version):
-        """Test that when namespacePools is enabled, helm renders a Role and a RoleBinding for each namespace in the pool + release namespace."""
+        """Test that when namespacePools is enabled, helm renders a Role and a
+        RoleBinding for each namespace in the pool + release namespace."""
 
         # rbacEnabled and clusterRoles and namespacePools set to true, should create Roles and Rolebindings for namespace in Pool
         # and ignore the cluster role configuration
@@ -140,7 +142,8 @@ class TestAstronomerConfigSyncer:
             assert role_binding["subjects"][0] == expected_subject
 
     def test_astronomer_config_syncer_rbac_all_disabled(self, kube_version):
-        """Test that if rbacEnabled and namespacePools are disabled, we do not create any RBAC resources"""
+        """Test that if rbacEnabled and namespacePools are disabled, we do not
+        create any RBAC resources."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -161,7 +164,8 @@ class TestAstronomerConfigSyncer:
     def test_astronomer_config_syncer_cronjob_namespace_pool_enabled(
         self, kube_version
     ):
-        """Test that when namespace pool is enabled, config-syncer's container is configured to use namespaces from the pool"""
+        """Test that when namespace pool is enabled, config-syncer's container
+        is configured to use namespaces from the pool."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
         doc = render_chart(
             kube_version=kube_version,
@@ -191,7 +195,8 @@ class TestAstronomerConfigSyncer:
     def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(
         self, kube_version
     ):
-        """Test that when namespacePools is disabled, config-syncer cronjob is configured not to target any namespace."""
+        """Test that when namespacePools is disabled, config-syncer cronjob is
+        configured not to target any namespace."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
         doc = render_chart(
             kube_version=kube_version,
@@ -223,7 +228,8 @@ class TestAstronomerConfigSyncer:
     def test_astronomer_config_syncer_cronjob_default_schedule(
         self, test_data, kube_version
     ):
-        """Test that if no schedule is provided for configSyncer, helm automatically generates a random one"""
+        """Test that if no schedule is provided for configSyncer, helm
+        automatically generates a random one."""
 
         doc = render_chart(
             name=test_data[0],

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -10,7 +10,8 @@ from tests import supported_k8s_versions, get_containers_by_name
 )
 class TestAstronomerNamespacePools:
     def test_astronomer_namespace_pools_rbac(self, kube_version):
-        """Test that helm renders astronomer/commander RBAC resources properly when working with namespace pools"""
+        """Test that helm renders astronomer/commander RBAC resources properly
+        when working with namespace pools."""
 
         # rbacEnabled and clusterRoles and namespacePools set to true, should create Roles and Rolebindings for namespace in Pool
         # and ignore the cluster role configuration
@@ -67,7 +68,8 @@ class TestAstronomerNamespacePools:
             assert role_binding["subjects"][0] == expected_subject
 
     def test_astronomer_namespace_pools_namespaces(self, kube_version):
-        """Test that Namespaces resources are rendered properly when using namespacePools feature"""
+        """Test that Namespaces resources are rendered properly when using
+        namespacePools feature."""
         # If namespace Pools creation enabled -> create the namespaces
         namespaces = ["my-namespace-1", "my-namespace-2"]
         docs = render_chart(
@@ -128,7 +130,8 @@ class TestAstronomerNamespacePools:
     def test_astronomer_namespace_pools_commander_deployment_configuration(
         self, kube_version
     ):
-        """Test that commander deployment is configured properly when enabling namespace pools"""
+        """Test that commander deployment is configured properly when enabling
+        namespace pools."""
 
         namespaces = ["my-namespace-1", "my-namespace-2"]
         doc = render_chart(
@@ -195,7 +198,8 @@ class TestAstronomerNamespacePools:
         assert not manual_ns_env_found
 
     def test_astronomer_namespace_pools_houston_configmap(self, kube_version):
-        """Test that Houston production.yaml configuration parameters are configured properly when using namespacePools feature"""
+        """Test that Houston production.yaml configuration parameters are
+        configured properly when using namespacePools feature."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
         doc = render_chart(
             kube_version=kube_version,
@@ -243,7 +247,9 @@ class TestAstronomerNamespacePools:
         assert "preCreatedNamespaces" not in deployments_config["deployments"]
 
     def test_astronomer_namespace_pools_fluentd_configmap(self, kube_version):
-        """Test that when namespace Pools is enabled, and a list of namespaces is provided, helm render fluentd configmap correctly, with a regex targeting pods in the provided namespaces only."""
+        """Test that when namespace Pools is enabled, and a list of namespaces
+        is provided, helm render fluentd configmap correctly, with a regex
+        targeting pods in the provided namespaces only."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
         doc = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -9,7 +9,8 @@ import jmespath
     supported_k8s_versions,
 )
 def test_astronomer_registry_statefulset(kube_version):
-    """Test that helm renders a good statefulset template for astronomer registry."""
+    """Test that helm renders a good statefulset template for astronomer
+    registry."""
     docs = render_chart(
         kube_version=kube_version,
         show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],

--- a/tests/chart_tests/test_astronomer_registry_configmap.py
+++ b/tests/chart_tests/test_astronomer_registry_configmap.py
@@ -12,7 +12,8 @@ from tests.chart_tests.helm_template_generator import render_chart
     supported_k8s_versions,
 )
 def test_astronomer_registry_configmap_defaults(kube_version):
-    """Test that helm renders a good configmap template for astronomer registry."""
+    """Test that helm renders a good configmap template for astronomer
+    registry."""
     docs = render_chart(
         kube_version=kube_version,
         show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
@@ -34,7 +35,8 @@ def test_astronomer_registry_configmap_defaults(kube_version):
     supported_k8s_versions,
 )
 def test_astronomer_registry_redirect_disabled(kube_version):
-    """Test that helm renders astronomer registry configmap template with redirect disabled."""
+    """Test that helm renders astronomer registry configmap template with
+    redirect disabled."""
     docs = render_chart(
         kube_version=kube_version,
         values={"astronomer": {"registry": {"redirect": {"disable": True}}}},

--- a/tests/chart_tests/test_cves.py
+++ b/tests/chart_tests/test_cves.py
@@ -10,8 +10,8 @@ from tests.chart_tests.helm_template_generator import render_chart
 )
 @pytest.mark.skip(reason="No longer needed, images were patched.")
 def test_log4shell(kube_version):
-    """
-    Ensure remediation settings are in place for log4j log4shell CVE-2021-44228
+    """Ensure remediation settings are in place for log4j log4shell
+    CVE-2021-44228.
 
     https://github.com/astronomer/issues/issues/3880
     """

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -41,7 +41,8 @@ class TestAllPodSpecContainers:
         ids=[f"{x['kind']}/{x['metadata']['name']}" for x in pod_manager_docs],
     )
     def test_default_chart_with_basedomain(self, doc):
-        """Test that each container in each pod spec renders and has some required fields."""
+        """Test that each container in each pod spec renders and has some
+        required fields."""
         c_by_name = get_containers_by_name(doc, include_init_containers=True)
         for name, container in c_by_name.items():
             assert container["image"], f"container {name} does not have an image: {doc}"
@@ -76,7 +77,8 @@ class TestAllPodSpecContainers:
     def test_all_default_charts_with_private_registry(self, doc):
         """Test that each chart uses the privateRegistry.
 
-        This only finds default images, not the many which are hidden behind feature flags.
+        This only finds default images, not the many which are hidden
+        behind feature flags.
         """
         c_by_name = get_containers_by_name(doc)
 
@@ -87,7 +89,8 @@ class TestAllPodSpecContainers:
 
 
 class TestDuplicateEnvironment:
-    """Parametrize all the docs that have container specs and test them for duplicate env vars."""
+    """Parametrize all the docs that have container specs and test them for
+    duplicate env vars."""
 
     values = {
         "global": {
@@ -118,7 +121,7 @@ class TestDuplicateEnvironment:
         ids=[f"{x['kind']}/{x['metadata']['name']}" for x in trimmed_docs],
     )
     def test_env_vars_have_no_duplicates(self, doc):
-        """Test that there are no duplicate env vars"""
+        """Test that there are no duplicate env vars."""
         if doc["kind"] in pod_managers:
             for container in doc["spec"]["template"]["spec"].get("containers") or []:
                 assert (

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -68,7 +68,8 @@ class TestElasticSearch:
         )
 
     def test_elasticsearch_with_sysctl_disabled(self, kube_version):
-        """Test ElasticSearch master, data and client with sysctl config/values.yaml."""
+        """Test ElasticSearch master, data and client with sysctl
+        config/values.yaml."""
         docs = render_chart(
             kube_version=kube_version,
             values={"elasticsearch": {"sysctlInitContainer": {"enabled": False}}},
@@ -84,7 +85,8 @@ class TestElasticSearch:
             assert not doc["spec"]["template"]["spec"]["initContainers"]
 
     def test_elasticsearch_fsgroup_defaults(self, kube_version):
-        """Test ElasticSearch master, data and client with fsGroup default values"""
+        """Test ElasticSearch master, data and client with fsGroup default
+        values."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -101,7 +103,8 @@ class TestElasticSearch:
             }
 
     def test_elasticsearch_securitycontext_defaults(self, kube_version):
-        """Test ElasticSearch master, data with securityContext default values"""
+        """Test ElasticSearch master, data with securityContext default
+        values."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -118,7 +121,8 @@ class TestElasticSearch:
             assert pod_data["securityContext"]["runAsUser"] == 1000
 
     def test_elasticsearch_securitycontext_overrides(self, kube_version):
-        """Test ElasticSearch master, data with securityContext custom values"""
+        """Test ElasticSearch master, data with securityContext custom
+        values."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -207,7 +211,8 @@ class TestElasticSearch:
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_index_pattern_defaults(self, kube_version):
-        """Test External Elasticsearch Service Index Pattern Search defaults."""
+        """Test External Elasticsearch Service Index Pattern Search
+        defaults."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -239,7 +244,7 @@ class TestElasticSearch:
         assert "vector.$remote_user.*/$1" in es_index
 
     def test_elasticsearch_exporter_securitycontext_defaults(self, kube_version):
-        """Test ElasticSearch Exporter with securityContext default values"""
+        """Test ElasticSearch Exporter with securityContext default values."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -254,7 +259,7 @@ class TestElasticSearch:
         assert pod_data["securityContext"] is None
 
     def test_elasticsearch_exporter_securitycontext_overrides(self, kube_version):
-        """Test ElasticSearch Exporter with securityContext default values"""
+        """Test ElasticSearch Exporter with securityContext default values."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -16,7 +16,8 @@ secret = base64.b64encode(b"sample-secret").decode()
 )
 class TestExternalElasticSearch:
     def test_externalelasticsearch_with_secret(self, kube_version):
-        """Test External ElasticSearch with secret passed from config/values.yaml."""
+        """Test External ElasticSearch with secret passed from
+        config/values.yaml."""
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"customLogging": {"enabled": True, "secret": secret}}},
@@ -55,7 +56,8 @@ class TestExternalElasticSearch:
         } in jmespath.search("spec.ports", docs[3])
 
     def test_externalelasticsearch_with_secretname(self, kube_version):
-        """Test External ElasticSearch with secret passed as kubernetes secrets."""
+        """Test External ElasticSearch with secret passed as kubernetes
+        secrets."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -106,7 +108,8 @@ class TestExternalElasticSearch:
         } in jmespath.search("spec.ports", docs[3])
 
     def test_externalelasticsearch_with_awsSecretName(self, kube_version):
-        """Test External ElasticSearch with aws secret passed as kubernetes secret."""
+        """Test External ElasticSearch with aws secret passed as kubernetes
+        secret."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -166,7 +169,8 @@ class TestExternalElasticSearch:
         } in jmespath.search("spec.ports", docs[1])
 
     def test_externalelasticsearch_with_awsIAMRole(self, kube_version):
-        """Test External ElasticSearch with iam roles passed as Deployment annotation."""
+        """Test External ElasticSearch with iam roles passed as Deployment
+        annotation."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -214,7 +218,8 @@ class TestExternalElasticSearch:
         } in jmespath.search("spec.ports", docs[1])
 
     def test_externalelasticsearch_with_awsServiceAccountAnnotation(self, kube_version):
-        """Test External ElasticSearch with eks iam roles passed as Service Account Annotation."""
+        """Test External ElasticSearch with eks iam roles passed as Service
+        Account Annotation."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -363,7 +368,8 @@ class TestExternalElasticSearch:
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):
-        """Test External Elasticsearch Service Index Pattern Search defaults."""
+        """Test External Elasticsearch Service Index Pattern Search
+        defaults."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -388,7 +394,8 @@ class TestExternalElasticSearch:
         assert "fluentd.$remote_user.*/$1" in es_index
 
     def test_external_es_index_pattern_with_sidecar_logging_enabled(self, kube_version):
-        """Test External Elasticsearch Service Index Pattern Search with sidecar logging."""
+        """Test External Elasticsearch Service Index Pattern Search with
+        sidecar logging."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -9,7 +9,8 @@ import jmespath
     supported_k8s_versions,
 )
 def test_fluentd_daemonset(kube_version):
-    """Test that helm renders a volume mount for private ca certificates for fluentd daemonset when private-ca-certificates are enabled."""
+    """Test that helm renders a volume mount for private ca certificates for
+    fluentd daemonset when private-ca-certificates are enabled."""
     docs = render_chart(
         kube_version=kube_version,
         values={"global": {"privateCaCerts": ["private-root-ca"]}},
@@ -73,7 +74,8 @@ def test_fluentd_daemonset(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_clusterrolebinding(kube_version):
-    """Test that helm renders a good ClusterRoleBinding template for fluentd when rbacEnabled=True."""
+    """Test that helm renders a good ClusterRoleBinding template for fluentd
+    when rbacEnabled=True."""
     docs = render_chart(
         kube_version=kube_version,
         values={"global": {"rbacEnabled": True}},
@@ -102,7 +104,8 @@ def test_fluentd_clusterrolebinding(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
-    """Test that when namespace Pools is disabled, and manualNamespaces is enabled, helm renders fluentd configmap targeting all namespaces."""
+    """Test that when namespace Pools is disabled, and manualNamespaces is
+    enabled, helm renders fluentd configmap targeting all namespaces."""
     doc = render_chart(
         kube_version=kube_version,
         values={
@@ -127,7 +130,9 @@ def test_fluentd_configmap_manual_namespaces_enabled(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_version):
-    """Test that when namespace Pools and manualNamespaceNamesEnabled are disabled, helm renders a default fluentd configmap looking at an environment variable"""
+    """Test that when namespace Pools and manualNamespaceNamesEnabled are
+    disabled, helm renders a default fluentd configmap looking at an
+    environment variable."""
     doc = render_chart(
         kube_version=kube_version,
         values={
@@ -154,7 +159,9 @@ def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(kube_ve
     supported_k8s_versions,
 )
 def test_fluentd_configmap_configure_extra_log_stores(kube_version):
-    """Test that when namespace Pools and manualNamespaceNamesEnabled are disabled, helm renders a default fluentd configmap looking at an environment variable"""
+    """Test that when namespace Pools and manualNamespaceNamesEnabled are
+    disabled, helm renders a default fluentd configmap looking at an
+    environment variable."""
     doc = render_chart(
         kube_version=kube_version,
         values={
@@ -184,7 +191,8 @@ def test_fluentd_configmap_configure_extra_log_stores(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_pod_securityContextOverride(kube_version):
-    """Test that helm renders a container securityContext when securityContext is enabled."""
+    """Test that helm renders a container securityContext when securityContext
+    is enabled."""
 
     docs = render_chart(
         kube_version=kube_version,
@@ -205,7 +213,8 @@ def test_fluentd_pod_securityContextOverride(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_container_securityContextOverride(kube_version):
-    """Test that helm renders a container securityContext when securityContext is enabled."""
+    """Test that helm renders a container securityContext when securityContext
+    is enabled."""
 
     docs = render_chart(
         kube_version=kube_version,
@@ -235,7 +244,8 @@ def test_fluentd_container_securityContextOverride(kube_version):
     supported_k8s_versions,
 )
 def test_fluentd_securityContext_empty_by_default(kube_version):
-    """Test that no securityContext is present by default on pod or container"""
+    """Test that no securityContext is present by default on pod or
+    container."""
 
     docs = render_chart(
         kube_version=kube_version,

--- a/tests/chart_tests/test_fluentd_index_configmap.py
+++ b/tests/chart_tests/test_fluentd_index_configmap.py
@@ -8,7 +8,8 @@ from tests import supported_k8s_versions
     supported_k8s_versions,
 )
 def test_registry_configmap(kube_version):
-    """Test that helm renders an expected registry-configmap to validate regionendpoint flag"""
+    """Test that helm renders an expected registry-configmap to validate
+    regionendpoint flag."""
     docs = render_chart(
         kube_version=kube_version,
         show_only=["charts/fluentd/templates/fluentd-index-template-configmap.yaml"],

--- a/tests/chart_tests/test_global_storageclass.py
+++ b/tests/chart_tests/test_global_storageclass.py
@@ -19,7 +19,7 @@ supported_types = [("-", ""), ("astrosc", "astrosc")]
     ids=[x[0] for x in supported_types],
 )
 def test_global_storageclass(supported_types, expected_output):
-    """Test globalstorageclass feature of alertmanager statefulset template"""
+    """Test globalstorageclass feature of alertmanager statefulset template."""
     docs = render_chart(
         values={"global": {"storageClass": supported_types}},
         show_only=chart_files,

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -26,7 +26,8 @@ def test_deployment_should_render(kube_version):
     supported_k8s_versions,
 )
 def test_deployment_should_render_extra_env(kube_version):
-    """Test that helm renders extra environment variables to the grafana-deployment resource when provided."""
+    """Test that helm renders extra environment variables to the grafana-
+    deployment resource when provided."""
     docs = render_chart(
         kube_version=kube_version,
         values={"global": {"ssl": {"enabled": True}}},

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -49,7 +49,8 @@ def test_houston_configmap():
 
 
 def test_houston_configmap_with_namespaceFreeFormEntry_true():
-    """Validate the houston configmap's embedded data with namespaceFreeFormEntry=True."""
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry=True."""
 
     docs = render_chart(
         values={"global": {"namespaceFreeFormEntry": True}},
@@ -60,7 +61,8 @@ def test_houston_configmap_with_namespaceFreeFormEntry_true():
 
 
 def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
-    """Validate the houston configmap's embedded data with namespaceFreeFormEntry defaults."""
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry defaults."""
     docs = render_chart(
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
@@ -69,7 +71,8 @@ def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
 
 
 def test_houston_configmap_with_customlogging_enabled():
-    """Validate the houston configmap and its embedded data with customLogging."""
+    """Validate the houston configmap and its embedded data with
+    customLogging."""
     docs = render_chart(
         values={"global": {"customLogging": {"enabled": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -98,7 +101,8 @@ def test_houston_configmapwith_scc_enabled():
 
 
 def test_houston_configmap_with_azure_enabled():
-    """Validate the houston configmap and its embedded data with azure enabled."""
+    """Validate the houston configmap and its embedded data with azure
+    enabled."""
     docs = render_chart(
         values={"global": {"azure": {"enabled": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -117,7 +121,8 @@ def test_houston_configmap_with_azure_enabled():
 
 
 def test_houston_configmap_with_config_syncer_enabled():
-    """Validate the houston configmap and its embedded data with configSyncer enabled."""
+    """Validate the houston configmap and its embedded data with configSyncer
+    enabled."""
     docs = render_chart(
         values={"astronomer": {"configSyncer": {"enabled": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -142,7 +147,8 @@ def test_houston_configmap_with_config_syncer_enabled():
 
 
 def test_houston_configmap_with_config_syncer_disabled():
-    """Validate the houston configmap and its embedded data with configSyncer disabled."""
+    """Validate the houston configmap and its embedded data with configSyncer
+    disabled."""
     docs = render_chart(
         values={"astronomer": {"configSyncer": {"enabled": False}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -162,7 +168,8 @@ def test_houston_configmap_with_config_syncer_disabled():
 
 
 def test_houston_configmap_with_loggingsidecar_enabled():
-    """Validate the houston configmap and its embedded data with loggingSidecar."""
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
         values={
@@ -198,7 +205,8 @@ def test_houston_configmap_with_loggingsidecar_enabled():
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
-    """Validate the houston configmap and its embedded data with loggingSidecar."""
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
     sidecar_container_name = "sidecar-log-test"
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
@@ -239,7 +247,8 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
 
 
 def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
-    """Validate the houston configmap and its embedded data with loggingSidecar customConfig Enabled."""
+    """Validate the houston configmap and its embedded data with loggingSidecar
+    customConfig Enabled."""
     sidecar_container_name = "sidecar-log-test"
     terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
@@ -317,7 +326,8 @@ cron_test_data = [
     "test_data", cron_test_data, ids=[x[0] for x in cron_test_data]
 )
 def test_cron_splay(test_data):
-    """Test that our adler32sum method of generating deterministic random numbers works."""
+    """Test that our adler32sum method of generating deterministic random
+    numbers works."""
     doc = render_chart(
         name=test_data[0],
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -335,7 +345,8 @@ def test_cron_splay(test_data):
 
 
 def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
-    """Validate the houston configmap and its embedded data with updateAirflowCheck and updateRuntimeCheck."""
+    """Validate the houston configmap and its embedded data with
+    updateAirflowCheck and updateRuntimeCheck."""
     docs = render_chart(
         values={
             "astronomer": {
@@ -357,7 +368,8 @@ def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
 
 
 def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
-    """Validate the houston configmap and its embedded data with updateAirflowCheck and updateRuntimeCheck."""
+    """Validate the houston configmap and its embedded data with
+    updateAirflowCheck and updateRuntimeCheck."""
     docs = render_chart(
         values={
             "astronomer": {

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -65,7 +65,8 @@ class TestNatsStatefulSet:
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 
     def test_nats_statefulset_with_affinity_and_tolerations(self, kube_version):
-        """Test that nats statefulset renders proper nodeSelector, affinity, and tolerations"""
+        """Test that nats statefulset renders proper nodeSelector, affinity,
+        and tolerations."""
         values = {
             "nats": {
                 "nodeSelector": {"role": "astro"},
@@ -118,7 +119,8 @@ class TestNatsStatefulSet:
         assert spec["tolerations"] == values["nats"]["tolerations"]
 
     def test_nats_statefulset_with_global_affinity_and_tolerations(self, kube_version):
-        """Test that nats statefulset renders proper nodeSelector, affinity, and tolerations with global config"""
+        """Test that nats statefulset renders proper nodeSelector, affinity,
+        and tolerations with global config."""
         values = {
             "global": {
                 "platformNodePool": {
@@ -175,7 +177,7 @@ class TestNatsStatefulSet:
         )
 
     def test_nats_statefulset_with_default_cluster_name(self, kube_version):
-        """Test that nats configmap has cluster name defined"""
+        """Test that nats configmap has cluster name defined."""
         values = {
             "nats": {},
         }
@@ -189,7 +191,7 @@ class TestNatsStatefulSet:
         assert "release-name-nats" in nats_cm
 
     def test_nats_statefulset_with_default_cluster_name_overrides(self, kube_version):
-        """Test that nats configmap has cluster name which allows overrides"""
+        """Test that nats configmap has cluster name which allows overrides."""
         values = {
             "nats": {"cluster": {"name": "astronats"}},
         }

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -18,7 +18,8 @@ class TestNginx:
         assert "loadBalancerSourceRanges" not in doc["spec"]
 
     def test_nginx_with_ingress_annotations(self):
-        """Deployment should contain the given ingress annotations when they are specified."""
+        """Deployment should contain the given ingress annotations when they
+        are specified."""
         doc = render_chart(
             values={
                 "nginx": {
@@ -35,7 +36,8 @@ class TestNginx:
         )
 
     def test_nginx_type_loadbalancer(self):
-        """Deployment works with type LoadBalancer and some LB customizations."""
+        """Deployment works with type LoadBalancer and some LB
+        customizations."""
         doc = render_chart(
             values={
                 "nginx": {

--- a/tests/chart_tests/test_poddisruptionbudget.py
+++ b/tests/chart_tests/test_poddisruptionbudget.py
@@ -6,7 +6,7 @@ from tests import git_root_dir
 
 class TestHoustonPDB:
     def test_houston_pdb_cronjobs(self):
-        """Test that pdbs do not touch houston cronjobs or workers"""
+        """Test that pdbs do not touch houston cronjobs or workers."""
         templates = [
             "charts/astronomer/templates/houston/cronjobs/houston-expire-deployments-cronjob.yaml",
             "charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml",
@@ -26,7 +26,7 @@ class TestHoustonPDB:
             ), f"ERROR: tempplate '{show_only}' matched houston"
 
     def test_houston_pdb_workers(self):
-        """Test that pdbs do not touch houston cronjobs or workers"""
+        """Test that pdbs do not touch houston cronjobs or workers."""
         template = (
             "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml"
         )
@@ -39,7 +39,7 @@ class TestHoustonPDB:
 
     def test_houston_api_pdb_match_labels(self):
         # sourcery skip: class-extract-method
-        """Houston pdb should have the right matchLabels"""
+        """Houston pdb should have the right matchLabels."""
         template = (
             "charts/astronomer/templates/houston/api/houston-pod-disruption-budget.yaml"
         )
@@ -50,7 +50,7 @@ class TestHoustonPDB:
         assert match_labels["component"] == "houston"
 
     def test_houston_api_pdb_deployment(self):
-        """Houston pdb should have the right matchLabels"""
+        """Houston pdb should have the right matchLabels."""
         template = "charts/astronomer/templates/houston/api/houston-deployment.yaml"
         labels = render_chart(show_only=[template])[0]["spec"]["template"]["metadata"][
             "labels"
@@ -71,7 +71,8 @@ class TestPDB:
     ]
 
     def test_pod_disruption_budgets_default(self, kube_version):
-        """Validate that default PodDisruptionBudget configs use latest available API version."""
+        """Validate that default PodDisruptionBudget configs use latest
+        available API version."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -85,7 +86,8 @@ class TestPDB:
             assert all(x["apiVersion"] == "policy/v1" for x in docs)
 
     def test_pod_disruption_budgets_use_legacy(self, kube_version):
-        """Allow global.useLegacyPodDisruptionBudget to use policy/v1beta1 until k8s 1.25.0"""
+        """Allow global.useLegacyPodDisruptionBudget to use policy/v1beta1
+        until k8s 1.25.0."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -104,7 +106,8 @@ class TestPDB:
             assert ValueError("policy/v1beta1 is not supported in k8s 1.25+")
 
     def test_global_pdb_disabled(self, kube_version):
-        """Validate that there are no PDBs when global.podDisruptionBudgetsEnabled is False."""
+        """Validate that there are no PDBs when
+        global.podDisruptionBudgetsEnabled is False."""
         docs = render_chart(
             values={"global": {"podDisruptionBudgetsEnabled": False}},
             kube_version=kube_version,

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -24,7 +24,8 @@ class TestPostgresql:
         assert "initContainers" not in doc["spec"]["template"]["spec"]
 
     def test_postgresql_statefulset_with_volumePermissions_enabled(self, kube_version):
-        """Test postgresql statefulset when volumePermissions init container is enabled."""
+        """Test postgresql statefulset when volumePermissions init container is
+        enabled."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_private_registry.py
+++ b/tests/chart_tests/test_private_registry.py
@@ -5,8 +5,8 @@ from tests.chart_tests.helm_template_generator import render_chart
 
 
 def test_private_registry_repository_image_names_the_same_as_public_ones():
-    """test that image names dont change when using a custom repo because that breaks
-    pull-through caching proxies in use by various customers."""
+    """test that image names dont change when using a custom repo because that
+    breaks pull-through caching proxies in use by various customers."""
 
     extra_globals = {
         "blackboxExporterEnabled": True,
@@ -51,7 +51,8 @@ def test_private_registry_repository_image_names_the_same_as_public_ones():
 
 
 def test_private_registry_repository_overrides_work():
-    """image names should always contain the new repository when it is specified."""
+    """image names should always contain the new repository when it is
+    specified."""
     repository = "bob-the-registry"
     docs = render_chart(
         values={
@@ -123,6 +124,7 @@ private_registry_docs_image_pull_secrets = (
     ids=private_registry_docs_image_pull_secrets.keys(),
 )
 def test_private_registry_repository_image_pull_secret(image_pull_secrets):
-    """Specs must contain imagePullSecrets for private repository when it is specified."""
+    """Specs must contain imagePullSecrets for private repository when it is
+    specified."""
     assert image_pull_secrets is not None
     assert {"name": "bob-the-registry-secret"} in image_pull_secrets

--- a/tests/chart_tests/test_privateca.py
+++ b/tests/chart_tests/test_privateca.py
@@ -19,7 +19,8 @@ class TestPrivateCaDaemonset:
         assert doc["spec"]["template"]["spec"]["containers"][0]["name"] == "cert-copy"
 
     def test_privateca_daemonset_disabled(self, kube_version):
-        """Test that no daemonset is rendered when privateCaCertsAddToHost is disabled."""
+        """Test that no daemonset is rendered when privateCaCertsAddToHost is
+        disabled."""
         with pytest.raises(CalledProcessError):
             render_chart(
                 kube_version=kube_version,
@@ -38,7 +39,8 @@ class TestPrivateCaDaemonset:
             )
 
     def test_privateca_daemonset_enabled(self, kube_version):
-        """Test that the daemonset is rendered with valid properties when enabled."""
+        """Test that the daemonset is rendered with valid properties when
+        enabled."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -109,7 +111,8 @@ class TestPrivateCaDaemonset:
 )
 class TestPrivateCaPsp:
     def test_privateca_psp_enabled_cacertaddtohost_disabled(self, kube_version):
-        """Test that there is nothing rendered when psp is enabled and privateCaCertsAddToHost is disabled."""
+        """Test that there is nothing rendered when psp is enabled and
+        privateCaCertsAddToHost is disabled."""
         with pytest.raises(CalledProcessError):
             render_chart(
                 kube_version=kube_version,
@@ -125,7 +128,8 @@ class TestPrivateCaPsp:
             )
 
     def test_privateca_psp_disabled_cacertaddtohost_enabled(self, kube_version):
-        """Test that nothing is rendered when psp is disabled and privateCaCertsAddToHost is enabled"""
+        """Test that nothing is rendered when psp is disabled and
+        privateCaCertsAddToHost is enabled."""
         with pytest.raises(CalledProcessError):
             render_chart(
                 kube_version=kube_version,
@@ -141,7 +145,8 @@ class TestPrivateCaPsp:
             )
 
     def test_privateca_psp_enabled(self, kube_version):
-        """Test that psp is rendered when psp is enabled and privateCaCertsAddToHost is enabled."""
+        """Test that psp is rendered when psp is enabled and
+        privateCaCertsAddToHost is enabled."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=["templates/trust-private-ca-on-all-nodes/psp.yaml"],

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -27,7 +27,7 @@ class TestProbes:
         "container", chart_containers.values(), ids=chart_containers.keys()
     )
     def test_container_readiness_probes(self, container):
-        """Ensure all containers have liveness and readiness probes"""
+        """Ensure all containers have liveness and readiness probes."""
 
         if container["key"] in ignore_list:
             pytest.skip("Info: Unsupported resource: " + container["key"])
@@ -38,7 +38,7 @@ class TestProbes:
         "container", chart_containers.values(), ids=chart_containers.keys()
     )
     def test_container_liveness_probes(self, container):
-        """Ensure all containers have liveness and readiness probes"""
+        """Ensure all containers have liveness and readiness probes."""
 
         if container["key"] in ignore_list:
             pytest.skip("Info: Unsupported resource: " + container["key"])

--- a/tests/chart_tests/test_prometheus_alerts_configmap.py
+++ b/tests/chart_tests/test_prometheus_alerts_configmap.py
@@ -63,7 +63,8 @@ class TestPrometheusAlertConfigmap:
                     self.process_record(rule)
 
     def test_prometheus_alerts_configmap_with_different_name_and_ns(self, kube_version):
-        """Validate the prometheus alerts configmap does not conflate helm deployment name and namespace."""
+        """Validate the prometheus alerts configmap does not conflate helm
+        deployment name and namespace."""
         docs = render_chart(
             name="foo-name",
             namespace="bar-ns",
@@ -78,7 +79,8 @@ class TestPrometheusAlertConfigmap:
         assert not re.search(r'namespace="foo-name"', config_yaml)
 
     def test_prometheus_alerts_configmap_with_addition_alerts(self, kube_version):
-        """Validate the prometheus alerts configmap renders additional alerts."""
+        """Validate the prometheus alerts configmap renders additional
+        alerts."""
 
         additional_alerts = {
             "airflow": '- alert: ExampleAirflowAlert\n  expr: 100 * sum(increase(airflow_ti_failures[30m])) / (sum(increase(airflow_ti_failures[30m])) + sum(increase(airflow_ti_successes[30m]))) > 10\n  for: 15m\n  labels:\n    tier: airflow\n  annotations:\n    summary: The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf "%q" "{{ printf \\"%.2f\\" $value }}%" }} of the time over the past 30 minutes\n    description: Task instances failing above threshold\n',

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -28,7 +28,8 @@ class TestPrometheusConfigConfigmap:
         assert doc["metadata"]["name"] == "release-name-prometheus-config"
 
     def test_prometheus_config_configmap_with_different_name_and_ns(self, kube_version):
-        """Validate the prometheus config configmap does not conflate deployment name and namespace."""
+        """Validate the prometheus config configmap does not conflate
+        deployment name and namespace."""
         doc = render_chart(
             name="foo-name",
             namespace="bar-ns",
@@ -69,7 +70,8 @@ class TestPrometheusConfigConfigmap:
         assert all(x in targets for x in target_checks)
 
     def test_prometheus_config_configmap_external_labels(self, kube_version):
-        """Prometheus should have an external_labels section in config.yaml when external_labels is specified in helm values."""
+        """Prometheus should have an external_labels section in config.yaml
+        when external_labels is specified in helm values."""
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -88,7 +90,8 @@ class TestPrometheusConfigConfigmap:
         }
 
     def test_promethesu_config_configmap_remote_write(self, kube_version):
-        """Prometheus should have a remote_write section in config.yaml when remote_write is specified in helm values."""
+        """Prometheus should have a remote_write section in config.yaml when
+        remote_write is specified in helm values."""
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -127,7 +130,8 @@ class TestPrometheusConfigConfigmap:
         ]
 
     def test_prometheus_config_configmap_with_node_exporter(self, kube_version):
-        """Validate the prometheus config configmap has the node-exporter enabled with params."""
+        """Validate the prometheus config configmap has the node-exporter
+        enabled with params."""
         doc = render_chart(
             name="foo-name",
             namespace="bar-ns",
@@ -148,7 +152,8 @@ class TestPrometheusConfigConfigmap:
         assert nodeExporterConfigs[0]["job_name"] == "node-exporter"
 
     def test_prometheus_config_configmap_without_node_exporter(self, kube_version):
-        """Validate the prometheus config configmap does not have node-exporter when it is not enabled."""
+        """Validate the prometheus config configmap does not have node-exporter
+        when it is not enabled."""
         doc = render_chart(
             name="foo-name",
             namespace="bar-ns",
@@ -193,7 +198,8 @@ class TestPrometheusConfigConfigmap:
     def test_prometheus_config_release_relabel_with_free_from_namespace(
         self, kube_version
     ):
-        """Prometheus should not have a regex for release name when free form namespace is enabled."""
+        """Prometheus should not have a regex for release name when free form
+        namespace is enabled."""
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,

--- a/tests/chart_tests/test_psp.py
+++ b/tests/chart_tests/test_psp.py
@@ -40,7 +40,8 @@ class TestPspEnabled:
 
     @pytest.mark.parametrize("psp_docs", psp_docs, ids=psp_doc_ids)
     def test_psp(self, kube_version, psp_docs):
-        """Test that helm errors when pspEnabled=False, and renders a good PodSecurityPolicy template when pspEnabled=True."""
+        """Test that helm errors when pspEnabled=False, and renders a good
+        PodSecurityPolicy template when pspEnabled=True."""
 
         docs = render_chart(
             kube_version=kube_version,
@@ -96,7 +97,8 @@ class TestPspEnabled:
         "clusterrole_docs", clusterrole_docs, ids=clusterrole_doc_ids
     )
     def test_clusterrole(self, kube_version, clusterrole_docs):
-        """Test that helm errors when pspEnabled=False, and renders a good ClusterRole template when pspEnabled=True."""
+        """Test that helm errors when pspEnabled=False, and renders a good
+        ClusterRole template when pspEnabled=True."""
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"pspEnabled": False}},
@@ -140,7 +142,8 @@ class TestPspEnabled:
         ids=clusterrolebinding_doc_ids,
     )
     def test_clusterrolebinding(self, kube_version, clusterrolebinding_docs):
-        """Test that helm errors when pspEnabled=False, and renders a good ClusterRoleBinding template when pspEnabled=True."""
+        """Test that helm errors when pspEnabled=False, and renders a good
+        ClusterRoleBinding template when pspEnabled=True."""
 
         docs = render_chart(
             kube_version=kube_version,
@@ -191,7 +194,8 @@ class TestPspEnabled:
         ids=rolebinding_doc_ids,
     )
     def test_rolebinding(self, kube_version, rolebinding_docs):
-        """Test that helm errors when pspEnabled=False, and renders a good RoleBinding template when pspEnabled=True."""
+        """Test that helm errors when pspEnabled=False, and renders a good
+        RoleBinding template when pspEnabled=True."""
 
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_registry_configmap_with_s3Enabled.py
+++ b/tests/chart_tests/test_registry_configmap_with_s3Enabled.py
@@ -9,7 +9,8 @@ import yaml
     supported_k8s_versions,
 )
 def test_registry_configmap(kube_version):
-    """Test that helm renders an expected registry-configmap to validate regionendpoint flag"""
+    """Test that helm renders an expected registry-configmap to validate
+    regionendpoint flag."""
     docs = render_chart(
         kube_version=kube_version,
         values={

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -26,9 +26,7 @@ commander_expected_result = {
     supported_k8s_versions,
 )
 def test_scc_disabled(kube_version):
-    """
-    Test all things scc related when scc is disabled.
-    """
+    """Test all things scc related when scc is disabled."""
     docs = render_chart(
         kube_version=kube_version,
         values={
@@ -51,9 +49,7 @@ def test_scc_disabled(kube_version):
     supported_k8s_versions,
 )
 def test_scc_enabled(kube_version):
-    """
-    Test all things scc related when scc is disabled.
-    """
+    """Test all things scc related when scc is disabled."""
 
     docs = render_chart(
         kube_version=kube_version,

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -65,7 +65,8 @@ class TestStanStatefulSet:
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 
     def test_stan_statefulset_with_affinity_and_tolerations(self, kube_version):
-        """Test that stan statefulset renders proper nodeSelector, affinity, and tolerations"""
+        """Test that stan statefulset renders proper nodeSelector, affinity,
+        and tolerations."""
         values = {
             "stan": {
                 "nodeSelector": {"role": "astro"},
@@ -118,7 +119,8 @@ class TestStanStatefulSet:
         assert spec["tolerations"] == values["stan"]["tolerations"]
 
     def test_stan_statefulset_with_global_affinity_and_tolerations(self, kube_version):
-        """Test that stan statefulset renders proper nodeSelector, affinity, and tolerations with global config"""
+        """Test that stan statefulset renders proper nodeSelector, affinity,
+        and tolerations with global config."""
         values = {
             "global": {
                 "platformNodePool": {
@@ -216,7 +218,8 @@ class TestStanStatefulSet:
         assert c_by_name["stan"]["imagePullPolicy"] == "Always"
 
     def test_stan_statefulset_with_private_registry(self, kube_version):
-        """Test that stan statefulset properly uses the private registry images."""
+        """Test that stan statefulset properly uses the private registry
+        images."""
         private_registry = "private-registry.example.com"
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_sts_volume_claim_annotations.py
+++ b/tests/chart_tests/test_sts_volume_claim_annotations.py
@@ -21,7 +21,7 @@ class TestStatefulSetsAnnotations:
             assert not vct[0]["metadata"].get("annotations")
 
     def test_es_sts_with_overridden_annotations(self, kube_version):
-        """Test es sts for the volume claim templates annotations"""
+        """Test es sts for the volume claim templates annotations."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -48,7 +48,7 @@ class TestStatefulSetsAnnotations:
             ]["volumeClaimTemplates"][0]["metadata"]["annotations"]
 
     def test_prometheus_sts_with_overridden_annotations(self, kube_version):
-        """Test prometheus sts for the volume claim templates annotations"""
+        """Test prometheus sts for the volume claim templates annotations."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -73,7 +73,7 @@ class TestStatefulSetsAnnotations:
             } == doc["spec"]["volumeClaimTemplates"][0]["metadata"]["annotations"]
 
     def test_registry_sts_with_overridden_annotations(self, kube_version):
-        """Test registry sts for the volume claim templates annotations"""
+        """Test registry sts for the volume claim templates annotations."""
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -100,7 +100,7 @@ class TestStatefulSetsAnnotations:
             } == doc["spec"]["volumeClaimTemplates"][0]["metadata"]["annotations"]
 
     def test_stan_sts_with_overridden_annotations(self, kube_version):
-        """Test stan sts for the volume claim templates annotations"""
+        """Test stan sts for the volume claim templates annotations."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -20,7 +20,9 @@ if not (release_name := getenv("RELEASE_NAME")):
 
 @pytest.fixture(scope="function")
 def nginx(request, kube_client):
-    """This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra.
+
+    To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
@@ -31,7 +33,9 @@ def nginx(request, kube_client):
 
 @pytest.fixture(scope="function")
 def houston_api(request, kube_client):
-    """This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra.
+
+    To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
@@ -42,7 +46,9 @@ def houston_api(request, kube_client):
 
 @pytest.fixture(scope="function")
 def prometheus(request):
-    """This is the host fixture for testinfra. To read more, please see
+    """This is the host fixture for testinfra.
+
+    To read more, please see
     the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
@@ -77,9 +83,8 @@ def es_client(request, kube_client):
 
 @pytest.fixture(scope="session")
 def docker_client(request):
-    """This is a text fixture for the docker client,
-    should it be needed in a test
-    """
+    """This is a text fixture for the docker client, should it be needed in a
+    test."""
     docker_client = docker.from_env()
     yield docker_client
     docker_client.close()
@@ -87,8 +92,10 @@ def docker_client(request):
 
 @pytest.fixture(scope="session")
 def kube_client(request, in_cluster=False):
-    """
-    Return a kubernetes client. By default, use kube-config. If running in a pod, use k8s service account.
+    """Return a kubernetes client.
+
+    By default, use kube-config. If running in a pod, use k8s service
+    account.
     """
 
     k8s_client = get_kube_client(in_cluster)

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""
-This file is for system testing the Astronomer Helm chart.
+"""This file is for system testing the Astronomer Helm chart.
 
-Many of these tests use pytest fixtures that use testinfra to exec
-into running pods so we can inspect the run-time environment.
+Many of these tests use pytest fixtures that use testinfra to exec into
+running pods so we can inspect the run-time environment.
 """
 
 import json
@@ -27,7 +26,7 @@ def test_default_disabled(kube_client):
 
 
 def test_prometheus_user(prometheus):
-    """Ensure user is 'nobody'"""
+    """Ensure user is 'nobody'."""
     user = prometheus.check_output("whoami")
     assert (
         user == "nobody"
@@ -35,7 +34,7 @@ def test_prometheus_user(prometheus):
 
 
 def test_houston_config(houston_api):
-    """Make assertions about Houston's configuration"""
+    """Make assertions about Houston's configuration."""
     data = houston_api.check_output(
         "echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -"
     )
@@ -66,7 +65,7 @@ def test_nginx_can_reach_default_backend(nginx):
 
 @pytest.mark.flaky(reruns=20, reruns_delay=10)
 def test_prometheus_targets(prometheus):
-    """Ensure all Prometheus targets are healthy"""
+    """Ensure all Prometheus targets are healthy."""
     data = prometheus.check_output(
         "wget --timeout=5 -qO- http://localhost:9090/api/v1/targets"
     )
@@ -114,7 +113,7 @@ def test_core_dns_metrics_are_collected(prometheus):
 
 
 def test_houston_metrics_are_collected(prometheus):
-    """Ensure Houston metrics are collected and prefixed with 'houston_'"""
+    """Ensure Houston metrics are collected and prefixed with 'houston_'."""
     data = prometheus.check_output(
         "wget --timeout=5 -qO- http://localhost:9090/api/v1/query?query=houston_up"
     )
@@ -125,10 +124,8 @@ def test_houston_metrics_are_collected(prometheus):
 
 
 def test_prometheus_config_reloader_works(prometheus, kube_client):
-    """
-    Ensure that Prometheus reloads its config when the cofigMap is updated
-    and the reloader sidecar triggers the reload
-    """
+    """Ensure that Prometheus reloads its config when the cofigMap is updated
+    and the reloader sidecar triggers the reload."""
     # define new value we'll use for the config change
     new_scrape_interval = "31s"
 
@@ -190,11 +187,12 @@ def test_prometheus_config_reloader_works(prometheus, kube_client):
 def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart(
     houston_api, kube_client
 ):
-    """
-    Test when helm upgrade occurs without Houston pods restarting that a
-    Houston container restart will not miss the Houston connection backend secret
+    """Test when helm upgrade occurs without Houston pods restarting that a
+    Houston container restart will not miss the Houston connection backend
+    secret.
 
-    Regression test for: https://github.com/astronomer/issues/issues/2251
+    Regression test for:
+    https://github.com/astronomer/issues/issues/2251
     """
     if not (helm_chart_path := getenv("HELM_CHART_PATH")):
         raise Exception(
@@ -244,21 +242,24 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
 
 
 def test_cve_2021_44228_es_client(es_client):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
+    configured."""
     assert "-Dlog4j2.formatMsgNoLookups=true" in es_client.check_output(
         "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
 
 def test_cve_2021_44228_es_data(es_data):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
+    configured."""
     assert "-Dlog4j2.formatMsgNoLookups=true" in es_data.check_output(
         "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
 
 def test_cve_2021_44228_es_master(es_master):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true configured."""
+    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
+    configured."""
     assert "-Dlog4j2.formatMsgNoLookups=true" in es_master.check_output(
         "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -20,7 +20,6 @@ container_list = get_pod_running_containers()
     ids=container_list.keys(),
 )
 def test_container_non_root(request, container):
-
     if container["_name"] in container_ignore_list:
         pytest.skip("Info: Unsupported container: " + container["_name"])
 

--- a/tests/functional_tests/test_versioning.py
+++ b/tests/functional_tests/test_versioning.py
@@ -15,10 +15,8 @@ git_root_dir = Path(
 
 
 def test_astro_sub_chart_version_match():
-    """
-    Tests that Chart.yaml and charts/astronomer/Chart.yaml
-    have matching versions.
-    """
+    """Tests that Chart.yaml and charts/astronomer/Chart.yaml have matching
+    versions."""
     with open(git_root_dir / "Chart.yaml") as f:
         astro_chart_dot_yaml = yaml.safe_load(f.read())
 
@@ -32,11 +30,9 @@ def test_astro_sub_chart_version_match():
 
 @mark.skip(reason="https://github.com/astronomer/issues/issues/2486")
 def test_downgrade_then_upgrade():
-    """
-    If the patch version is greater than zero,
-    check that we can perform a version downgrade,
-    followed by version upgrade back to the current version
-    """
+    """If the patch version is greater than zero, check that we can perform a
+    version downgrade, followed by version upgrade back to the current
+    version."""
     helm_chart_path = getenv("HELM_CHART_PATH")
     if not helm_chart_path:
         raise Exception(


### PR DESCRIPTION
## Description

Add a new pre-commit hook to automatically format python docstrings.

## Related Issues

N/A, but internal discussion is here: <https://astronomer.slack.com/archives/C0179EM5DBP/p1664410552812329>

## Testing

This hook only modifies comments.

## Merging

Should be merged into all supported branches. If there are conflicts, just add the hook and run pre-commit and commit all changes.