### PR TITLE
bump astro-ui to 0.31.12 and chart to rc3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2023-01
+      - image: quay.io/astronomer/ci-pre-commit:2023-02
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     parallelism: 8
     resource_class: xlarge
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -171,7 +171,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -306,7 +306,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
-                - quay.io/astronomer/ap-astro-ui:0.31.11
+                - quay.io/astronomer/ap-astro-ui:0.31.12
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-10
                 - quay.io/astronomer/ap-base:3.16.3

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.31.2-rc2
-appVersion: 0.31.2-rc2
+version: 0.31.2-rc3
+appVersion: 0.31.2-rc3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.31.2-rc2
+version: 0.31.2-rc3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.31.11
+    tag: 0.31.12
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Bump astronomer helm chart to rc3 and astro-ui to 0.31.12

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.31.2
