### PR TITLE
added network policy for registry and commander

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -81,6 +81,11 @@ spec:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-populate-hourly-ta-metrics
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-cleanup-airflow-db
     ports:
     - protocol: TCP
       port: {{ .Values.ports.commanderGRPC }}

--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -40,6 +40,11 @@ spec:
           release: {{ .Release.Name }}
     - podSelector:
         matchLabels:
+          tier: astronomer
+          component: houston-cleanup-airflow-db
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
           tier: monitoring
           component: prometheus
           release: {{ .Release.Name }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
               "--purge-archive={{ .Values.houston.cleanupAirflowDb.purgeArchive }}",
               "--provider={{ .Values.houston.cleanupAirflowDb.provider }}",
               "--bucket-name={{ .Values.houston.cleanupAirflowDb.bucketName }}",
-              "--connection-id={{ .Values.houston.cleanupAirflowDb.connectionId }}"]
+              "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -81,6 +81,12 @@ spec:
           tier: astronomer
           release: {{ .Release.Name }}
           component: houston-populate-hourly-ta-metrics
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
+          component: houston-cleanup-airflow-db
+
     {{- if .Values.global.authSidecar.enabled  }}
     - namespaceSelector:
         matchLabels:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -202,7 +202,7 @@ houston:
     bucketName: "/tmp"
 
     # Airflow provider connection id to connect to provider bucket, read more - https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html
-    connectionId: ""
+    providerEnvSecretName: ""
 
   # Cleanup task usage data and task audit data in Houston
   # This runs as a CronJob


### PR DESCRIPTION
## Description

- Added network policy for registry and commander for airflow db cleanup cron
- Replaced connection Id cron variable with provider env secret name

## Related Issues

https://github.com/astronomer/issues/issues/5451

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.32.0
