### PR TITLE
Add houston-cleanup-task-usage-data CronJob

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -1,7 +1,7 @@
 ##########################################
 ## Houston Cleanup Task Usage data CronJob
 ##########################################
-{{- if .Values.houston.cleanupTaskUsageData.enabled }}
+{{- if .Values.global.taskUsageMetricsEnabled }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -14,7 +14,6 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   schedule: {{ .Values.houston.cleanupTaskUsageData.schedule }}
-  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -44,7 +43,6 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "cleanup-task-usage-data", "--", "--older-than={{ .Values.houston.cleanupTaskUsageData.olderThan }}", "--dry-run={{ .Values.houston.cleanupTaskUsageData.dryRun }}", "--canary={{ .Values.houston.cleanupTaskUsageData.canary }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -5,7 +5,7 @@
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: houston-cleanup-task-usage-data
+  name: "{{ .Release.Name }}-houston-cleanup-task-usage-data"
   labels:
     tier: astronomer
     component: houston-cleanup

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -1,0 +1,57 @@
+##########################################
+## Houston Cleanup Task Usage data CronJob
+##########################################
+{{- if .Values.houston.cleanupTaskUsageData.enabled }}
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: houston-cleanup-task-usage-data
+  labels:
+    tier: astronomer
+    component: houston-cleanup
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: {{ .Values.houston.cleanupTaskUsageData.schedule }}
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-cleanup
+            release: {{ .Release.Name }}
+            app: houston-cleanup
+            version: {{ .Chart.Version }}
+          {{- if .Values.global.istio.enabled }}
+          annotations:
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+        spec:
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          containers:
+            - name: cleanup
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
+              args: ["yarn", "cleanup-task-usage-data", "--", "--older-than={{ .Values.houston.cleanupTaskUsageData.olderThan }}", "--dry-run={{ .Values.houston.cleanupTaskUsageData.dryRun }}", "--canary={{ .Values.houston.cleanupTaskUsageData.canary }}"]
+              volumeMounts:
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                {{- include "houston_environment" . | indent 16 }}
+          volumes:
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}
+{{- end }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -72,6 +72,8 @@ data:
       kibanaUIEnabled: false
       {{ end }}
 
+      taskUsageMetricsEnabled: {{ .Values.global.taskUsageMetricsEnabled }}
+
       {{ if .Values.global.features.namespacePools.enabled }}
       hardDeleteDeployment: true
       manualNamespaceNames: true

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -172,9 +172,6 @@ houston:
   # Cleanup task usage data and task audit data in Houston
   # This runs as a CronJob
   cleanupTaskUsageData:
-    # Enable cleanup CronJob
-    enabled: true
-
     # Run at 23:40 every night
     schedule: "40 23 * * *"  # https://crontab.guru/#40_23_*_*_*
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -169,6 +169,24 @@ houston:
     # Only run on deployments marked as canary
     canary: false
 
+  # Cleanup task usage data and task audit data in Houston
+  # This runs as a CronJob
+  cleanupTaskUsageData:
+    # Enable cleanup CronJob
+    enabled: true
+
+    # Default here is to run at midnight every night
+    schedule: "0 0 * * *"
+
+    # Cleanup deployments older than this many days
+    olderThan: 90
+
+    # Print out the deployments that should be cleaned up and skip actual cleanup
+    dryRun: false
+
+    # Only run on deployments marked as canary
+    canary: false
+
   # Check for Astronomer Platform Updates
   # This runs as a CronJob
   updateCheck:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -175,8 +175,8 @@ houston:
     # Enable cleanup CronJob
     enabled: true
 
-    # Default here is to run at midnight every night
-    schedule: "0 0 * * *"
+    # Run at 23:40 every night
+    schedule: "40 23 * * *"  # https://crontab.guru/#40_23_*_*_*
 
     # Cleanup deployments older than this many days
     olderThan: 90

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -9,54 +9,44 @@ from tests import supported_k8s_versions
     supported_k8s_versions,
 )
 class TestAstronomerHoustonTaskMetricsCronjobs:
