### PR TITLE
release-0.28 backport security fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,11 +272,8 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.30.3
-                - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
-                - quay.io/astronomer/ap-awsesproxy:1.3-8
+                - quay.io/astronomer/ap-astro-ui:0.28.16
                 - quay.io/astronomer/ap-base:3.16.2-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.28.6
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
@@ -285,24 +282,19 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
-                - quay.io/astronomer/ap-fluentd:1.15.1
+                - quay.io/astronomer/ap-fluentd:1.14.6-1
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-houston-api:0.28.26
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
+                - quay.io/astronomer/ap-kubed:0.13.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1
                 - quay.io/astronomer/ap-nats-server:2.8.1-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
-                - quay.io/astronomer/ap-openresty:1.21.4-2
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
-                - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.1
-                - quay.io/astronomer/ap-registry:3.16.2-1
-                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.28.16
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-cli-install:0.26.8
-                - quay.io/astronomer/ap-commander:0.28.6
+                - quay.io/astronomer/ap-commander:0.28.7
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,7 +272,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.28.16
+                - quay.io/astronomer/ap-astro-ui:0.28.17
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.28.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,11 +281,11 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.9
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.14.6-1
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.28.26
-                - quay.io/astronomer/ap-kibana:7.17.5
+                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.5.0
                 - quay.io/astronomer/ap-kubed:0.13.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,7 +282,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
-                - quay.io/astronomer/ap-fluentd:1.14.6-1
+                - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.28.26
                 - quay.io/astronomer/ap-kibana:7.17.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.28.26
+                - quay.io/astronomer/ap-houston-api:0.28.28
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-kubed:0.13.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,13 +272,16 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.28.16
-                - quay.io/astronomer/ap-base:3.16.2
+                - quay.io/astronomer/ap-astro-ui:0.30.3
+                - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
+                - quay.io/astronomer/ap-awsesproxy:1.3-8
+                - quay.io/astronomer/ap-base:3.16.2-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.28.6
                 - quay.io/astronomer/ap-configmap-reloader:0.7.1
-                - quay.io/astronomer/ap-curator:5.8.4-18
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.9
+                - quay.io/astronomer/ap-curator:5.8.4-19
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
@@ -286,15 +289,20 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6
-                - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-kubed:0.13.2
-                - quay.io/astronomer/ap-nats-exporter:0.10.0
-                - quay.io/astronomer/ap-nats-server:2.8.1-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-2
+                - quay.io/astronomer/ap-kube-state:2.6.0
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
-                - quay.io/astronomer/ap-node-exporter:1.3.1
-                - quay.io/astronomer/ap-prometheus:2.37.0
+                - quay.io/astronomer/ap-node-exporter:1.4.0
+                - quay.io/astronomer/ap-openresty:1.21.4-2
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
+                - quay.io/astronomer/ap-postgres-exporter:0.11.1
+                - quay.io/astronomer/ap-postgresql:11.15.0-1
+                - quay.io/astronomer/ap-prometheus:2.37.1
+                - quay.io/astronomer/ap-registry:3.16.2-1
+                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -1,3 +1,7 @@
 # We are not using SSH as per this comment.
 # https://github.com/astronomer/astronomer/pull/1522#issuecomment-1128470766
 CVE-2022-27191
+# more info for CVE-2022-1996 available in https://github.com/kubernetes/ingress-nginx/issues/8745
+CVE-2022-1996
+# golang.org/x/net CVE
+CVE-2022-27664

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.4.2
+airflowChartVersion: 1.4.3
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.28.6
+    tag: 0.28.7
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.26
+    tag: 0.28.28
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.16
+    tag: 0.28.17
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-18
+    tag: 5.8.4-19
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-4
+    tag: 1.3-8
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.14.6-1
+    tag: 1.15.2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.9
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.5.0
+    tag: 2.6.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-2
+    tag: 2.8.1-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.21.1-2
+  tag: 0.22.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.3.1
+  tag: 1.4.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.0
+    tag: 2.37.1
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2
+    tag: 3.16.2-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-2
+    tag: 0.24.5-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0
+    tag: 0.10.0-1
     pullPolicy: IfNotPresent
 
 stan:

--- a/values.yaml
+++ b/values.yaml
@@ -94,6 +94,17 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
+  rootAdmin:
+    username: root@example.com
+
+  # Sidecar Logging
+  loggingSidecar:
+    enabled: false
+    name: sidecar-log-consumer
+    image: quay.io/astronomer/ap-vector:0.23.0
+    terminationEndpoint: http://localhost:8000/quitquitquit
+    customConfig: false
+
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -94,17 +94,6 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
-  rootAdmin:
-    username: root@example.com
-
-  # Sidecar Logging
-  loggingSidecar:
-    enabled: false
-    name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.23.0
-    terminationEndpoint: http://localhost:8000/quitquitquit
-    customConfig: false
-
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false


### PR DESCRIPTION
## Description

image | old | new
--    | --  | --
ap-registry |  3.16.2 | 3.16.2-1
ap-db-bootstrapper | 0.26.9 |  0.26.11
ap-elasticsearch | 7.17.5 | 7.17.6
ap-curator | 5.8.4-18 | 5.8.4-19
ap-base | 3.16.2  | 3.16.2-1
ap-kibana  | 7.17.5 | 7.17.6   
ap-awsesproxy | 1.3-4 | 1.3-8
ap-kube-state | 2.5.0 | 2.6.0
ap-nats-server | 2.8.1-2 | 2.8.1-3
ap-nats-exporter | 0.10.0 | 0.10.0-1
ap-blackbox-exporter | 0.21.1-2 | 0.22.0 
ap-node-exporter  | 1.3.1 | 1.4.0
ap-prometheus | 2.37.0 | 2.37.1
ap-nats-streaming | 0.24.5-2 | 0.24.5-3
ap-fluentd | 1.15.1 | 1.15.2
ap-commander | 0.28.6 | 0.28.7
ap-houston | 0.28.26  | 0.28.28
ap-astro-ui | 0.28.16 | 0.28.17

**additionalNotes**

updates airflowChartVersion 1.4.2 ->  1.4.3

## Related Issues

https://github.com/astronomer/issues/issues/5065

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
