### PR TITLE
fix template when private registry is used for pgbouncer krb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ show-docker-images: ## Show all docker images and versions used in the helm char
 		2>/dev/null \
 		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
 
-.PHONY: show-docker-images
+.PHONY: show-docker-images-with-private-registry
 show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
 	@helm template . \
 		-f tests/enable_all_features.yaml \

--- a/charts/pgbouncer/templates/_helpers.yaml
+++ b/charts/pgbouncer/templates/_helpers.yaml
@@ -9,7 +9,7 @@
 
 {{ define "pgbouncer.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-pgbouncer-krb:{{ .Values.images.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-pgbouncer-krb:{{ .Values.image.tag }}
 {{- else -}}
 {{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
 {{- end }}

--- a/tests/chart_tests/test_pgbouncer.py
+++ b/tests/chart_tests/test_pgbouncer.py
@@ -92,7 +92,6 @@ class TestPGBouncerDeployment:
         assert doc["apiVersion"] == "apps/v1"
 
         for name, container in c_by_name.items():
-            print(container["image"])
             assert container["image"].startswith(
                 private_registry
             ), f"Container named '{name}' does not use registry '{private_registry}': {container}"

--- a/tests/chart_tests/test_pgbouncer.py
+++ b/tests/chart_tests/test_pgbouncer.py
@@ -64,3 +64,35 @@ class TestPGBouncerDeployment:
 
         labels = doc["spec"]["template"]["metadata"]["labels"]
         assert labels.get("test_label") == "test_label1"
+
+    def test_pgbouncer_deployment_with_private_registry(self, kube_version):
+        """Test that pgbouncer deployment properly uses the private registry
+        images."""
+        private_registry = "private-registry.example.com"
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/pgbouncer/templates/pgbouncer-deployment.yaml"],
+            values={
+                "global": {
+                    "privateRegistry": {
+                        "enabled": True,
+                        "repository": private_registry,
+                    },
+                    "pgbouncer": {"enabled": True},
+                }
+            },
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc, include_init_containers=True)
+
+        assert doc["kind"] == "Deployment"
+        assert doc["apiVersion"] == "apps/v1"
+
+        for name, container in c_by_name.items():
+            print(container["image"])
+            assert container["image"].startswith(
+                private_registry
+            ), f"Container named '{name}' does not use registry '{private_registry}': {container}"


### PR DESCRIPTION
## Description

when private registry is set to true and  pgbouncer  is enabled  this change  wont work as expected since the referenced tag location is wrong. This PR corrects the behavior and resolves it 

## Related Issues

https://github.com/astronomer/issues/issues/5318

## Testing

validated via unit testing

## Merging

cherry-pick to all valid release branches.
