### PR TITLE
update elastic packages 8.8.1 -> 8.8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,12 +338,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.4
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
-                - quay.io/astronomer/ap-elasticsearch:8.8.1
+                - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
                 - quay.io/astronomer/ap-grafana:10.0.2
                 - quay.io/astronomer/ap-houston-api:0.32.15
                 - quay.io/astronomer/ap-init:3.16.5-1
-                - quay.io/astronomer/ap-kibana:8.8.1
+                - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 8.8.1
+    tag: 8.8.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 8.8.1
+    tag: 8.8.2
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

Generic updates from elastic with minor internal improvements

release notes:

Kibana -> https://www.elastic.co/guide/en/kibana/current/release-notes-8.8.2.html
Elasticsearch -> https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-8.8.2.html

## Related Issues

https://github.com/astronomer/issues/issues/5721

## Testing

QA should able to validate es services should work as expected 

## Merging

cherry-pick to release-0.33
