### PR TITLE
update vector image to resolve openssl CVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,7 +346,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
-                - quay.io/astronomer/ap-vector:0.26.0
+                - quay.io/astronomer/ap-vector:0.26.0-2
           context:
             - slack_team-software-infra-bot
 

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.26.0
+    image: quay.io/astronomer/ap-vector:0.26.0-2
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION
## Description

resolves openssl and libcrypto CVE

## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

QA should validate the sidecar funtionality should work as expected

## Merging

cherry-pick to all valid release branches.
