### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,11 +353,11 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-5
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
-                - quay.io/astronomer/ap-postgres-exporter:0.11.1-1
+                - quay.io/astronomer/ap-postgres-exporter:0.12.0
                 - quay.io/astronomer/ap-postgresql:15.2.0
                 - quay.io/astronomer/ap-prometheus:2.37.6
                 - quay.io/astronomer/ap-registry:3.16.5
-                - quay.io/astronomer/ap-vector:0.28.2
+                - quay.io/astronomer/ap-vector:0.28.2-1
           context:
             - slack_team-software-infra-bot
 

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.11.1-1
+  tag: 0.12.0
   pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.28.2
+    image: quay.io/astronomer/ap-vector:0.28.2-1
     customConfig: false
     extraEnv: []
     resources: {}


### PR DESCRIPTION
## Description

* bump ap-vector 0.28.2 -> 0.28.2-1
* bump ap-postgres-exporter 0.11.1-1 -> 0.12.0

Additional Changes:

postgres exporter had a issue where ssl mode is not set properly which resulted in allways set to sslmode=prefer this  image includes those changes and fixes the odd behavior

## Related Issues

https://github.com/astronomer/issues/issues/5565

## Testing

QA/dev should able to postgres exporter metrics for incluster postgres 

## Merging

Cherry-pick to release-0.31
