### PR TITLE
Use vector 0.26.0-4 with ap-base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
-                - quay.io/astronomer/ap-vector:0.26.0-2
+                - quay.io/astronomer/ap-vector:0.26.0-4
           context:
             - slack_team-software-infra-bot
 

--- a/values.yaml
+++ b/values.yaml
@@ -110,7 +110,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.26.0-2
+    image: quay.io/astronomer/ap-vector:0.26.0-4
     terminationEndpoint: http://localhost:8000/quitquitquit
     customConfig: false
     extraEnv: []


### PR DESCRIPTION
## Description

Use vector 0.26.0-4 with ap-base

## Related Issues

- <https://github.com/astronomer/issues/issues/5472>
- <https://github.com/astronomer/ap-vendor/pull/500>

## Testing

Normal logging sidecar testing should cover this.

## Merging

This should be merged everywhere.
