### PR TITLE
ap-commander 0.32.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.15
-                - quay.io/astronomer/ap-commander:0.32.4
+                - quay.io/astronomer/ap-commander:0.32.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.4
+    tag: 0.32.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

ap-commander 0.32.5

## Related Issues

- Commander PR: https://github.com/astronomer/commander/pull/161

## Testing

CI tests should be enough

## Merging

Merge to release-0.32
