### PR TITLE
fix CVE-2022-3996 in vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,7 +275,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.31.9
-                - quay.io/astronomer/ap-auth-sidecar:1.23.3
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
@@ -296,8 +296,8 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-3
                 - quay.io/astronomer/ap-nats-server:2.8.4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6
-                - quay.io/astronomer/ap-nginx-es:1.23.3
-                - quay.io/astronomer/ap-nginx:1.3.1-1
+                - quay.io/astronomer/ap-nginx-es:1.23.3-1
+                - quay.io/astronomer/ap-nginx:1.3.1-2
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-5

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.3
+    tag: 1.23.3-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.1-1
+    tag: 1.3.1-2
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/values.yaml
+++ b/values.yaml
@@ -126,7 +126,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.3
+    tag: 1.23.3-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

* bump ap-auth-sidecar 1.23.3 -> 1.23.3-1
* bump ap-nginx-es  1.23.3 -> 1.23.3-1 
* bump ap-nginx 1.23.3 -> 1.23.3-1 
* resolves CVE-2022-3996 


## Related Issues

https://github.com/astronomer/issues/issues/5328

## Testing

NA

## Merging

cherry-pick release-0.30 , release-0.31
