### PR TITLE
release-0.25 backport security fixes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.25.5
-                - quay.io/astronomer/ap-configmap-reloader:0.7.1
+                - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,28 +266,28 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.25.9
-                - quay.io/astronomer/ap-base:3.16.2
+                - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.25.5
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
-                - quay.io/astronomer/ap-curator:5.8.4-18
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.9
+                - quay.io/astronomer/ap-curator:5.8.4-19
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.15.1
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.25.15
-                - quay.io/astronomer/ap-kibana:7.17.5
+                - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:1.7.2
                 - quay.io/astronomer/ap-kubed:0.13.2
-                - quay.io/astronomer/ap-nats-exporter:0.10.0
-                - quay.io/astronomer/ap-nats-server:2.8.1-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-1
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:0.51.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.0
-                - quay.io/prometheus/node-exporter:v1.2.2
+                - quay.io/astronomer/ap-node-exporter:1.4.0
+                - quay.io/astronomer/ap-prometheus:2.37.1
           context:
             - slack_team-software-infra-bot
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,15 +10,15 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-18
+    tag: 5.8.4-19
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.1
+    tag: 1.15.2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-2
+    tag: 2.8.1-3
     pullPolicy: IfNotPresent
 
 nats:
@@ -174,7 +174,7 @@ reloader:
 # Prometheus NATS Exporter configuration.
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.10.0
+  image: quay.io/astronomer/ap-nats-exporter:0.10.0-1
   pullPolicy: IfNotPresent
   # resource configuration for the metrics sidecar
   resources: {}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-2
+  tag: 0.22.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -2,8 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 image:
-  repository: quay.io/prometheus/node-exporter
-  tag: v1.2.2
+  repository: quay.io/astronomer/ap-node-exporter
+  tag: 1.4.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.0
+    tag: 2.37.1
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -23,7 +23,7 @@ images:
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.7.1
+    tag: 0.8.0
     pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,11 +6,11 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-1
+    tag: 0.24.5-3
     pullPolicy: IfNotPresent
 
 stan:
@@ -147,7 +147,7 @@ store:
 #######################################
 exporter:
   enabled: true
-  image: quay.io/astronomer/ap-nats-exporter:0.10.0
+  image: quay.io/astronomer/ap-nats-exporter:0.10.0-1
   pullPolicy: IfNotPresent
   resources: {}
   #  limits:

--- a/tests/test_privateca.py
+++ b/tests/test_privateca.py
@@ -46,6 +46,10 @@ class TestDaemonset:
                     "privateCaCerts": ["private-ca-cert-foo", "private-ca-cert-bar"],
                     "privateCaCertsAddToHost": {
                         "enabled": True,
+                        "certCopier": {
+                            "repository": "alpine",
+                            "tag": "3.14",
+                        },
                     },
                 }
             },

--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ global:
     hostDirectory: /etc/docker/certs.d
     certCopier:
       repository: alpine
-      tag: 3.14
+      tag: 3.16
       pullPolicy: IfNotPresent
 
 
@@ -88,8 +88,8 @@ global:
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false
-    repository: nginxinc/nginx-unprivileged
-    tag: stable
+    repository: quay.io/astronomer/ap-auth-sidecar
+    tag: 1.23.1-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

image | old | new
--    | --  | --
ap-base | 3.16.2  | 3.16.2-1
ap-registry |  3.16.2 | 3.16.2-1
ap-db-bootstrapper | 0.26.9 |  0.26.11
ap-elasticsearch | 7.17.5 | 7.17.6
ap-kibana  | 7.17.5 | 7.17.6   
ap-curator | 5.8.4-18 | 5.8.4-19
ap-fluentd | 1.15.1 | 1.15.2
ap-nats-server | 2.8.1-2 | 2.8.1-3
ap-nats-exporter | 0.10.0 | 0.10.0-1
ap-blackbox-exporter | 0.21.1-2 | 0.22.0 
ap-node-exporter  | 1.2.2 | 1.4.0
ap-prometheus | 2.37.0 | 2.37.1
ap-nats-streaming | 0.24.5-1 | 0.24.5-3
ap-auth-sidecar | | 1.23.1-1
ap-configmap-reloader | 0.7.1 | 0.8.0


Additional Updates
replaced nginxinc/nginx-unprivileged:latest  -> quay.io/astronomer/ap-auth-sidecar:1.23.1-1
replaced alpine:3.14 -> alpine:3.16
replaced quay.io/prometheus/node-exporter:v1.2.2 -> quay.io/astronomer/ap-node-exporter:1.4.0

## Related Issues

https://github.com/astronomer/issues/issues/5065

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
