### PR TITLE
update houston image in release-0.28

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.28.28
+                - quay.io/astronomer/ap-houston-api:0.28.29
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-kubed:0.13.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.28
+    tag: 0.28.29
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston image in release-0.28

0.28.28 -> 0.28.29

Upgrades nodejs version from 14 to 16

## Related Issues

NA

## Testing

Platform should work without any issues to QA

## Merging

merging to release-0.28.
