### PR TITLE
release 0.30 backport changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
                 - quay.io/astronomer/ap-commander:0.30.4
-                - quay.io/astronomer/ap-configmap-reloader:0.7.1
+                - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,8 +296,8 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
-                - quay.io/astronomer/ap-fluentd:1.15.1
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-elasticsearch:7.17.5
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,16 +295,16 @@ workflows:
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.9
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.3.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.5
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
+                - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.1
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
-                - quay.io/astronomer/ap-kibana:7.17.5
-                - quay.io/astronomer/ap-kube-state:2.6.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
-                - quay.io/astronomer/ap-nats-server:2.8.1-3
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
+                - quay.io/astronomer/ap-kibana:7.17.6
+                - quay.io/astronomer/ap-kube-state:2.5.0
+                - quay.io/astronomer/ap-nats-exporter:0.9.3-2
+                - quay.io/astronomer/ap-nats-server:2.8.1-2
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-2
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.4.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,10 +301,10 @@ workflows:
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.30.19
                 - quay.io/astronomer/ap-kibana:7.17.6
-                - quay.io/astronomer/ap-kube-state:2.5.0
-                - quay.io/astronomer/ap-nats-exporter:0.9.3-2
-                - quay.io/astronomer/ap-nats-server:2.8.1-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-2
+                - quay.io/astronomer/ap-kube-state:2.6.0
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
+                - quay.io/astronomer/ap-nats-server:2.8.1-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
                 - quay.io/astronomer/ap-nginx-es:1.23.1-1
                 - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
@@ -312,9 +312,9 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.0
-                - quay.io/astronomer/ap-registry:3.16.2
-                - quay.io/astronomer/ap-vector:0.23.0
+                - quay.io/astronomer/ap-prometheus:2.37.1
+                - quay.io/astronomer/ap-registry:3.16.2-1
+                - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,8 +312,9 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.1
-                - quay.io/astronomer/ap-registry:3.16.2-1
+                - quay.io/astronomer/ap-prometheus:2.37.0
+                - quay.io/astronomer/ap-registry:3.16.2
+                - quay.io/astronomer/ap-vector:0.23.0
           context:
             - slack_team-software-infra-bot
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -57,6 +57,7 @@ data:
 
     # Airflow deployment configuration
     deployments:
+      namespaceFreeFormEntry: {{ .Values.global.namespaceFreeFormEntry }}
       # Airflow chart settings
       # Static helm configurations for this chart are found below.
       chart:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.3.0
+    tag: 1.5.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.1
+    tag: 1.15.2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.5
+    tag: 7.17.6
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -30,7 +30,7 @@ data:
         {{- tpl .Values.additionalAlerts.airflow $ | nindent 8 }}
         {{- end }}
         - alert: AirflowDeploymentUnhealthy
-          expr: sum by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) - count by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)"}) < 0
+          expr: sum by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)"}) - count by(release) (kube_pod_container_status_running{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)"}) < 0
           for: 15m # Rough number but should be enough to clear deployments with a reasonable amount of workers
           labels:
             tier: airflow
@@ -96,8 +96,8 @@ data:
 
         - alert: ContainerMemoryNearTheLimitInDeployment
           expr: |
-            (container_memory_working_set_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)", container_name!~"POD|istio-proxy"} /
-            container_spec_memory_limit_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower)", container_name!~"POD|istio-proxy"}) * 100 > 95 < +Inf
+            (container_memory_working_set_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)", container_name!~"POD|istio-proxy"} /
+            container_spec_memory_limit_bytes{container=~".*(scheduler|scheduler-gc|webserver|worker|statsd|pgbouncer|metrics-exporter|redis|flower|triggerer)", container_name!~"POD|istio-proxy"}) * 100 > 95 < +Inf
           for: 1h
           labels:
             tier: airflow

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -270,8 +270,12 @@ data:
             action: labeldrop
           # Required for multi-namespace mode
           - source_labels: [namespace]
+            {{- if .Values.global.namespaceFreeFormEntry }}
+            # use default regex pattern (.*) when namespaceFreeFormEntry is enabled
+            {{- else}}
             regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"
+            {{- end}}
             target_label: release
         {{- else}}
         # this drops node metrics that we want in the cloud, but maybe shouldn't be scraping

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -41,7 +41,7 @@ images:
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.7.1
+    tag: 0.8.0
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -21,7 +21,6 @@ def common_test_cases(docs):
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-
     airflow_local_settings = prod["deployments"]["helm"]["airflow"][
         "airflowLocalSettings"
     ]
@@ -47,6 +46,26 @@ def test_houston_configmap():
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
         assert prod["deployments"]["helm"]["sccEnabled"] is False
