### PR TITLE
revert to valid circleci machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2204:2022.09.1 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2022.07.1 # https://circleci.com/developer/machine/image/ubuntu-2204
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -149,7 +149,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2204:2022.09.1 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2022.07.1 # https://circleci.com/developer/machine/image/ubuntu-2204
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
## Description

revert back ubuntu-2204:2022.09.1  -> ubuntu-2204:2022.07.1. As per https://circleci.com/developer/machine/image/ubuntu-2204 vm image list

## Related Issues

Issue Description:
Job was rejected because resource class medium, image ubuntu-2204:2022.09.1 is not a valid resource class

## Testing

NA

## Merging

merge to all valid release branches
