### PR TITLE
Adding CircleCI Job to trigger `test_upgrade` on RC build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,19 @@ jobs:
             set -e
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
+  trigger-rc-test:
+    executor: python/default
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
+
   release-to-public:
     docker:
       - image: quay.io/astronomer/ci-helm-release:2023-03
@@ -383,6 +396,9 @@ workflows:
             - approve-internal-release
             - platform-1-22-15
             - platform-1-26-0
+      - trigger-rc-test:
+          requires:
+            - approve-internal-release
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ workflows:
             - platform-1-26-0
       - trigger-rc-test:
           requires:
-            - approve-internal-release
+            - release-to-internal
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ executors:
 
 orbs:
   slack: circleci/slack@4.10.1
+  python: circleci/python@2.1.1
 
 parameters:
   scan-docker-images:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -175,6 +175,19 @@ jobs:
             set -e
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
+  trigger-rc-test:
+    executor: python/default
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
+
   release-to-public:
     docker:
       - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
@@ -277,6 +290,9 @@ workflows:
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
             - platform-{{ version | replace(".", "-") }}
 {%- endfor %}
+      - trigger-rc-test:
+          requires:
+            - approve-internal-release
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -293,7 +293,7 @@ workflows:
 {%- endfor %}
       - trigger-rc-test:
           requires:
-            - approve-internal-release
+            - release-to-internal
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -8,6 +8,7 @@ executors:
 
 orbs:
   slack: circleci/slack@4.10.1
+  python: circleci/python@2.1.1
 
 parameters:
   scan-docker-images:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -68,7 +68,7 @@ def main(circleci_token: str, astro_path: str):
             f"INFO: Skipping calling workflow as no valid version found for the RC test. Below files are found at path: {astro_path}."
         )
         print(json.dumps(file_list))
