### PR TITLE
Add CircleCI info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ parameters:
 jobs:
   trivy-scan-docker:
     docker:
-      - image: docker:20.10.14-git
+      - image: docker:20.10.18-git
     shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
@@ -31,7 +31,7 @@ jobs:
       BASH_ENV: /etc/profile
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.18
       - checkout
       - run:
           name: Pull Docker image
@@ -106,7 +106,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.14
+          version: 20.10.18
       - checkout
       - run:
           name: Create chart-tests-cache-key.txt
@@ -151,7 +151,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2204:2022.10.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: ubuntu-2204:2022.10.2
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -161,12 +161,11 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.10.5
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   release-to-public:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -176,13 +175,12 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.10.5
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 
   platform-1-21-14:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.21.14
@@ -198,7 +196,7 @@ jobs:
           when: always
   platform-1-22-15:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.22.15
@@ -214,7 +212,7 @@ jobs:
           when: always
   platform-1-23-13:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.23.13
@@ -230,7 +228,7 @@ jobs:
           when: always
   platform-1-24-7:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:2022.10.2
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.24.7
@@ -251,7 +249,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.14
+          version: 20.10.18
       - run:
           name: Check that commander image uses same Airflow chart version
           command: make validate-commander-airflow-version
@@ -386,7 +384,7 @@ commands:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.14
+          version: 20.10.18
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -440,7 +438,7 @@ commands:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.14
+          version: 20.10.18
       - run:
           name: Build the Docker image
           command: |
@@ -490,7 +488,6 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-            pyenv global 3.10.5
             pip install astronomer_e2e_test
             astronomer-ci publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1
 

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -149,7 +149,7 @@ jobs:
 
   release-to-internal:
     machine:
-      image: ubuntu-2204:2022.10.2 # https://circleci.com/developer/machine/image/ubuntu-2204
+      image: {{ machine_image_version }}
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -159,12 +159,11 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.10.5
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   release-to-public:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: {{ machine_image_version }}
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -174,13 +173,12 @@ jobs:
           command: |
             set -e
             sudo apt-get update && sudo apt-get install -y ca-certificates curl
-            pyenv global 3.10.5
             bin/release-helm-chart -p /tmp/workspace/astronomer-*.tgz
       - publish-github-release
 {% for version in kube_versions %}
   platform-{{ version | replace(".", "-") }}:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: {{ machine_image_version }}
       resource_class: xlarge
     environment:
       KUBE_VERSION: v{{ version }}
@@ -406,7 +404,6 @@ commands:
           name: Create a release on GitHub
           command: |
             set -xe
-            pyenv global 3.10.5
             pip install astronomer_e2e_test
             astronomer-ci publish-github-release --github-repository $CIRCLE_PROJECT_REPONAME --github-organization $CIRCLE_PROJECT_USERNAME --commitish $CIRCLE_SHA1
 

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -9,11 +9,18 @@ from jinja2 import Template
 
 # When adding a new version, look up the most
 # recent patch version on Dockerhub
-# https://hub.docker.com/r/kindest/node/tags
 # This should match what is in tests/__init__.py
-KUBE_VERSIONS = ["1.21.14", "1.22.15", "1.23.13", "1.24.7"]
+# https://hub.docker.com/r/kindest/node/tags
+kube_versions = [
+    "1.21.14",
+    "1.22.15",
+    "1.23.13",
+    "1.24.7",
+]
 # https://circleci.com/docs/2.0/building-docker-images/#docker-version
-CI_REMOTE_DOCKER_VERSION = "20.10.14"
+ci_remote_docker_version = "20.10.18"
+# https://circleci.com/developer/machine/image/ubuntu-2204
+machine_image_version = "ubuntu-2204:2022.10.2"
 
 
 def list_docker_images(path):
@@ -36,9 +43,10 @@ def main():
     templated_file_content = Path(config_template_path).read_text()
     template = Template(templated_file_content)
     config = template.render(
-        kube_versions=KUBE_VERSIONS,
+        kube_versions=kube_versions,
         docker_images=docker_images,
-        remote_docker_version=CI_REMOTE_DOCKER_VERSION,
+        machine_image_version=machine_image_version,
+        remote_docker_version=ci_remote_docker_version,
     )
     with open(config_path, "w") as circle_ci_config_file:
         warning_header = (

--- a/bin/repo-state-report.sh
+++ b/bin/repo-state-report.sh
@@ -5,9 +5,20 @@ GIT_ORIGIN=$(git config --get remote.origin.url)
 GIT_SHA=$(git rev-parse HEAD)$(if [[ -n "$(git status --porcelain)" ]] ; then echo " DIRTY" ; fi)
 BUILD_DATE_ISO8601=$(date +%FT%T%z)
 
-cat <<EOF
-Git repo:   ${GIT_ORIGIN}
-Git branch: ${GIT_BRANCH}
-Git SHA:    ${GIT_SHA}
-Build time: ${BUILD_DATE_ISO8601}
-EOF
+output=(
+    "Build time:  ${BUILD_DATE_ISO8601}"
+    "Git repo:    ${GIT_ORIGIN}"
+    "Git branch:  ${GIT_BRANCH}"
+    "Git SHA:     ${GIT_SHA}"
+)
+
+[[ -n "${CIRCLE_BUILD_URL}" ]] && output+=( "CircleCI Build URL:       ${CIRCLE_BUILD_URL}" )
+[[ -n "${CIRCLE_BUILD_NUM}" ]] && output+=( "CircleCI Build Number:    ${CIRCLE_BUILD_NUM}" )
+[[ -n "${CIRCLE_REPOSITORY_URL}" ]] && output+=( "CircleCI Repository URL:  ${CIRCLE_REPOSITORY_URL}" )
+[[ -n "${CIRCLE_SHA1}" ]] && output+=( "CircleCI SHA1:            ${CIRCLE_SHA1}" )
+[[ -n "${CIRCLE_WORKFLOW_ID}" ]] && output+=( "CircleCI Workflow ID:     ${CIRCLE_WORKFLOW_ID}" )
+[[ -n "${CIRCLE_JOB}" ]] && output+=( "CircleCI Job:             ${CIRCLE_JOB}" )
+
+for item in "${output[@]}" ; do
+    echo "$item"
+done


### PR DESCRIPTION
## Description

- Improve the helm repo state script by adding CircleCI information.
- Templatize the machine image version and use the latest version everywhere
- Bump docker minor version to 20.10.18
- Stop using pyenv since we're well past python2

## Related Issues

https://github.com/astronomer/issues/issues/5152

## Testing

```
$ helm pull astronomer-internal/astronomer --version 0.31.0-rc3-build67164
$ tar -xzf astronomer-0.31.0-rc3-build67164.tgz
$ cat astronomer/repo_state.log
Build time:  2022-11-14T23:53:53+0000
Git repo:    git@github.com:astronomer/astronomer.git
Git branch:  5152-improve-repo-state-report
Git SHA:     1d298135e30a2e8cfa9843deb15de8a31ca97b81
CircleCI Build URL:       https://circleci.com/gh/astronomer/astronomer/67164
CircleCI Build Number:    67164
CircleCI Repository URL:  git@github.com:astronomer/astronomer.git
CircleCI SHA1:            1d298135e30a2e8cfa9843deb15de8a31ca97b81
CircleCI Workflow ID:     792cfe84-a083-40a1-904f-0b6128b3cbe1
CircleCI Job:             build-artifact
```

## Merging

This should be merged to all supported branches.