### PR TITLE
allow cronjob to talk to houston

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -35,6 +35,11 @@ spec:
     {{- end }}
     - podSelector:
         matchLabels:
+          tier: astronomer
+          component: houston-populate-hourly-task-audit-metrics
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
           tier: monitoring
           component: prometheus
           release: {{ .Release.Name }}


### PR DESCRIPTION
## Description

allow for houston-populate-hourly-task-audit-metrics to be able to talk to housotn

## Related Issues

N/A

## Testing

tested in dev

## Merging

release-0.31
