### PR TITLE
Relabeling to release for precreatednamespaces and also namespaceFreeFormEntry

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -278,6 +278,16 @@ data:
             replacement: "$1"
             {{- end}}
             target_label: release
+          {{- if .Values.global.features.namespacePools.enabled }}
+          - source_labels: [pod]
+            regex: "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
+            replacement: "$1"
+            target_label: release
+          - source_labels: [resourcequota]
+            regex: "(.+)-resource-quota$"
+            replacement: "$1"
+            target_label: release
+          {{- end }}
         {{- else}}
         # this drops node metrics that we want in the cloud, but maybe shouldn't be scraping
         # if we are in a shared cluster in enterprise

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -270,21 +270,18 @@ data:
           - regex: 'label_kubernetes_pod_operator'
             action: labeldrop
           # Required for multi-namespace mode
-          - source_labels: [namespace]
-            {{- if .Values.global.namespaceFreeFormEntry }}
-            # use default regex pattern (.*) when namespaceFreeFormEntry is enabled
-            {{- else}}
-            regex: "^{{ .Release.Namespace }}-(.*$)"
-            replacement: "$1"
-            {{- end}}
-            target_label: release
-          {{- if .Values.global.features.namespacePools.enabled }}
+          {{- if or .Values.global.features.namespacePools.enabled .Values.global.namespaceFreeFormEntry }}
           - source_labels: [pod]
             regex: "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
             replacement: "$1"
             target_label: release
           - source_labels: [resourcequota]
             regex: "(.+)-resource-quota$"
+            replacement: "$1"
+            target_label: release
+          {{- else}}
+          - source_labels: [namespace]
+            regex: "^{{ .Release.Namespace }}-(.*$)"
             replacement: "$1"
             target_label: release
           {{- end }}

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -10,7 +10,8 @@ import jmespath
     supported_k8s_versions,
 )
 class TestPrometheusConfigConfigmap:
-    show_only = ["charts/prometheus/templates/prometheus-config-configmap.yaml"]
+    show_only = [
+        "charts/prometheus/templates/prometheus-config-configmap.yaml"]
 
     def test_prometheus_config_configmap(self, kube_version):
         """Validate the prometheus config configmap and its embedded data."""
@@ -203,8 +204,10 @@ class TestPrometheusConfigConfigmap:
         )
 
         assert len(metric_relabel_config_search_result) == 1
-        assert metric_relabel_config_search_result[0]["source_labels"] == ["namespace"]
-        assert metric_relabel_config_search_result[0]["regex"] == "^testnamespace-(.*$)"
+        assert metric_relabel_config_search_result[0]["source_labels"] == [
+            "namespace"]
+        assert metric_relabel_config_search_result[
+            0]["regex"] == "^testnamespace-(.*$)"
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
@@ -235,7 +238,8 @@ class TestPrometheusConfigConfigmap:
             metric_relabel_config_search_result[0]["regex"]
             == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
         )
-        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
+        assert metric_relabel_config_search_result[0]["source_labels"] == [
+            "pod"]
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
@@ -270,7 +274,7 @@ class TestPrometheusConfigConfigmap:
             for x in list(config_yaml["scrape_configs"])
             if x["job_name"] == "kubernetes-apiservers"
         ] == [True]
-        
+
     def test_prometheus_config_release_relabel_with_pre_created_namespace(
         self, kube_version
     ):
@@ -301,7 +305,8 @@ class TestPrometheusConfigConfigmap:
             metric_relabel_config_search_result[0]["regex"]
             == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
         )
-        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
+        assert metric_relabel_config_search_result[0]["source_labels"] == [
+            "pod"]
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -10,8 +10,7 @@ import jmespath
     supported_k8s_versions,
 )
 class TestPrometheusConfigConfigmap:
-    show_only = [
-        "charts/prometheus/templates/prometheus-config-configmap.yaml"]
+    show_only = ["charts/prometheus/templates/prometheus-config-configmap.yaml"]
 
     def test_prometheus_config_configmap(self, kube_version):
         """Validate the prometheus config configmap and its embedded data."""
@@ -204,10 +203,8 @@ class TestPrometheusConfigConfigmap:
         )
 
         assert len(metric_relabel_config_search_result) == 1
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            "namespace"]
-        assert metric_relabel_config_search_result[
-            0]["regex"] == "^testnamespace-(.*$)"
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["namespace"]
+        assert metric_relabel_config_search_result[0]["regex"] == "^testnamespace-(.*$)"
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
@@ -238,8 +235,7 @@ class TestPrometheusConfigConfigmap:
             metric_relabel_config_search_result[0]["regex"]
             == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
         )
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            "pod"]
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
@@ -305,8 +301,7 @@ class TestPrometheusConfigConfigmap:
             metric_relabel_config_search_result[0]["regex"]
             == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
         )
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            "pod"]
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == "release"
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -179,9 +179,11 @@ class TestPrometheusConfigConfigmap:
 
     def test_prometheus_config_release_relabel(self, kube_version):
         """Prometheus should have a regex for release name."""