-  def test_astronomer_cleanup_task_usage_cron_defaults(self, kube_version):
-    # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
-      docs = render_chart(
-          kube_version=kube_version,
-          values={
-              "global": {
-                "taskUsageMetricsEnabled" : False
-              }
-          },
-          show_only=[
-              "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
-          ],
-      )
-      assert len(docs) == 0
-    
-  def test_astronomer_cleanup_task_usage_cron_feature_enabled(self, kube_version):
-  # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
-    docs = render_chart(
-        kube_version=kube_version,
-        values={
-            "global": {
-              "taskUsageMetricsEnabled" : True
-            }
-        },
-        show_only=[
-            "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
-        ],
-    )
+    def test_astronomer_cleanup_task_usage_cron_defaults(self, kube_version):
+        # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": False}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
+            ],
+        )
+        assert len(docs) == 0
 
-    assert len(docs) == 1
-    assert docs[0]["kind"] == "CronJob"
-    assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
-    assert docs[0]["spec"]["schedule"] == "40 23 * * *"
-  
-  def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
-    """Validate the houston configmap and its embedded data with
-    taskUsageMetricsEnabled."""
+    def test_astronomer_cleanup_task_usage_cron_feature_enabled(self, kube_version):
+        # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": True}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
+            ],
+        )
 
-    docs = render_chart(
-        values={
-            "global": {
-                "taskUsageMetricsEnabled": True
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert (
+            docs[0]["metadata"]["name"]
+            == "release-name-houston-cleanup-task-usage-data"
+        )
+        assert docs[0]["spec"]["schedule"] == "40 23 * * *"
 
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod_yaml["deployments"]["taskUsageMetricsEnabled"] is True
-      
+    def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
+        """Validate the houston configmap and its embedded data with
+        taskUsageMetricsEnabled."""
+
+        docs = render_chart(
+            values={"global": {"taskUsageMetricsEnabled": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod_yaml["deployments"]["taskUsageMetricsEnabled"] is True

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -1,0 +1,62 @@
+from tests.chart_tests.helm_template_generator import render_chart
+import pytest
+import yaml
+from tests import supported_k8s_versions
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestAstronomerHoustonTaskMetricsCronjobs:
+  def test_astronomer_cleanup_task_usage_cron_defaults(self, kube_version):
+    # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
+      docs = render_chart(
+          kube_version=kube_version,
+          values={
+              "global": {
+                "taskUsageMetricsEnabled" : False
+              }
+          },
+          show_only=[
+              "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
+          ],
+      )
+      assert len(docs) == 0
+    
+  def test_astronomer_cleanup_task_usage_cron_feature_enabled(self, kube_version):
+  # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
+    docs = render_chart(
+        kube_version=kube_version,
+        values={
+            "global": {
+              "taskUsageMetricsEnabled" : True
+            }
+        },
+        show_only=[
+            "charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml",
+        ],
+    )
+
+    assert len(docs) == 1
+    assert docs[0]["kind"] == "CronJob"
+    assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
+    assert docs[0]["spec"]["schedule"] == "40 23 * * *"
+  
+  def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
+    """Validate the houston configmap and its embedded data with
+    taskUsageMetricsEnabled."""
+
+    docs = render_chart(
+        values={
+            "global": {
+                "taskUsageMetricsEnabled": True
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["deployments"]["taskUsageMetricsEnabled"] is True
+      

--- a/values.yaml
+++ b/values.yaml
@@ -107,6 +107,8 @@ global:
   rootAdmin:
     username: root@example.com
 
+  taskUsageMetricsEnabled: false
+
   # Sidecar Logging
   loggingSidecar:
     enabled: false


### PR DESCRIPTION
## Description

This is a cronjob to hard delete task usage data in houston db older than 90 days

## Related Issues

https://github.com/astronomer/issues/issues/5070

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.31.0
