### PR TITLE
disable es security settings by default

### DIFF
--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -38,6 +38,12 @@ data:
         enabled: ${HTTP_CORS_ENABLE}
         allow-origin: ${HTTP_CORS_ALLOW_ORIGIN}
 
+
+    # disable xpack security by default
+    xpack:
+      security:
+        enabled: false
+
     # Setting the ping schedule explicitly ensures that
     # tcp_keep_alive configuration does not cause components
     # to have their connections terminated.

--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -24,8 +24,7 @@ data:
       data: ${NODE_DATA}
       ingest: ${NODE_INGEST}
       max_local_storage_nodes: ${MAX_LOCAL_STORAGE_NODES}
-
-    processors: ${PROCESSORS:1}
+      processors: ${PROCESSORS:1}
 
     network.host: 0.0.0.0
 


### PR DESCRIPTION
## Description

This PR disables Elasticsearch built-in security features which are not used by astronomer. 
Additionally it suppresses the fluent warnings related to elastic build in security as well

## Related Issues

https://github.com/astronomer/issues/issues/4400

## Testing

QA should not see any warnings in fluend  similar to below
```
warning: 299 Elasticsearch-7.17.3-5ad023604c8d7416c9eb6c0eadb62b14e766caff "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."
warning: 299 Elasticsearch-7.17.3-5ad023604c8d7416c9eb6c0eadb62b14e766caff "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."
warning: 299 Elasticsearch-7.17.3-5ad023604c8d7416c9eb6c0eadb62b14e766caff "Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/security-minimal-setup.html to enable security."
```

## Merging

cherry-pick to all supported release branches
