### PR TITLE
resolve CVE-2022-29162

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,12 +279,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.10
+                - quay.io/astronomer/ap-cli-install:0.26.11
                 - quay.io/astronomer/ap-commander:0.31.3
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-23
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.14
-                - quay.io/astronomer/ap-default-backend:0.28.11
+                - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.10
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.11
+    tag: 0.28.12
     pullPolicy: IfNotPresent
 
 ingressClass: ~


### PR DESCRIPTION
## Description

resolves CVE-2022-29162 
update ap-cli-install 0.26.10 -> 0.26.11
update ap-default-backend 0.28.11 -> 0.28.12

## Related Issues

https://github.com/astronomer/issues/issues/5328

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
