### PR TITLE
update commander version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.12
-                - quay.io/astronomer/ap-commander:0.31.4
+                - quay.io/astronomer/ap-commander:0.31.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.31.4
+    tag: 0.31.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION


## Description

* bump ap-commander 0.31.4 -> 0.31.5

## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

QA should able to deploy airflow without any issues

## Merging

cherry-pick to release-0.31.
