### PR TITLE
update prometheus 2.37.2 -> 2.37.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.17.0
-                - quay.io/astronomer/ap-prometheus:2.37.2
+                - quay.io/astronomer/ap-prometheus:2.37.3
                 - quay.io/astronomer/ap-registry:3.16.2-4
                 - quay.io/astronomer/ap-vector:0.24.1-1
           context:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,10 +18,9 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.2
+    tag: 2.37.3
     pullPolicy: IfNotPresent
   configReloader:
-    # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
     tag: 0.8.0
     pullPolicy: IfNotPresent


### PR DESCRIPTION


## Description

* bump prometheus 2.37.2 -> 2.37.3
Link to release notes https://github.com/prometheus/prometheus/releases/tag/v2.37.3

## Related Issues

https://github.com/astronomer/issues/issues/5247

## Testing

NA

## Merging

cherry-pick to all release branches.
