### PR TITLE
add service account to registry service

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -131,6 +131,10 @@
 {{ printf "%s-houston-bootstrapper" .Release.Name }}
 {{- end }}
 
+{{ define "registry.ServiceAccount" -}}
+{{ printf "%s-registry" .Release.Name }}
+{{- end }}
+
 {{- define "registry.gcsVolume" }}
 - name: gcs-keyfile
   secret:

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -132,7 +132,11 @@
 {{- end }}
 
 {{ define "registry.ServiceAccount" -}}
+{{- if .Values.registry.serviceAccount.name -}}
+{{ printf "%s-%s" .Release.Name .Values.registry.serviceAccount.name }}
+{{- else -}}
 {{ printf "%s-registry" .Release.Name }}
+{{- end }}
 {{- end }}
 
 {{- define "registry.gcsVolume" }}

--- a/charts/astronomer/templates/registry/registry-serviceaccount.yaml
+++ b/charts/astronomer/templates/registry/registry-serviceaccount.yaml
@@ -1,0 +1,15 @@
+################################
+## Registry ServiceAccount
+#################################
+{{- if .Values.registry.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "registry.ServiceAccount" . }}
+  labels:
+    release: {{ .Release.Name }}
+    chart: {{ .Chart.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+{{- toYaml .Values.registry.serviceAccount.annotations | nindent 4 }}
+{{- end -}}

--- a/charts/astronomer/templates/registry/registry-serviceaccount.yaml
+++ b/charts/astronomer/templates/registry/registry-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Registry ServiceAccount
 #################################
-{{- if .Values.registry.serviceAccount.create -}}
+{{- if .Values.registry.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -45,6 +45,7 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-configmap.yaml") . | sha256sum }}
     spec:
+      serviceAccountName: {{ template "registry.ServiceAccount" . }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -45,7 +45,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/registry/registry-configmap.yaml") . | sha256sum }}
     spec:
+{{- if .Values.registry.serviceAccount.create }}
       serviceAccountName: {{ template "registry.ServiceAccount" . }}
+{{- end }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -358,6 +358,15 @@ registry:
 
   extraEnv: []
 
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: "registry"
+
   persistence:
     # Enable persistent storage
     enabled: true

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -360,7 +360,7 @@ registry:
 
   serviceAccount:
     # Specifies whether a service account should be created
-    create: true
+    create: false
     # Annotations to add to the service account
     annotations: {}
     # The name of the service account to use.

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -365,7 +365,7 @@ registry:
     annotations: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
-    name: "registry"
+    name: ""
 
   persistence:
     # Enable persistent storage

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -48,7 +48,6 @@ class TestRegistryStatefulset:
         assert doc["metadata"]["name"] == "release-name-registry"
         assert extra_env in doc["spec"]["template"]["spec"]["containers"][0]["env"]
 
-
     def test_astronomer_registry_statefulset_with_serviceaccount_enabled_defaults(
         self, kube_version
     ):

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -47,3 +47,82 @@ class TestRegistryStatefulset:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
         assert extra_env in doc["spec"]["template"]["spec"]["containers"][0]["env"]
+
+
+    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_defaults(
+        self, kube_version
+    ):
+        """Test that helm renders statefulset and serviceAccount template for astronomer
+        registry with SA enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"registry": {"serviceAccount": {"create": True}}}},
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml",
+                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
+            ],
+        )
+        assert len(docs) == 2
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+        assert doc["spec"]["serviceAccountName"] == "release-name-registry"
+
+        doc = docs[1]
+        assert doc["kind"] == "ServiceAccount"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+
+    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_with_custom_name(
+        self, kube_version
+    ):
+        """Test that helm renders statefulset and serviceAccount template for astronomer
+        registry with SA enabled with custom name."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "registry": {
+                        "serviceAccount": {"create": True, "name": "customregistrysa"}
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml",
+                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
+            ],
+        )
+        assert len(docs) == 2
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+        assert doc["spec"]["serviceAccountName"] == "customregistrysa"
+
+        doc = docs[1]
+        assert doc["kind"] == "ServiceAccount"
+        assert doc["apiVersion"] == "v1"
+        assert doc["spec"]["serviceAccountName"] == "release-name-customregistrysa"
+
+    def test_astronomer_registry_statefulset_with_serviceaccount_disabled(
+        self, kube_version
+    ):
+        """Test that helm renders statefulset template for astronomer
+        registry with SA disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "registry": {
+                        "serviceAccount": {"create": True, "name": "customregistrysa"}
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml",
+                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
+            ],
+        )
+        assert len(docs) == 2
+        assert "serviceAccountName" not in docs[0]["spec"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -142,4 +142,4 @@ class TestRegistryStatefulset:
             ],
         )
         assert len(docs) == 2
-        assert "serviceAccountName" not in docs[0]["spec"]
+        assert "serviceAccountName" not in docs[0]["spec"]["template"]["spec"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -135,17 +135,11 @@ class TestRegistryStatefulset:
         registry with SA disabled."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "registry": {
-                        "serviceAccount": {"create": True, "name": "customregistrysa"}
-                    }
-                }
-            },
+            values={},
             show_only=[
                 "charts/astronomer/templates/registry/registry-statefulset.yaml",
                 "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
             ],
         )
-        assert len(docs) == 2
+        assert len(docs) == 1
         assert "serviceAccountName" not in docs[0]["spec"]["template"]["spec"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -75,7 +75,10 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert doc["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-registry"
+        assert (
+            doc["spec"]["template"]["spec"]["serviceAccountName"]
+            == "release-name-registry"
+        )
 
         doc = docs[1]
         assert doc["kind"] == "ServiceAccount"
@@ -114,7 +117,10 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert doc["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-customregistrysa"
+        assert (
+            doc["spec"]["template"]["spec"]["serviceAccountName"]
+            == "release-name-customregistrysa"
+        )
 
         doc = docs[1]
         assert doc["kind"] == "ServiceAccount"


### PR DESCRIPTION
## Description

Registry is by default configured to use default serviceAccount , this changes allows user to enable serviceAccount to be added either with custom name or default name. This allows user to make use of IRSA and GKE Managed Identity.

## Related Issues

https://github.com/astronomer/issues/issues/5692

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
