### PR TITLE
allow fluentd to gather gitsync relay pod logs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2023-01
+      - image: quay.io/astronomer/ci-pre-commit:2023-02
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     parallelism: 8
     resource_class: xlarge
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -171,7 +171,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -97,7 +97,7 @@ data:
       @type kubernetes_metadata
     </filter>
 
-    # Filter down by namespace and component (scheduler/webserver/worker/triggerer)
+    # Filter down by namespace and component (scheduler/webserver/worker/triggerer/git-sync-relay)
     <filter kubernetes.**>
       @type grep
       <regexp>
@@ -117,7 +117,7 @@ data:
       </regexp>
       <regexp>
         key $.kubernetes.labels.component
-        pattern ^(scheduler|webserver|worker|triggerer)$
+        pattern ^(scheduler|webserver|worker|triggerer|git-sync-relay)$
       </regexp>
     </filter>
 


### PR DESCRIPTION
## Description

currently we don't capture gitsync relay pod logs . In case after deployment it goes into error state ( like clone error or branch error) , customer should get access to k8s cluster for that release and verify those errors. This way it can send them to elasticsearch and can be used for further processing

## Related Issues

https://github.com/astronomer/issues/issues/5246

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