+        namespace = "testnamespace"
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
+            namespace=namespace,
             values={"global": {"features": {"namespacePools": {"enabled": False}}},
                     "astronomer": {
                     "houston": {
@@ -199,14 +201,12 @@ class TestPrometheusConfigConfigmap:
             "metric_relabel_configs[?target_label == 'release']",
             scrape_config_search_result[0],
         )
-        print("metric_relabel_config_search_result..",
-              metric_relabel_config_search_result)
 
         assert len(metric_relabel_config_search_result) == 1
         assert metric_relabel_config_search_result[0]["source_labels"] == [
             'namespace']
         assert metric_relabel_config_search_result[0][
-            "regex"] == "^{{ .Release.Namespace }}-(.*$)"
+            "regex"] == "^testnamespace-(.*$)"
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
         assert metric_relabel_config_search_result[0]["target_label"] == 'release'
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -10,8 +10,7 @@ import jmespath
     supported_k8s_versions,
 )
 class TestPrometheusConfigConfigmap:
-    show_only = [
-        "charts/prometheus/templates/prometheus-config-configmap.yaml"]
+    show_only = ["charts/prometheus/templates/prometheus-config-configmap.yaml"]
 
     def test_prometheus_config_configmap(self, kube_version):
         """Validate the prometheus config configmap and its embedded data."""
@@ -184,12 +183,13 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             namespace=namespace,
-            values={"global": {"features": {"namespacePools": {"enabled": False}}},
-                    "astronomer": {
+            values={
+                "global": {"features": {"namespacePools": {"enabled": False}}},
+                "astronomer": {
                     "houston": {
                         "config": {"deployments": {"namespaceFreeFormEntry": False}},
                     },
-            },
+                },
             },
         )[0]
 
@@ -203,12 +203,10 @@ class TestPrometheusConfigConfigmap:
         )
 
         assert len(metric_relabel_config_search_result) == 1
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            'namespace']
-        assert metric_relabel_config_search_result[0][
-            "regex"] == "^testnamespace-(.*$)"
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["namespace"]
+        assert metric_relabel_config_search_result[0]["regex"] == "^testnamespace-(.*$)"
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"
-        assert metric_relabel_config_search_result[0]["target_label"] == 'release'
+        assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
     def test_prometheus_config_release_relabel_with_free_from_namespace(
         self, kube_version
@@ -233,18 +231,20 @@ class TestPrometheusConfigConfigmap:
         )
 
         assert len(metric_relabel_config_search_result) == 2
-        assert metric_relabel_config_search_result[0][
-            "regex"] == '(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$'
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            'pod']
-        assert metric_relabel_config_search_result[0]["replacement"] == '$1'
-        assert metric_relabel_config_search_result[0]["target_label"] == 'release'
+        assert (
+            metric_relabel_config_search_result[0]["regex"]
+            == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
+        )
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
+        assert metric_relabel_config_search_result[0]["replacement"] == "$1"
+        assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
-        assert metric_relabel_config_search_result[1]["regex"] == '(.+)-resource-quota$'
+        assert metric_relabel_config_search_result[1]["regex"] == "(.+)-resource-quota$"
         assert metric_relabel_config_search_result[1]["source_labels"] == [
-            'resourcequota']
-        assert metric_relabel_config_search_result[1]["replacement"] == '$1'
-        assert metric_relabel_config_search_result[1]["target_label"] == 'release'
+            "resourcequota"
+        ]
+        assert metric_relabel_config_search_result[1]["replacement"] == "$1"
+        assert metric_relabel_config_search_result[1]["target_label"] == "release"
 
     def test_prometheus_config_insecure_skip_verify(self, kube_version):
         """Test that insecure_skip_verify is rendered correctly in the config when specified."""
@@ -280,7 +280,10 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             values={
-                "global": {"features": {"namespacePools": {"enabled": True}}, "namespaceFreeFormEntry": False}
+                "global": {
+                    "features": {"namespacePools": {"enabled": True}},
+                    "namespaceFreeFormEntry": False,
+                }
             },
         )[0]
 
@@ -294,15 +297,17 @@ class TestPrometheusConfigConfigmap:
         )
 
         assert len(metric_relabel_config_search_result) == 2
-        assert metric_relabel_config_search_result[0][
-            "regex"] == '(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$'
-        assert metric_relabel_config_search_result[0]["source_labels"] == [
-            'pod']
-        assert metric_relabel_config_search_result[0]["replacement"] == '$1'
-        assert metric_relabel_config_search_result[0]["target_label"] == 'release'
+        assert (
+            metric_relabel_config_search_result[0]["regex"]
+            == "(.*?)(?:-webserver.*|-scheduler.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
+        )
+        assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
+        assert metric_relabel_config_search_result[0]["replacement"] == "$1"
+        assert metric_relabel_config_search_result[0]["target_label"] == "release"
 
-        assert metric_relabel_config_search_result[1]["regex"] == '(.+)-resource-quota$'
+        assert metric_relabel_config_search_result[1]["regex"] == "(.+)-resource-quota$"
         assert metric_relabel_config_search_result[1]["source_labels"] == [
-            'resourcequota']
-        assert metric_relabel_config_search_result[1]["replacement"] == '$1'
-        assert metric_relabel_config_search_result[1]["target_label"] == 'release'
+            "resourcequota"
+        ]
+        assert metric_relabel_config_search_result[1]["replacement"] == "$1"
+        assert metric_relabel_config_search_result[1]["target_label"] == "release"


### PR DESCRIPTION
## Description

For pre-created namespaces pods, Relabeling and storing the release names in `release` tag, so that they can be fetched by the query made from houston, under metrics tab

## Related Issues

[4650](https://github.com/astronomer/issues/issues/4650)

## Testing

Kind cluster locally. Also, spinning up a separate cluster.


## Merging

0.32.1