### PR TITLE
fixUpdateRootAdminJob pull password from secret instead of random

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -57,7 +57,10 @@ spec:
                       name: astronomer-root-admin-credentials
                       key: username
                 - name: ROOT_ADMIN_PASSWORD
-                  value: {{ randAlphaNum 20 | b64enc | quote }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: astronomer-root-admin-credentials
+                      key: password
               command: ["yarn"]
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["update-root-admin-password", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]


### PR DESCRIPTION
## Description

Instead of generating a random password we need to pull the password from the k8s secrets.

## Related Issues

astronomer/issues#5185
## Testing

trying to test in dev

## Merging

0.31