### PR TITLE
airflowChartVersion: 1.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.16.5-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.23.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.17
-                - quay.io/astronomer/ap-commander:0.32.7
+                - quay.io/astronomer/ap-commander:0.33.0
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.7
+    tag: 0.33.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.7
+airflowChartVersion: 1.9.0
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

Bump airflowChartVersion to 1.9.0.

## Related Issues

- https://github.com/astronomer/issues/issues/5670

## Testing

This is a big jump, from OSS airflow chart 1.8 to 1.11, so we should be extra careful to investigate things that are not working perfectly during testing.

## Merging

This could be merged everywhere that 1.8.x was used if we want to do that, otherwise we can just put it in 0.33.