### PR TITLE
Adding Trigger to call feature_stack deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   trigger-rc-test:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -192,7 +192,7 @@ jobs:
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
 
   trigger-feature-stack-release:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,19 @@ jobs:
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
 
+  trigger-feature-stack-release:
+    executor: python/default
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
+
   release-to-public:
     docker:
       - image: quay.io/astronomer/ci-helm-release:2023-03
@@ -400,6 +413,12 @@ workflows:
       - trigger-rc-test:
           requires:
             - release-to-internal
+      - approve-feature-stack-release:
+          type: approval
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
+            - approve-feature-stack-release
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,10 +415,18 @@ workflows:
             - release-to-internal
       - approve-feature-stack-release:
           type: approval
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - trigger-feature-stack-release:
           requires:
             - release-to-internal
             - approve-feature-stack-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -189,6 +189,19 @@ jobs:
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
 
+  trigger-feature-stack-release:
+    executor: python/default
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
+
   release-to-public:
     docker:
       - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
@@ -294,6 +307,12 @@ workflows:
       - trigger-rc-test:
           requires:
             - release-to-internal
+      - approve-feature-stack-release:
+          type: approval
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
+            - approve-feature-stack-release
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -309,10 +309,18 @@ workflows:
             - release-to-internal
       - approve-feature-stack-release:
           type: approval
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - trigger-feature-stack-release:
           requires:
             - release-to-internal
             - approve-feature-stack-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -177,7 +177,7 @@ jobs:
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   trigger-rc-test:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -190,7 +190,7 @@ jobs:
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
 
   trigger-feature-stack-release:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -99,15 +99,16 @@ def main(circleci_token: str, astro_path: str, branch: str):
     print("INFO: Waiting until pipeline starts running. It will wait for 5 min.")
     pipeline_state = "pending"
     counter = 0
-    while "pending" != pipeline_state:
-        time.sleep(60)
+
+    while "pending" == pipeline_state:
+        time.sleep(10)
         job_state_resp = get_job_state(
             circleci_token=circleci_token, pipeline_id=pipeline_id
         )
         pipeline_state = json.loads(job_state_resp)["items"][0]["status"]
         counter = counter + 1
 
-        if counter == 5:
+        if counter == 6:
             break
 
     if "success" != pipeline_state and "running" != pipeline_state:

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -111,6 +111,7 @@ def main(circleci_token: str, astro_path: str, branch: str):
             break
 
     if "success" != pipeline_state and "running" != pipeline_state:
