### PR TITLE
update grafana version includes dashboard fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:7.17.10
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
-                - quay.io/astronomer/ap-grafana:8.5.24-2
+                - quay.io/astronomer/ap-grafana:8.5.26
                 - quay.io/astronomer/ap-houston-api:0.32.13
                 - quay.io/astronomer/ap-init:3.16.5
                 - quay.io/astronomer/ap-kibana:7.17.10

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 8.5.24-2
+    tag: 8.5.26
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

* update grafana version 8.5.24-2 -> 8.5.26
*  fixes platform dashboard for missing metrics


## Related Issues

https://github.com/astronomer/issues/issues/5660

## Testing

QA should able to verify platform dashboard overview dashboard showing the data properly

## Merging

cherry-pick to release 0.30, 0.32