-        exit(0)
+        raise SystemExit(0)
 
     # Trigger the workflow
 

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+This script is used to run test_upgrade script.
+"""
+
+import argparse
+import http.client
+import json
+import os
+import re
+import time
+from pathlib import Path
+
+CHECK_PIPELINE_STATUES_TIMER_MIN = 5
+GITHUB_ORG = "astronomer"
+CIRCLECI_URL = "circleci.com"
+REPO = "terraform-aws-astronomer"
+REPO_BRANCH = "master"
+
+parent_directory = Path(__file__).parent.parent
+circleci_directory = parent_directory / ".circleci"
+
+
+def run_workflow(circleci_token: str, parameters: dict = None):
+    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL, timeout=15)
+    api_endpoint = f"/api/v2/project/github/{GITHUB_ORG}/{REPO}/pipeline"
+
+    headers = {"content-type": "application/json", "Circle-Token": circleci_token}
+
+    payload = {"branch": REPO_BRANCH}
+
+    if parameters is not None:
+        payload["parameters"] = parameters
+
+    circle_ci_conn.request(
+        method="POST", url=api_endpoint, body=json.dumps(payload), headers=headers
+    )
+    resp = circle_ci_conn.getresponse().read().decode("utf-8")
+    circle_ci_conn.close()
+    return resp
+
+
+def get_job_state(circleci_token: str, pipeline_id: str):
+    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL)
+    api_endpoint = f"/api/v2/pipeline/{pipeline_id}/workflow"
+
+    headers = {"content-type": "application/json", "Circle-Token": circleci_token}
+
+    circle_ci_conn.request(method="GET", url=api_endpoint, headers=headers)
+    resp = circle_ci_conn.getresponse().read().decode("utf-8")
+    circle_ci_conn.close()
+    return resp
+
+
+def main(circleci_token: str, astro_path: str):
+    # Getting Astronomer Helm Chart - FileName
+    file_list = os.listdir(astro_path)
+
+    astro_version = None
+    for file_name in file_list:
+        x = re.search("astronomer-.*.tgz", file_name)
+        if x is not None:
+            astro_version = file_name
+
+    # Trigger the workflow
+
+    astro_version = astro_version.removeprefix("astronomer-")
+    astro_version = astro_version.removesuffix(".tgz")
+
+    parameters = {"astro_version": astro_version, "test_upgrade_workflow_gen": True}
+
+    print("INFO: Printing parameters")
+    print(json.dumps(parameters, indent=1))
+
+    # Run Workflow
+    run_workflow_resp = run_workflow(
+        circleci_token=circleci_token, parameters=parameters
+    )
+
+    pipeline_id = json.loads(run_workflow_resp)["id"]
+    pipeline_number = json.loads(run_workflow_resp)["number"]
+
+    # Printing Info
+    print(
+        f"CircleCI JOB URL = https://app.circleci.com/pipelines/github/{GITHUB_ORG}/{REPO}/{pipeline_number}"
+    )
+
+    print("INFO: Waiting till pipeline starts running. It will wait for 5 mins.")
+    pipeline_state = "pending"
+    counter = 0
+    while "pending" != pipeline_state:
+        time.sleep(60)
+        job_state_resp = get_job_state(
+            circleci_token=circleci_token, pipeline_id=pipeline_id
+        )
+        pipeline_state = json.loads(job_state_resp)["items"][0]["status"]
+        counter = counter + 1
+
+        if counter == 5:
+            break
+
+    if "success" != pipeline_state and "running" != pipeline_state:
+        return exit(1)
+    else:
+        return exit(0)
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser(description="Optional app description")
+
+    # Required positional argument
+    arg_parser.add_argument("--circleci_token", type=str, required=True)
+    arg_parser.add_argument("--astro_path", type=str, required=True)
+
+    args = arg_parser.parse_args()
+
+    main(astro_path=args.astro_path, circleci_token=args.circleci_token)

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -59,8 +59,15 @@ def main(circleci_token: str, astro_path: str):
     astro_version = None
     for file_name in file_list:
         x = re.search("astronomer-.*.tgz", file_name)
-        if x is not None:
+        if x is not None and astro_version is None and "rc" in astro_version:
             astro_version = file_name
+
+    if astro_version is None:
+        print(
+            f"Error: No valid version found for RC test. Below files are found at path: {astro_path}."
+        )
+        print(json.dumps(file_list))
+        exit(0)
 
     # Trigger the workflow
 

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -93,7 +93,7 @@ def main(circleci_token: str, astro_path: str):
         f"CircleCI JOB URL = https://app.circleci.com/pipelines/github/{GITHUB_ORG}/{REPO}/{pipeline_number}"
     )
 
-    print("INFO: Waiting till pipeline starts running. It will wait for 5 mins.")
+    print("INFO: Waiting until pipeline starts running. It will wait for 5 min.")
     pipeline_state = "pending"
     counter = 0
     while "pending" != pipeline_state:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -60,6 +60,7 @@ def main(circleci_token: str, astro_path: str):
     for file_name in file_list:
         x = re.search("astronomer-.*.tgz", file_name)
         if x is not None and astro_version is None and "rc" in file_name:
+            print(f"INFO: Found file {file_name}")
             astro_version = file_name
 
     if astro_version is None:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -108,7 +108,7 @@ def main(circleci_token: str, astro_path: str):
             break
 
     if "success" != pipeline_state and "running" != pipeline_state:
-        return exit(1)
+        raise SystemError(1)
     else:
         raise SystemExit(0)
 

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -65,7 +65,7 @@ def main(circleci_token: str, astro_path: str):
 
     if astro_version is None:
         print(
-            f"Error: No valid version found for RC test. Below files are found at path: {astro_path}."
+            f"INFO: Skipping calling workflow as no valid version found for the RC test. Below files are found at path: {astro_path}."
         )
         print(json.dumps(file_list))
         exit(0)

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -59,7 +59,7 @@ def main(circleci_token: str, astro_path: str):
     astro_version = None
     for file_name in file_list:
         x = re.search("astronomer-.*.tgz", file_name)
-        if x is not None and astro_version is None and "rc" in astro_version:
+        if x is not None and astro_version is None and "rc" in file_name:
             astro_version = file_name
 
     if astro_version is None:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -110,7 +110,7 @@ def main(circleci_token: str, astro_path: str):
     if "success" != pipeline_state and "running" != pipeline_state:
         return exit(1)
     else:
-        return exit(0)
+        raise SystemExit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adding CircleCI Job extending workflow `build-and-release-helm-chart` to trigger `test_upgrade` workflow of `terraform-aws-astronomer` on RC build.

## Related Issues

Issue: https://github.com/astronomer/issues/issues/5461

## Testing

As this is the CircleCI Workflow, it can be tested as execution.

## Merging

- [release-0.32](https://github.com/astronomer/astronomer/tree/release-0.32)
- [release-0.31](https://github.com/astronomer/astronomer/tree/release-0.31)
- [release-0.30](https://github.com/astronomer/astronomer/tree/release-0.30)