### PR TITLE
add extraFlags option for prometheus service

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -106,7 +106,7 @@ spec:
             - "--web.external-url=https://prometheus.{{ .Values.global.baseDomain }}"
             {{- end }}
             {{- range .Values.extraFlags }}
-            - --{{ . }}
+            - {{ . }}
             {{- end }}
           volumeMounts:
             - name: prometheus-config-volume

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -105,6 +105,9 @@ spec:
             {{- if .Values.global.baseDomain }}
             - "--web.external-url=https://prometheus.{{ .Values.global.baseDomain }}"
             {{- end }}
+            {{- range .Values.extraFlags }}
+            - --{{ . }}
+            {{- end }}
           volumeMounts:
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/config

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -130,5 +130,5 @@ additionalAlerts:
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 # external_labels: {}
 
-extraFlags: {}
+extraFlags: []
 #- "log.level=debug"

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -129,3 +129,6 @@ additionalAlerts:
 # Prometheus config file global.external_labels stanza
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write
 # external_labels: {}
+
+extraFlags: {}
+#- "log.level=debug"

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -131,4 +131,4 @@ additionalAlerts:
 # external_labels: {}
 
 extraFlags: []
-#- "log.level=debug"
+#- "--log.level=debug"

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -89,3 +89,16 @@ class TestPrometheusStatefulset:
         assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 30
         assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 31
         assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 32
+
+    def test_prometheus_with_extraFlags(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus": {"extraFlags": {"-": "log.level=debug"}},
+            },
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        print(c_by_name["prometheus"]["args"])
+        assert "--log.level=debug" in c_by_name["prometheus"]["args"]

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -107,12 +107,19 @@ class TestPrometheusStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "prometheus": {"extraFlags": ["--enable-feature=remote-write-receiver","--enable-feature=agent"]},
+                "prometheus": {
+                    "extraFlags": [
+                        "--enable-feature=remote-write-receiver",
+                        "--enable-feature=agent",
+                    ]
+                },
             },
             show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         print(c_by_name["prometheus"]["args"])
-        assert "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
+        assert (
+            "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
+        )
         assert "--enable-feature=agent" in c_by_name["prometheus"]["args"]

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -94,7 +94,7 @@ class TestPrometheusStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "prometheus": {"extraFlags": ["log.level=debug"]},
+                "prometheus": {"extraFlags": ["--log.level=debug"]},
             },
             show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
         )

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -94,7 +94,7 @@ class TestPrometheusStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "prometheus": {"extraFlags": {"-": "log.level=debug"}},
+                "prometheus": {"extraFlags": ["log.level=debug"]},
             },
             show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
         )

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -102,3 +102,17 @@ class TestPrometheusStatefulset:
         c_by_name = get_containers_by_name(docs[0])
         print(c_by_name["prometheus"]["args"])
         assert "--log.level=debug" in c_by_name["prometheus"]["args"]
+
+    def test_prometheus_with_multiple_extraFlags(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus": {"extraFlags": ["--enable-feature=remote-write-receiver","--enable-feature=agent"]},
+            },
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        print(c_by_name["prometheus"]["args"])
+        assert "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
+        assert "--enable-feature=agent" in c_by_name["prometheus"]["args"]


### PR DESCRIPTION
## Description

current we don't support passing extraFlags which prometheus offers for tuning, this PR addresses that issue and allows configurable flags

## Related Issues

https://github.com/astronomer/issues/issues/5284

## Testing

QA can validate this option with

```yaml
prometheus:
   extraFlags:
   - "--log.level=debug"
```
## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
