### PR TITLE
Update release 0.28 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,10 +258,10 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.11
-                - quay.io/astronomer/ap-commander:0.28.7
+                - quay.io/astronomer/ap-commander:0.28.8
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-23
-                - quay.io/astronomer/ap-db-bootstrapper:0.26.14
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.0
                 - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
                 - quay.io/astronomer/ap-grafana:8.5.15
-                - quay.io/astronomer/ap-houston-api:0.28.29
+                - quay.io/astronomer/ap-houston-api:0.28.30
                 - quay.io/astronomer/ap-init:3.16.3
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.6.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
-                - quay.io/astronomer/ap-astro-ui:0.28.17
+                - quay.io/astronomer/ap-astro-ui:0.28.18
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.28.8-rc1
-appVersion: 0.28.8-rc1
+version: 0.28.8-rc2
+appVersion: 0.28.8-rc2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.28.8-rc1
+version: 0.28.8-rc2
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.4.3
+airflowChartVersion: 1.4.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.28.7
+    tag: 0.28.8
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.14
+    tag: 0.31.0
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.28.29
+    tag: 0.28.30
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.28.17
+    tag: 0.28.18
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.26.14
+    tag: 0.31.0
     pullPolicy: IfNotPresent
 
 backendSecretName: ~


### PR DESCRIPTION
## Description

* bump db-bootstrapper  0.26.14 -> 0.31.0 
* bump commander 0.28.7 -> 0.28.8
* update airflow chart version 1.4.3 -> 1.4.4
* bump ap-houston 0.28.29 -> 0.28.30

## Related Issues

NA

## Testing

QA should able to able to deploy platform and airflow without any issues 

## Merging

cherry-pick and direct merge to release-0.28 since its already diverged with lots of changes.
