### PR TITLE
allow updates url to be added as env vars to houston

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -226,6 +226,16 @@ s3:
   value: {{ template "houston.nats.servers" . }}
 - name: NATS__CLUSTER_ID
   value: {{ .Release.Name }}-stan
+{{- if .Values.houston.updateAirflowCheck.enabled }}
+- name: HOUSTON_SCRIPT_UPDATE_SERVICE_URL
+  value: {{ .Values.houston.updateAirflowCheck.url }}
+{{- end }}
+
+{{- if .Values.houston.updateRuntimeCheck.enabled }}
+- name: HOUSTON_SCRIPT_UPDATE_RUNTIME_SERVICE_URL
+  value: {{ .Values.houston.updateRuntimeCheck.url }}
+{{- end }}
+
 {{- end }}
 
 {{- define "houston_volume_mounts" }}

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -134,3 +134,80 @@ class TestHoustonApiDeployment:
             jmespath.search("spec.template.spec.imagePullSecrets[0].name", docs[0])
             == secretName
         )
+
+    def test_houston_api_deployment_with_updates_url_enabled(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateRuntimeCheck": {"enabled": True},
+                        "updateAirflowCheck": {"enabled": True},
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc, include_init_containers=False)
+        houston_env = c_by_name["houston"]["env"]
+        expected_runtime_env = {
+            "name": "HOUSTON_SCRIPT_UPDATE_RUNTIME_SERVICE_URL",
+            "value": "https://updates.astronomer.io/astronomer-runtime",
+        }
+        assert expected_runtime_env in houston_env
+
+        expected_airflow_env = {
+            "name": "HOUSTON_SCRIPT_UPDATE_SERVICE_URL",
+            "value": "https://updates.astronomer.io/astronomer-certified",
+        }
+
+        assert expected_airflow_env in houston_env
+
+    def test_houston_api_deployment_with_updates_url_overrides(self, kube_version):
+        CUSTOM_RUNTIME_URL = "https://test.me.io/astronomer-runtime"
+        CUSTOM_CERTIFIED_URL = "https://test.me.io/astronomer-certified"
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateAirflowCheck": {
+                            "enabled": True,
+                            "url": CUSTOM_CERTIFIED_URL,
+                        },
+                        "updateRuntimeCheck": {
+                            "enabled": True,
+                            "url": CUSTOM_RUNTIME_URL,
+                        },
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc, include_init_containers=False)
+        houston_env = c_by_name["houston"]["env"]
+
+        expected_runtime_env = {
+            "name": "HOUSTON_SCRIPT_UPDATE_RUNTIME_SERVICE_URL",
+            "value": CUSTOM_RUNTIME_URL,
+        }
+        assert expected_runtime_env in houston_env
+
+        expected_airflow_env = {
+            "name": "HOUSTON_SCRIPT_UPDATE_SERVICE_URL",
+            "value": CUSTOM_CERTIFIED_URL,
+        }
+
+        assert expected_airflow_env in houston_env


### PR DESCRIPTION
## Description

Allow updates url for runtime and certified to be passed to env vars.
This resolves an issue where customer/user to add url separately as env vars to houston pods

## Related Issues

https://github.com/astronomer/issues/issues/5127

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
