### PR TITLE
add git-sync-relay labels in prometheus

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -272,7 +272,7 @@ data:
           # Required for multi-namespace mode (non auto-generated namespaces should be relabeled differently)
           {{- if or .Values.global.features.namespacePools.enabled .Values.global.namespaceFreeFormEntry .Values.global.manualNamespaceNamesEnabled}}
           - source_labels: [pod]
-            regex: "(.*?)(?:-webserver.*|-scheduler.*|-worker.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
+            regex: "(.*?)(?:-webserver.*|-scheduler.*|-worker.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*|-git-sync-relay.*)?$"
             replacement: "$1"
             target_label: release
           - source_labels: [resourcequota]

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -293,7 +293,7 @@ class TestPrometheusConfigConfigmap:
         assert len(metric_relabel_config_search_result) == 2
         assert (
             metric_relabel_config_search_result[0]["regex"]
-            == "(.*?)(?:-webserver.*|-scheduler.*|-worker.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*)?$"
+            == "(.*?)(?:-webserver.*|-scheduler.*|-worker.*|-cleanup.*|-pgbouncer.*|-statsd.*|-triggerer.*|-run-airflow-migrations.*|-git-sync-relay.*)?$"
         )
         assert metric_relabel_config_search_result[0]["source_labels"] == ["pod"]
         assert metric_relabel_config_search_result[0]["replacement"] == "$1"


### PR DESCRIPTION
## Description

include git-sync-relay lable to show pod status in astro-ui when precreated namespace or namespace free form entry

## Related Issues

https://github.com/astronomer/issues/issues/4650

## Testing

QA should able to see pod status in astro-ui

## Merging

cherry-pick to release-0.32
