### PR TITLE
update commander image and default airflow version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.13
-                - quay.io/astronomer/ap-commander:0.32.0
+                - quay.io/astronomer/ap-commander:0.32.2
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.1
+airflowChartVersion: 1.8.3
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.0
+    tag: 0.32.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

This PR includes fixes for migrating airflow chart 1.7.x to 1.8.x  along with commander changes 

* bump commander 0.32.0 -> 0.32.2
* bump airflow chart 1.8.0 -> 1.8.3

## Related Issues

https://github.com/astronomer/issues/issues/5500

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
