### PR TITLE
resolves CVE-2023-0464 in ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,14 +328,14 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.25.0-1
                 - quay.io/astronomer/ap-astro-ui:0.32.2
                 - quay.io/astronomer/ap-auth-sidecar:1.23.4
-                - quay.io/astronomer/ap-awsesproxy:1.3-11
+                - quay.io/astronomer/ap-awsesproxy:1.3-12
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.13
                 - quay.io/astronomer/ap-commander:0.32.0
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.1
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.2
                 - quay.io/astronomer/ap-default-backend:0.28.14
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
@@ -351,11 +351,11 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.23.4
                 - quay.io/astronomer/ap-nginx:1.3.1-3
                 - quay.io/astronomer/ap-node-exporter:1.5.0
-                - quay.io/astronomer/ap-openresty:1.21.4-4
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-6
+                - quay.io/astronomer/ap-openresty:1.21.4-5
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1-1
                 - quay.io/astronomer/ap-postgresql:15.2.0
-                - quay.io/astronomer/ap-prometheus:2.37.5-1
+                - quay.io/astronomer/ap-prometheus:2.37.6
                 - quay.io/astronomer/ap-registry:3.16.5
                 - quay.io/astronomer/ap-vector:0.28.2
           context:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,8 +329,8 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.32.2
                 - quay.io/astronomer/ap-auth-sidecar:1.23.4
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
-                - quay.io/astronomer/ap-base:3.16.3-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
+                - quay.io/astronomer/ap-base:3.16.5
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.13
                 - quay.io/astronomer/ap-commander:0.32.0
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
@@ -342,12 +342,12 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.22
                 - quay.io/astronomer/ap-houston-api:0.32.4
-                - quay.io/astronomer/ap-init:3.16.3-1
+                - quay.io/astronomer/ap-init:3.16.5
                 - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.7.0-1
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-4
-                - quay.io/astronomer/ap-nats-server:2.8.4-2
-                - quay.io/astronomer/ap-nats-streaming:0.24.6-2
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-5
+                - quay.io/astronomer/ap-nats-server:2.8.4-3
+                - quay.io/astronomer/ap-nats-streaming:0.24.6-3
                 - quay.io/astronomer/ap-nginx-es:1.23.4
                 - quay.io/astronomer/ap-nginx:1.3.1-3
                 - quay.io/astronomer/ap-node-exporter:1.5.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.11.1-1
                 - quay.io/astronomer/ap-postgresql:15.2.0
                 - quay.io/astronomer/ap-prometheus:2.37.5-1
-                - quay.io/astronomer/ap-registry:3.16.3-2
+                - quay.io/astronomer/ap-registry:3.16.5
                 - quay.io/astronomer/ap-vector:0.28.2
           context:
             - slack_team-software-infra-bot

--- a/.circleci/trivyignore
+++ b/.circleci/trivyignore
@@ -5,6 +5,7 @@ CVE-2022-27191
 CVE-2022-1996
 # golang.org/x/net CVE
 CVE-2022-27664
+CVE-2022-41723
 # golang.org/x/text
 CVE-2022-32149
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.3-2
+    tag: 3.16.5
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.1
+    tag: 0.31.2
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.16.3-2
+    tag: 3.16.5
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-4
+    tag: 1.21.4-5
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-11
+    tag: 1.3-12
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.1
+    tag: 0.31.2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.4-2
+    tag: 2.8.4-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-4
+    tag: 0.10.0-5
     pullPolicy: IfNotPresent
 
 

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-6
+  tag: 1.17.0-7
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.23.0-3
+  tag: 0.23.0-4
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.5-1
+    tag: 2.37.6
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.16.3-1
+    tag: 3.16.5
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.6-2
+    tag: 0.24.6-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-4
+    tag: 0.10.0-5
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

resolves CVE-2023-0464 in ap-vendor packages 
| Image Name                     | Old Tag             |    New Tag     |
| ----------------------    | -------------     | ------------- | 
| ap-blackbox-exporter    | 0.23.0-3             |     0.23.0-4     |
| ap-curator                       | 7.0.0-3                |      7.0.0-4       |
| ap-git-daemon                | 3.16.3-2              |     3.16.5         |
| ap-init                              | 3.16.3-1                | 3.16.5         |
| ap-nats-exporter            | 0.10.0-4               | 0.10.0-5 |
| ap-nats-server                | 2.8.4-2                 | 2.8.4-3  |
| ap-nats-streaming          | 0.24.6-2               | 0.24.6-3 |
| ap-registry                       | 3.16.3-2                | 3.16.5|
| ap-aws-es-proxy  | 1.3-11 |  1.3-12 |
| ap-pgbouncer-krb | 1.17.0-6 |  1.17.0-7 |
| ap-awsesproxy | 1.3-11 | 1.3-12 |
| ap-db-bootstrapper | 0.31.1 | 0.31.2 |
| ap-openresty. | 1.21.4-4 | 1.21.4-5|
| ap-pgbouncer-krb | 1.17.0-6 | 1.17.0-7 |
| ap-prometheus | 2.37.5-1 | 2.37.6 | 


## Related Issues

https://github.com/astronomer/issues/issues/5565

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
