### PR TITLE
update prometheus version 2.45.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
-                - quay.io/astronomer/ap-prometheus:2.37.8
+                - quay.io/astronomer/ap-prometheus:2.45.0
                 - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.37.8
+    tag: 2.45.0
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader


### PR DESCRIPTION
## Description

upgrade prometheus to newer LTS version 2.45.0

https://prometheus.io/docs/introduction/release-cycle/#list-of-lts-releases

![image](https://github.com/astronomer/astronomer/assets/81585115/579bb00e-a1dc-42b5-9321-672afad3e28b)


## Related Issues

https://github.com/astronomer/issues/issues/5711

## Testing

QA should able to validate  the prometheus features without issues

## Merging

cherry-pick to all valid releases
