### PR TITLE
ap-awsesproxy 1.3-10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,7 +276,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.23.0
                 - quay.io/astronomer/ap-astro-ui:0.31.9
                 - quay.io/astronomer/ap-auth-sidecar:1.23.2
-                - quay.io/astronomer/ap-awsesproxy:1.3-9
+                - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0
                 - quay.io/astronomer/ap-cli-install:0.26.9

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-9
+    tag: 1.3-10
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description

* resolves CVE-2021-44716 CVE-2022-27664 in awsesproxy service

## Related Issues

https://github.com/astronomer/issues/issues/5299

## Testing

NA

## Merging

cherry-pick to valid release branches.
