### PR TITLE
add extraenv support for registry backend service

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -74,6 +74,9 @@ spec:
             {{- else }}
             value: {{ randAlphaNum 32 }}
             {{- end }}
+{{- if .Values.registry.extraEnv }}
+{{ toYaml .Values.registry.extraEnv | indent 10 }}
+{{- end }}
           resources:
 {{ toYaml .Values.registry.resources | indent 12 }}
           volumeMounts:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -356,6 +356,8 @@ registry:
   #   cpu: 100m
   #   memory: 128Mi
 
+  extraEnv: []
+
   persistence:
     # Enable persistent storage
     enabled: true

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -30,8 +30,8 @@ class TestRegistryStatefulset:
         )
 
     def test_astronomer_registry_statefulset_with_customenv(self, kube_version):
-        """Test that helm renders a good statefulset template for astronomer
-        registry."""
+        """Test that helm renders statefulset template for astronomer
+        registry with custom env values."""
         docs = render_chart(
             kube_version=kube_version,
             values={

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -32,16 +32,10 @@ class TestRegistryStatefulset:
     def test_astronomer_registry_statefulset_with_custom_env(self, kube_version):
         """Test that helm renders statefulset template for astronomer
         registry with custom env values."""
+        extra_env = {"name": "TEST_ENV_VAR_876", "value": "test"}
         docs = render_chart(
             kube_version=kube_version,
-            extra_env = {"name": "TEST_ENV_VAR_876", "value": "test"}
-            values={
-                "astronomer": {
-                    "registry": {
-                        "extraEnv": [extra_env]
-                    }
-                }
-            },
+            values={"astronomer": {"registry": {"extraEnv": [extra_env]}}},
             show_only=[
                 "charts/astronomer/templates/registry/registry-statefulset.yaml"
             ],

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -8,20 +8,49 @@ import jmespath
     "kube_version",
     supported_k8s_versions,
 )
-def test_astronomer_registry_statefulset(kube_version):
-    """Test that helm renders a good statefulset template for astronomer
-    registry."""
-    docs = render_chart(
-        kube_version=kube_version,
-        show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
-    )
+class TestRegistryStatefulset:
+    def test_astronomer_registry_statefulset(self, kube_version):
+        """Test that helm renders a good statefulset template for astronomer
+        registry."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml"
+            ],
+        )
 
-    assert len(docs) == 1
-    doc = docs[0]
-    assert doc["kind"] == "StatefulSet"
-    assert doc["apiVersion"] == "apps/v1"
-    assert doc["metadata"]["name"] == "release-name-registry"
-    assert any(
-        "quay.io/astronomer/ap-registry:" in item
-        for item in jmespath.search("spec.template.spec.containers[*].image", doc)
-    )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+        assert any(
+            "quay.io/astronomer/ap-registry:" in item
+            for item in jmespath.search("spec.template.spec.containers[*].image", doc)
+        )
+
+    def test_astronomer_registry_statefulset_with_customenv(self, kube_version):
+        """Test that helm renders a good statefulset template for astronomer
+        registry."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "registry": {
+                        "extraEnv": [{"name": "REGISTRY_ENV_STORAGE", "value": "test"}]
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml"
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+        assert {"name": "REGISTRY_ENV_STORAGE", "value": "test"} in doc["spec"][
+            "template"
+        ]["spec"]["containers"][0]["env"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -34,10 +34,11 @@ class TestRegistryStatefulset:
         registry with custom env values."""
         docs = render_chart(
             kube_version=kube_version,
+            extra_env = {"name": "TEST_ENV_VAR_876", "value": "test"}
             values={
                 "astronomer": {
                     "registry": {
-                        "extraEnv": [{"name": "REGISTRY_ENV_STORAGE", "value": "test"}]
+                        "extraEnv": [extra_env]
                     }
                 }
             },
@@ -51,6 +52,4 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert {"name": "REGISTRY_ENV_STORAGE", "value": "test"} in doc["spec"][
-            "template"
-        ]["spec"]["containers"][0]["env"]
+        assert extra_env in doc["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -29,7 +29,7 @@ class TestRegistryStatefulset:
             for item in jmespath.search("spec.template.spec.containers[*].image", doc)
         )
 
-    def test_astronomer_registry_statefulset_with_customenv(self, kube_version):
+    def test_astronomer_registry_statefulset_with_custom_env(self, kube_version):
         """Test that helm renders statefulset template for astronomer
         registry with custom env values."""
         docs = render_chart(

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -9,7 +9,7 @@ import jmespath
     supported_k8s_versions,
 )
 class TestRegistryStatefulset:
-    def test_astronomer_registry_statefulset(self, kube_version):
+    def test_astronomer_registry_statefulset_defaults(self, kube_version):
         """Test that helm renders a good statefulset template for astronomer
         registry."""
         docs = render_chart(

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 ##################################
 global:
   # Base domain for all subdomains exposed through ingress
-  baseDomain: example.com
+  baseDomain: ~
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,7 @@
 ##################################
 global:
   # Base domain for all subdomains exposed through ingress
-  baseDomain: ~
+  baseDomain: example.com
 
   # Name of secret containing TLS certificate
   tlsSecret: astronomer-tls


### PR DESCRIPTION
## Description

Allow referencing custom env vars and secret ref in registry env vars to remove sensitive information passed as direct values in config. 

## Related Issues

https://github.com/astronomer/issues/issues/4559

## Testing

QA should able to verify by passing env vars for registry configuration

## Merging

cherry-pick to release-0.30 and release-0.32.
