### PR TITLE
Better signaling between primary and sidecar container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.5
                 - quay.io/astronomer/ap-registry:3.16.3-2
-                - quay.io/astronomer/ap-vector:0.26.0-4
+                - quay.io/astronomer/ap-vector:0.28.2
           context:
             - slack_team-software-infra-bot
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -106,7 +106,6 @@ data:
         enabled: true
         name: {{ .Values.global.loggingSidecar.name }}
         image: {{ .Values.global.loggingSidecar.image }}
-        terminationEndpoint: {{ .Values.global.loggingSidecar.terminationEndpoint }}
         customConfig: {{ .Values.global.loggingSidecar.customConfig }}
         {{- if .Values.global.loggingSidecar.extraEnv}}
         extraEnv: {{- .Values.global.loggingSidecar.extraEnv | toYaml | nindent 8 }}
@@ -261,18 +260,46 @@ data:
                   container.command = ["tini", "--", "/entrypoint"]
                   pod.spec.containers[0] = container
       {{ if .Values.global.loggingSidecar.enabled }}
-                  # For sidecar logging we override the default entrypoint to redirect
-                  # logs to files that are consumed by the sidecar container. The command
-                  # ends with a POST to {{ .Values.global.loggingSidecar.terminationEndpoint }}, which signals the
-                  # sidecar log consumer to exit.
-                  log_cmd = "1> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/out.log ) 2> >( tee -a /var/log/{{ .Values.global.loggingSidecar.name }}/err.log >&2 )"
+                  # For sidecar logging we override the default entrypoint to redirect logs to
+                  # files that are consumed by the sidecar container. The command ends by creating
+                  # the file /var/log/sidecar-log-consumer/finished, which signals the sidecar log
+                  # consumer to exit.
+                  from textwrap import dedent
+                  cmd_init = dedent(
+                      r"""
+                      echo '
+                      import signal
+                      import sys
+                      import subprocess
+                      import time
+                      from pathlib import Path
+                      process = subprocess.Popen(sys.argv[1:])
+                      def handler(signum, frame):
+                          process.kill()
+                          print("Process killed")
+                      signal.signal(signal.SIGINT, handler)
+                      while True:
+                          time.sleep(5)
+                          with open("/var/log/sidecar-log-consumer/heartbeat", "w") as f:
+                              f.write(f"{time.time()}\n")
+                          if process.poll() is not None:
+                              break
+                      print("Process exited")
+                      Path("/var/log/sidecar-log-consumer/finished").touch()
+                      ' | python3 - """
+                  )
+                  log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "
                   if container.args[0:3] == ["airflow", "tasks", "run"]:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
-                      command_str = "/entrypoint " + ' '.join([str(arg) for arg in container.args]) + " " + log_cmd + "; curl -fsSL --retry 5 --max-time 10 --retry-connrefused -XPOST {{ .Values.global.loggingSidecar.terminationEndpoint }}"
+                      command_str = (
+                          cmd_init
+                          + " /entrypoint "
+                          + " ".join([str(arg) for arg in container.args])
+                          + log_cmd
+                      )
                       new_args.append(command_str)
                       container.args = new_args
-
       {{ end }}
               else:
                   # In the case of KPO, we allow Airflow to overwrite the entrypoint

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -170,7 +170,6 @@ def test_houston_configmap_with_config_syncer_disabled():
 def test_houston_configmap_with_loggingsidecar_enabled():
     """Validate the houston configmap and its embedded data with
     loggingSidecar."""
