### PR TITLE
release-0.30 backport  components fix for astro-ui and houston images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
-                - quay.io/astronomer/ap-astro-ui:0.30.6
+                - quay.io/astronomer/ap-astro-ui:0.30.7
                 - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-8
                 - quay.io/astronomer/ap-base:3.16.2-1
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.22
+                - quay.io/astronomer/ap-houston-api:0.30.23
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.30.3-rc1
-appVersion: 0.30.3-rc1
+version: 0.30.3-rc2
+appVersion: 0.30.3-rc2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.30.3-rc1
+version: 0.30.3-rc2
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.22
+    tag: 0.30.23
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.30.6
+    tag: 0.30.7
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION


## Description

* bump ap-astro-ui 0.30.6 -> 0.30.7
* bump ap-houston-api 0.30.22 -> 0.30.23


## Related Issues

Related https://github.com/astronomer/issues/issues/4954

## Testing

QA should able to override components defaults

## Merging

cherry-pick to release-0.30 .
