### PR TITLE
add table flag for airflow db cleanup

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -51,7 +51,8 @@ spec:
               "--purge-archive={{ .Values.houston.cleanupAirflowDb.purgeArchive }}",
               "--provider={{ .Values.houston.cleanupAirflowDb.provider }}",
               "--bucket-name={{ .Values.houston.cleanupAirflowDb.bucketName }}",
-              "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}"]
+              "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}"
+              "--tables={{ .Values.houston.cleanupAirflowDb.tables }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
               "--purge-archive={{ .Values.houston.cleanupAirflowDb.purgeArchive }}",
               "--provider={{ .Values.houston.cleanupAirflowDb.provider }}",
               "--bucket-name={{ .Values.houston.cleanupAirflowDb.bucketName }}",
-              "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}"
+              "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}",
               "--tables={{ .Values.houston.cleanupAirflowDb.tables }}"]
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -204,6 +204,9 @@ houston:
     # Airflow provider connection id to connect to provider bucket, read more - https://airflow.apache.org/docs/apache-airflow/stable/howto/connection.html
     providerEnvSecretName: ""
 
+    # Run cleanup on specific table or list of tables in a comma separated format
+    tables: ""
+
   # Cleanup task usage data and task audit data in Houston
   # This runs as a CronJob
   cleanupTaskUsageData:


### PR DESCRIPTION
## Description

Allows airflow db cleanup to accept list of tables or run cleanup on specific tables based on the customer needs.

## Related Issues

NA

## Testing

QA/dev should able to pass specific table and should validate exported data should only have that table data in CSV format

## Merging

cherry-pick to release-0.32
