### PR TITLE
update nginx packages 1.25.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -327,16 +327,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0-1
                 - quay.io/astronomer/ap-astro-ui:0.32.6
-                - quay.io/astronomer/ap-auth-sidecar:1.24.0-3
+                - quay.io/astronomer/ap-auth-sidecar:1.25.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-13
                 - quay.io/astronomer/ap-base:3.16.5-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-5
-                - quay.io/astronomer/ap-cli-install:0.26.16
+                - quay.io/astronomer/ap-cli-install:0.26.17
                 - quay.io/astronomer/ap-commander:0.32.7
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.4
-                - quay.io/astronomer/ap-default-backend:0.28.17
+                - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.1
                 - quay.io/astronomer/ap-fluentd:1.15.3-2
@@ -348,7 +348,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
-                - quay.io/astronomer/ap-nginx-es:1.24.0-3
+                - quay.io/astronomer/ap-nginx-es:1.25.1
                 - quay.io/astronomer/ap-nginx:1.7.1-2
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-8

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.16
+    tag: 0.26.17
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.24.0-3
+    tag: 1.25.1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.17
+    tag: 0.28.18
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -127,7 +127,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.24.0-3
+    tag: 1.25.1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

upgrades nginx version 1.25.1

## Related Issues

https://github.com/astronomer/issues/issues/5712

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to all valid release branches
