### PR TITLE
Allow `/_cluster/state/version`

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -71,6 +71,11 @@ data:
           proxy_set_header Content-Length "";
           proxy_set_header X-Original-URI $request_uri;
         }
+
+        location = /_cluster/state/version {
+          proxy_pass http://elasticsearch;
+        }
+
         location ~ ^/ {
           deny all;
         }

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -313,6 +313,7 @@ class TestElasticSearch:
                 "location ~* /_bulk$ { rewrite /_bulk(.*) /fluentd.$remote_user.*/_bulk$1 break;",
                 "location ~* /_count$ { rewrite /_count(.*) /fluentd.$remote_user.*/_count$1 break;",
                 "location ~* /_search$ { rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;",
+                "location = /_cluster/state/version { proxy_pass http://elasticsearch; }",
                 "location ~ ^/ { deny all; } } }",
             ]
         )
@@ -341,6 +342,7 @@ class TestElasticSearch:
                 "location ~* /_count$ { rewrite /_count(.*) /vector.$remote_user.*/_count$1 break;",
                 "location ~* /_search$ { rewrite /_search(.*) /vector.$remote_user.*/_search$1 break;",
                 "location ~ ^/ { deny all; } } }",
+                "location = /_cluster/state/version { proxy_pass http://elasticsearch; }",
             ]
         )
 


### PR DESCRIPTION
## Description

Allow the version endpoint through the proxy unmodified.

## Related Issues

https://github.com/astronomer/issues/issues/5434 which is a follow-up to https://github.com/astronomer/issues/issues/5417

## Testing

We have unit tests for this, but really we need functional tests for these kinds of things. We do not do an airflow deployment into the CI workflow, so there's no way to test this with the existing test setup. I think a good middle-ground is to launch a pod with the labels of a webserver pod and run these proxy tests from there, but I also think we can handle that in a follow-up ticket so that this can be merged and shipped quickly.

As for QA testing, this is a really minor change that I'm not sure has any consequence right now, but could potentially solve unobserved failure scenarios. I've tested this in staging and it looks good, so I think we're good for testing and nothing further needs to be done above what has been done for testing the other changes in https://github.com/astronomer/issues/issues/5417

## Merging

Merge everywhere that the other changes in https://github.com/astronomer/issues/issues/5417 were merged to.