### PR TITLE
Improving QA Workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,19 +410,15 @@ workflows:
             - approve-internal-release
             - platform-1-22-15
             - platform-1-26-0
-      - trigger-rc-test:
-          requires:
-            - release-to-internal
-      - approve-feature-stack-release:
+      - approve-rc-test:
           type: approval
           filters:
             branches:
               only:
                 - '/^release-0\.\d+$/'
-      - trigger-feature-stack-release:
+      - trigger-rc-test:
           requires:
-            - release-to-internal
-            - approve-feature-stack-release
+            - approve-rc-test
           filters:
             branches:
               only:
@@ -482,6 +478,13 @@ workflows:
           requires:
             - platform-1-22-15
             - platform-1-26-0
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -304,19 +304,15 @@ workflows:
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
             - platform-{{ version | replace(".", "-") }}
 {%- endfor %}
-      - trigger-rc-test:
-          requires:
-            - release-to-internal
-      - approve-feature-stack-release:
+      - approve-rc-test:
           type: approval
           filters:
             branches:
               only:
                 - '/^release-0\.\d+$/'
-      - trigger-feature-stack-release:
+      - trigger-rc-test:
           requires:
-            - release-to-internal
-            - approve-feature-stack-release
+            - approve-rc-test
           filters:
             branches:
               only:
@@ -373,6 +369,13 @@ workflows:
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
             - platform-{{ version | replace(".", "-") }}
 {%- endfor %}
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - trigger-feature-stack-release:
+          requires:
+            - release-to-internal
           filters:
             branches:
               only:


### PR DESCRIPTION
## Description

- Now trigger the RC test on approval to avoid calling on each internal release from the release branch. 
- Removing the feature stack update from `build-and-release-helm-chart` workflow as the internal release will fail if not unique tag. For the release branch, we don't generate the unique tag instead we use the static tag from Chart.
- Adding feature stack update to workflow `qa-build-and-release-helm-chart` workflow.

## Related Issues

https://github.com/astronomer/issues/issues/5507

## Testing

N/A

## Merging

- release-0.30
- release-0.31
- release-0.32
