### PR TITLE
fix flower UI ingress issue

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -140,6 +140,12 @@ data:
           # Enable FlowerUI flag by default
           flower:
             enabled: true
+
+          # Set Flower URL prefix to empty string
+          config:
+            celery:
+              flower_url_prefix: ''
+
           webserver:
             {{ if .Values.configSyncer.enabled }}
             extraVolumeMounts:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -142,6 +142,7 @@ data:
             enabled: true
 
           # Set Flower URL prefix to empty string
+          # Remove after https://github.com/apache/airflow/issues/27402 is resolved
           config:
             celery:
               flower_url_prefix: ''


### PR DESCRIPTION
## Description

while using celery executor flower UI getting 404 due to incorrect url_prefix. This PR fixes that issue until upstream resolves them in the chart

## Related Issues

- https://github.com/astronomer/issues/issues/5252
- https://github.com/apache/airflow/issues/27402

## Testing

QA should able to see flower UI without any issues

## Merging

merge to release-0.31.
