### PR TITLE
Bump component versions to ap-base 3.16.3 (#1768)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,12 +266,12 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.30.10
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
-                - quay.io/astronomer/ap-base:3.16.2-4
-                - quay.io/astronomer/ap-blackbox-exporter:0.23.0
+                - quay.io/astronomer/ap-base:3.16.3
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.10
                 - quay.io/astronomer/ap-commander:0.30.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:5.8.4-22
+                - quay.io/astronomer/ap-curator:5.8.4-23
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.14
                 - quay.io/astronomer/ap-default-backend:0.28.11
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
@@ -279,21 +279,21 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.15
                 - quay.io/astronomer/ap-houston-api:0.30.32
-                - quay.io/astronomer/ap-init:3.16.2-4
+                - quay.io/astronomer/ap-init:3.16.3
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-2
-                - quay.io/astronomer/ap-nats-server:2.8.1-4
-                - quay.io/astronomer/ap-nats-streaming:0.24.5-4
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-3
+                - quay.io/astronomer/ap-nats-server:2.8.4
+                - quay.io/astronomer/ap-nats-streaming:0.24.6
                 - quay.io/astronomer/ap-nginx-es:1.23.3-1
                 - quay.io/astronomer/ap-nginx:1.3.1-2
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-4
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-5
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.17.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
-                - quay.io/astronomer/ap-registry:3.16.2-4
+                - quay.io/astronomer/ap-registry:3.16.3
                 - quay.io/astronomer/ap-vector:0.24.1-1
           context:
             - slack_team-software-infra-bot

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.2-4
+    tag: 3.16.3
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.16.2-4
+    tag: 3.16.3
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-22
+    tag: 5.8.4-23
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.1-4
+    tag: 2.8.4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-2
+    tag: 0.10.0-3
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-4
+  tag: 1.17.0-5
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.23.0
+  tag: 0.23.0-1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.16.2-4
+    tag: 3.16.3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.5-4
+    tag: 0.24.6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-2
+    tag: 0.10.0-3
     pullPolicy: IfNotPresent
 
 stan:


### PR DESCRIPTION
## Description

* Bump component versions to those that use ap-base 3.16.3

## Related Issues

https://github.com/astronomer/issues/issues/5291

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

This PR already merged to master and release-0.31. Left out in release-0.30 so re-adding them
