### PR TITLE
update postgresql version 11.18.0 

### DIFF
--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -7,3 +7,7 @@ CVE-2022-1996
 CVE-2022-27664
 # golang.org/x/text
 CVE-2022-32149
+
+# github.com/opencontainers/runc 1.0.1 
+# upstream not intrested in resolving the CVE
+CVE-2022-29162

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.17.0-1
+  tag: 11.18.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

exclude CVE-2022-29162 in gosu service used in postgresql
update postgresql version 11.18.0 

## Related Issues

NA

## Testing

NA.

## Merging

cherry-pick to release-0.30,release-0.31.
