### PR TITLE
Fix private registry init containers

### DIFF
--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -41,7 +41,7 @@ Create chart name and version as used by the chart label.
 
 {{ define "prometheus.init.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.images.init.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-init:{{ .Values.images.init.tag }}
 {{- else -}}
 {{ .Values.images.init.repository }}:{{ .Values.images.init.tag }}
 {{- end }}

--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -41,7 +41,7 @@ Return the list of peers in a NATS Streaming cluster.
 
 {{ define "stan.init.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.images.init.tag }}
+{{ .Values.global.privateRegistry.repository }}/ap-init:{{ .Values.images.init.tag }}
 {{- else -}}
 {{ .Values.images.init.repository }}:{{ .Values.images.init.tag }}
 {{- end }}

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -77,6 +77,10 @@ class TestAllPodSpecContainers:
         "enabled": True,
         "repository": private_repo,
     }
+    private_values["global"]["authSidecar"] = {
+        "enabled": True,
+        "repository": f"{private_repo}/ap-auth-sidecar",
+    }
     private_repo_docs = render_chart(values=private_values)
     pod_manager_docs_private = [
         doc for doc in private_repo_docs if doc["kind"] in pod_managers
@@ -116,7 +120,7 @@ class TestAllPodSpecContainers:
             ), f"The spec for '{pod_container}' does not use the same image for public and private registry configurations."
             assert container["image"].startswith(
                 self.private_repo
-            ), f"The container '{name}' does not use the privateRegistry repo '{self.private_repo}': {container}"
+            ), f"The spec for '{pod_container}' does not use the privateRegistry repo '{self.private_repo}': {container}"
 
 
 @pytest.mark.skip(


### PR DESCRIPTION
## Description

- Add more tests to validate privateRegistry functionality.
- Fix a two cases where privateRegistry was not being used.

## Related Issues

https://github.com/astronomer/issues/issues/5698

## Testing

Tests are included for the bug fixes so no human testing is necessary.

## Merging

This bugfix should be merged to all supported branches.