### PR TITLE
update houston api version 0.31.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.8-1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16
-                - quay.io/astronomer/ap-houston-api:0.31.17
+                - quay.io/astronomer/ap-houston-api:0.31.18
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.31.17
+    tag: 0.31.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.31.17 -> 0.31.18

## Related Issues

https://github.com/astronomer/issues/issues/5221

## Testing

QA should able to override  AIRFLOW_LOGGING ENV var 

## Merging

cherry-pick to release-0.31 branch.
