### PR TITLE
update openresty image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.25.1
                 - quay.io/astronomer/ap-nginx:1.8.1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-8
+                - quay.io/astronomer/ap-openresty:1.21.4-9
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-8
+    tag: 1.21.4-9
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy


### PR DESCRIPTION
## Description

resolves CVE  CVE-2023-3138  in openresty image and upgrades alpine to 3.18

## Related Issues

https://github.com/astronomer/issues/issues/5655

## Testing

NA

## Merging

cherry-pick to release-0.33
