### PR TITLE
nginx base images in vendor packages (#1860)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,16 +327,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.30.12
-                - quay.io/astronomer/ap-auth-sidecar:1.23.3-2
+                - quay.io/astronomer/ap-auth-sidecar:1.23.4
                 - quay.io/astronomer/ap-awsesproxy:1.3-11
                 - quay.io/astronomer/ap-base:3.16.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.12
+                - quay.io/astronomer/ap-cli-install:0.26.13
                 - quay.io/astronomer/ap-commander:0.30.7
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.1
-                - quay.io/astronomer/ap-default-backend:0.28.13
+                - quay.io/astronomer/ap-default-backend:0.28.14
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.9
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
@@ -348,7 +348,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-4
                 - quay.io/astronomer/ap-nats-server:2.8.4-2
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-2
-                - quay.io/astronomer/ap-nginx-es:1.23.3-2
+                - quay.io/astronomer/ap-nginx-es:1.23.4
                 - quay.io/astronomer/ap-nginx:1.3.1-3
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.12
+    tag: 0.26.13
     pullPolicy: IfNotPresent
 
 astroUI:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.23.3-2
+    tag: 1.23.4
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.13
+    tag: 0.28.14
     pullPolicy: IfNotPresent
 
 ingressClass: ~

--- a/values.yaml
+++ b/values.yaml
@@ -123,7 +123,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.23.3-2
+    tag: 1.23.4
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION


## Description

* nginx base images in vendor packages

* update ap-cli-install 0.26.12 -> 0.26.13

* update scan images

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
