### PR TITLE
Use new ap-init image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,6 +286,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
                 - quay.io/astronomer/ap-houston-api:0.31.4
+                - quay.io/astronomer/ap-init:3.16.2-4
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -13,7 +13,7 @@ images:
     tag: 7.17.6
     pullPolicy: IfNotPresent
   init:
-    repository: quay.io/astronomer/ap-base
+    repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
     tag: 3.16.2-4
     pullPolicy: IfNotPresent
   curator:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -5,7 +5,7 @@
 ##################################
 images:
   init:
-    repository: quay.io/astronomer/ap-base
+    repository: quay.io/astronomer/ap-init
     tag: 3.16.2-4
     pullPolicy: IfNotPresent
   stan:


### PR DESCRIPTION
## Description

Use the new ap-init image for stan initContainer in order to avoid running as root user.

## Related Issues

- https://github.com/astronomer/issues/issues/5150
- https://github.com/astronomer/ap-vendor/pull/440 blocked by this merge. once 440 is is merged we should re-run tests here.

## Testing

Stan should come up and run normally. This should be covered by CI testing, so no manual testing is needed.

## Merging

Merge to all supported branches.
