### PR TITLE
remove uid changes from main config

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -18,7 +18,6 @@ images:
 
 securityContext:
     runAsNonRoot: true
-    runAsUser: 472
 
 backendSecretName: ~
 backendConnection:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -17,7 +17,7 @@ images:
     pullPolicy: IfNotPresent
 
 securityContext:
-    runAsNonRoot: true
+  runAsNonRoot: true
 
 backendSecretName: ~
 backendConnection:

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -78,3 +78,23 @@ class TestGrafanaDeployment:
         assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
             "runAsNonRoot": True
         }
+
+    def test_deployment_with_securitycontext_overrides(self, kube_version):
+        """Test that the grafana-deployment renders with the expected securityContext."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "grafana": {
+                    "securityContext": {"runAsNonRoot": True, "runAsUser": 467}
+                }
+            },
+            show_only=[DEPLOYMENT_FILE],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "runAsNonRoot": True,
+            "runAsUser": 467
+        }

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -84,9 +84,7 @@ class TestGrafanaDeployment:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "grafana": {
-                    "securityContext": {"runAsNonRoot": True, "runAsUser": 467}
-                }
+                "grafana": {"securityContext": {"runAsNonRoot": True, "runAsUser": 467}}
             },
             show_only=[DEPLOYMENT_FILE],
         )
@@ -96,5 +94,5 @@ class TestGrafanaDeployment:
         assert doc["kind"] == "Deployment"
         assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
             "runAsNonRoot": True,
-            "runAsUser": 467
+            "runAsUser": 467,
         }

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -12,59 +12,69 @@ DEPLOYMENT_FILE = "charts/grafana/templates/grafana-deployment.yaml"
     "kube_version",
     supported_k8s_versions,
 )
-def test_deployment_should_render(kube_version):
-    """Test that the grafana-deployment renders without error."""
-    docs = render_chart(
-        kube_version=kube_version,
-        show_only=[DEPLOYMENT_FILE],
-    )
-    assert len(docs) == 1
+class TestGrafanaDeployment:
+    def test_deployment_should_render(self, kube_version):
+        """Test that the grafana-deployment renders without error."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[DEPLOYMENT_FILE],
+        )
+        assert len(docs) == 1
 
+    def test_deployment_should_render_extra_env(self, kube_version):
+        """Test that helm renders extra environment variables to the grafana-
+        deployment resource when provided."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"ssl": {"enabled": True}}},
+            show_only=[DEPLOYMENT_FILE],
+        )
 
-@pytest.mark.parametrize(
-    "kube_version",
-    supported_k8s_versions,
-)
-def test_deployment_should_render_extra_env(kube_version):
-    """Test that helm renders extra environment variables to the grafana-
-    deployment resource when provided."""
-    docs = render_chart(
-        kube_version=kube_version,
-        values={"global": {"ssl": {"enabled": True}}},
-        show_only=[DEPLOYMENT_FILE],
-    )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        grafana_container = None
+        for container in doc["spec"]["template"]["spec"]["containers"]:
+            if container["name"] == "grafana":
+                grafana_container = container
+                break
+        assert grafana_container is not None
+        assert len(grafana_container["env"]) == 3
 
-    assert len(docs) == 1
-    doc = docs[0]
-    assert doc["kind"] == "Deployment"
-    grafana_container = None
-    for container in doc["spec"]["template"]["spec"]["containers"]:
-        if container["name"] == "grafana":
-            grafana_container = container
-            break
-    assert grafana_container is not None
-    assert len(grafana_container["env"]) == 3
-
-    docs = render_chart(
-        kube_version=kube_version,
-        values={
-            "global": {"ssl": {"enabled": True}},
-            "grafana": {
-                "extraEnvVars": [
-                    {"name": "GF_SMTP_ENABLED", "value": "true"},
-                    {"name": "GF_SMTP_HOST", "value": "smtp.astronomer.io"},
-                ]
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"ssl": {"enabled": True}},
+                "grafana": {
+                    "extraEnvVars": [
+                        {"name": "GF_SMTP_ENABLED", "value": "true"},
+                        {"name": "GF_SMTP_HOST", "value": "smtp.astronomer.io"},
+                    ]
+                },
             },
-        },
-        show_only=[DEPLOYMENT_FILE],
-    )
+            show_only=[DEPLOYMENT_FILE],
+        )
 
-    assert len(docs) == 1
-    doc = docs[0]
-    grafana_container = None
-    for container in doc["spec"]["template"]["spec"]["containers"]:
-        if container["name"] == "grafana":
-            grafana_container = container
-            break
-    assert grafana_container is not None
-    assert len(grafana_container["env"]) == 5
+        assert len(docs) == 1
+        doc = docs[0]
+        grafana_container = None
+        for container in doc["spec"]["template"]["spec"]["containers"]:
+            if container["name"] == "grafana":
+                grafana_container = container
+                break
+        assert grafana_container is not None
+        assert len(grafana_container["env"]) == 5
+
+    def test_deployment_with_securitycontext_defaults(self, kube_version):
+        """Test that the grafana-deployment renders with the expected securityContext."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[DEPLOYMENT_FILE],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "runAsNonRoot": True
+        }


### PR DESCRIPTION
## Description

runAsUser in grafana  securityContext creates a constraint in openshift not to run the deployment since the UID range is not in specified range of openshift approved  ones.

## Related Issues

https://github.com/astronomer/issues/issues/5737

## Testing

QA should able to see grafana pod in running status

## Merging

cherry-pick to release-0.32, 0.33
