### PR TITLE
add gitsync network policy exclusion for gitsync relay logs

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-ingress-networkpolicy.yaml
@@ -44,6 +44,11 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: git-sync-relay
+          tier: airflow
     {{- end }}
     ports:
     - protocol: TCP

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -43,6 +43,11 @@ spec:
         matchLabels:
           component: triggerer
           tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: git-sync-relay
+          tier: airflow
     {{- end }}
     ports:
     - protocol: TCP

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -283,6 +283,12 @@ class TestElasticSearch:
                     "matchLabels": {"component": "triggerer", "tier": "airflow"}
                 },
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
+                },
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -288,7 +288,7 @@ class TestElasticSearch:
                 "podSelector": {
                     "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
                 },
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_nginx_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -365,6 +365,12 @@ class TestExternalElasticSearch:
                     "matchLabels": {"component": "triggerer", "tier": "airflow"}
                 },
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {
+                    "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
+                },
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -370,7 +370,7 @@ class TestExternalElasticSearch:
                 "podSelector": {
                     "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
                 },
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):


### PR DESCRIPTION
## Description

Allow gitsync relay pod to ingest logs to elasticsearch from vector container.
This PR adds extra network policies to allow git-sync-relay pod vector sidecar to connect elasticsearch

## Related Issues

https://github.com/astronomer/issues/issues/5246

## Testing

QA should able to see logs when used in combination with vector and incluster es and external es proxy in elasticsearch

## Merging

This is a release-0.32 feature should get cherry-picked  once its available.
