### PR TITLE
update elasticsearch packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -334,11 +334,11 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.13
                 - quay.io/astronomer/ap-commander:0.32.2
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:7.0.0-2
+                - quay.io/astronomer/ap-curator:7.0.0-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2
                 - quay.io/astronomer/ap-default-backend:0.28.14
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
-                - quay.io/astronomer/ap-elasticsearch:7.17.9
+                - quay.io/astronomer/ap-elasticsearch:7.17.9-1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.22
                 - quay.io/astronomer/ap-houston-api:0.32.4

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 7.17.9
+    tag: 7.17.9-1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 7.0.0-2
+    tag: 7.0.0-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
## Description

Resolves CVE's as mentioned in the issue ticket

update ap-elasticsearch. 7.17.9 -> 7.17.9-1
update  ap-curator 7.0.0-2 -> 7.0.0-4

## Related Issues

https://github.com/astronomer/issues/issues/5581

## Testing

QA should able to run curator service without any issues and elasticsearch should work as expected

## Merging

cherry-pick to release-0.32.
