### PR TITLE
update platform images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
-                - quay.io/astronomer/ap-astro-ui:0.31.10
+                - quay.io/astronomer/ap-astro-ui:0.31.13
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
                 - quay.io/astronomer/ap-base:3.16.3-2
@@ -330,7 +330,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.8-1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16
-                - quay.io/astronomer/ap-houston-api:0.31.15
+                - quay.io/astronomer/ap-houston-api:0.31.17
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.31.15
+    tag: 0.31.17
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.31.10
+    tag: 0.31.13
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

* bump ap-houston-api 0.31.15 -> 0.31.17
* bump ap-astro-ui   0.31.10 ->  0.31.13

## Related Issues

https://github.com/astronomer/issues/issues/5365
https://github.com/astronomer/issues/issues/5381


## Testing

QA should now able to test with docker buildx images with this release 

## Merging

cherry-pick to release-0.31, release-0.32
