### PR TITLE
add cron jobs to registry network policy

### DIFF
--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -72,10 +72,10 @@ spec:
           component: houston-worker
           release: {{ .Release.Name }}
     - podSelector:
-      matchLabels:
-        tier: astronomer
-        release: {{ .Release.Name }}
-        component: houston-populate-daily-task-metrics
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-populate-daily-task-metrics
     - podSelector:
         matchLabels:
           tier: astronomer

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -71,11 +71,11 @@ spec:
           tier: astronomer
           component: houston-worker
           release: {{ .Release.Name }}
-      - podSelector:
-        matchLabels:
-          tier: astronomer
-          release: {{ .Release.Name }}
-          component: houston-populate-daily-task-metrics
+    - podSelector:
+      matchLabels:
+        tier: astronomer
+        release: {{ .Release.Name }}
+        component: houston-populate-daily-task-metrics
     - podSelector:
         matchLabels:
           tier: astronomer

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -71,6 +71,16 @@ spec:
           tier: astronomer
           component: houston-worker
           release: {{ .Release.Name }}
+      - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-populate-daily-task-metrics
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-populate-hourly-task-audit-metrics
     {{- if .Values.global.authSidecar.enabled  }}
     - namespaceSelector:
         matchLabels:


### PR DESCRIPTION
## Description

add cron job network policies for registry, two new cron jobs were unable to communicate with registry we forgot to add the network policies 

## Related Issues

Related https://github.com/astronomer/issues/issues/5118
## Testing

will be tested in dev

## Merging

0.31