### PR TITLE
Update image template to use ap-image instead of ap-base.

### DIFF
--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Return the list of peers in a NATS Streaming cluster.
 
 {{ define "stan.init.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.images.init.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-init:{{ .Values.images.init.tag }}
 {{- else -}}
 {{ .Values.images.init.repository }}:{{ .Values.images.init.tag }}
 {{- end }}


### PR DESCRIPTION
Update astronomer stan to use the correct image name when a private registry is specified.

## Description

Until now stan always incorrectly used the ap-base name but the ap-image tag when private registry was enabled. Tags were closely enoogh version that it just happened to work.

## Related Issues

[Do not merge this PR until this text is replaced with links to related issues.
](https://github.com/astronomer/issues/issues/5698)

## Testing

Visual inspection of helm -n astronomer template ~/astronomer --set global.privateRegistry.enabled=false |grep "ap-init" -B only

## Merging

All currently supported release branches.