### PR TITLE
update nginx ingress controller version 1.8.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,7 +349,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.1
-                - quay.io/astronomer/ap-nginx:1.7.1-2
+                - quay.io/astronomer/ap-nginx:1.8.1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-8
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.7.1-2
+    tag: 1.8.1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

release notes -> https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.8.1

resolves CVE-2023-35945 CVE 

## Related Issues

https://github.com/astronomer/issues/issues/5719

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
