### PR TITLE
ap-postgresql 15.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.21.4-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1
-                - quay.io/astronomer/ap-postgresql:11.18.0-1
+                - quay.io/astronomer/ap-postgresql:15.2.0
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
                 - quay.io/astronomer/ap-vector:0.26.0-2

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 11.18.0-1
+  tag: 15.2.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

ap-postgresql 15.2.0.  This should not be merged until we are ready for 0.32.

## Related Issues

- https://github.com/astronomer/issues/issues/5374
- https://github.com/astronomer/issues/issues/5454

## Testing

This is a big jump so we should definitely keep an eye out for any changes to postgres behaviors. We should expect improved performance.

## Merging

This is only meant for release-0.32 and newer.

## Communication and docs

Upgrading to this is not possible without manual intervention, and customers who are using in-cluster postgres (which goes against our advice and is not a supported configuration) should be advised about this change and urged to migrate away from in-cluster postgres. AFAIK we are not planning to support an upgrade path from postgres 11 to 15 because in-cluster postgres was never a supported configuration for production. CC @astronomer/docs 