### PR TITLE
limit public access to houston v1 metrics endpoint

### DIFF
--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/v1/(registry\/events|alerts|elasticsearch/metrics) {
+      location ~ ^/v1/(registry\/events|alerts|elasticsearch|metrics) {
         deny all;
         return 403;
       }

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/v1/(registry\/events|alerts|elasticsearch) {
+      location ~ ^/v1/(registry\/events|alerts|elasticsearch/metrics) {
         deny all;
         return 403;
       }

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -66,7 +66,7 @@ class TestIngress:
         annotations = jmespath.search("metadata.annotations", doc)
         assert (
             annotations["nginx.ingress.kubernetes.io/configuration-snippet"]
-            == r"""location ~ ^/v1/(registry\/events|alerts|elasticsearch) {
+            == r"""location ~ ^/v1/(registry\/events|alerts|elasticsearch|metrics) {
   deny all;
   return 403;
 }


### PR DESCRIPTION
## Description

currently we expose houston v1 metrics endpoint to identify the status of houston pod and generate alerts. This was available publically as well, this change now restricts public access since all those were consumed using internal service url

## Related Issues

https://github.com/astronomer/issues/issues/5187

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
