### PR TITLE
update vendor package to resolve CVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,18 +273,18 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.23.0
+                - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.31.9
-                - quay.io/astronomer/ap-auth-sidecar:1.23.2
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.9
+                - quay.io/astronomer/ap-cli-install:0.26.10
                 - quay.io/astronomer/ap-commander:0.31.2
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-23
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.14
-                - quay.io/astronomer/ap-default-backend:0.28.10
+                - quay.io/astronomer/ap-default-backend:0.28.11
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
@@ -296,7 +296,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-3
                 - quay.io/astronomer/ap-nats-server:2.8.4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6
-                - quay.io/astronomer/ap-nginx-es:1.23.2
+                - quay.io/astronomer/ap-nginx-es:1.23.3
                 - quay.io/astronomer/ap-nginx:1.3.1-1
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-3

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.23.0
+    tag: 0.25.0
     pullPolicy: IfNotPresent
 
 resources:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.9
+    tag: 0.26.10
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.2
+    tag: 1.23.3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.10
+    tag: 0.28.11
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/values.yaml
+++ b/values.yaml
@@ -126,7 +126,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.2
+    tag: 1.23.3
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION

## Description

resolves multiple CVE's in vendor packages

* bump ap-auth-sidecar 1.23.2 -> 1.23.3
* bump ap-default-backend 0.28.10 -> 0.28.11
* bump ap-nginx-es 1.23.2 -> 1.23.3
* bump ap-cli-install 0.26.9 -> 0.26.10
* bump ap-alertmanager 0.23.0 -> 0.25.0

## Related Issues

https://github.com/astronomer/issues/issues/5322
https://github.com/astronomer/issues/issues/5321

## Testing

NA

## Merging

cherry-pick to all valid release branches
