### PR TITLE
Incremental functional test improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
 
   platform-1-22-15:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.22.15
@@ -208,7 +208,7 @@ jobs:
           when: always
   platform-1-23-13:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.23.13
@@ -224,7 +224,7 @@ jobs:
           when: always
   platform-1-24-7:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.24.7
@@ -240,7 +240,7 @@ jobs:
           when: always
   platform-1-25-3:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.25.3
@@ -256,7 +256,7 @@ jobs:
           when: always
   platform-1-26-0:
     machine:
-      image: ubuntu-2204:2022.10.2
+      image: ubuntu-2204:2023.02.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.26.0
@@ -547,7 +547,7 @@ commands:
           name: Install Astronomer chart
           command: |
             echo 'export PATH="/tmp/bin:/tmp/google-cloud-sdk/bin:$PATH"' >> "$HOME/.bashrc"
-            set -e
+            set -xe
             HELM_CHART_PATH='/tmp/workspace/astronomer-*.tgz' bin/run-ci << parameters.astronomer-tags >>
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -438,7 +438,7 @@ commands:
           name: Install Astronomer chart
           command: |
             echo 'export PATH="/tmp/bin:/tmp/google-cloud-sdk/bin:$PATH"' >> "$HOME/.bashrc"
-            set -e
+            set -xe
             HELM_CHART_PATH='/tmp/workspace/astronomer-*.tgz' bin/run-ci << parameters.astronomer-tags >>
       - store_test_results:
           path: test-results

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -22,7 +22,7 @@ kube_versions = [
 # https://circleci.com/docs/2.0/building-docker-images/#docker-version
 ci_remote_docker_version = "20.10.18"
 # https://circleci.com/developer/machine/image/ubuntu-2204
-machine_image_version = "ubuntu-2204:2022.10.2"
+machine_image_version = "ubuntu-2204:2023.02.1"
 ci_runner_version = datetime.datetime.now().strftime("%Y-%m")
 
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: '(venv|\.vscode)' # regex
 repos:
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.5.0
+    rev: v1.5.1
     hooks:
       - id: docformatter
         args: ["--wrap-summaries=125", "--wrap-descriptions=125"]
@@ -28,11 +28,11 @@ repos:
     rev: 23.1.0
     hooks:
       - id: black
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: "v0.0.253"
     hooks:
-      - id: pyupgrade
-        args: ["--py39-plus"]
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --ignore, E501]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -62,12 +62,6 @@ repos:
           ]
       - id: sort-simple-yaml
       - id: trailing-whitespace
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        args:
-          - --ignore=E501,W503
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.2
     hooks:

--- a/tests/functional_tests/__init__.py
+++ b/tests/functional_tests/__init__.py
@@ -1,0 +1,13 @@
+from kubernetes import client, config
+
+
+def get_core_v1_client(in_cluster=False):
+    """Return a Core v1 API client."""
+    if in_cluster:
+        print("Using in cluster kubernetes configuration")
+        config.load_incluster_config()
+    else:
+        print("Using kubectl kubernetes configuration")
+        config.load_kube_config()
+
+    return client.CoreV1Api()

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -5,7 +5,7 @@ from os import getenv
 import docker
 import pytest
 import testinfra
-from kubernetes import client, config
+from . import get_core_v1_client
 
 if not (namespace := getenv("NAMESPACE")):
     print("NAMESPACE env var is not present, using 'astronomer' namespace")
@@ -19,31 +19,31 @@ if not (release_name := getenv("RELEASE_NAME")):
 
 
 @pytest.fixture(scope="function")
-def nginx(request, kube_client):
+def nginx(core_v1_client):
     """This is the host fixture for testinfra.
 
     To read more, please see the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    pod = get_pod_by_label_selector(kube_client, "component=ingress-controller")
+    pod = get_pod_by_label_selector(core_v1_client, "component=ingress-controller")
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace={namespace}")
 
 
 @pytest.fixture(scope="function")
-def houston_api(request, kube_client):
+def houston_api(core_v1_client):
     """This is the host fixture for testinfra.
 
     To read more, please see the testinfra documentation:
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    pod = get_pod_by_label_selector(kube_client, "component=houston")
+    pod = get_pod_by_label_selector(core_v1_client, "component=houston")
     yield testinfra.get_host(f"kubectl://{pod}?container=houston&namespace={namespace}")
 
 
 @pytest.fixture(scope="function")
