### PR TITLE
Allow configuring kubernetes-apiservers with insecure_skip_verify

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -60,6 +60,7 @@ data:
         scheme: https
         tls_config:
           ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          insecure_skip_verify: {{ .Values.config.scrape_configs.kubernetes_apiservers.tls_config.insecure_skip_verify }}
         bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
         relabel_configs:
           - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -140,3 +140,14 @@ additionalAlerts:
 
 extraFlags: []
 #- "--log.level=debug"
+
+kubernetes_apiservers_insecure_skip_verify: false
+
+# Amost mirror the prometheus config data structure for values we want to customize.
+# Convert lists to dicts for more explicit assignment.
+# Convert dashes to underscores for golang compatibility.
+config:
+  scrape_configs:
+    kubernetes_apiservers:
+      tls_config:
+        insecure_skip_verify: false

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -27,6 +27,13 @@ class TestPrometheusConfigConfigmap:
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-prometheus-config"
 
+        config_yaml = yaml.safe_load(doc["data"]["config"])
+        assert [
+            x["tls_config"]["insecure_skip_verify"]
+            for x in list(config_yaml["scrape_configs"])
+            if x["job_name"] == "kubernetes-apiservers"
+        ] == [False]
+
     def test_prometheus_config_configmap_with_different_name_and_ns(self, kube_version):
         """Validate the prometheus config configmap does not conflate
         deployment name and namespace."""
@@ -46,7 +53,6 @@ class TestPrometheusConfigConfigmap:
             },
         )[0]
 
-        # config_yaml = doc["data"]["config"]
         config_yaml = yaml.safe_load(doc["data"]["config"])
         targets = [
             x["static_configs"][0]["targets"]
@@ -218,3 +224,28 @@ class TestPrometheusConfigConfigmap:
         )
         assert "regex" not in metric_relabel_config_search_result[0]
         assert "replacement" not in metric_relabel_config_search_result[0]
+
+    def test_prometheus_config_insecure_skip_verify(self, kube_version):
+        """Test that insecure_skip_verify is rendered correctly in the config when specified."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "prometheus": {
+                    "config": {
+                        "scrape_configs": {
+                            "kubernetes_apiservers": {
+                                "tls_config": {"insecure_skip_verify": True}
+                            }
+                        }
+                    },
+                },
+            },
+        )[0]
+
+        config_yaml = yaml.safe_load(doc["data"]["config"])
+        assert [
+            x["tls_config"]["insecure_skip_verify"]
+            for x in list(config_yaml["scrape_configs"])
+            if x["job_name"] == "kubernetes-apiservers"
+        ] == [True]


### PR DESCRIPTION
## Description

Allow configuring kubernetes-apiservers with insecure_skip_verify. This starts a pattern of mirroring the prometheus config in helm values with some slight tweaks to make it more helm friendly.

## Related Issues

- https://github.com/astronomer/issues/issues/5612
- https://github.com/astronomer/astronomer/issues/1880

## Testing

Unit tests are included. I have not run any functional tests, though the changes match what was purported to fix the problem being solved.

## Merging

This should be merged into 0.30, 0.32
