### PR TITLE
update grafana image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.2
-                - quay.io/astronomer/ap-grafana:8.5.15
+                - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.31.15
                 - quay.io/astronomer/ap-init:3.16.3
                 - quay.io/astronomer/ap-kibana:7.17.8

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.15
+    tag: 8.5.16
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION


## Description

* bump grafana 8.5.15 -> 8.5.16
* resolves CVE-2022-27664,CVE-2022-41721,CVE-2022-32149

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA should validate grafana working as expected .

## Merging

cherry-pick to all valid releases.
