### PR TITLE
backport loggingsidecar extra env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.19
+                - quay.io/astronomer/ap-houston-api:0.30.21
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -104,6 +104,10 @@ data:
         image: {{ .Values.global.loggingSidecar.image }}
         terminationEndpoint: {{ .Values.global.loggingSidecar.terminationEndpoint }}
         customConfig: {{ .Values.global.loggingSidecar.customConfig }}
+        {{- if .Values.global.loggingSidecar.extraEnv}}
+        extraEnv:
+{{- .Values.global.loggingSidecar.extraEnv | toYaml | nindent 8 }}
+        {{- end }}
       {{- end }}
 
       # These values get passed directly into the airflow helm deployments

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.19
+    tag: 0.30.21
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/values.yaml
+++ b/values.yaml
@@ -111,6 +111,7 @@ global:
     image: quay.io/astronomer/ap-vector:0.23.3-1
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
+    extraEnv: []
 
   # Deploy auth sidecar to use openshift native features
   authSidecar:


### PR DESCRIPTION
## Description

Ability to add env vars to logging sidecars

## Related Issues

https://github.com/astronomer/issues/issues/5106
https://github.com/astronomer/issues/issues/5095

## Testing

QA should able to pass extra env to logging sidecar and should able to validate passed env in logging sidecar

## Merging

cherry-picked to release-0.30
