### PR TITLE
Removing RC keyword filter (#1862)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             set -e
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
-  trigger-rc-test:
+  trigger-upgrade-test:
     executor: docker-executor
     resource_class: small
     steps:
@@ -186,7 +186,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - run:
-          name: Triggering RC testing for upgrade path
+          name: Triggering testing for upgrade path
           command: |
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
@@ -199,7 +199,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - run:
-          name: Triggering RC testing for upgrade path
+          name: Triggering update to feature cluster
           command: |
             set -e
             bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
@@ -410,17 +410,16 @@ workflows:
             - approve-internal-release
             - platform-1-22-15
             - platform-1-26-0
-      - approve-rc-test:
+      - approve-upgrade-test:
           type: approval
-          requires:
-            - release-to-internal
           filters:
             branches:
               only:
                 - '/^release-0\.\d+$/'
-      - trigger-rc-test:
+      - trigger-upgrade-test:
           requires:
-            - approve-rc-test
+            - release-to-internal
+            - approve-upgrade-test
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -176,7 +176,7 @@ jobs:
             set -e
             bin/release-helm-chart /tmp/workspace/astronomer-*.tgz
 
-  trigger-rc-test:
+  trigger-upgrade-test:
     executor: docker-executor
     resource_class: small
     steps:
@@ -184,7 +184,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - run:
-          name: Triggering RC testing for upgrade path
+          name: Triggering testing for upgrade path
           command: |
             set -e
             bin/trigger_rc_tests.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST
@@ -197,7 +197,7 @@ jobs:
           at: /tmp/workspace
       - checkout
       - run:
-          name: Triggering RC testing for upgrade path
+          name: Triggering update to feature cluster
           command: |
             set -e
             bin/trigger_feature_stack_update.py --astro_path=/tmp/workspace --circleci_token=$CIRCLECI_API_KEY_TEST --branch=$CIRCLE_BRANCH
@@ -304,17 +304,16 @@ workflows:
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
             - platform-{{ version | replace(".", "-") }}
 {%- endfor %}
-      - approve-rc-test:
+      - approve-upgrade-test:
           type: approval
-          requires:
-            - release-to-internal
           filters:
             branches:
               only:
                 - '/^release-0\.\d+$/'
-      - trigger-rc-test:
+      - trigger-upgrade-test:
           requires:
-            - approve-rc-test
+            - release-to-internal
+            - approve-upgrade-test
           filters:
             branches:
               only:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -59,7 +59,7 @@ def main(circleci_token: str, astro_path: str):
     astro_version = None
     for file_name in file_list:
         x = re.search("astronomer-.*.tgz", file_name)
-        if x is not None and astro_version is None and "rc" in file_name:
+        if x is not None and astro_version is None:
             print(f"INFO: Found file {file_name}")
             astro_version = file_name
 


### PR DESCRIPTION
## Description

Remove the `rc` keyword to filter when triggering the upgrade test.

(cherry picked from commit 3f4039ae88471c0b274a3cd091e78fe98e2a5b75)

## Related Issues

https://github.com/astronomer/issues/issues/5566

## Testing

No testing require as it is CI flow change.

## Master PR

https://github.com/astronomer/astronomer/pull/1862