### PR TITLE
Confine user actions to the index of the user performing the action

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -36,6 +36,24 @@ data:
         proxy_set_header Connection "Keep-Alive";
         proxy_set_header Proxy-Connection "Keep-Alive";
 
+        location ~* /_count$ {
+          {{- if .Values.global.loggingSidecar.enabled }}
+          rewrite /_count(.*) /vector.$remote_user.*/_count$1 break;
+          {{- else }}
+          rewrite /_count(.*) /fluentd.$remote_user.*/_count$1 break;
+          {{- end }}
+          proxy_pass http://elasticsearch;
+        }
+
+        location ~* /_bulk$ {
+          {{- if .Values.global.loggingSidecar.enabled }}
+          rewrite /_bulk(.*) /vector.$remote_user.*/_bulk$1 break;
+          {{- else }}
+          rewrite /_bulk(.*) /fluentd.$remote_user.*/_bulk$1 break;
+          {{- end }}
+          proxy_pass http://elasticsearch;
+        }
+
         location ~* /_search$ {
           {{- if .Values.global.loggingSidecar.enabled }}
           rewrite /_search(.*) /vector.$remote_user.*/_search$1 break;
@@ -44,6 +62,7 @@ data:
           {{- end }}
           proxy_pass http://elasticsearch;
         }
+
         location = /auth {
           internal;
           proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -36,6 +36,8 @@ data:
         proxy_set_header Connection "Keep-Alive";
         proxy_set_header Proxy-Connection "Keep-Alive";
 
+        # The following "location" rules limit airflow interactions to only their indices. Any further
+        # additions should follow this pattern.
         location ~* /_count$ {
           {{- if .Values.global.loggingSidecar.enabled }}
           rewrite /_count(.*) /vector.$remote_user.*/_count$1 break;

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -36,26 +36,22 @@ data:
         proxy_set_header Connection "Keep-Alive";
         proxy_set_header Proxy-Connection "Keep-Alive";
 
-        location ~ ^/ {
-          proxy_pass http://elasticsearch;
-        }
-
-        location = /_search {
-          # This combined with disabling explicit index searching downstream
-          # prevents any deployment from being able to query any other indexes.
+        location ~* /_search$ {
           {{- if .Values.global.loggingSidecar.enabled }}
-          rewrite ^/(.*) /vector.$remote_user.*/$1 break;
+          rewrite /_search(.*) /vector.$remote_user.*/_search$1 break;
           {{- else }}
-          rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;
+          rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;
           {{- end }}
           proxy_pass http://elasticsearch;
         }
-
         location = /auth {
           internal;
           proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;
           proxy_set_header Content-Length "";
           proxy_set_header X-Original-URI $request_uri;
+        }
+        location ~ ^/ {
+          deny all;
         }
       }
     }

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -310,6 +310,8 @@ class TestElasticSearch:
         assert all(
             x in nginx_config
             for x in [
+                "location ~* /_bulk$ { rewrite /_bulk(.*) /fluentd.$remote_user.*/_bulk$1 break;",
+                "location ~* /_count$ { rewrite /_count(.*) /fluentd.$remote_user.*/_count$1 break;",
                 "location ~* /_search$ { rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;",
                 "location ~ ^/ { deny all; } } }",
             ]
@@ -335,6 +337,8 @@ class TestElasticSearch:
         assert all(
             x in nginx_config
             for x in [
+                "location ~* /_bulk$ { rewrite /_bulk(.*) /vector.$remote_user.*/_bulk$1 break;",
+                "location ~* /_count$ { rewrite /_count(.*) /vector.$remote_user.*/_count$1 break;",
                 "location ~* /_search$ { rewrite /_search(.*) /vector.$remote_user.*/_search$1 break;",
                 "location ~ ^/ { deny all; } } }",
             ]


### PR DESCRIPTION
## Description

Add nginx rewrite rules that lock all user operations into their own indices.

## Related Issues

- https://github.com/astronomer/issues/issues/5417
- https://astronomer.slack.com/archives/C04P3TRUV3L

## Testing

This should be tested with both sidecar and vector.

@jedcunningham and I have personally tested these changes in a dedicated AWS cluster and they all look good to us.

## Merging

These changes should be good to merge everywhere.