### PR TITLE
Remove the ability for a user to change root admin username

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.31.5
+                - quay.io/astronomer/ap-houston-api:0.31.6
                 - quay.io/astronomer/ap-init:3.16.2-4
                 - quay.io/astronomer/ap-kibana:7.17.6
                 - quay.io/astronomer/ap-kube-state:2.6.0

--- a/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
@@ -12,5 +12,5 @@ metadata:
     component: astronomer-root-admin-credentials
 type: Opaque
 data:
-  username: {{ .Values.global.rootAdmin.username | b64enc | quote }}
+  username: {{ "root@example.com" | b64enc | quote }}
   password: {{ randAlphaNum 20 | b64enc | quote }}

--- a/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
@@ -12,4 +12,15 @@ metadata:
     component: astronomer-root-admin-credentials
 type: Opaque
 data:
+  {{- $secret := lookup "v1" "Secret" .Release.Namespace "astronomer-root-admin-credentials" -}}
+  {{- if $secret -}}
+  {{/*
+    Reusing existing secret data
+  */}}
+  password: {{ $secret.data.password }}
+  {{- else -}}
+  {{/*
+      Generate new data
+  */}}
   password: {{ randAlphaNum 20 | b64enc | quote }}
+  {{- end -}}

--- a/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-root-admin-secret.yaml
@@ -12,5 +12,4 @@ metadata:
     component: astronomer-root-admin-credentials
 type: Opaque
 data:
-  username: {{ "root@example.com" | b64enc | quote }}
   password: {{ randAlphaNum 20 | b64enc | quote }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -51,11 +51,6 @@ spec:
                     secretKeyRef:
                       name: {{ template "houston.backendSecret" . }}
                       key: connection
-                - name: ROOT_ADMIN_USERNAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: astronomer-root-admin-credentials
-                      key: username
                 - name: ROOT_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -63,7 +58,7 @@ spec:
                       key: password
               command: ["yarn"]
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-              args: ["update-root-admin-password", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
+              args: ["update-root-admin-password", "--password=$(ROOT_ADMIN_PASSWORD)"]
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/create-root-admin-job.yaml
@@ -50,7 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           command: ["yarn"]
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
-          args: ["create-root-admin", "--username=$(ROOT_ADMIN_USERNAME)", "--password=$(ROOT_ADMIN_PASSWORD)"]
+          args: ["create-root-admin", "--password=$(ROOT_ADMIN_PASSWORD)"]
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}
             {{- include "custom_ca_volume_mounts" . | indent 12 }}
@@ -60,11 +60,6 @@ spec:
                 secretKeyRef:
                   name: {{ template "houston.backendSecret" . }}
                   key: connection
-            - name: ROOT_ADMIN_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: astronomer-root-admin-credentials
-                  key: username
             - name: ROOT_ADMIN_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.31.5
+    tag: 0.31.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/tests/chart_tests/test_houston_root_admin_secret.py
+++ b/tests/chart_tests/test_houston_root_admin_secret.py
@@ -22,7 +22,4 @@ class TestHoustonSecretHoustonRootAdminCredentials:
         doc = docs[0]
 
         assert doc["kind"] == "Secret"
-        username = base64.b64decode(doc["data"]["username"])
-
-        assert username == b"root@example.com"
         assert len(base64.b64decode(doc["data"]["password"])) == 20

--- a/values.yaml
+++ b/values.yaml
@@ -104,9 +104,6 @@ global:
   # Enables namespace labels for network policies
   networkNSLabels: false
 
-  rootAdmin:
-    username: root@example.com
-
   taskUsageMetricsEnabled: false
 
   # Sidecar Logging


### PR DESCRIPTION
## Description

Remove the ability for a user to change root admin username
Reuses root admin secret if it already exists

## Related Issues

astronomer/issues#5218
astronomer/issues#5220
astronomer/issues#5226


## Testing

locally in kind

## Merging

0.31