### PR TITLE
update vendor images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.30.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-21
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.11
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.13
                 - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,11 +295,11 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.23.2
                 - quay.io/astronomer/ap-nginx:1.3.1-1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
-                - quay.io/astronomer/ap-openresty:1.21.4-2
+                - quay.io/astronomer/ap-openresty:1.21.4-3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.15.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.1
+                - quay.io/astronomer/ap-prometheus:2.37.2
                 - quay.io/astronomer/ap-registry:3.16.2-4
                 - quay.io/astronomer/ap-vector:0.23.3-1
           context:

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -5,3 +5,5 @@ CVE-2022-27191
 CVE-2022-1996
 # golang.org/x/net CVE
 CVE-2022-27664
+# golang.org/x/text
+CVE-2022-32149

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.11
+    tag: 0.26.13
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-2
+    tag: 1.21.4-3
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.11
+    tag: 0.26.13
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.1
+    tag: 2.37.2
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader


### PR DESCRIPTION

## Description

* bump ap-db-bootstrapper 0.26.11 -> 0.26.13
* bump ap-prometheus 2.37.1 -> 2.37.2

## Related Issues

NA

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to all valid release branches.
