### PR TITLE
update fluentd image version 1.15.3-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
-                - quay.io/astronomer/ap-fluentd:1.15.2
+                - quay.io/astronomer/ap-fluentd:1.15.3-1
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.31.15
                 - quay.io/astronomer/ap-init:3.16.3

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.2
+    tag: 1.15.3-1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION


## Description

* bump fluentd 1.15.2 -> 1.15.3-1
* adds kafka plugin support

## Related Issues

https://github.com/astronomer/issues/issues/5330

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to release-0.31.
