### PR TITLE
update grafana version 10.0.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -340,7 +340,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.1
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
-                - quay.io/astronomer/ap-grafana:10.0.1
+                - quay.io/astronomer/ap-grafana:10.0.2
                 - quay.io/astronomer/ap-houston-api:0.32.15
                 - quay.io/astronomer/ap-init:3.16.5-1
                 - quay.io/astronomer/ap-kibana:8.8.1

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.0.1
+    tag: 10.0.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update grafana version 10.0.2

resolves multiple CVE
https://github.com/advisories/GHSA-69cg-p879-7622
https://github.com/advisories/GHSA-fxg5-wq6x-vr4w
https://github.com/advisories/GHSA-vvpx-j8f3-3w6h
https://github.com/advisories/GHSA-69ch-w2m2-3vjp

Fix grafana cli syntax

## Related Issues

https://github.com/astronomer/issues/issues/5707

## Testing

QA should able to validate existing graphs should work as usual without any issues.

## Merging

cherry-pick to all valid releases
