### PR TITLE
update fluentd image 1.15.1 -> 1.15.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.15.1
+                - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.5

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.1
+    tag: 1.15.2
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
## Description

update fluentd package 1.15.1 -> 1.15.2
Release notes https://github.com/fluent/fluentd/releases/tag/v1.15.2

## Related Issues

https://github.com/astronomer/issues/issues/5076
## Testing

QA should verify if fluentd works as expected

## Merging

cherry-pick to all supported release branches
