### PR TITLE
Integrate Prisma Cloud Docker Image Scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0-1
-                - quay.io/astronomer/ap-astro-ui:0.33.1
+                - quay.io/astronomer/ap-astro-ui:0.33.2
                 - quay.io/astronomer/ap-auth-sidecar:1.25.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-13
                 - quay.io/astronomer/ap-base:3.18.0-1
@@ -404,7 +404,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
                 - quay.io/astronomer/ap-grafana:10.0.2
-                - quay.io/astronomer/ap-houston-api:0.33.1
+                - quay.io/astronomer/ap-houston-api:0.33.2
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: 20.10.24
-      - checkout
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -99,7 +98,7 @@ jobs:
       - run:
           name: scan image
           command: |
-            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD << parameters.docker_image >>
+            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD --details << parameters.docker_image >>
 
   run_pre_commit:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
       - run:
           name: Install twistcli
           command: |
+            apk add --update-cache --upgrade curl
             curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
             chmod +x twistcli
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,30 @@ jobs:
           paths:
             - /tmp/workspace/trivy-cache
 
+  twistcli-scan-docker:
+    docker:
+      - image: docker:20.10.24-git
+    shell: /bin/sh -leo pipefail
+    parameters:
+      docker_image:
+        type: string
+    steps:
+      - setup_remote_docker:
+          version: 20.10.24
+      - checkout
+      - run:
+          name: Pull Docker image
+          command: docker pull << parameters.docker_image >>
+      - run:
+          name: Install twistcli
+          command: |
+            curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
+            chmod +x twistcli
+      - run:
+          name: scan image
+          command: |
+            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD << parameters.docker_image >>
+
   run_pre_commit:
     docker:
       - image: quay.io/astronomer/ci-pre-commit:2023-07
@@ -360,6 +384,45 @@ workflows:
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - slack_team-software-infra-bot
+      - twistcli-scan-docker:
+          matrix:
+            parameters:
+              docker_image:
+                - quay.io/astronomer/ap-alertmanager:0.25.0-1
+                - quay.io/astronomer/ap-astro-ui:0.33.1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.1
+                - quay.io/astronomer/ap-awsesproxy:1.3-13
+                - quay.io/astronomer/ap-base:3.18.0-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0
+                - quay.io/astronomer/ap-cli-install:0.26.17
+                - quay.io/astronomer/ap-commander:0.33.1
+                - quay.io/astronomer/ap-configmap-reloader:0.11.0
+                - quay.io/astronomer/ap-curator:8.0.4
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.4
+                - quay.io/astronomer/ap-default-backend:0.28.18
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
+                - quay.io/astronomer/ap-elasticsearch:8.8.2
+                - quay.io/astronomer/ap-fluentd:1.16.1-1
+                - quay.io/astronomer/ap-grafana:10.0.2
+                - quay.io/astronomer/ap-houston-api:0.33.1
+                - quay.io/astronomer/ap-init:3.18.0
+                - quay.io/astronomer/ap-kibana:8.8.2
+                - quay.io/astronomer/ap-kube-state:2.8.2
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-6
+                - quay.io/astronomer/ap-nats-server:2.8.4-4
+                - quay.io/astronomer/ap-nats-streaming:0.24.6-4
+                - quay.io/astronomer/ap-nginx-es:1.25.1
+                - quay.io/astronomer/ap-nginx:1.8.1
+                - quay.io/astronomer/ap-node-exporter:1.6.1
+                - quay.io/astronomer/ap-openresty:1.21.4-9
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
+                - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
+                - quay.io/astronomer/ap-postgresql:15.2.0-3
+                - quay.io/astronomer/ap-prometheus:2.45.0
+                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-vector:0.28.2-3
+          context:
+            - twistcli
 
   build-and-release-helm-chart:
     when:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -84,7 +84,6 @@ jobs:
     steps:
       - setup_remote_docker:
           version: {{ remote_docker_version }}
-      - checkout
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -97,7 +96,7 @@ jobs:
       - run:
           name: scan image
           command: |
-            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD << parameters.docker_image >>
+            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD --details << parameters.docker_image >>
 
   run_pre_commit:
     docker:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -91,6 +91,7 @@ jobs:
       - run:
           name: Install twistcli
           command: |
+            apk add --update-cache --upgrade curl
             curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
             chmod +x twistcli
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -74,6 +74,30 @@ jobs:
           paths:
             - /tmp/workspace/trivy-cache
 
+  twistcli-scan-docker:
+    docker:
+      - image: docker:{{ remote_docker_version }}-git
+    shell: /bin/sh -leo pipefail
+    parameters:
+      docker_image:
+        type: string
+    steps:
+      - setup_remote_docker:
+          version: {{ remote_docker_version }}
+      - checkout
+      - run:
+          name: Pull Docker image
+          command: docker pull << parameters.docker_image >>
+      - run:
+          name: Install twistcli
+          command: |
+            curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
+            chmod +x twistcli
+      - run:
+          name: scan image
+          command: |
+            ./twistcli images scan --address $CONSOLE_URL --user=$USER --password=$PASSWORD << parameters.docker_image >>
+
   run_pre_commit:
     docker:
       - image: quay.io/astronomer/ci-pre-commit:{{ ci_runner_version }}
@@ -265,6 +289,15 @@ workflows:
 {%- endfor %}
           context:
             - slack_team-software-infra-bot
+      - twistcli-scan-docker:
+          matrix:
+            parameters:
+              docker_image:
+{%- for image in docker_images %}
+                - {{ image }}
+{%- endfor %}
+          context:
+            - twistcli
 
   build-and-release-helm-chart:
     when:


### PR DESCRIPTION
## Description

Adding integration of Prisma Cloud Docker Image Scans using `twistcli`.

## Related Issues

N/A

## Testing

This change was tested directly by calling the Circleci job. 

Example: https://app.circleci.com/pipelines/github/astronomer/astronomer/9133/workflows/91275c9f-c0c4-4ebb-8b34-6ddb354196b3

## Merging

All active releases.
