### PR TITLE
update vendor packages to resolve CVE-2023-0286

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.31.4
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.0
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.1
                 - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,8 +327,8 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.0
                 - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.8
-                - quay.io/astronomer/ap-fluentd:1.15.3-1
+                - quay.io/astronomer/ap-elasticsearch:7.17.8-1
+                - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.31.15
                 - quay.io/astronomer/ap-init:3.16.3-1
@@ -343,7 +343,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.21.4-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.18.0
+                - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
                 - quay.io/astronomer/ap-vector:0.26.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.0
+    tag: 0.31.1
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.8
+    tag: 7.17.8-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.3-1
+    tag: 1.15.3-2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.0
+    tag: 0.31.1
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.18.0
+  tag: 11.18.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION

## Description

* bump ap-elasticsearch 7.17.8 -> 7.17.8-1
* bump ap-fluentd 1.15.3-1 -> 1.15.3-2
* bump ap-postgresql 11.18.0 -> 11.18.0-1
* bump ap-db-boostrapper 0.30.0 -> 0.30.1

## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
