### PR TITLE
update vector service image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.17.0
                 - quay.io/astronomer/ap-prometheus:2.37.2
                 - quay.io/astronomer/ap-registry:3.16.2-4
-                - quay.io/astronomer/ap-vector:0.23.3-1
+                - quay.io/astronomer/ap-vector:0.24.1-1
           context:
             - slack_team-software-infra-bot
 

--- a/values.yaml
+++ b/values.yaml
@@ -113,7 +113,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.23.3-1
+    image: quay.io/astronomer/ap-vector:0.24.1-1
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION

## Description

* bump 0.23.3-1  -> 0.24.1-1
* resolves libexpat1  CVE-2022-43680 

## Related Issues

https://github.com/astronomer/issues/issues/5203

## Testing

QA should validate the sidecar logging feature log 

## Merging

cherry-pick to release-0.30,0.31.
