### PR TITLE
Patch release 0.29.5 - backport changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.29.15
+                - quay.io/astronomer/ap-astro-ui:0.29.17
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-8
                 - quay.io/astronomer/ap-base:3.16.2-1
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.29.37
+                - quay.io/astronomer/ap-houston-api:0.29.39
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-houston-api:0.29.37
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1
@@ -313,7 +313,6 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.1
                 - quay.io/astronomer/ap-registry:3.16.2-1
-                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,14 +286,14 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.29.15
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
-                - quay.io/astronomer/ap-awsesproxy:1.3-7
-                - quay.io/astronomer/ap-base:3.16.2
-                - quay.io/astronomer/ap-blackbox-exporter:0.21.1-2
+                - quay.io/astronomer/ap-awsesproxy:1.3-8
+                - quay.io/astronomer/ap-base:3.16.2-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.29.7
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
-                - quay.io/astronomer/ap-curator:5.8.4-18
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.9
+                - quay.io/astronomer/ap-curator:5.8.4-19
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
@@ -301,18 +301,19 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6
-                - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0
-                - quay.io/astronomer/ap-nats-server:2.8.1-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-1
+                - quay.io/astronomer/ap-kube-state:2.6.0
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
-                - quay.io/astronomer/ap-node-exporter:1.3.1
+                - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.21.4-2
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.0
-                - quay.io/astronomer/ap-registry:3.16.2
+                - quay.io/astronomer/ap-prometheus:2.37.1
+                - quay.io/astronomer/ap-registry:3.16.2-1
+                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,11 +296,11 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.29.37
-                - quay.io/astronomer/ap-kibana:7.17.5
+                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0
                 - quay.io/astronomer/ap-nats-server:2.8.1-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
-                - quay.io/astronomer/ap-commander:0.29.7
+                - quay.io/astronomer/ap-commander:0.29.8
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -297,7 +297,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
-                - quay.io/astronomer/ap-fluentd:1.15.1
+                - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -3,3 +3,5 @@
 CVE-2022-27191
 # more info for CVE-2022-1996 available in https://github.com/kubernetes/ingress-nginx/issues/8745
 CVE-2022-1996
+# golang.org/x/net CVE
+CVE-2022-27664

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.29.37
+    tag: 0.29.39
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.29.15
+    tag: 0.29.17
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.6.3
+airflowChartVersion: 1.6.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.29.7
+    tag: 0.29.8
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-18
+    tag: 5.8.4-19
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-7
+    tag: 1.3-8
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.1
+    tag: 1.15.2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-2
+    tag: 2.8.1-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-2
+  tag: 0.22.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.3.1
+  tag: 1.4.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -118,14 +118,16 @@ spec:
             httpGet:
               path: /-/healthy
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
               path: /-/ready
               port: {{ .Values.ports.http }}
-            initialDelaySeconds: 10
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
       securityContext:
         fsGroup: 65534
         runAsNonRoot: true

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -33,6 +33,16 @@ resources: {}
 #   cpu: 100m
 #   memory: 128Mi
 
+# probe configurations for prometheus container
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 3
+
 configMapReloader:
   resources: {}
     # limits:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -17,7 +17,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.0
+    tag: 2.37.1
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-1
+    tag: 0.24.5-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 stan:

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -48,3 +48,44 @@ class TestPrometheusStatefulset:
             {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
             {"mountPath": "/prometheus", "name": "data"},
         ]
+        # check default liveness probe values
+        assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10
+        assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 5
+        assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 3
+        # check default readiness probe values
+        assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 10
+        assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 5
+        assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 3
+
+    def test_prometheus_sts_override_probes(self, kube_version):
+        """Test override of probe values."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "prometheus": {
+                    "livenessProbe": {
+                        "initialDelaySeconds": 20,
+                        "periodSeconds": 21,
+                        "failureThreshold": 22,
+                    },
+                    "readinessProbe": {
+                        "initialDelaySeconds": 30,
+                        "periodSeconds": 31,
+                        "failureThreshold": 32,
+                    },
+                }
+            },
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc)
+        # check modified liveness probe values
+        assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 20
+        assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 21
+        assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 22
+        # check modified readiness probe values
+        assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 30
+        assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 31
+        assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 32

--- a/values.yaml
+++ b/values.yaml
@@ -105,7 +105,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.23.0
+    image: quay.io/astronomer/ap-vector:0.23.3-1
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
 


### PR DESCRIPTION
## Description

release 0.29 - backport changes
include CVE fixes and enhancements

## Related Issues


Issue Link: https://github.com/astronomer/issues/issues/5050
Issue Link: https://github.com/astronomer/issues/issues/5065
Issue Link: https://github.com/astronomer/issues/issues/4981

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

https://github.com/astronomer/astronomer/commit/9b46dbb1b76eb8d142250cac54c57ff3c9ed5ea5
https://github.com/astronomer/astronomer/commit/ea2a67c9720ff0b2c7001f2052955a65b3d4b3b5
