### PR TITLE
allows loggingsidecar resource overrides

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -107,8 +107,10 @@ data:
         terminationEndpoint: {{ .Values.global.loggingSidecar.terminationEndpoint }}
         customConfig: {{ .Values.global.loggingSidecar.customConfig }}
         {{- if .Values.global.loggingSidecar.extraEnv}}
-        extraEnv:
-{{- .Values.global.loggingSidecar.extraEnv | toYaml | nindent 8 }}
+        extraEnv: {{- .Values.global.loggingSidecar.extraEnv | toYaml | nindent 8 }}
+        {{- end }}
+        {{- if .Values.global.loggingSidecar.resources}}
+        resources: {{- .Values.global.loggingSidecar.resources | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -366,6 +366,56 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
 
 
+def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    sidecar_container_name = "sidecar-log-test"
+    terminationEndpoint = "http://localhost:8000/quitquitquit"
+    image_name = "quay.io/astronomer/ap-vector:0.22.3"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "image": image_name,
+                    "resources": {
+                        "requests": {"memory": "386Mi", "cpu": "100m"},
+                        "limits": {"memory": "386Mi", "cpu": "100m"},
+                    },
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = "1> >( tee -a /var/log/{sidecar_container_name}/out.log ) 2> >( tee -a /var/log/{sidecar_container_name}/err.log >&2 )"'.format(
+        sidecar_container_name=sidecar_container_name
+    )
+    assert (
+        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    )
+    assert (
+        terminationEndpoint
+        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    )
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "terminationEndpoint": terminationEndpoint,
+        "customConfig": False,
+        "resources": {
+            "requests": {"memory": "386Mi", "cpu": "100m"},
+            "limits": {"memory": "386Mi", "cpu": "100m"},
+        },
+    }
+
+    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+
+
 cron_test_data = [
     ("development-angular-system-6091", 3),
     ("development-arithmetic-phases-5695", 3),
@@ -462,6 +512,5 @@ def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
     doc = docs[0]
 
     prod = yaml.safe_load(doc["data"]["production.yaml"])
-    print(prod)
     assert prod["updateAirflowCheckEnabled"] is False
     assert prod["updateRuntimeCheckEnabled"] is False

--- a/values.yaml
+++ b/values.yaml
@@ -117,6 +117,13 @@ global:
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []
+    resources: {}
+    #  requests:
+    #    cpu: "100m"
+    #    memory: "386Mi"
+    #  limits:
+    #    cpu: "100m"
+    #    memory: "386Mi"
 
   # Deploy auth sidecar to use openshift native features
   authSidecar:


### PR DESCRIPTION
## Description

Allow loggingsidecar resource to override the default limits from astronomer platform 

## Related Issues

https://github.com/astronomer/issues/issues/5029

## Testing

QA should able to pass custom resources to logging sidecar and able to see them on logging deployments

## Merging

cherry-pick to release-0.30.
