### PR TITLE
update commander and airflow chart version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,7 +290,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
                 - quay.io/astronomer/ap-cli-install:0.26.8
-                - quay.io/astronomer/ap-commander:0.30.4
+                - quay.io/astronomer/ap-commander:0.30.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.30.3-rc2
-appVersion: 0.30.3-rc2
+version: 0.30.3-rc3
+appVersion: 0.30.3-rc3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.30.3-rc2
+version: 0.30.3-rc3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.0
+airflowChartVersion: 1.7.1
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.30.4
+    tag: 0.30.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION


## Description

bump ap-commander 0.30.4 -> 0.30.5
airflowChartVersion 1.7.0 -> 1.7.1

## Related Issues

https://github.com/astronomer/issues/issues/5065

## Testing

QA should able to deploy airflow and pgbouncer services should function normally

## Merging

cherry-pick to release-0.30.
