### PR TITLE
vector 0.24.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -296,7 +296,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.17.0
                 - quay.io/astronomer/ap-prometheus:2.37.3
                 - quay.io/astronomer/ap-registry:3.16.2-4
-                - quay.io/astronomer/ap-vector:0.24.1-1
+                - quay.io/astronomer/ap-vector:0.24.2
           context:
             - slack_team-software-infra-bot
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: circle-config-yaml
         name: Checks for consistency between config.yml and config.yml.j2
         language: python
-        files: "config.yml$|config.yml.j2|generate_circleci_config.py$|\/values.yaml$"
+        files: "config.yml$|config.yml.j2|generate_circleci_config.py$|values.yaml$"
         entry: .circleci/generate_circleci_config.py
         additional_dependencies: ["jinja2"]
   - repo: https://github.com/codespell-project/codespell

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.24.1-1
+    image: quay.io/astronomer/ap-vector:0.24.2
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION
## Description

vector 0.24.2, which solves CVE-2021-46848

## Related Issues

https://github.com/astronomer/issues/issues/5178

## Testing

Testing should be performed to validate that sidecar logs ship as expected.

## Merging

Merge into any branches that use vector 0.24.x