### PR TITLE
update nginx ingress controller 1.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-3
                 - quay.io/astronomer/ap-nginx-es:1.23.4
-                - quay.io/astronomer/ap-nginx:1.3.1-3
+                - quay.io/astronomer/ap-nginx:1.7.0
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-5
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.3.1-3
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

resolves multiple CRITICAL and HIGH cve in ingress controller service

## Related Issues

https://github.com/astronomer/issues/issues/5582
https://github.com/astronomer/issues/issues/5575

## Testing

QA should able to access astronomer platform ingress and airflow ingress without any issues 

## Merging

cherry-pick to release-0.32
