### PR TITLE
release-0.28 backport CVE fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.28.17
-                - quay.io/astronomer/ap-auth-sidecar:1.23.3
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
@@ -275,8 +275,8 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-4
-                - quay.io/astronomer/ap-nginx-es:1.23.3
-                - quay.io/astronomer/ap-nginx:1.3.1
+                - quay.io/astronomer/ap-nginx-es:1.23.3-1
+                - quay.io/astronomer/ap-nginx:1.3.1-2
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.19.9-1
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,12 +257,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.10
+                - quay.io/astronomer/ap-cli-install:0.26.11
                 - quay.io/astronomer/ap-commander:0.28.7
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-21
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
-                - quay.io/astronomer/ap-default-backend:0.28.11
+                - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.19.9-1
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.17.0
+                - quay.io/astronomer/ap-postgresql:11.17.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.1
                 - quay.io/astronomer/ap-registry:3.16.2-4
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,12 +264,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
                 - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.6
+                - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.15
                 - quay.io/astronomer/ap-houston-api:0.28.29
                 - quay.io/astronomer/ap-init:3.16.2-4
-                - quay.io/astronomer/ap-kibana:7.17.6
+                - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.6.0
                 - quay.io/astronomer/ap-kubed:0.13.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.19.9-1
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.17.0-1
+                - quay.io/astronomer/ap-postgresql:11.18.0
                 - quay.io/astronomer/ap-prometheus:2.37.1
                 - quay.io/astronomer/ap-registry:3.16.2-4
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,7 +266,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
-                - quay.io/astronomer/ap-grafana:8.5.10
+                - quay.io/astronomer/ap-grafana:8.5.15
                 - quay.io/astronomer/ap-houston-api:0.28.29
                 - quay.io/astronomer/ap-init:3.16.2-4
                 - quay.io/astronomer/ap-kibana:7.17.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,18 +251,18 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.23.0
+                - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.28.17
-                - quay.io/astronomer/ap-auth-sidecar:1.23.1-1
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.2-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.22.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.8
+                - quay.io/astronomer/ap-cli-install:0.26.10
                 - quay.io/astronomer/ap-commander:0.28.7
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-21
                 - quay.io/astronomer/ap-db-bootstrapper:0.26.11
-                - quay.io/astronomer/ap-default-backend:0.28.9
+                - quay.io/astronomer/ap-default-backend:0.28.11
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.6
                 - quay.io/astronomer/ap-fluentd:1.15.2
@@ -275,7 +275,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-2
                 - quay.io/astronomer/ap-nats-server:2.8.1-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.5-4
-                - quay.io/astronomer/ap-nginx-es:1.23.1-1
+                - quay.io/astronomer/ap-nginx-es:1.23.3
                 - quay.io/astronomer/ap-nginx:1.3.1
                 - quay.io/astronomer/ap-node-exporter:1.4.0
                 - quay.io/astronomer/ap-openresty:1.19.9-1

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -5,3 +5,9 @@ CVE-2022-27191
 CVE-2022-1996
 # golang.org/x/net CVE
 CVE-2022-27664
+# golang.org/x/text
+CVE-2022-32149
+
+# github.com/opencontainers/runc 1.0.1
+# upstream not interested in resolving the CVE
+CVE-2022-29162

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.23.0
+    tag: 0.25.0
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.10
+    tag: 0.26.11
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.8
+    tag: 0.26.10
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.1-1
+    tag: 1.23.3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.3
+    tag: 1.23.3-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.10
+    tag: 8.5.15
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.6
+    tag: 7.17.8
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.1
+    tag: 1.3.1-2
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.11
+    tag: 0.28.12
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.9
+    tag: 0.28.11
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.17.0
+  tag: 11.17.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.17.0-1
+  tag: 11.18.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.1-1
+    tag: 1.23.3
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |

--- a/values.yaml
+++ b/values.yaml
@@ -98,7 +98,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.3
+    tag: 1.23.3-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

image | old | new
-- | -- | --
ap-alertmanager  | 0.23.0 | 0.25.0
ap-cli-install | 0.26.8 | 0.26.11
ap-nginx-es | 1.23.1-1 | 1.23.3-1 
ap-nginx | 1.3.1 | 1.3.1-1
ap-default-backend | 0.28.9 | 0.28.12
ap-postgresql | 11.17.0 | 11.18.0
ap-auth-sidecar | 1.23.1-1 | 1.23.3-1
ap-grafana | 8.5.10 | 8.5.15
ap-kibana | 7.17.6 | 7.17.8
ap-elasticearch | 7.17.6 | 7.17.8

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