+        print(f"Failed to run pipeline. Status {pipeline_state}")
         raise SystemError(1)
     else:
         raise SystemExit(0)

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This script is used to run test_upgrade script.
+This script is used to run feature_stack_release workflow from terraform-aws-astronomer.
 """
 
 import argparse
@@ -52,25 +52,23 @@ def get_job_state(circleci_token: str, pipeline_id: str):
     return resp
 
 
-def main(circleci_token: str, astro_path: str):
+def main(circleci_token: str, astro_path: str, branch: str):
     # Getting Astronomer Helm Chart - FileName
     file_list = os.listdir(astro_path)
 
     astro_version = None
     for file_name in file_list:
         x = re.search("astronomer-.*.tgz", file_name)
-        if x is not None and astro_version is None and "rc" in file_name:
+        if x is not None and astro_version is None:
             print(f"INFO: Found file {file_name}")
             astro_version = file_name
 
     if astro_version is None:
         print(
-            f"INFO: Skipping calling workflow as no valid version found for the RC test. Below files are found at path: {astro_path}."
+            f"INFO: Skipping calling workflow as no valid version. Below files are found at path: {astro_path}."
         )
         print(json.dumps(file_list))
         raise SystemExit(0)
-
-    # Trigger the workflow
 
     astro_version = astro_version.removeprefix("astronomer-")
     astro_version = astro_version.removesuffix(".tgz")
@@ -78,7 +76,8 @@ def main(circleci_token: str, astro_path: str):
     parameters = {
         "astro_version": astro_version,
         "workflow_gen": True,
-        "workflow_name": "test_upgrade",
+        "workflow_name": "feature_stack",
+        "workflow_extra_params_json": json.dumps({"release": branch}),
     }
 
     print("INFO: Printing parameters")
@@ -123,6 +122,7 @@ if __name__ == "__main__":
     # Required positional argument
     arg_parser.add_argument("--circleci_token", type=str, required=True)
     arg_parser.add_argument("--astro_path", type=str, required=True)
+    arg_parser.add_argument("--branch", type=str, required=True)
 
     args = arg_parser.parse_args()
 

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -41,7 +41,7 @@ def run_workflow(circleci_token: str, parameters: dict = None):
 
 
 def get_job_state(circleci_token: str, pipeline_id: str):
-    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL)
+    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL, timeout=15)
     api_endpoint = f"/api/v2/pipeline/{pipeline_id}/workflow"
 
     headers = {"content-type": "application/json", "Circle-Token": circleci_token}
@@ -119,7 +119,7 @@ def main(circleci_token: str, astro_path: str, branch: str):
 
 
 if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser(description="Optional app description")
+    arg_parser = argparse.ArgumentParser()
 
     # Required positional argument
     arg_parser.add_argument("--circleci_token", type=str, required=True)

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -126,4 +126,4 @@ if __name__ == "__main__":
 
     args = arg_parser.parse_args()
 
-    main(astro_path=args.astro_path, circleci_token=args.circleci_token)
+    main(astro_path=args.astro_path, circleci_token=args.circleci_token, branch=args.branch)

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -126,4 +126,8 @@ if __name__ == "__main__":
 
     args = arg_parser.parse_args()
 
-    main(astro_path=args.astro_path, circleci_token=args.circleci_token, branch=args.branch)
+    main(
+        astro_path=args.astro_path,
+        circleci_token=args.circleci_token,
+        branch=args.branch,
+    )

--- a/bin/trigger_feature_stack_update.py
+++ b/bin/trigger_feature_stack_update.py
@@ -111,7 +111,7 @@ def main(circleci_token: str, astro_path: str, branch: str):
             break
 
     if "success" != pipeline_state and "running" != pipeline_state:
-        print(f"Failed to run pipeline. Status {pipeline_state}")
+        print(f"Error: Failed to run pipeline. Last Status: {pipeline_state}")
         raise SystemError(1)
     else:
         raise SystemExit(0)

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -41,7 +41,7 @@ def run_workflow(circleci_token: str, parameters: dict = None):
 
 
 def get_job_state(circleci_token: str, pipeline_id: str):
-    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL)
+    circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL, timeout=15)
     api_endpoint = f"/api/v2/pipeline/{pipeline_id}/workflow"
 
     headers = {"content-type": "application/json", "Circle-Token": circleci_token}
@@ -118,7 +118,7 @@ def main(circleci_token: str, astro_path: str):
 
 
 if __name__ == "__main__":
-    arg_parser = argparse.ArgumentParser(description="Optional app description")
+    arg_parser = argparse.ArgumentParser()
 
     # Required positional argument
     arg_parser.add_argument("--circleci_token", type=str, required=True)

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -100,15 +100,15 @@ def main(circleci_token: str, astro_path: str):
     print("INFO: Waiting until pipeline starts running. It will wait for 5 min.")
     pipeline_state = "pending"
     counter = 0
-    while "pending" != pipeline_state:
-        time.sleep(60)
+    while "pending" == pipeline_state:
+        time.sleep(10)
         job_state_resp = get_job_state(
             circleci_token=circleci_token, pipeline_id=pipeline_id
         )
         pipeline_state = json.loads(job_state_resp)["items"][0]["status"]
         counter = counter + 1
 
-        if counter == 5:
+        if counter == 6:
             break
 
     if "success" != pipeline_state and "running" != pipeline_state:


### PR DESCRIPTION
## Description

Adding a trigger to call the `feature_stack` workflow that performs the deployment on the cluster. This will add the capability to refresh the cluster with the latest build immediately.

## Related Issues

https://github.com/astronomer/issues/issues/5507

## Merging

- release-0.30
- release-0.31