-def prometheus(request):
+def prometheus():
     """This is the host fixture for testinfra.
 
     To read more, please see the testinfra documentation:
@@ -57,7 +57,7 @@ def prometheus(request):
 
 
 @pytest.fixture(scope="function")
-def es_master(request):
+def es_master():
     pod = f"{release_name}-elasticsearch-master-0"
     yield testinfra.get_host(
         f"kubectl://{pod}?container=es-master&namespace={namespace}"
@@ -65,21 +65,23 @@ def es_master(request):
 
 
 @pytest.fixture(scope="function")
-def es_data(request):
+def es_data():
     pod = f"{release_name}-elasticsearch-data-0"
     yield testinfra.get_host(f"kubectl://{pod}?container=es-data&namespace={namespace}")
 
 
 @pytest.fixture(scope="function")
-def es_client(request, kube_client):
-    pod = get_pod_by_label_selector(kube_client, "component=elasticsearch,role=client")
+def es_client(core_v1_client):
+    pod = get_pod_by_label_selector(
+        core_v1_client, "component=elasticsearch,role=client"
+    )
     yield testinfra.get_host(
         f"kubectl://{pod}?container=es-client&namespace={namespace}"
     )
 
 
 @pytest.fixture(scope="session")
-def docker_client(request):
+def docker_client():
     """This is a text fixture for the docker client, should it be needed in a
     test."""
     docker_client = docker.from_env()
@@ -88,33 +90,21 @@ def docker_client(request):
 
 
 @pytest.fixture(scope="session")
-def kube_client(request, in_cluster=False):
+def core_v1_client(in_cluster=False):
     """Return a kubernetes client.
 
     By default, use kube-config. If running in a pod, use k8s service
     account.
     """
 
-    k8s_client = get_kube_client(in_cluster)
-    yield k8s_client
-
-
-def get_kube_client(in_cluster=False):
-    if in_cluster:
-        print("Using in cluster kubernetes configuration")
-        config.load_incluster_config()
-    else:
-        print("Using kubectl kubernetes configuration")
-        config.load_kube_config()
-
-    return client.CoreV1Api()
+    yield get_core_v1_client(in_cluster)
 
 
 def get_pod_by_label_selector(
-    kube_client, label_selector, pod_namespace=namespace
+    core_v1_client, label_selector, pod_namespace=namespace
 ) -> str:
     """Return the name of a pod found by label selector."""
-    pods = kube_client.list_namespaced_pod(
+    pods = core_v1_client.list_namespaced_pod(
         pod_namespace, label_selector=label_selector
     ).items
     assert (
@@ -125,7 +115,7 @@ def get_pod_by_label_selector(
 
 def get_pod_running_containers(pod_namespace=namespace):
     """Return the containers from pods found."""
-    pods = get_kube_client().list_namespaced_pod(pod_namespace).items
+    pods = get_core_v1_client().list_namespaced_pod(pod_namespace).items
 
     containers = {}
     for pod in pods:
@@ -136,7 +126,7 @@ def get_pod_running_containers(pod_namespace=namespace):
                 container["pod_name"] = pod_name
                 container["namespace"] = pod_namespace
 
-                key = pod_name + "_" + container_status.name
+                key = f"{pod_name}_{container_status.name}"
                 containers[key] = container
 
     return containers


### PR DESCRIPTION
## Description

These changes are mostly code reorganization. There aren't any code additions. There are minor removals.

- Use newer circleci ubuntu machine image
- Use ruff in place of pyupgrade, flake8
- Remove unneeded inclusion of the `request` pytest fixture
- Rename pytest fixture `get_kube_client` to `get_core_v1_client`
- Move `get_core_v1_client` out of `conftest.py` to `__init__.py` since it is not a fixture and will be used by more functions in the near future.
- Delete some old CoreDNS branching logic that is no longer relevant.
- Replace `randint` with `strftime('%s')` which is unique enough for our needs while providing useful information.
- Add some docstrings.
- Switch from raising an exception when `HELM_CHART_PATH` is unset to just skipping the test.

## Related Issues

This is indirectly related to https://github.com/astronomer/issues/issues/5437 I was working on that when making these changes, but they are not directly related, so I broke them out into their own PR.

## Testing

These are all test changes, so no additional testing is needed.

## Merging

These changes should be merged everywhere.