### PR TITLE
cherry-pick commits to release-0.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16-2
-                - quay.io/astronomer/ap-houston-api:0.30.33
+                - quay.io/astronomer/ap-houston-api:0.30.34
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
-                - quay.io/astronomer/ap-vector:0.26.0
+                - quay.io/astronomer/ap-vector:0.26.0-2
           context:
             - slack_team-software-infra-bot
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -305,36 +305,36 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.30.10
-                - quay.io/astronomer/ap-auth-sidecar:1.23.3-1
-                - quay.io/astronomer/ap-awsesproxy:1.3-10
-                - quay.io/astronomer/ap-base:3.16.3
-                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.11
+                - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
+                - quay.io/astronomer/ap-awsesproxy:1.3-11
+                - quay.io/astronomer/ap-base:3.16.3-2
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
+                - quay.io/astronomer/ap-cli-install:0.26.12
                 - quay.io/astronomer/ap-commander:0.30.6
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:5.8.4-23
+                - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.0
-                - quay.io/astronomer/ap-default-backend:0.28.12
+                - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
                 - quay.io/astronomer/ap-fluentd:1.15.3-1
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.30.32
-                - quay.io/astronomer/ap-init:3.16.3
+                - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.8
                 - quay.io/astronomer/ap-kube-state:2.7.0
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-3
-                - quay.io/astronomer/ap-nats-server:2.8.4
-                - quay.io/astronomer/ap-nats-streaming:0.24.6
-                - quay.io/astronomer/ap-nginx-es:1.23.3-1
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-4
+                - quay.io/astronomer/ap-nats-server:2.8.4-2
+                - quay.io/astronomer/ap-nats-streaming:0.24.6-2
+                - quay.io/astronomer/ap-nginx-es:1.23.3-2
                 - quay.io/astronomer/ap-nginx:1.3.1-2
                 - quay.io/astronomer/ap-node-exporter:1.5.0
-                - quay.io/astronomer/ap-openresty:1.21.4-3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-5
+                - quay.io/astronomer/ap-openresty:1.21.4-4
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
                 - quay.io/astronomer/ap-postgresql:11.18.0
                 - quay.io/astronomer/ap-prometheus:2.37.5
-                - quay.io/astronomer/ap-registry:3.16.3
+                - quay.io/astronomer/ap-registry:3.16.3-2
                 - quay.io/astronomer/ap-vector:0.26.0
           context:
             - slack_team-software-infra-bot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -313,11 +313,11 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.30.6
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.0
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.1
                 - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.8
-                - quay.io/astronomer/ap-fluentd:1.15.3-1
+                - quay.io/astronomer/ap-elasticsearch:7.17.8-1
+                - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.30.32
                 - quay.io/astronomer/ap-init:3.16.3-1
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.21.4-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.18.0
+                - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
                 - quay.io/astronomer/ap-vector:0.26.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2023-01
+      - image: quay.io/astronomer/ci-pre-commit:2023-02
     steps:
       - checkout
       - run:
@@ -107,7 +107,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     parallelism: 8
     resource_class: xlarge
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -171,7 +171,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-01
+      - image: quay.io/astronomer/ci-helm-release:2023-02
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -304,7 +304,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
-                - quay.io/astronomer/ap-astro-ui:0.30.10
+                - quay.io/astronomer/ap-astro-ui:0.30.12
                 - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
                 - quay.io/astronomer/ap-base:3.16.3-2
@@ -319,7 +319,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16-2
-                - quay.io/astronomer/ap-houston-api:0.30.32
+                - quay.io/astronomer/ap-houston-api:0.30.33
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,18 +316,18 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.1
                 - quay.io/astronomer/ap-default-backend:0.28.13
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
-                - quay.io/astronomer/ap-elasticsearch:7.17.8-1
+                - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.16
+                - quay.io/astronomer/ap-grafana:8.5.16-2
                 - quay.io/astronomer/ap-houston-api:0.30.32
                 - quay.io/astronomer/ap-init:3.16.3-1
-                - quay.io/astronomer/ap-kibana:7.17.8
+                - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-4
                 - quay.io/astronomer/ap-nats-server:2.8.4-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-2
                 - quay.io/astronomer/ap-nginx-es:1.23.3-2
