### PR TITLE
resolves CVE-2023-1999 in nginx base images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,7 +327,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0-1
                 - quay.io/astronomer/ap-astro-ui:0.32.4
-                - quay.io/astronomer/ap-auth-sidecar:1.24.0
+                - quay.io/astronomer/ap-auth-sidecar:1.24.0-1
                 - quay.io/astronomer/ap-awsesproxy:1.3-12
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
@@ -336,7 +336,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
                 - quay.io/astronomer/ap-curator:7.0.0-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2
-                - quay.io/astronomer/ap-default-backend:0.28.15
+                - quay.io/astronomer/ap-default-backend:0.28.16
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.10
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
@@ -348,10 +348,10 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-5
                 - quay.io/astronomer/ap-nats-server:2.8.4-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-3
-                - quay.io/astronomer/ap-nginx-es:1.24.0
+                - quay.io/astronomer/ap-nginx-es:1.24.0-1
                 - quay.io/astronomer/ap-nginx:1.7.1
                 - quay.io/astronomer/ap-node-exporter:1.5.0
-                - quay.io/astronomer/ap-openresty:1.21.4-6
+                - quay.io/astronomer/ap-openresty:1.21.4-7
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-1

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.24.0
+    tag: 1.24.0-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-6
+    tag: 1.21.4-7
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.15
+    tag: 0.28.16
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -126,7 +126,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.24.0
+    tag: 1.24.0-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

resolves CVE-2023-1999 in nginx base images


## Related Issues

https://github.com/astronomer/issues/issues/5646

## Testing

NA

## Merging

cherry-pick to release-0.32