+
+
+def test_houston_configmap_with_namespaceFreeFormEntry_true():
+    """Validate the houston configmap's embedded data with namespaceFreeFormEntry=True."""
+
+    docs = render_chart(
+        values={"global": {"namespaceFreeFormEntry": True}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is True
+
+
+def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
+    """Validate the houston configmap's embedded data with namespaceFreeFormEntry defaults."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
 
 def test_houston_configmap_with_customlogging_enabled():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -49,7 +49,8 @@ def test_houston_configmap():
 
 
 def test_houston_configmap_with_namespaceFreeFormEntry_true():
-    """Validate the houston configmap's embedded data with namespaceFreeFormEntry=True."""
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry=True."""
 
     docs = render_chart(
         values={"global": {"namespaceFreeFormEntry": True}},
@@ -60,7 +61,8 @@ def test_houston_configmap_with_namespaceFreeFormEntry_true():
 
 
 def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
-    """Validate the houston configmap's embedded data with namespaceFreeFormEntry defaults."""
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry defaults."""
     docs = render_chart(
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -242,7 +242,8 @@ class TestPrometheusConfigConfigmap:
     def test_prometheus_config_release_relabel_with_free_from_namespace(
         self, kube_version
     ):
-        """Prometheus should not have a regex for release name when free form namespace is enabled."""
+        """Prometheus should not have a regex for release name when free form
+        namespace is enabled."""
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -2,6 +2,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 from tests import supported_k8s_versions
 import yaml
+import jmespath
 
 
 @pytest.mark.parametrize(
@@ -212,3 +213,51 @@ class TestPrometheusConfigConfigmap:
         config_yaml = yaml.safe_load(doc["data"]["config"])
         job_names = [x["job_name"] for x in config_yaml["scrape_configs"]]
         assert "node-exporter" not in job_names
+
+    def test_prometheus_config_release_relabel(self, kube_version):
+        """Prometheus should have a regex for release name."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "astronomer": {
+                    "houston": {
+                        "config": {"deployments": {"namespaceFreeFormEntry": False}},
+                    },
+                },
+            },
+        )[0]
+
+        config = yaml.safe_load(doc["data"]["config"])
+        scrape_config_search_result = jmespath.search(
+            "scrape_configs[?job_name == 'kube-state']", config
+        )
+        metric_relabel_config_search_result = jmespath.search(
+            "metric_relabel_configs[?target_label == 'release']",
+            scrape_config_search_result[0],
+        )
+        assert metric_relabel_config_search_result[0]["regex"] == "^default-(.*$)"
+        assert metric_relabel_config_search_result[0]["replacement"] == "$1"
+
+    def test_prometheus_config_release_relabel_with_free_from_namespace(
+        self, kube_version
+    ):
+        """Prometheus should not have a regex for release name when free form namespace is enabled."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "global": {"namespaceFreeFormEntry": True},
+            },
+        )[0]
+
+        config = yaml.safe_load(doc["data"]["config"])
+        scrape_config_search_result = jmespath.search(
+            "scrape_configs[?job_name == 'kube-state']", config
+        )
+        metric_relabel_config_search_result = jmespath.search(
+            "metric_relabel_configs[?target_label == 'release']",
+            scrape_config_search_result[0],
+        )
+        assert "regex" not in metric_relabel_config_search_result[0]
+        assert "replacement" not in metric_relabel_config_search_result[0]

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -6,6 +6,8 @@ global:
   customLogging:
     awsSecretName: dummy
     enabled: true
+  loggingSidecar:
+    enabled: true
   pgbouncer:
     enabled: true
   postgresqlEnabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -37,7 +37,7 @@ global:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false
         names: []
-
+  namespaceFreeFormEntry: false
   # Use kube-lego
   acme: false
 


### PR DESCRIPTION
## Description

updates to vendor images
bump ap-config-reloader 0.7.1 -> 0.8.0
bump ap-elasticsearch 7.17.5 -> 7.17.6
bump ap-kibana 7.17.5 -> 7.17.6
bump ap-fluentd image 1.15.1 -> 1.15.2

Additionally Included:
namespaceFreeForm fixes 

## Related Issues
Related to https://github.com/astronomer/issues/issues/5003 
Related to https://github.com/astronomer/issues/issues/5036
Related to https://github.com/astronomer/issues/issues/5061
Related to https://github.com/astronomer/issues/issues/5065
Related to https://github.com/astronomer/issues/issues/5066
Related to https://github.com/astronomer/issues/issues/5076
Related to https://github.com/astronomer/issues/issues/5097

## Testing



## Merging

cherrypicked to release-0.30 branch.
