### PR TITLE
bump houston-api 0.31.21 and chart to rc4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2023-02
+      - image: quay.io/astronomer/ci-pre-commit:2023-03
     steps:
       - checkout
       - run:
@@ -111,7 +111,7 @@ jobs:
 
   unittest-charts:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-02
+      - image: quay.io/astronomer/ci-helm-release:2023-03
     parallelism: 8
     resource_class: xlarge
     steps:
@@ -166,7 +166,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-02
+      - image: quay.io/astronomer/ci-helm-release:2023-03
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -179,7 +179,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2023-02
+      - image: quay.io/astronomer/ci-helm-release:2023-03
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -330,7 +330,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.16-2
-                - quay.io/astronomer/ap-houston-api:0.31.19
+                - quay.io/astronomer/ap-houston-api:0.31.21
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.31.3-rc3
-appVersion: 0.31.3-rc3
+version: 0.31.3-rc4
+appVersion: 0.31.3-rc4
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.31.3-rc3
+version: 0.31.3-rc4
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.31.19
+    tag: 0.31.21
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

- Bump houston-api 0.31.19 -> 0.31.21
- Bump chart version to rc4

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.31
