### PR TITLE
update airflow chart version 1.7.0 -> 1.7.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.9
-                - quay.io/astronomer/ap-commander:0.30.4
+                - quay.io/astronomer/ap-commander:0.31.0
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-21
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.13

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.0
+airflowChartVersion: 1.7.2
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.30.4
+    tag: 0.31.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update airflow chart version 1.7.0 -> 1.7.2
update commander image 0.31.0

## Related Issues

https://github.com/astronomer/issues/issues/5224
https://github.com/astronomer/issues/issues/5207

## Testing

QA should validate and verify installation of airflow 

## Merging

cherry-pick to release-0.31 branch
