### PR TITLE
resolves CVE-2023-29491 in vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,20 +327,20 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0-1
                 - quay.io/astronomer/ap-astro-ui:0.32.4
-                - quay.io/astronomer/ap-auth-sidecar:1.24.0-1
+                - quay.io/astronomer/ap-auth-sidecar:1.24.0-2
                 - quay.io/astronomer/ap-awsesproxy:1.3-12
                 - quay.io/astronomer/ap-base:3.16.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.15
                 - quay.io/astronomer/ap-commander:0.32.5
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:7.0.0-4
+                - quay.io/astronomer/ap-curator:7.0.0-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.2
                 - quay.io/astronomer/ap-default-backend:0.28.16
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.10
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.24
+                - quay.io/astronomer/ap-grafana:8.5.24-2
                 - quay.io/astronomer/ap-houston-api:0.32.8
                 - quay.io/astronomer/ap-init:3.16.5
                 - quay.io/astronomer/ap-kibana:7.17.10
@@ -348,16 +348,16 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-5
                 - quay.io/astronomer/ap-nats-server:2.8.4-3
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-3
-                - quay.io/astronomer/ap-nginx-es:1.24.0-1
-                - quay.io/astronomer/ap-nginx:1.7.1
+                - quay.io/astronomer/ap-nginx-es:1.24.0-2
+                - quay.io/astronomer/ap-nginx:1.7.1-1
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-7
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-8
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-1
                 - quay.io/astronomer/ap-prometheus:2.37.8
                 - quay.io/astronomer/ap-registry:3.16.5
-                - quay.io/astronomer/ap-vector:0.28.2-1
+                - quay.io/astronomer/ap-vector:0.28.2-2
           context:
             - slack_team-software-infra-bot
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 7.0.0-4
+    tag: 7.0.0-5
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.24.0-1
+    tag: 1.24.0-2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.24
+    tag: 8.5.24-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.7.1
+    tag: 1.7.1-1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-7
+  tag: 1.17.0-8
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.28.2-1
+    image: quay.io/astronomer/ap-vector:0.28.2-2
     customConfig: false
     extraEnv: []
     resources: {}
@@ -126,7 +126,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.24.0-1
+    tag: 1.24.0-2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

| imageName | oldtag | newTag |
|--------|--------|--------|
| ap-auth-sidecar | 1.24.0-1 | 1.24.0-2 |
| ap-curator | 7.0.0-4 | 7.0.0-5 | 
| ap-grafana | 8.5.24-1 | 8.5.24-2 | 
| ap-nginx-es | 1.24.0-1 | 1.24.0-2 |
| ap-nginx | 1.7.1 | 1.7.1-1 | 
| ap-pgbouncer-krb | 1.17.0-7 | 1.17.0-8 |
| ap-vector| 0.28.2-1 | 0.28.2-2 |

## Related Issues

https://github.com/astronomer/issues/issues/5649

## Testing

QA should able to deploy all components without issues

## Merging

cherry-pick to release-0.32
