### PR TITLE
update commander and airflowChartVersion to 1.8.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.13
-                - quay.io/astronomer/ap-commander:0.32.2
+                - quay.io/astronomer/ap-commander:0.32.3
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.3
+airflowChartVersion: 1.8.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.2
+    tag: 0.32.3
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander and airflowChartVersion to 1.8.4

## Related Issues

NA

## Testing

QA should able to deploy airflow with the shipped commander image and airflow chart 

## Merging

cherry-pick to release-0.32
