### PR TITLE
ap-grafana 8.5.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.16-2
+                - quay.io/astronomer/ap-grafana:8.5.22
                 - quay.io/astronomer/ap-houston-api:0.32.1
                 - quay.io/astronomer/ap-init:3.16.3-1
                 - quay.io/astronomer/ap-kibana:7.17.9

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.16-2
+    tag: 8.5.22
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Bump grafana to a version that has newer dashboards, migrated dashboards, and deleted kube-dns dashboard.

## Related Issues

https://github.com/astronomer/ap-vendor/pull/506

## Testing

This has been tested in dev.

## Merging

This should be merged everywhere.