### PR TITLE
airflowChartVersion: 1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,7 +319,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.12
-                - quay.io/astronomer/ap-commander:0.31.5
+                - quay.io/astronomer/ap-commander:0.32.0
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.31.5
+    tag: 0.32.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.6
+airflowChartVersion: 1.8.1
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

Bump airflowChartVersion to 1.8.1, which fixes the statsd problem caused by statsd configmap changes in OSS airflow, along with other changes.

Here is the change set for astronomer/airflow-chart: https://github.com/astronomer/airflow-chart/compare/v1.7.6..09b8efc

## Related Issues

- https://github.com/astronomer/issues/issues/5476
- https://github.com/astronomer/airflow-chart/pull/409
- https://github.com/astronomer/commander/pull/146
- https://github.com/astronomer/astronomer/pull/1839

## Testing

I manually tested this in dev and in an aws cluster.

## Merging

This should only be merged to release-0.32, which is the only branch that uses astronomer/airflow-chart 1.8.x. We'll release new versions of astronomer/airflow-chart 1.7 for other branches.
