### PR TITLE
add cron job network policies for commander

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -71,6 +71,16 @@ spec:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-cleanup
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-populate-daily-task-metrics
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-populate-hourly-task-audit-metrics
     ports:
     - protocol: TCP
       port: {{ .Values.ports.commanderGRPC }}


### PR DESCRIPTION
## Description

add cron job network policies for commander, two new cron jobs were unable to communicate with commander we forgot to add the network policies 

## Related Issues

Related https://github.com/astronomer/issues/issues/5118
## Testing

will be tested in dev

## Merging

0.31