### PR TITLE
fix cron template render issue

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -362,7 +362,7 @@ data:
             This template is passed to the airflow chart as a string where the template is interpreted in that
             context, including the airflow-chart's .Release.Name.
             */}}
-            schedule: "'{{"{{"}}- add 3 (regexFind \".$\" (adler32sum .Release.Name)) -}}-59/15 * * * *'"
+            schedule: {{`'{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'`}}
             command:
             - airflow-cleanup-pods
             - --namespace={{`{{ .Release.Namespace }}`}}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -27,7 +27,7 @@ def common_test_cases(docs):
 
     assert (
         prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
-        == """'{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'"""
+        == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
     )
 
     # validate yaml-embedded python


### PR DESCRIPTION
## Description

Offloads job schedule timing to airflow chart to generate cron timing randomly for evenly distributing schedule

## Related Issues

https://github.com/astronomer/issues/issues/5670

## Testing

QA should able to validate different spread timings 

## Merging

cherry-pick to release-0.33
