### PR TITLE
update commader 0.31.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.11
-                - quay.io/astronomer/ap-commander:0.31.3
+                - quay.io/astronomer/ap-commander:0.31.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:5.8.4-23
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.5
+airflowChartVersion: 1.7.6
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.31.3
+    tag: 0.31.4
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

* bump airflow chart version 1.7.5 -> 1.7.6

## Related Issues

https://github.com/astronomer/issues/issues/5386

## Testing

QA should able to deploy airflow with platform without any issues

## Merging

cherry-pick to release-0.31.
