### PR TITLE
update houston ingress to support extra annotation

### DIFF
--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -28,6 +28,10 @@ metadata:
       }
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
+
+    {{- if .Values.houston.ingress.annotation  }}
+    {{ toYaml .Values.houston.ingress.annotation  }}
+    {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -30,7 +30,7 @@ metadata:
     {{- end }}
 
     {{- if .Values.houston.ingress.annotation  }}
-    {{ toYaml .Values.houston.ingress.annotation  }}
+    {{- toYaml .Values.houston.ingress.annotation  | nindent 4  }}
     {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -275,6 +275,10 @@ houston:
   # Add volumes to your containers
   extraVolumes: []
 
+  # Add custom annotation for houston ingress
+  ingress:
+    annotation: {}
+
 configSyncer:
   enabled: true
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -92,9 +92,9 @@ class TestIngress:
         annotations = jmespath.search("metadata.annotations", doc)
         assert (
             annotations["nginx.ingress.kubernetes.io/upstream-keepalive-connections"]
-            == "400"
+            == "9999"
         )
         assert (
             annotations["nginx.ingress.kubernetes.io/upstream-keepalive-timeout"]
-            == "120"
+            == "7777"
         )

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -75,8 +75,8 @@ class TestIngress:
 
     def test_houston_ingress_overrides(self, kube_version):
         custom_annotations = {
-            "nginx.ingress.kubernetes.io/upstream-keepalive-connections": "400",
-            "nginx.ingress.kubernetes.io/upstream-keepalive-timeout": "120",
+            "nginx.ingress.kubernetes.io/upstream-keepalive-connections": "9999",
+            "nginx.ingress.kubernetes.io/upstream-keepalive-timeout": "7777",
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -72,3 +72,29 @@ class TestIngress:
 }
 """
         )
+
+    def test_houston_ingress_overrides(self, kube_version):
+        custom_annotations = {
+            "nginx.ingress.kubernetes.io/upstream-keepalive-connections": "400",
+            "nginx.ingress.kubernetes.io/upstream-keepalive-timeout": "120",
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "houston": {"ingress": {"annotation": custom_annotations}}
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/ingress.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        annotations = jmespath.search("metadata.annotations", doc)
+        assert (
+            annotations["nginx.ingress.kubernetes.io/upstream-keepalive-connections"]
+            == "400"
+        )
+        assert (
+            annotations["nginx.ingress.kubernetes.io/upstream-keepalive-timeout"]
+            == "120"
+        )


### PR DESCRIPTION
## Description

currently we are unable to set specific ingress annotation overrides for houston. This change allows users to add customer ingress annotation supported by ingress providers

## Related Issues

https://github.com/astronomer/issues/issues/5385

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.31.2
