### PR TITLE
update postgres version 11.15.0-1 -> 11.17.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.21.4-3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.15.0-1
+                - quay.io/astronomer/ap-postgresql:11.17.0
                 - quay.io/astronomer/ap-prometheus:2.37.2
                 - quay.io/astronomer/ap-registry:3.16.2-4
                 - quay.io/astronomer/ap-vector:0.23.3-1

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.15.0-1
+  tag: 11.17.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION


## Description

* moving to next minor version 11.15.0 -> 11.17.0

Note: A dump/restore is not required for those running 11.X.

## Related Issues

https://github.com/astronomer/issues/issues/5101

## Testing

QA should able to run astronomer platform without any issues after upgrade

## Merging

cherry-pick to all valid release branches.
