### PR TITLE
resolves CVE-2023-0286 in astronomer vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,12 +320,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
                 - quay.io/astronomer/ap-base:3.16.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.11
+                - quay.io/astronomer/ap-cli-install:0.26.12
                 - quay.io/astronomer/ap-commander:0.31.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.0
-                - quay.io/astronomer/ap-default-backend:0.28.12
+                - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.3-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -318,7 +318,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.31.10
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
-                - quay.io/astronomer/ap-base:3.16.3
+                - quay.io/astronomer/ap-base:3.16.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.11
                 - quay.io/astronomer/ap-commander:0.31.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,14 +316,14 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.31.10
-                - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
-                - quay.io/astronomer/ap-awsesproxy:1.3-10
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
+                - quay.io/astronomer/ap-awsesproxy:1.3-11
                 - quay.io/astronomer/ap-base:3.16.3
-                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.11
                 - quay.io/astronomer/ap-commander:0.31.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:5.8.4-23
+                - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.0
                 - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
@@ -331,21 +331,21 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.15.3-1
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.31.15
-                - quay.io/astronomer/ap-init:3.16.3
+                - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-3
-                - quay.io/astronomer/ap-nats-server:2.8.4
-                - quay.io/astronomer/ap-nats-streaming:0.24.6
-                - quay.io/astronomer/ap-nginx-es:1.23.3-1
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-4
+                - quay.io/astronomer/ap-nats-server:2.8.4-2
+                - quay.io/astronomer/ap-nats-streaming:0.24.6-2
+                - quay.io/astronomer/ap-nginx-es:1.23.3-2
                 - quay.io/astronomer/ap-nginx:1.3.1-2
                 - quay.io/astronomer/ap-node-exporter:1.5.0
-                - quay.io/astronomer/ap-openresty:1.21.4-3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-5
+                - quay.io/astronomer/ap-openresty:1.21.4-4
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.18.0
                 - quay.io/astronomer/ap-prometheus:2.37.5
-                - quay.io/astronomer/ap-registry:3.16.3
+                - quay.io/astronomer/ap-registry:3.16.3-2
                 - quay.io/astronomer/ap-vector:0.26.0
           context:
             - slack_team-software-infra-bot

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.3
+    tag: 3.16.3-2
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.11
+    tag: 0.26.12
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.16.3
+    tag: 3.16.3-2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-23
+    tag: 7.0.0-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.3-1
+    tag: 1.23.3-2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-3
+    tag: 1.21.4-4
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-10
+    tag: 1.3-11
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.4
+    tag: 2.8.4-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-3
+    tag: 0.10.0-4
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.12
+    tag: 0.28.13
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-5
+  tag: 1.17.0-6
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.23.0-1
+  tag: 0.23.0-3
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.16.3
+    tag: 3.16.3-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.6
+    tag: 0.24.6-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-3
+    tag: 0.10.0-4
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -126,7 +126,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.3-1
+    tag: 1.23.3-2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description


resolves CVE-2023-0286 cve in ap-base packages reference in 


image | existing | new
-- | --| --|
awsesproxy | 1.3-10 | 1.3-11
blackbox-exporter | 0.23.0-1 | 0.23.0-3
curator |  5.8.4-23 | 7.0.0-2
init | 3.16.3 | 3.16.3-1
nats-exporter | 0.10.0-3 | 0.10.0-4
nats-server | 2.8.4 | 2.8.4-2
nats-streaming | 0.24.6 | 0.24.6-2
pgbouncer-krb | 1.17.0-5 | 1.17.0-6
registry | 3.16.3 | 3.16.3-2
ap-base | 3.16.3 | 3.16.3-2
default-backend | 0.28.12 | 0.28.13
ap-cli-install | 0.26.11 | 0.26.12

## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
