### PR TITLE
make externales proxy images to support private registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
           command: pre-commit run --all-files --show-diff-on-failure
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.0
+      - image: quay.io/astronomer/ap-build:0.2.3
     steps:
       - checkout
       - run:
@@ -143,7 +143,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.0
+      - image: quay.io/astronomer/ap-build:0.2.3
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -93,7 +93,7 @@ jobs:
           command: pre-commit run --all-files --show-diff-on-failure
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.0
+      - image: quay.io/astronomer/ap-build:0.2.3
     steps:
       - checkout
       - run:
@@ -141,7 +141,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.0
+      - image: quay.io/astronomer/ap-build:0.2.3
     steps:
       - checkout
       - run:

--- a/charts/external-es-proxy/templates/_helpers.tpl
+++ b/charts/external-es-proxy/templates/_helpers.tpl
@@ -83,3 +83,21 @@ imagePullSecrets:
   - name: {{ .Values.global.privateRegistry.secretName }}
 {{- end -}}
 {{- end -}}
+
+
+{{ define "esproxy.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-openresty:{{ .Values.images.esproxy.tag }}
+{{- else -}}
+{{ printf "%s:%s" .Values.images.esproxy.repository .Values.images.esproxy.tag }}
+{{- end }}
+{{- end }}
+
+
+{{ define "awsesproxy.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-awsesproxy:{{ .Values.images.awsproxy.tag }}
+{{- else -}}
+{{ printf "%s:%s" .Values.images.awsproxy.repository .Values.images.awsproxy.tag }}
+{{- end }}
+{{- end }}

--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.images.esproxy.repository }}:{{ .Values.images.esproxy.tag | default .Chart.AppVersion }}"
+          image: {{ template "esproxy.image" . }}
           imagePullPolicy: {{ .Values.images.esproxy.pullPolicy }}
           env:
 {{- if .Values.global.customLogging.secret }}
@@ -93,7 +93,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- if  or .Values.global.customLogging.awsSecretName  .Values.global.customLogging.awsServiceAccountAnnotation  .Values.global.customLogging.awsIAMRole}}
         - name: awsproxy
-          image: "{{ .Values.images.awsproxy.repository }}:{{ .Values.images.awsproxy.tag | default .Chart.AppVersion }}"
+          image: {{ template "awsesproxy.image" . }}
           command: ["/bin/sh","-c"]
           args: ["aws-es-proxy -listen :{{ .Values.service.awsproxy }}"]
           imagePullPolicy: {{ .Values.images.awsproxy.pullPolicy }}

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -4,7 +4,7 @@ import jmespath
 import pytest
 import yaml
 
-from tests import supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
 secret = base64.b64encode(b"sample-secret").decode()
@@ -419,3 +419,40 @@ class TestExternalElasticSearch:
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
         assert "vector.$remote_user.*/$1" in es_index
+
+    def test_external_es_with_private_registry_enabled(self, kube_version):
+        """Test External Elasticsearch Service with Private Registry
+        Enabled."""
+        private_registry = "private-registry.example.com"
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "privateRegistry": {
+                        "enabled": True,
+                        "repository": private_registry,
+                    },
+                    "customLogging": {
+                        "enabled": True,
+                        "scheme": "https",
+                        "host": "esdemo.example.com",
+                        "awsServiceAccountAnnotation": "arn:aws:iam::xxxxxxxx:role/customrole",
+                    },
+                },
+            },
+            show_only=[
+                "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        c_by_name = get_containers_by_name(doc, include_init_containers=False)
+
+        assert doc["kind"] == "Deployment"
+        assert doc["apiVersion"] == "apps/v1"
+        for name, container in c_by_name.items():
+            assert container["image"].startswith(
+                private_registry
+            ), f"Container named '{name}' does not use registry '{private_registry}': {container}"


### PR DESCRIPTION
## Description

currently external es proxy images does not support global private registry . This changes makes it compactible to support global private registry

## Related Issues

https://github.com/astronomer/issues/issues/5323

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to all valid release branches.
