### PR TITLE
release-0.30 update houston api image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.21
+                - quay.io/astronomer/ap-houston-api:0.30.22
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.21
+    tag: 0.30.22
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION


## Description

Bump 0.30.21 -> 0.30.22

Includes pgbouncer extraIni support, option to disable introspection api queries and finally block arm images

## Related Issues

https://github.com/astronomer/issues/issues/5032
https://github.com/astronomer/issues/issues/5044
https://github.com/astronomer/issues/issues/4894

## Testing

QA should validate based on linked issues

## Merging

merge to release-0.30
