### PR TITLE
Skip externalTrafficPolicy when using ClusterIP

### DIFF
--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -41,7 +41,7 @@ spec:
   {{- if .Values.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ .Values.loadBalancerSourceRanges | toJson }}
   {{- end }}
-  {{- if .Values.preserveSourceIP }}
+  {{- if or (.Values.preserveSourceIP) (eq .Values.serviceType "ClusterIP") }}
   externalTrafficPolicy: "Local"
   {{- else }}
   externalTrafficPolicy: "Cluster"

--- a/charts/nginx/templates/nginx-service.yaml
+++ b/charts/nginx/templates/nginx-service.yaml
@@ -41,10 +41,12 @@ spec:
   {{- if .Values.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{ .Values.loadBalancerSourceRanges | toJson }}
   {{- end }}
-  {{- if or (.Values.preserveSourceIP) (eq .Values.serviceType "ClusterIP") }}
+  {{- if not (eq .Values.serviceType "ClusterIP") }}
+  {{- if (.Values.preserveSourceIP) }}
   externalTrafficPolicy: "Local"
   {{- else }}
   externalTrafficPolicy: "Cluster"
+  {{- end }}
   {{- end }}
   selector:
     tier: {{ template "nginx.name" . }}

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -19,16 +19,27 @@ class TestNginx:
         assert "loadBalancerSourceRanges" not in doc["spec"]
 
     @pytest.mark.parametrize(
-        "service_type,external_traffic_policy",
+        "service_type,external_traffic_policy,preserve_source_ip",
         [
-            ("ClusterIP", "Local"),
-            ("NodePort", "Cluster"),
-            ("LoadBalancer", "Cluster"),
-            ("ExternalName", "Cluster"),
+            ("ClusterIP", "Local", False),
+            ("NodePort", "Cluster", False),
+            ("LoadBalancer", "Cluster", False),
+            ("ExternalName", "Cluster", False),
+            ("ClusterIP", "Local", True),
+            ("NodePort", "Local", True),
+            ("LoadBalancer", "Local", True),
+            ("ExternalName", "Local", True),
         ],
     )
-    def test_nginx_service_servicetype(self, service_type, external_traffic_policy):
-        values = {"nginx": {"serviceType": service_type}}
+    def test_nginx_service_servicetype(
+        self, service_type, external_traffic_policy, preserve_source_ip
+    ):
+        values = {
+            "nginx": {
+                "serviceType": service_type,
+                "preserveSourceIP": preserve_source_ip,
+            }
+        }
         doc = render_chart(
             values=values,
             show_only=["charts/nginx/templates/nginx-service.yaml"],

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -1,4 +1,5 @@
 from tests.chart_tests.helm_template_generator import render_chart
+import pytest
 
 
 class TestNginx:
@@ -16,6 +17,24 @@ class TestNginx:
         assert doc["metadata"]["name"] == "release-name-nginx"
         assert "loadBalancerIP" not in doc["spec"]
         assert "loadBalancerSourceRanges" not in doc["spec"]
+
+    @pytest.mark.parametrize(
+        "service_type,external_traffic_policy",
+        [
+            ("ClusterIP", "Local"),
+            ("NodePort", "Cluster"),
+            ("LoadBalancer", "Cluster"),
+            ("ExternalName", "Cluster"),
+        ],
+    )
+    def test_nginx_service_servicetype(self, service_type, external_traffic_policy):
+        values = {"nginx": {"serviceType": service_type}}
+        doc = render_chart(
+            values=values,
+            show_only=["charts/nginx/templates/nginx-service.yaml"],
+        )[0]
+        assert doc["spec"]["type"] == service_type
+        assert doc["spec"]["externalTrafficPolicy"] == external_traffic_policy
 
     def test_nginx_with_ingress_annotations(self):
         """Deployment should contain the given ingress annotations when they

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -21,11 +21,11 @@ class TestNginx:
     @pytest.mark.parametrize(
         "service_type,external_traffic_policy,preserve_source_ip",
         [
-            ("ClusterIP", "Local", False),
+            ("ClusterIP", None, False),
             ("NodePort", "Cluster", False),
             ("LoadBalancer", "Cluster", False),
             ("ExternalName", "Cluster", False),
-            ("ClusterIP", "Local", True),
+            ("ClusterIP", None, True),
             ("NodePort", "Local", True),
             ("LoadBalancer", "Local", True),
             ("ExternalName", "Local", True),
@@ -34,6 +34,12 @@ class TestNginx:
     def test_nginx_service_servicetype(
         self, service_type, external_traffic_policy, preserve_source_ip
     ):
+        """Verify that ClusterIP never has an externalTrafficPolicy, and other
+        configurations are correct according to spec.
+
+        More details and links about this behavior linked in PR
+        https://github.com/astronomer/astronomer/pull/1726
+        """
         values = {
             "nginx": {
                 "serviceType": service_type,
@@ -45,7 +51,7 @@ class TestNginx:
             show_only=["charts/nginx/templates/nginx-service.yaml"],
         )[0]
         assert doc["spec"]["type"] == service_type
-        assert doc["spec"]["externalTrafficPolicy"] == external_traffic_policy
+        assert doc["spec"].get("externalTrafficPolicy") == external_traffic_policy
 
     def test_nginx_with_ingress_annotations(self):
         """Deployment should contain the given ingress annotations when they


### PR DESCRIPTION
## Description

In #1052 we merged a change that was mostly good, but had one edge case that was broken, which is that when the serviceType is ClusterIP, there can be no externalTrafficPolicy.

## Related Issues

- Internal ticket describing the core problem being fixed here: <https://github.com/astronomer/issues/issues/4991>
- Original PR where the change that caused this problem was made: <https://github.com/astronomer/astronomer/pull/1052>

## Testing

I've added tests for the new code change as well as previously untested configuration combinations.

## Merging

The original problem showed up in 0.29.2, so this should be merged to 0.29, 0.30, 0.31.

## More details

- <https://kubernetes.io/docs/concepts/services-networking/service/#external-traffic-policy>
- <https://www.asykim.com/blog/deep-dive-into-kubernetes-external-traffic-policies>