### PR TITLE
Updating Cronjob Naming Convention to Limit Name Length to 52 Characters

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -4,7 +4,7 @@
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-update-root-admin-password-cronjob
+  name: {{ .Release.Name }}-upd-root-adm-pwd-cron
   labels:
     tier: astronomer
     component: houston-update-root-admin-password-cronjob

--- a/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml
@@ -4,7 +4,7 @@
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:
-  name: {{ .Release.Name }}-upd-root-adm-pwd-cron
+  name: {{ .Release.Name }}-update-root-adm-pwd
   labels:
     tier: astronomer
     component: houston-update-root-admin-password-cronjob


### PR DESCRIPTION
## Description

Platform version 0.31.3
Updating Cronjob Naming Convention to Limit Name Length to 52 Characters.

There is a corn job - charts/astronomer/templates/houston/cronjobs/houston-update-root-admin-password.yaml

Cronjob takes the following as name - 

```
metadata:
  name: {{ .Release.Name }}-update-root-admin-password-cronjob
```

Changed to "upd-root-adm-pwd-cron"


## Related Issues

Few of the customers when the release name is added it is exceeding 52 char limit leading to the failure of upgrade.
Example: if a customer has release name "prod-data-astronomer" then "cronjob is prod-data-astronomer--update-root-admin-password-cronjob" and when they upgrade from 0.30.2 or any lower version to 0.31.3 then it fails.

[gh-issue](https://github.com/astronomer/issues/issues/5522)
[zendesk](https://astronomer.zendesk.com/agent/tickets/17584)



