### PR TITLE
final changes for openssl CVE in vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,18 +327,18 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.1
                 - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.8-1
+                - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.16
+                - quay.io/astronomer/ap-grafana:8.5.16-2
                 - quay.io/astronomer/ap-houston-api:0.31.18
                 - quay.io/astronomer/ap-init:3.16.3-1
-                - quay.io/astronomer/ap-kibana:7.17.8
+                - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-4
                 - quay.io/astronomer/ap-nats-server:2.8.4-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-2
                 - quay.io/astronomer/ap-nginx-es:1.23.3-2
-                - quay.io/astronomer/ap-nginx:1.3.1-2
+                - quay.io/astronomer/ap-nginx:1.3.1-3
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.8-1
+    tag: 7.17.9
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.16
+    tag: 8.5.16-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.8
+    tag: 7.17.9
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.1-2
+    tag: 1.3.1-3
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

resolves openssl and libcrypto CVE's in vendor base packages

image | existing | new
-- | --| --|
ap-elasticsearch | 7.17.8-1 | 7.17.9
ap-grafana| 8.5.16 | 8.5.16-2
ap-kibana | 7.17.8 |  7.17.9
ap-nginx | 1.3.1-2 |  1.3.1-3
## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
