### PR TITLE
Adding Trigger to call feature_stack deployment (#1842)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,7 @@ jobs:
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   trigger-rc-test:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -182,6 +182,19 @@ jobs:
           command: |
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
+
+  trigger-feature-stack-release:
+    executor: docker-executor
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
 
   release-to-public:
     docker:
@@ -388,6 +401,20 @@ workflows:
       - trigger-rc-test:
           requires:
             - release-to-internal
+      - approve-feature-stack-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
+            - approve-feature-stack-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -169,7 +169,7 @@ jobs:
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
   trigger-rc-test:
-    executor: python/default
+    executor: docker-executor
     resource_class: small
     steps:
       - attach_workspace:
@@ -180,6 +180,19 @@ jobs:
           command: |
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
+
+  trigger-feature-stack-release:
+    executor: docker-executor
+    resource_class: small
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Triggering RC testing for upgrade path
+          command: |
+            set -e
+            bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
 
   release-to-public:
     docker:
@@ -282,6 +295,20 @@ workflows:
       - trigger-rc-test:
           requires:
             - release-to-internal
+      - approve-feature-stack-release:
+          type: approval
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
+            - approve-feature-stack-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - approve-public-release:
           type: approval
           requires:


### PR DESCRIPTION
## Description

Adding a trigger to call the `feature_stack` workflow that performs the deployment on the cluster. This will add the capability to refresh the cluster with the latest build immediately.

## Related Issues

https://github.com/astronomer/issues/issues/5507

## Master PR

https://github.com/astronomer/astronomer/pull/1842