### PR TITLE
cron fetch task usage data and populate audit table

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-data
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-data
@@ -1,0 +1,54 @@
+########################################
+## Houston Populate Daily Task Metrics CronJob
+########################################
+{{- if .Values.houston.populateDailyTaskMetrics.enabled }}
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: houston-populate-daily-task-metrics
+  labels:
+    tier: astronomer
+    component: houston-populate-daily-task-metrics
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: {{ .Values.houston.populateDailyTaskMetrics.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-populate-daily-task-metrics
+            release: {{ .Release.Name }}
+            app: houston-populate-daily-task-metrics
+            version: {{ .Chart.Version }}
+          {{- if .Values.global.istio.enabled }}
+          annotations:
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+        spec:
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          containers:
+            - name: populate-daily-task-metrics
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
+              args: ["yarn", "populate-daily-task-metrics", "--", "--dry-run={{ .Values.houston.populateDailyTaskMetrics.dryRun }}"]
+              volumeMounts:
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                {{- include "houston_environment" . | indent 16 }}
+          volumes:
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}
+{{- end }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
@@ -1,11 +1,11 @@
-########################################
+##############################################
 ## Houston Populate Daily Task Metrics CronJob
-########################################
-{{- if .Values.houston.populateDailyTaskMetrics.enabled }}
+##############################################
+{{- if .Values.global.taskUsageMetricsEnabled }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: houston-populate-daily-task-metrics
+  name: "{{ .Release.Name }}-houston-populate-daily-task-metrics"
   labels:
     tier: astronomer
     component: houston-populate-daily-task-metrics

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml
@@ -1,0 +1,53 @@
+########################################
+## Houston Populate Hourly Audit Task Metrics CronJob
+########################################
+{{- if .Values.global.taskUsageMetricsEnabled }}
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: "{{ .Release.Name }}-houston-populate-hourly-task-audit-metrics"
+  labels:
+    tier: astronomer
+    component: houston-populate-hourly-task-audit-metrics
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: {{ .Values.houston.populateHourlyTaskAuditMetrics.schedule }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-populate-hourly-task-audit-metrics
+            release: {{ .Release.Name }}
+            app: houston-populate-hourly-task-audit-metrics
+            version: {{ .Chart.Version }}
+          {{- if .Values.global.istio.enabled }}
+          annotations:
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+        spec:
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          containers:
+            - name: populate-daily-task-metrics
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              args: ["yarn", "populate-hourly-task-audit-metrics"]
+              volumeMounts:
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                {{- include "houston_environment" . | indent 16 }}
+          volumes:
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}
+{{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -223,8 +223,8 @@ houston:
   # Populate daily task usage data
   # This runs as a CronJob
   populateDailyTaskMetrics:
-    # Default here is to run at 01:30 every night
-    schedule: "30 1 * * *"
+    # Default here is to run at 02:30 every night
+    schedule: "30 2 * * *"
 
     # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
     dryRun: false

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -220,7 +220,20 @@ houston:
     # Default here is to run at 00:43 every night https://crontab.guru/#43_0_*_*_*
     schedule: "43 0 * * *"
 
+  # Populate daily task usage data
+  # This runs as a CronJob
+  populateDailyTaskMetrics:
+    # Enable check updates CronJob
+    enabled: true
 
+    # Default here is to run at 00:10 every night
+    schedule: "10 0 * * *"
+    
+    # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
+    dryRun: false
+  
+  # this option allows to override airflow releases config
+  #
   airflowReleasesConfig:
     # example of usage:
     # available_releases:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -223,11 +223,8 @@ houston:
   # Populate daily task usage data
   # This runs as a CronJob
   populateDailyTaskMetrics:
-    # Enable check updates CronJob
-    enabled: true
-
-    # Default here is to run at 00:10 every night
-    schedule: "10 0 * * *"
+    # Default here is to run at 01:30 every night
+    schedule: "30 1 * * *"
 
     # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
     dryRun: false

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -229,6 +229,10 @@ houston:
     # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
     dryRun: false
 
+  populateHourlyTaskAuditMetrics:
+    # Run at minute 57 every hour https://crontab.guru/#57_*_*_*_*
+    schedule: "57 * * * *"
+
   # this option allows to override airflow releases config
   #
   airflowReleasesConfig:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -228,10 +228,10 @@ houston:
 
     # Default here is to run at 00:10 every night
     schedule: "10 0 * * *"
-    
+
     # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
     dryRun: false
-  
+
   # this option allows to override airflow releases config
   #
   airflowReleasesConfig:

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -10,7 +10,6 @@ from tests import supported_k8s_versions
 )
 class TestAstronomerHoustonTaskMetricsCronjobs:
     def test_astronomer_cleanup_task_usage_cron_defaults(self, kube_version):
-        # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"taskUsageMetricsEnabled": False}},
@@ -21,7 +20,6 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert len(docs) == 0
 
     def test_astronomer_cleanup_task_usage_cron_feature_enabled(self, kube_version):
-        # First rbacEnabled set to true and namespacePools disabled, should create a ClusterRole and ClusterRoleBinding
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"taskUsageMetricsEnabled": True}},
@@ -37,6 +35,33 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
             == "release-name-houston-cleanup-task-usage-data"
         )
         assert docs[0]["spec"]["schedule"] == "40 23 * * *"
+
+    def test_astronomer_populate_daily_task_metrics_defaults(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": False}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
+    def test_astronomer_populate_daily_task_metrics_feature_enabled(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": True}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert (
+            docs[0]["metadata"]["name"]
+            == "release-name-houston-populate-daily-task-metrics"
+        )
+        assert docs[0]["spec"]["schedule"] == "30 1 * * *"
 
     def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
         """Validate the houston configmap and its embedded data with

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -9,6 +9,35 @@ from tests import supported_k8s_versions
     supported_k8s_versions,
 )
 class TestAstronomerHoustonTaskMetricsCronjobs:
+    def test_astronomer_hourly_audit_task_metrics_cron_defaults(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": False}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
+    def test_astronomer_cleanup_hourly_audit_task_metrics_cron_feature_enabled(
+        self, kube_version
+    ):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"taskUsageMetricsEnabled": True}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert (
+            docs[0]["metadata"]["name"]
+            == "release-name-houston-populate-hourly-task-audit-metrics"
+        )
+        assert docs[0]["spec"]["schedule"] == "57 * * * *"
+
     def test_astronomer_cleanup_task_usage_cron_defaults(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -61,7 +61,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
             docs[0]["metadata"]["name"]
             == "release-name-houston-populate-daily-task-metrics"
         )
-        assert docs[0]["spec"]["schedule"] == "30 1 * * *"
+        assert docs[0]["spec"]["schedule"] == "30 2 * * *"
 
     def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
         """Validate the houston configmap and its embedded data with


### PR DESCRIPTION
## Description

cron to fetch task usage data and populate audit table

## Related Issues

Related https://github.com/astronomer/issues/issues/5072

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.31
