### PR TITLE
add secret list for alertmanager

### DIFF
--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -55,6 +55,13 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
             {{- end }}
+            {{- range $i, $config := .Values.secret }}
+            - name: {{ $config.envName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $config.secretName }}
+                  key: {{ default "value" $config.secretKey }}
+            {{- end }}
           args:
             - --config.file=/etc/config/alertmanager.yaml
             - --storage.path={{ .Values.dataDir }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -34,6 +34,8 @@ persistence:
 
 env: {}
 
+secret: []
+
 ports:
   http: 9093
 


### PR DESCRIPTION
## Description

Add secret list for alertmanager env vars.

## Related Issues

[Issue #5361](https://github.com/astronomer/issues/issues/5361)

## Testing

Add secret list to helm values and ensure that it is added to the alert manager statefulset pod. Below is an example:

```yaml
alertmanager:
  secret: 
    - envName: SERVICE_NOW_PASSWORD
      secretName: service-now-secret
      secretKey: password
```

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