-                - quay.io/astronomer/ap-nginx:1.3.1-2
+                - quay.io/astronomer/ap-nginx:1.3.1-3
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.12
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.8
-                - quay.io/astronomer/ap-fluentd:1.15.2
+                - quay.io/astronomer/ap-fluentd:1.15.3-1
                 - quay.io/astronomer/ap-grafana:8.5.16
                 - quay.io/astronomer/ap-houston-api:0.30.32
                 - quay.io/astronomer/ap-init:3.16.3

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.32
+    tag: 0.30.33
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.30.10
+    tag: 0.30.12
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.0
+    tag: 0.31.1
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.33
+    tag: 0.30.34
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.3
+    tag: 3.16.3-2
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.11
+    tag: 0.26.12
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.8
+    tag: 7.17.8-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.16.3
+    tag: 3.16.3-2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 5.8.4-23
+    tag: 7.0.0-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.3-1
+    tag: 1.23.3-2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.8-1
+    tag: 7.17.9
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-3
+    tag: 1.21.4-4
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-10
+    tag: 1.3-11
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.2
+    tag: 1.15.3-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.15.3-1
+    tag: 1.15.3-2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.0
+    tag: 0.31.1
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.16
+    tag: 8.5.16-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 7.17.8
+    tag: 7.17.9
     pullPolicy: IfNotPresent
 
 clusterName: "astronomer"

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.4
+    tag: 2.8.4-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-3
+    tag: 0.10.0-4
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.12
+    tag: 0.28.13
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.1-2
+    tag: 1.3.1-3
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-5
+  tag: 1.17.0-6
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.18.0
+  tag: 11.18.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.23.0-1
+  tag: 0.23.0-3
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.16.3
+    tag: 3.16.3-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.6
+    tag: 0.24.6-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-3
+    tag: 0.10.0-4
     pullPolicy: IfNotPresent
 
 stan:

--- a/values.yaml
+++ b/values.yaml
@@ -124,7 +124,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.3-1
+    tag: 1.23.3-2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |

--- a/values.yaml
+++ b/values.yaml
@@ -108,7 +108,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.26.0
+    image: quay.io/astronomer/ap-vector:0.26.0-2
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION
## Description

cherry-pick CVE commits to release-0.30 branch 

image-name | current | new
-- | -- | --
ap-astro-ui |0.30.10 | 0.30.12
ap-auth-sidecar |1.23.3-1 | 1.23.3-2
ap-awsesproxy |1.3-10 |  1.3-11
ap-base | 3.16.3 | 3.16.3-2 
ap-blackbox-exporter | 0.23.0-1 |  0.23.0-3 
ap-cli-install | 0.26.11 |  0.26.12
ap-curator | 5.8.4-23 |  7.0.0-2
ap-db-bootstrapper  | 0.31.0 | 0.31.1
ap-default-backend | 0.28.12 |  0.28.13
ap-elasticsearch | 7.17.8 | 7.17.9
ap-fluentd  |1.15.2 |  1.15.3-2
ap-grafana |8.5.16 |  8.5.16-2
ap-houston-api | 0.30.32 |  0.30.34
ap-init | 3.16.3 |  3.16.3-1
ap-kibana | 7.17.8 | 7.17.9
ap-nats-exporter | 0.10.0-3 | 0.10.0-4
ap-nats-server | 2.8.4 |  2.8.4-2
ap-nats-streaming |0.24.6 |  0.24.6-2
ap-nginx-es | 1.23.3-1 | 1.23.3-2
ap-nginx | 1.3.1-2 | 1.3.1-3
ap-openresty | 1.21.4-3 | 1.21.4-4
ap-pgbouncer-krb | 1.17.0-5 | 1.17.0-6
ap-postgresql |11.18.0 | 11.18.0-1
ap-registry | 3.16.3 | 3.16.3-2
ap-vector | 0.26.0 |  0.26.0-2
              


## Related Issues

https://github.com/astronomer/issues/issues/5419

## Testing

QA should able to deploy astronomer platform wiithout any issues

## Merging

cherry-pick to release-0.30.
