### PR TITLE
release-0.30 ap-houston-api:0.30.24

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.23
+                - quay.io/astronomer/ap-houston-api:0.30.24
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.23
+    tag: 0.30.24
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION


## Description

* bump ap-houston-api 0.30.23 -> 0.30.24

## Related Issues

https://github.com/astronomer/issues/issues/5144

## Testing

QA should able to customize runtime min airflow version and runtime version 

```
    config:
      deployments:
        minAstroRuntimeVersion: 4.2.1
        airflowMinimumAstroRuntimeVersion: 2.2.4
```     

## Merging

cherry-pick to release-0.30 .
