### PR TITLE
Update local-dev text to give accurate instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ and set the pull policy to "Never".
 kubectl edit deployment -n astronomer <your deployment>
 ```
 
-#### Change Kubernetes version:
+#### Specify the Kubernetes version:
 
 ```sh
 bin/reset-local-dev -K 1.24.7

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ Modify the "tags:" in configs/local-dev.yaml
 - logging (large impact on RAM use): ElasticSearch, Kibana, Fluentd (aka 'EFK' stack)
 - monitoring: Prometheus
 
-#### Add a Docker image into KinD's nodes (so it's available for pods):
+#### Load a Docker image into KinD's nodes (so it's available for pods)
 
 ```sh
 kind load docker-image $your_local_image_name_with_tag
 ```
 
-#### Make use of that image:
+#### Make use of that image
 
 Make note of your pod name
 
@@ -79,13 +79,13 @@ and set the pull policy to "Never".
 kubectl edit deployment -n astronomer <your deployment>
 ```
 
-#### Specify the Kubernetes version:
+#### Specify the Kubernetes version
 
 ```sh
 bin/reset-local-dev -K 1.24.7
 ```
 
-#### Locally test HA configurations:
+#### Locally test HA configurations
 
 You need a powerful computer to run the HA testing locally. 28 GB or more of memory should be available to Docker.
 

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -82,7 +82,7 @@ cat <<EOF
   command to find the root password:
 
     kubectl -n ${NAMESPACE} get secrets astronomer-root-admin-credentials \\
-      -o go-template --template='{{.data.password|base64decode}}{{\"\n\"}}'
+      -o go-template --template='{{.data.password|base64decode}}{{"\n"}}'
 
   Next, run the following command to port-forward into the kind cluster so you can
   access the web UI:

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -66,30 +66,33 @@ helm install -f "$CONFIG_FILE" \
   "$GIT_ROOT"
 
 
-echo '
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
- Please run the following command to configure kubectl:
+  Astronomer is launching and should be available shortly. Run the following command
+  to configure kubectl to access the kind cluster that Astronomer is running in:
 
-     export KUBECONFIG="$(kind get kubeconfig-path --name=kind)"
+    kind export kubeconfig
 
-'
-echo "
- Astronomer is launching. You can check the status with:
+  You can then check the status with:
 
-     kubectl get pods -n ${NAMESPACE}
+    kubectl get pods -n ${NAMESPACE}
 
+  After Astronomer is up (all pods running, all containers up), find the root login
+  credentials:
 
- After Astronomer is up (all pods running, all containers up), do this to start a connection to the service:
+    kubectl -n ${NAMESPACE} get secrets astronomer-root-admin-credentials \\
+      -o go-template --template='{{.data.password|base64decode}}{{\"\n\"}}'
 
-     sudo -E kubectl port-forward -n ${NAMESPACE} svc/astronomer-nginx 443
+  Next, port-forward into the kind cluster so you can access the application:
 
+    sudo -E kubectl port-forward -n ${NAMESPACE} svc/astronomer-nginx 443
 
- Then you can access the service here: https://app.localtest.me
+  You can then access the service here: https://app.localtest.me
 
- You can clean up like this:
+  Run the following command to remove everything:
 
-     kind delete cluster
+    kind delete cluster
 
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-"
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -74,23 +74,24 @@ cat <<EOF
 
     kind export kubeconfig
 
-  You can then check the status with:
+  Run the following command to check the progress of the Astronomer installation:
 
     kubectl get pods -n ${NAMESPACE}
 
-  After Astronomer is up (all pods running, all containers up), find the root login
-  credentials:
+  After Astronomer is up (all pods running, all containers up), run the following
+  command to find the root password:
 
     kubectl -n ${NAMESPACE} get secrets astronomer-root-admin-credentials \\
       -o go-template --template='{{.data.password|base64decode}}{{\"\n\"}}'
 
-  Next, port-forward into the kind cluster so you can access the application:
+  Next, run the following command to port-forward into the kind cluster so you can
+  access the web UI:
 
     sudo -E kubectl port-forward -n ${NAMESPACE} svc/astronomer-nginx 443
 
-  You can then access the service here: https://app.localtest.me
+  You can then access the web UI here: https://app.localtest.me
 
-  Run the following command to remove everything:
+  Run the following command to delete the cluster and all installed software:
 
     kind delete cluster
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -27,7 +27,7 @@ Download the CLI:
 
     curl -sSL https://install.{{ .Values.global.baseDomain }} | sudo bash
 
-We have guides available at https://www.astronomer.io/guides/ and are always available to help.
+We have guides available at https://docs.astronomer.io/learn and are always available to help.
 
 {{- else }}
 


### PR DESCRIPTION
## Description

Update instructions with modern kind syntax and also syntaxes that give the user instruction on how to log into astronomer root user account now that we have public signups disabled by default.

## Related Issues

N/A, just stuff I found while developing locally.

## Testing

This change modifies test scripts, so as long as tests pass then we're good with that. It would also be good to verify that the text at the end of the CI invocation of `bin/reset-local-dev` is correct. I've already verified it on my local machine.

## Merging

Merge everywhere.
