### PR TITLE
update vector 0.24.2 -> 0.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,7 +337,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.18.0
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3
-                - quay.io/astronomer/ap-vector:0.24.2
+                - quay.io/astronomer/ap-vector:0.26.0
           context:
             - slack_team-software-infra-bot
 

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.24.2
+    image: quay.io/astronomer/ap-vector:0.26.0
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION
## Description

update vector 0.24.2 -> 0.26.0

## Related Issues

https://github.com/astronomer/issues/issues/5178

## Testing

QA should validate vector service should work as usual

## Merging

cherry-pick to all valid release branches.
