### PR TITLE
bump houston and airflowChartVersion for 0.30.7 rc2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.15
-                - quay.io/astronomer/ap-commander:0.30.8
+                - quay.io/astronomer/ap-commander:0.30.9
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:7.17.9-1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
                 - quay.io/astronomer/ap-grafana:8.5.24
-                - quay.io/astronomer/ap-houston-api:0.30.35
+                - quay.io/astronomer/ap-houston-api:0.30.36
                 - quay.io/astronomer/ap-init:3.16.5
                 - quay.io/astronomer/ap-kibana:7.17.9
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.30.7-rc1
-appVersion: 0.30.7-rc1
+version: 0.30.7-rc2
+appVersion: 0.30.7-rc2
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.30.7-rc1
+version: 0.30.7-rc2
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.30.8
+    tag: 0.30.9
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.7.8
+airflowChartVersion: 1.7.9
 
 nodeSelector: {}
 affinity: {}
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.30.35
+    tag: 0.30.36
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/external-es-proxy/templates/_helpers.tpl
+++ b/charts/external-es-proxy/templates/_helpers.tpl
@@ -83,3 +83,21 @@ imagePullSecrets:
   - name: {{ .Values.global.privateRegistry.secretName }}
 {{- end -}}
 {{- end -}}
+
+
+{{ define "esproxy.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-openresty:{{ .Values.images.esproxy.tag }}
+{{- else -}}
+{{ printf "%s:%s" .Values.images.esproxy.repository .Values.images.esproxy.tag }}
+{{- end }}
+{{- end }}
+
+
+{{ define "awsesproxy.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-awsesproxy:{{ .Values.images.awsproxy.tag }}
+{{- else -}}
+{{ printf "%s:%s" .Values.images.awsproxy.repository .Values.images.awsproxy.tag }}
+{{- end }}
+{{- end }}

--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.images.esproxy.repository }}:{{ .Values.images.esproxy.tag | default .Chart.AppVersion }}"
+          image: {{ template "esproxy.image" . }}
           imagePullPolicy: {{ .Values.images.esproxy.pullPolicy }}
           env:
 {{- if .Values.global.customLogging.extraEnv }}
@@ -96,7 +96,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
 {{- if  or .Values.global.customLogging.awsSecretName  .Values.global.customLogging.awsServiceAccountAnnotation  .Values.global.customLogging.awsIAMRole}}
         - name: awsproxy
-          image: "{{ .Values.images.awsproxy.repository }}:{{ .Values.images.awsproxy.tag | default .Chart.AppVersion }}"
+          image: {{ template "awsesproxy.image" . }}
           command: ["/bin/sh","-c"]
           args: ["aws-es-proxy -listen :{{ .Values.service.awsproxy }}"]
           imagePullPolicy: {{ .Values.images.awsproxy.pullPolicy }}

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -4,7 +4,7 @@ import jmespath
 import pytest
 import yaml
 
-from tests import supported_k8s_versions
+from tests import supported_k8s_versions, get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 
 secret = base64.b64encode(b"sample-secret").decode()


### PR DESCRIPTION
## Description

airflowChartVersion: 1.7.8 -> 1.7.9
houston: 0.30.35 -> 0.30.36
commander: 0.30.8 -> 0.30.9

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
