### PR TITLE
update ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -286,12 +286,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.14
                 - quay.io/astronomer/ap-default-backend:0.28.10
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
-                - quay.io/astronomer/ap-grafana:8.5.10
+                - quay.io/astronomer/ap-grafana:8.5.13
                 - quay.io/astronomer/ap-houston-api:0.31.11
                 - quay.io/astronomer/ap-init:3.16.2-4
-                - quay.io/astronomer/ap-kibana:7.17.6
+                - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-4

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.10
+    tag: 8.5.13
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"


### PR DESCRIPTION


## Description

* bump ap-kibana 7.17.6 -> 7.17.8
* bump ap-elasticsearch 7.17.6 -> 7.17.8
* bump ap-grafana 8.5.10 -> 8.5.13

## Related Issues

NA - since these image updates dont fix any CRITICAL cve.

## Testing

QA should verify after upgrades these service should work as expected.

## Merging

cherry-pick all valid release branches.
