### PR TITLE
update vendor packages (#1761)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.13
-                - quay.io/astronomer/ap-houston-api:0.31.11
+                - quay.io/astronomer/ap-houston-api:0.30.29
                 - quay.io/astronomer/ap-init:3.16.2-4
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,12 +267,12 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.23.2
                 - quay.io/astronomer/ap-awsesproxy:1.3-9
                 - quay.io/astronomer/ap-base:3.16.2-4
-                - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0
                 - quay.io/astronomer/ap-cli-install:0.26.9
                 - quay.io/astronomer/ap-commander:0.30.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:5.8.4-21
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.13
+                - quay.io/astronomer/ap-curator:5.8.4-22
+                - quay.io/astronomer/ap-db-bootstrapper:0.26.14
                 - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
@@ -281,18 +281,18 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.30.29
                 - quay.io/astronomer/ap-init:3.16.2-4
                 - quay.io/astronomer/ap-kibana:7.17.6
-                - quay.io/astronomer/ap-kube-state:2.6.0
+                - quay.io/astronomer/ap-kube-state:2.7.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-4
                 - quay.io/astronomer/ap-nginx-es:1.23.2
                 - quay.io/astronomer/ap-nginx:1.3.1-1
-                - quay.io/astronomer/ap-node-exporter:1.4.0
+                - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.17.0
-                - quay.io/astronomer/ap-prometheus:2.37.2
+                - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.2-4
                 - quay.io/astronomer/ap-vector:0.24.1-1
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.30.8
                 - quay.io/astronomer/ap-auth-sidecar:1.23.2
-                - quay.io/astronomer/ap-awsesproxy:1.3-9
+                - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0
                 - quay.io/astronomer/ap-cli-install:0.26.9

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,12 +275,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.14
                 - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
-                - quay.io/astronomer/ap-grafana:8.5.10
-                - quay.io/astronomer/ap-houston-api:0.30.29
+                - quay.io/astronomer/ap-grafana:8.5.13
+                - quay.io/astronomer/ap-houston-api:0.31.11
                 - quay.io/astronomer/ap-init:3.16.2-4
-                - quay.io/astronomer/ap-kibana:7.17.6
+                - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.13
+    tag: 0.26.14
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-21
+    tag: 5.8.4-22
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-9
+    tag: 1.3-10
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.10
+    tag: 8.5.13
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.13
+    tag: 0.26.14
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.6.0
+    tag: 2.7.0
     pullPolicy: IfNotPresent
 
 env: {}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.22.0-1
+  tag: 0.23.0
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.4.0
+  tag: 1.5.0
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -36,7 +36,7 @@ postgresqlExporter:
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.2
+    tag: 2.37.5
     pullPolicy: IfNotPresent
   configReloader:
     # repository: astronomerinc/ap-config-reloader

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -1,5 +1,5 @@
 import pytest
-
+import tests.chart_tests as chart_tests
 from tests import get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 import re


### PR DESCRIPTION
## Description

image | old | new
-- | -- | --
ap-db-bootstrapper  | 0.26.13  | 0.26.14
ap-curator | 5.8.4-21 | 5.8.4-22
ap-kube-state | 2.6.0 | 2.7.0
ap-blackbox-exporter | 0.22.0-1 | 0.23.0
ap-node-exporter | 1.4.1 | 1.5.0
ap-prometheus | 2.37.3 | 2.37.5
ap-kibana | 7.17.6 |  7.17.8
ap-elasticsearch | 7.17.6 | 7.17.8
ap-grafana | 8.5.10 | 8.5.13
awsesproxy | 1.3-9 |  1.3-10

## Related Issues

https://github.com/astronomer/issues/issues/5290
https://github.com/astronomer/issues/issues/5287
https://github.com/astronomer/issues/issues/5286

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
