### PR TITLE
update nginx base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,16 +285,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.30.3
-                - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
+                - quay.io/astronomer/ap-auth-sidecar:1.23.2
                 - quay.io/astronomer/ap-awsesproxy:1.3-8
                 - quay.io/astronomer/ap-base:3.16.2-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0
-                - quay.io/astronomer/ap-cli-install:0.26.8
+                - quay.io/astronomer/ap-cli-install:0.26.9
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-19
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
-                - quay.io/astronomer/ap-default-backend:0.28.9
+                - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
@@ -305,7 +305,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-1
                 - quay.io/astronomer/ap-nats-server:2.8.1-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-3
-                - quay.io/astronomer/ap-nginx-es:1.23.1-1
+                - quay.io/astronomer/ap-nginx-es:1.23.2
                 - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.21.4-2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.8
+    tag: 0.26.9
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.1-1
+    tag: 1.23.2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.9
+    tag: 0.28.10
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/values.yaml
+++ b/values.yaml
@@ -129,7 +129,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.1-1
+    tag: 1.23.2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION


## Description

* bump ap-nginx-es 1.23.1-1 -> 1.23.2
* bump ap-default-backend 0.28.9 ->  0.28.10
* bump ap-auth-sidecar 1.23.1-1 -> 1.23.2

## Related Issues

https://github.com/astronomer/issues/issues/5174

## Testing

NA

## Merging

cherry-pick to all valid release branches
