### PR TITLE
Refactor houston config's handling of cron splay

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -359,8 +359,10 @@ data:
             Generate a deterministic random-ish decimal digit from the .Release.Name, which is used to generate
             the minute field of the cron schedule. This is effectively a splay seeded by the release name.
             This is used to spread the load of this job away from high-use minutes 0,15,30,45.
+            This template is passed to the airflow chart as a string where the template is interpreted in the
+            context of the airflow-chart's .Release.Name.
             */}}
-            schedule: "{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *"
+            schedule: "'{{"{{"}}- add 3 (regexFind \".$\" (adler32sum .Release.Name)) -}}-59/15 * * * *'"
             command:
             - airflow-cleanup-pods
             - --namespace={{`{{ .Release.Namespace }}`}}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -359,8 +359,8 @@ data:
             Generate a deterministic random-ish decimal digit from the .Release.Name, which is used to generate
             the minute field of the cron schedule. This is effectively a splay seeded by the release name.
             This is used to spread the load of this job away from high-use minutes 0,15,30,45.
-            This template is passed to the airflow chart as a string where the template is interpreted in the
-            context of the airflow-chart's .Release.Name.
+            This template is passed to the airflow chart as a string where the template is interpreted in that
+            context, including the airflow-chart's .Release.Name.
             */}}
             schedule: "'{{"{{"}}- add 3 (regexFind \".$\" (adler32sum .Release.Name)) -}}-59/15 * * * *'"
             command:

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -25,6 +25,11 @@ def common_test_cases(docs):
         "airflowLocalSettings"
     ]
 
+    assert (
+        prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
+        == """'{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'"""
+    )
+
     # validate yaml-embedded python
     ast.parse(airflow_local_settings.encode())
 
@@ -343,7 +348,6 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    print(prod_yaml)
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
     assert (
         log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
@@ -412,61 +416,6 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
     }
 
     assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-cron_test_data = [
-    ("development-angular-system-6091", 3),
-    ("development-arithmetic-phases-5695", 3),
-    ("development-empty-aurora-8527", 3),
-    ("development-explosive-inclination-4552", 3),
-    ("development-infrared-nadir-2873", 3),
-    ("development-barren-telemetry-6087", 4),
-    ("development-geocentric-cluster-5666", 4),
-    ("development-mathematical-supernova-1523", 4),
-    ("development-cometary-terrestrial-2880", 5),
-    ("development-nuclear-gegenschein-1657", 5),
-    ("development-quasarian-telescope-4189", 5),
-    ("development-traditional-universe-0643", 5),
-    ("development-asteroidal-space-6369", 6),
-    ("development-blazing-horizon-1542", 6),
-    ("development-boreal-inclination-4658", 6),
-    ("development-exact-ionosphere-3963", 6),
-    ("development-extrasolar-meteor-4188", 6),
-    ("development-inhabited-dust-4345", 6),
-    ("development-nebular-singularity-6518", 6),
-    ("development-arithmetic-sky-0424", 7),
-    ("development-true-century-8320", 7),
-    ("development-angular-radian-2199", 8),
-    ("development-scientific-cosmonaut-1863", 8),
-    ("development-uninhabited-wavelength-9355", 8),
-    ("development-false-spacecraft-1944", 9),
-    ("development-mathematical-equator-2284", 9),
-    ("development-amateur-horizon-3115", 12),
-    ("development-devoid-terminator-0587", 12),
-    ("development-optical-asteroid-4621", 12),
-]
-
-
-@pytest.mark.parametrize(
-    "test_data", cron_test_data, ids=[x[0] for x in cron_test_data]
-)
-def test_cron_splay(test_data):
-    """Test that our adler32sum method of generating deterministic random
-    numbers works."""
-    doc = render_chart(
-        name=test_data[0],
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )[0]
-
-    production_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    cron_schedule = production_yaml["deployments"]["helm"]["airflow"]["cleanup"][
-        "schedule"
-    ]
-    cron_minute = cron_schedule.split("-")[0]
-    # We are comparing after the addition of 3, which happens in the configmap template
-    assert (
-        str(test_data[1]) == cron_minute
-    ), f'test_data should be: ("{test_data[0]}", {cron_minute}),'
 
 
 def test_houston_configmapwith_update_airflow_runtime_checks_enabled():


### PR DESCRIPTION
## Description

Refactor houston configmap's handling of cleanup cron splay.

## Related Issues

https://github.com/astronomer/issues/issues/5670

## Testing

We have unit tests for the changes here, but seeing the cron splay in e2e tests will be required for us to be confident that everything is in place.

## Merging

This should only be merged to branches that support airflowChartVersion 1.9.0
