### PR TITLE
Adding timeoutSeconds option in the prometheus block #5324

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -125,6 +125,7 @@ spec:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /-/ready
@@ -132,6 +133,7 @@ spec:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
       securityContext:
         fsGroup: 65534
         runAsNonRoot: true

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -37,13 +37,13 @@ resources: {}
 livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
-  failureThreshold: 3
   timeoutSeconds: 1
+  failureThreshold: 3
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
-  failureThreshold: 3
   timeoutSeconds: 1
+  failureThreshold: 3
 
 configMapReloader:
   resources: {}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -38,10 +38,12 @@ livenessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
   failureThreshold: 3
+  timeoutSeconds: 1
 readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 5
   failureThreshold: 3
+  timeoutSeconds: 1
 
 configMapReloader:
   resources: {}

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -52,10 +52,12 @@ class TestPrometheusStatefulset:
         assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10
         assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 5
         assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 3
+        assert c_by_name["prometheus"]["livenessProbe"]["timeoutSeconds"] == 1
         # check default readiness probe values
         assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 10
         assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 5
         assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 3
+        assert c_by_name["prometheus"]["readinessProbe"]["timeoutSeconds"] == 1
 
     def test_prometheus_sts_override_probes(self, kube_version):
         """Test override of probe values."""
@@ -68,11 +70,13 @@ class TestPrometheusStatefulset:
                         "initialDelaySeconds": 20,
                         "periodSeconds": 21,
                         "failureThreshold": 22,
+                        "timeoutSeconds": 15,
                     },
                     "readinessProbe": {
                         "initialDelaySeconds": 30,
                         "periodSeconds": 31,
                         "failureThreshold": 32,
+                        "timeoutSeconds": 15,
                     },
                 }
             },
@@ -85,10 +89,12 @@ class TestPrometheusStatefulset:
         assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 20
         assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 21
         assert c_by_name["prometheus"]["livenessProbe"]["failureThreshold"] == 22
+        assert c_by_name["prometheus"]["livenessProbe"]["timeoutSeconds"] == 15
         # check modified readiness probe values
         assert c_by_name["prometheus"]["readinessProbe"]["initialDelaySeconds"] == 30
         assert c_by_name["prometheus"]["readinessProbe"]["periodSeconds"] == 31
         assert c_by_name["prometheus"]["readinessProbe"]["failureThreshold"] == 32
+        assert c_by_name["prometheus"]["readinessProbe"]["timeoutSeconds"] == 15
 
     def test_prometheus_with_extraFlags(self, kube_version):
         docs = render_chart(


### PR DESCRIPTION
## Description

Adding `timeoutSeconds` option in liveness and readiness for the prometheus block in the helm chart to make the value persistent.

Customers are not able to set timeoutSeconds in the prometheus block through the helm.

## Related Issues

https://github.com/astronomer/issues/issues/5324

## Testing

This can be tested by providing any numeric value to `timeoutSeconds` in values.YAML file and verifying the same in the Prometheus STS.

## Merging

"This should be safe to merge to all supported branches." - DanielH