### PR TITLE
add option to allow extraenv in esproxy service

### DIFF
--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -49,6 +49,9 @@ spec:
           image: {{ template "esproxy.image" . }}
           imagePullPolicy: {{ .Values.images.esproxy.pullPolicy }}
           env:
+{{- if .Values.global.customLogging.extraEnv }}
+{{ toYaml .Values.global.customLogging.extraEnv | indent 10 }}
+{{- end }}
 {{- if .Values.global.customLogging.secret }}
           - name: ES_SECRET
             value: {{.Values.global.customLogging.secret }}

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -464,7 +464,7 @@ class TestExternalElasticSearch:
             ), f"Container named '{name}' does not use registry '{private_registry}': {container}"
 
     def test_externalelasticsearch_with_extraenv(self, kube_version):
-        """Test External ElasticSearch with secret passed from
+        """Test External ElasticSearch with custom env passed from
         config/values.yaml."""
         docs = render_chart(
             kube_version=kube_version,
@@ -489,6 +489,6 @@ class TestExternalElasticSearch:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-external-es-proxy"
-        assert {"name": "TEST_VAR_NAME", "value": "test_var_value"} in doc["spec"]["template"][
-            "spec"
-        ]["containers"][0]["env"]
+        assert {"name": "TEST_VAR_NAME", "value": "test_var_value"} in doc["spec"][
+            "template"
+        ]["spec"]["containers"][0]["env"]

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -474,7 +474,7 @@ class TestExternalElasticSearch:
                         "enabled": True,
                         "secret": secret,
                         "extraEnv": [
-                            {"name": "NO_PROXY", "value": "127.0.0.1"},
+                            {"name": "TEST_VAR_NAME", "value": "test_var_value"},
                         ],
                     }
                 }

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -489,6 +489,6 @@ class TestExternalElasticSearch:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-external-es-proxy"
-        assert {"name": "NO_PROXY", "value": "127.0.0.1"} in doc["spec"]["template"][
+        assert {"name": "TEST_VAR_NAME", "value": "test_var_value"} in doc["spec"]["template"][
             "spec"
         ]["containers"][0]["env"]

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -462,3 +462,33 @@ class TestExternalElasticSearch:
             assert container["image"].startswith(
                 private_registry
             ), f"Container named '{name}' does not use registry '{private_registry}': {container}"
+
+    def test_externalelasticsearch_with_extraenv(self, kube_version):
+        """Test External ElasticSearch with secret passed from
+        config/values.yaml."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "customLogging": {
+                        "enabled": True,
+                        "secret": secret,
+                        "extraEnv": [
+                            {"name": "NO_PROXY", "value": "127.0.0.1"},
+                        ],
+                    }
+                }
+            },
+            show_only=[
+                "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-external-es-proxy"
+        assert {"name": "NO_PROXY", "value": "127.0.0.1"} in doc["spec"]["template"][
+            "spec"
+        ]["containers"][0]["env"]

--- a/values.yaml
+++ b/values.yaml
@@ -189,15 +189,16 @@ global:
 
   # External ES logging
   customLogging:
-    enabled: false
+    enabled: true
     scheme: https
     host: ""
     port: ""
     secret: ""
     #secretName: ~
-    #awsSecretName: ~
+    awsSecretName: help
     #awsIAMRole: ~
     #awsServiceAccountAnnotation: ~
+    extraEnv: []
 
   ## Add annotations to all the auth sidecar deployed ingress resources
   ##

--- a/values.yaml
+++ b/values.yaml
@@ -189,13 +189,13 @@ global:
 
   # External ES logging
   customLogging:
-    enabled: true
+    enabled: false
     scheme: https
     host: ""
     port: ""
     secret: ""
     #secretName: ~
-    awsSecretName: help
+    #awsSecretName: ~
     #awsIAMRole: ~
     #awsServiceAccountAnnotation: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Support allowing extraEnv values for es proxy service 

## Related Issues

https://github.com/astronomer/issues/issues/5559
https://github.com/astronomer/issues/issues/5544

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.32.0
