### PR TITLE
5182 test cronjob name len 

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-task-audit-metrics.yaml
@@ -5,7 +5,7 @@
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: "{{ .Release.Name }}-houston-populate-hourly-task-audit-metrics"
+  name: "{{ .Release.Name }}-houston-populate-hourly-ta-metrics"
   labels:
     tier: astronomer
     component: houston-populate-hourly-task-audit-metrics

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -85,7 +85,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert docs[0]["kind"] == "CronJob"
         assert (
             docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-hourly-task-audit-metrics"
+            == "release-name-houston-populate-hourly-ta-metrics"
         )
         assert docs[0]["spec"]["schedule"] == "57 * * * *"
 
@@ -111,7 +111,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert docs[0]["kind"] == "CronJob"
         assert (
             docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-hourly-task-audit-metrics"
+            == "release-name-houston-populate-hourly-ta-metrics"
         )
         assert docs[0]["spec"]["schedule"] == "90 * * * *"
 

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -12,6 +12,23 @@ annotation_validator = re.compile(
 pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 
 
+class TestAllCronJobs:
+    chart_values = chart_tests.get_all_features()
+
+    def test_ensure_cronjob_names_are_max_52_chars(self):
+        """Cronjob names must be DNS_MAX_LEN - TIMESTAMP_LEN, which is 52 chars."""
+        default_docs = render_chart(values=self.chart_values)
+        cronjobs = [
+            doc for doc in default_docs if doc["kind"].lower() == "CronJob".lower()
+        ]
+
+        for doc in cronjobs:
+            name_len = len(doc["metadata"]["name"])
+            assert (
+                name_len <= 52
+            ), f'{doc["metadata"]["name"]} is too long at {name_len} characters'
+
+
 class TestAllPodSpecContainers:
     """Test pod spec containers for some defaults."""
 

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -13,4 +13,5 @@ global:
   postgresqlEnabled: true
   prometheusPostgresExporterEnabled: true
   pspEnabled: true
+  taskUsageMetricsEnabled: True
   veleroEnabled: true


### PR DESCRIPTION
## Description

change name for hourly audit log as it was too long and daniel added a test for testing it 

## Related Issues

https://github.com/astronomer/issues/issues/5182

## Testing

pipeline tests

## Merging

0.31/ main