### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,11 +340,11 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.9-1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.22
+                - quay.io/astronomer/ap-grafana:8.5.24
                 - quay.io/astronomer/ap-houston-api:0.32.6
                 - quay.io/astronomer/ap-init:3.16.5
                 - quay.io/astronomer/ap-kibana:7.17.9
-                - quay.io/astronomer/ap-kube-state:2.7.0-1
+                - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-5
                 - quay.io/astronomer/ap-nats-server:2.8.4-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-3
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-1
-                - quay.io/astronomer/ap-prometheus:2.37.6
+                - quay.io/astronomer/ap-prometheus:2.37.8
                 - quay.io/astronomer/ap-registry:3.16.5
                 - quay.io/astronomer/ap-vector:0.28.2-1
           context:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.22
+    tag: 8.5.24
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.7.0-1
+    tag: 2.8.2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.6
+    tag: 2.37.8
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader


### PR DESCRIPTION


## Description

* bump ap-grafana 8.5.22 -> 8.5.24
* bump ap-kube-state 2.7.0-1 -> 2.8.2
* bump ap-prometheus 2.37.6 -> 2.37.8

## Related Issues

https://github.com/astronomer/issues/issues/5620
https://github.com/astronomer/issues/issues/5621

## Testing

QA should validate services should work as expected 

## Merging

cherry-pick to release-0.32, release-0.30
