### PR TITLE
4927 double commander memory resources

### DIFF
--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -1,7 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import supported_k8s_versions
-import jmespath
+from tests import supported_k8s_versions, get_containers_by_name
 
 
 @pytest.mark.parametrize(
@@ -9,7 +8,7 @@ import jmespath
     supported_k8s_versions,
 )
 class TestAstronomerCommander:
-    def test_astronomer_commander_deployment(self, kube_version):
+    def test_astronomer_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for
         astronomer/commander."""
         docs = render_chart(
@@ -24,17 +23,14 @@ class TestAstronomerCommander:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-commander"
-        assert any(
-            image_name.startswith("quay.io/astronomer/ap-commander:")
-            for image_name in jmespath.search(
-                "spec.template.spec.containers[*].image", doc
-            )
+        c_by_name = get_containers_by_name(doc)
+        assert len(c_by_name) == 1
+        assert c_by_name["commander"]["image"].startswith(
+            "quay.io/astronomer/ap-commander:"
         )
-        assert len(doc["spec"]["template"]["spec"]["containers"]) == 1
-        env_vars = {
-            x["name"]: x["value"]
-            for x in doc["spec"]["template"]["spec"]["containers"][0]["env"]
-        }
+        assert c_by_name["commander"]["resources"]["limits"]["memory"] == "4Gi"
+        assert c_by_name["commander"]["resources"]["requests"]["memory"] == "2Gi"
+        env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "300"
 
     def test_astronomer_commander_deployment_upgrade_timeout(self, kube_version):
@@ -56,18 +52,13 @@ class TestAstronomerCommander:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-commander"
-        assert any(
-            image_name.startswith("quay.io/astronomer/ap-commander:")
-            for image_name in jmespath.search(
-                "spec.template.spec.containers[*].image", doc
-            )
+        c_by_name = get_containers_by_name(doc)
+        assert len(c_by_name) == 1
+        assert c_by_name["commander"]["image"].startswith(
+            "quay.io/astronomer/ap-commander:"
         )
 
-        assert len(doc["spec"]["template"]["spec"]["containers"]) == 1
-        env_vars = {
-            x["name"]: x["value"]
-            for x in doc["spec"]["template"]["spec"]["containers"][0]["env"]
-        }
+        env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
 
     def test_astronomer_commander_rbac_cluster_role_enabled(self, kube_version):

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -28,8 +28,8 @@ class TestAstronomerCommander:
         assert c_by_name["commander"]["image"].startswith(
             "quay.io/astronomer/ap-commander:"
         )
-        assert c_by_name["commander"]["resources"]["limits"]["memory"] == "4Gi"
-        assert c_by_name["commander"]["resources"]["requests"]["memory"] == "2Gi"
+        assert c_by_name["commander"]["resources"]["limits"]["memory"] == "2Gi"
+        assert c_by_name["commander"]["resources"]["requests"]["memory"] == "1Gi"
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "300"
 

--- a/values.yaml
+++ b/values.yaml
@@ -307,10 +307,10 @@ astronomer:
     resources:
       requests:
         cpu: "250m"
-        memory: "2Gi"
+        memory: "1Gi"
       limits:
         cpu: "500m"
-        memory: "4Gi"
+        memory: "2Gi"
 
   registry:
     resources:

--- a/values.yaml
+++ b/values.yaml
@@ -307,10 +307,10 @@ astronomer:
     resources:
       requests:
         cpu: "250m"
-        memory: "512Mi"
+        memory: "2Gi"
       limits:
         cpu: "500m"
-        memory: "1024Mi"
+        memory: "4Gi"
 
   registry:
     resources:


### PR DESCRIPTION
## Description

Increase commander resources. Refactor some tests.

## Related Issues

- https://github.com/astronomer/issues/issues/4927

## Testing

Most of these changes are test changes. The others are deployed to prod, with the exception that the memory limit isn't increased quite as much here. Looking at the past month, the highest we got was just above 4GB total memory usage for the entire deployment, with each individual pod not going over 2Gi. With that in mind, no manual testing is needed here. The only time we'd get near the new limit is under severely strained circumstances.

## Merging

This should be merged into all supported branches.