### PR TITLE
update prometheus configmap reloader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.30.4
-                - quay.io/astronomer/ap-configmap-reloader:0.7.1
+                - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -23,7 +23,7 @@ images:
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.7.1
+    tag: 0.8.0
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
## Description

bump 0.7.1 -> 0.8.0
Includes golang module cve fixes

## Related Issues

https://github.com/astronomer/issues/issues/5097

## Testing

QA should validate if configmap updates reflects in prometheus

## Merging

cherry-pick to release-0.25,0.28,0.29,0.30.
