### PR TITLE
bug-fix-sidecar-fails-to-terminate

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -258,7 +258,7 @@ data:
                   if container.args[0:3] == ["airflow", "tasks", "run"]:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
-                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"
+                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL --retry 5 --max-time 10 --retry-connrefused -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"
                       new_args.append(command_str)
                       container.args = new_args
 


### PR DESCRIPTION
## Description

Sidecar Occasionally Fails To Terminate

## Related Issues

curl query changed to 

`curl -fsSL --retry 5 --max-time 10 --retry-connrefused -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"`

Earlier it was 

`curl -fsSL -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"`

## Testing

There doesn't seem to be an easy way to test the added behavior because we don't have a rich functional test setup. I'd say we will have to leave this as "just make sure sidecar log containers continue to function" for now. (filled in by @danielhoherd)

## Merging

Merge everywhere that sidecar logging exists. (filled in by @danielhoherd)