### PR TITLE
Add delay for nats.ackWait, upgradeTimeout. Improve some test syntaxes.

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -119,7 +119,9 @@ houston:
 
   # Any Houston configuration. Reference here:
   # https://github.com/astronomer/houston-api/blob/main/config/default.yaml
-  config: {}
+  config:
+    nats:
+      ackWait: 600000
 
   # Worker to connect to NATS
   worker:
@@ -294,7 +296,7 @@ commander:
   airGapped:
     # Enable airgapped mode
     enabled: false
-  upgradeTimeout: 300
+  upgradeTimeout: 600
 
   # Add extra containers to your commander deployment.
   extraContainers: []

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -31,7 +31,7 @@ class TestAstronomerCommander:
         assert c_by_name["commander"]["resources"]["limits"]["memory"] == "2Gi"
         assert c_by_name["commander"]["resources"]["requests"]["memory"] == "1Gi"
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
-        assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "300"
+        assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
 
     def test_astronomer_commander_deployment_upgrade_timeout(self, kube_version):
         """Test that helm renders a good deployment template for
@@ -41,7 +41,7 @@ class TestAstronomerCommander:
         """
         docs = render_chart(
             kube_version=kube_version,
-            values={"astronomer": {"commander": {"upgradeTimeout": 600}}},
+            values={"astronomer": {"commander": {"upgradeTimeout": 997}}},
             show_only=[
                 "charts/astronomer/templates/commander/commander-deployment.yaml"
             ],
@@ -59,7 +59,7 @@ class TestAstronomerCommander:
         )
 
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
-        assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
+        assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "997"
 
     def test_astronomer_commander_rbac_cluster_role_enabled(self, kube_version):
         """Test that if rbacEnabled and clusterRoles are enabled but

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -16,7 +16,7 @@ def common_test_cases(docs):
 
     local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
 
-    assert local_prod == {}
+    assert local_prod == {"nats": {"ackWait": 600000}}
 
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -41,7 +41,7 @@ def test_houston_configmap():
     # Ensure airflow elasticsearch param is at correct location
     assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
     # Ensure elasticsearch client param is at the correct location and contains http://
-    assert ("node" in prod["elasticsearch"]["client"]) is True
+    assert "node" in prod["elasticsearch"]["client"]
     assert prod["elasticsearch"]["client"]["node"].startswith("http://")
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default
@@ -82,7 +82,7 @@ def test_houston_configmap_with_customlogging_enabled():
     doc = docs[0]
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    assert ("node" in prod["elasticsearch"]["client"]) is True
+    assert "node" in prod["elasticsearch"]["client"]
     assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
 
 
@@ -201,7 +201,7 @@ def test_houston_configmap_with_loggingsidecar_enabled():
         "terminationEndpoint": "http://localhost:8000/quitquitquit",
         "customConfig": False,
     }
-    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
@@ -243,7 +243,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
         "terminationEndpoint": terminationEndpoint,
         "customConfig": False,
     }
-    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
 def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
@@ -286,7 +286,7 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
         "terminationEndpoint": terminationEndpoint,
         "customConfig": True,
     }
-    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides():
@@ -363,7 +363,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
         ],
     }
 
-    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides():
@@ -413,7 +413,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
         },
     }
 
-    assert ("vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]) is True
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
 cron_test_data = [


### PR DESCRIPTION
## Description

Increase timeouts related to airflow upgrades. This is due to a new dag parsing behavior in Airflow that makes upgrades take longer when there are lots of dags present.

## Related Issues

- Issue: https://github.com/astronomer/issues/issues/5301
- These changes were already applied to Nebula in https://github.com/astronomer/google-environments/pull/1031 

## Testing

Tests are added, but it wouldn't be bad to double-check them in QA testing.

## Merging

This should be merged to all supported releases because it addresses a core airflow behavior.