### PR TITLE
Masked token from request_uri and referrer in nginx ingress logs

### DIFF
--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -52,7 +52,7 @@ data:
 
           -- Check if the parameter should be masked
           if paramsToMask[paramName] then
-              paramValue = "********" -- Replace the value with asterisks
+              paramValue = "REDACTED" -- Replace the value with asterisks
           end
 
           table.insert(queryParams, paramName .. "=" .. paramValue)
@@ -89,7 +89,7 @@ data:
 
           -- Check if the parameter should be masked
           if paramsToMask[paramName] then
-              paramValue = "********" -- Replace the value with asterisks
+              paramValue = "REDACTED" -- Replace the value with asterisks
           end
 
           table.insert(queryParams, paramName .. "=" .. paramValue)

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -52,7 +52,7 @@ data:
 
           -- Check if the parameter should be masked
           if paramsToMask[paramName] then
-              paramValue = "REDACTED" -- Replace the value with asterisks
+              paramValue = "REDACTED" -- Replace the value with REDACTED
           end
 
           table.insert(queryParams, paramName .. "=" .. paramValue)
@@ -89,7 +89,7 @@ data:
 
           -- Check if the parameter should be masked
           if paramsToMask[paramName] then
-              paramValue = "REDACTED" -- Replace sensitive data with 'REDACTED'
+              paramValue = "REDACTED" -- Replace sensitive data with REDACTED
           end
 
           table.insert(queryParams, paramName .. "=" .. paramValue)

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -25,7 +25,81 @@ data:
   log-format-upstream: '{"timestamp": "$time_iso8601", "requestID": "$req_id", "proxyUpstreamName":
     "$proxy_upstream_name", "proxyAlternativeUpstreamName": "$proxy_alternative_upstream_name","upstreamStatus":
     "$upstream_status", "upstreamAddr": "$upstream_addr","httpRequest":{"requestMethod":
-    "$request_method", "requestUrl": "$host$request_uri", "status": $status,"requestSize":
+    "$request_method", "requestUrl": "$host$request_uri_masked", "status": $status,"requestSize":
     "$request_length", "responseSize": "$upstream_response_length", "userAgent": "$http_user_agent",
-    "remoteIp": "$remote_addr", "referer": "$http_referer", "latency": "$upstream_response_time
+    "remoteIp": "$remote_addr", "referer": "$http_referer_masked", "latency": "$upstream_response_time
     s", "protocol":"$server_protocol"}}'
+  server-snippet: |
+    set_by_lua_block $request_uri_masked {
+      local url = ngx.var.request_uri
+      if url == nil or url == '' then
+        return url
+      end
+      local paramsToMask = {
+        token = true
+      }
+      local maskedUrl = url
+      local queryStringStart = string.find(url, "?")
+      -- Check if there is a query string in the URL
+      if queryStringStart then
+        -- Extract the query string
+        local queryString = string.sub(url, queryStringStart + 1)
+        local queryParams = {}
+
+        -- Split the query string into individual parameters
+        for param in string.gmatch(queryString, "([^&]+)") do
+          local paramName, paramValue = string.match(param, "(.+)=(.+)")
+
+          -- Check if the parameter should be masked
+          if paramsToMask[paramName] then
+              paramValue = "********" -- Replace the value with asterisks
+          end
+
+          table.insert(queryParams, paramName .. "=" .. paramValue)
+        end
+
+        -- Reconstruct the masked query string
+        local maskedQueryString = table.concat(queryParams, "&")
+
+        -- Replace the original query string with the masked query string
+        maskedUrl = string.sub(url, 1, queryStringStart) .. maskedQueryString
+      end
+      return maskedUrl
+    }
+
+    set_by_lua_block $http_referer_masked {
+      local url = ngx.var.http_referer
+      if url == nil or url == '' then
+        return url
+      end
+      local paramsToMask = {
+        token = true
+      }
+      local maskedUrl = url
+      local queryStringStart = string.find(url, "?")
+      -- Check if there is a query string in the URL
+      if queryStringStart then
+        -- Extract the query string
+        local queryString = string.sub(url, queryStringStart + 1)
+        local queryParams = {}
+
+        -- Split the query string into individual parameters
+        for param in string.gmatch(queryString, "([^&]+)") do
+          local paramName, paramValue = string.match(param, "(.+)=(.+)")
+
+          -- Check if the parameter should be masked
+          if paramsToMask[paramName] then
+              paramValue = "********" -- Replace the value with asterisks
+          end
+
+          table.insert(queryParams, paramName .. "=" .. paramValue)
+        end
+
+        -- Reconstruct the masked query string
+        local maskedQueryString = table.concat(queryParams, "&")
+
+        -- Replace the original query string with the masked query string
+        maskedUrl = string.sub(url, 1, queryStringStart) .. maskedQueryString
+      end
+      return maskedUrl
+    }

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -89,7 +89,7 @@ data:
 
           -- Check if the parameter should be masked
           if paramsToMask[paramName] then
-              paramValue = "REDACTED" -- Replace the value with asterisks
+              paramValue = "REDACTED" -- Replace sensitive data with 'REDACTED'
           end
 
           table.insert(queryParams, paramName .. "=" .. paramValue)


### PR DESCRIPTION
## Description

Mask the `token` query param in referrer and request url string, in our nginx logs

## Related Issues

[#5608
](https://github.com/astronomer/issues/issues/5608)
## Testing

Local kind cluster

## Merging

0.32.1