-    terminationEndpoint = "http://localhost:8000/quitquitquit"
     docs = render_chart(
         values={
             "global": {
@@ -190,15 +189,10 @@ def test_houston_configmap_with_loggingsidecar_enabled():
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
-    assert (
-        terminationEndpoint
-        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": "sidecar-log-consumer",
         "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "terminationEndpoint": "http://localhost:8000/quitquitquit",
         "customConfig": False,
     }
     assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
@@ -208,7 +202,6 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
     """Validate the houston configmap and its embedded data with
     loggingSidecar."""
     sidecar_container_name = "sidecar-log-test"
-    terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
@@ -232,15 +225,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
-    assert (
-        terminationEndpoint
-        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "terminationEndpoint": terminationEndpoint,
         "customConfig": False,
     }
     assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
@@ -250,7 +238,6 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
     """Validate the houston configmap and its embedded data with loggingSidecar
     customConfig Enabled."""
     sidecar_container_name = "sidecar-log-test"
-    terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
@@ -275,15 +262,10 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
-    assert (
-        terminationEndpoint
-        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "terminationEndpoint": terminationEndpoint,
         "customConfig": True,
     }
     assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
@@ -293,7 +275,6 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     """Validate the houston configmap and its embedded data with
     loggingSidecar."""
     sidecar_container_name = "sidecar-log-test"
-    terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
@@ -337,15 +318,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
-    assert (
-        terminationEndpoint
-        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "terminationEndpoint": terminationEndpoint,
         "customConfig": False,
         "extraEnv": [
             {
@@ -370,7 +346,6 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
     """Validate the houston configmap and its embedded data with
     loggingSidecar."""
     sidecar_container_name = "sidecar-log-test"
-    terminationEndpoint = "http://localhost:8000/quitquitquit"
     image_name = "quay.io/astronomer/ap-vector:0.22.3"
     docs = render_chart(
         values={
@@ -397,15 +372,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
-    assert (
-        terminationEndpoint
-        in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "terminationEndpoint": terminationEndpoint,
         "customConfig": False,
         "resources": {
             "requests": {"memory": "386Mi", "cpu": "100m"},

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -185,7 +185,7 @@ def test_houston_configmap_with_loggingsidecar_enabled():
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = "1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 )"'
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
@@ -219,9 +219,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = "1> >( tee -a /var/log/{sidecar_container_name}/out.log ) 2> >( tee -a /var/log/{sidecar_container_name}/err.log >&2 )"'.format(
-        sidecar_container_name=sidecar_container_name
-    )
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
@@ -256,9 +254,7 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = "1> >( tee -a /var/log/{sidecar_container_name}/out.log ) 2> >( tee -a /var/log/{sidecar_container_name}/err.log >&2 )"'.format(
-        sidecar_container_name=sidecar_container_name
-    )
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
@@ -312,9 +308,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     print(prod_yaml)
-    log_cmd = 'log_cmd = "1> >( tee -a /var/log/{sidecar_container_name}/out.log ) 2> >( tee -a /var/log/{sidecar_container_name}/err.log >&2 )"'.format(
-        sidecar_container_name=sidecar_container_name
-    )
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )
@@ -366,9 +360,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = "1> >( tee -a /var/log/{sidecar_container_name}/out.log ) 2> >( tee -a /var/log/{sidecar_container_name}/err.log >&2 )"'.format(
-        sidecar_container_name=sidecar_container_name
-    )
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     )

--- a/values.yaml
+++ b/values.yaml
@@ -110,8 +110,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.26.0-4
-    terminationEndpoint: http://localhost:8000/quitquitquit
+    image: quay.io/astronomer/ap-vector:0.28.2
     customConfig: false
     extraEnv: []
     resources: {}


### PR DESCRIPTION
## Description

Refactor logging sidecar signaling mechanism to be filesystem based. Handle brutal killing of airflow container in kubernetes executor pods.

This change goes hand in hand with the vector changes in this PR https://github.com/astronomer/ap-vendor/pull/511

## Related Issues

https://github.com/astronomer/issues/issues/5469

## Testing

I have done a lot of testing with this while iterating on it. I'm fairly confident all cases are covered, but as it is with humans, especially when working on iterations of something, it's possible that I've missed some cases. We will definitely need to test these changes in all known sidecar logging configurations.

## Merging

This is being merged into 0.31 because that is the branch I used when testing. These changes are compatible with 0.32 though, so they can be cherry-picked to main and to 0.32.0. I have not tested these changes against 0.30, but it seems like they would be compatible, and they certainly should be merged there in order to fix the root cause of the issue being solved, which is covered in the ticket that is linked above.
