### PR TITLE
update ap-base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,13 +272,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.31.1
                 - quay.io/astronomer/ap-auth-sidecar:1.23.2
-                - quay.io/astronomer/ap-awsesproxy:1.3-8
-                - quay.io/astronomer/ap-base:3.16.2-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.22.0
+                - quay.io/astronomer/ap-awsesproxy:1.3-9
+                - quay.io/astronomer/ap-base:3.16.2-4
+                - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.9
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:5.8.4-19
+                - quay.io/astronomer/ap-curator:5.8.4-21
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
@@ -288,18 +288,18 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.31.4
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-1
-                - quay.io/astronomer/ap-nats-server:2.8.1-3
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-3
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-2
+                - quay.io/astronomer/ap-nats-server:2.8.1-4
+                - quay.io/astronomer/ap-nats-streaming:0.24.5-4
                 - quay.io/astronomer/ap-nginx-es:1.23.2
                 - quay.io/astronomer/ap-nginx:1.3.1-1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.21.4-2
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-3
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.1
-                - quay.io/astronomer/ap-registry:3.16.2-1
+                - quay.io/astronomer/ap-registry:3.16.2-4
                 - quay.io/astronomer/ap-vector:0.23.3-1
           context:
             - slack_team-software-infra-bot

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2-1
+    tag: 3.16.2-4
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2-1
+    tag: 3.16.2-4
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-19
+    tag: 5.8.4-21
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-8
+    tag: 1.3-9
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-3
+    tag: 2.8.1-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-1
+    tag: 0.10.0-2
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-3
+  tag: 1.17.0-4
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.22.0
+  tag: 0.22.0-1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-base
-    tag: 3.16.2-1
+    tag: 3.16.2-4
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-3
+    tag: 0.24.5-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-1
+    tag: 0.10.0-2
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

image | old | new
-- | -- | --
ap-awsesproxy  |  1.3-8 | 1.3-9
ap-base | 3.16.2-1   |3.16.2-4
ap-blackbox-exporter | 0.22.0 | 0.22.0-1
ap-curator | 5.8.4-19 | 5.8.4-21
ap-nats-exporter | 0.10.0-1 | 0.10.0-2
ap-nats-server | 2.8.1-3 | 2.8.1-4
ap-nats-streaming | 0.24.5-3 | 0.24.5-4
ap-pgbouncer-krb | 1.17.0-3 | 1.17.0-4
ap-registry | 3.16.2-1 | 3.16.2-4


## Related Issues

https://github.com/astronomer/issues/issues/5189

## Testing

None of the updates here are huge, so testing should only involve looking to see if the components continue to work.

## Merging

cherry-pick to all valid release branches
