### PR TITLE
add openshift scc template to prometheus node exporter

### DIFF
--- a/templates/scc/astronomer-nodeexporter-scc.yaml
+++ b/templates/scc/astronomer-nodeexporter-scc.yaml
@@ -1,0 +1,38 @@
+##########################################################
+## Astronomer Node Exporter SecurityContextConstraints  ##
+##########################################################
+{{- if and .Values.global.sccEnabled .Values.global.nodeExporterSccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+    color: blue
+  name: {{ .Release.Name }}-prometheus-node-exporter-scc
+priority: 15
+allowPrivilegedContainer: true
+readOnlyRootFilesystem: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus-node-exporter
+volumes:
+- configMap
+- hostPath
+- secret
+- projected
+- emptyDir
+fsGroup:
+  type: RunAsAny
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowPrivilegeEscalation: true
+{{- end }}

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -25,47 +25,43 @@ commander_expected_result = {
     "kube_version",
     supported_k8s_versions,
 )
-def test_scc_disabled(kube_version):
-    """Test all things scc related when scc is disabled."""
-    docs = render_chart(
-        kube_version=kube_version,
-        values={
-            "global": {
-                "sccEnabled": False,
-                "features": {"namespacePools": {"enabled": False}},
-            }
-        },
-        show_only=show_only,
-    )
-    houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
+class TestScc:
+    def test_scc_disabled(self, kube_version):
+        """Test all things scc related when scc is disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "sccEnabled": False,
+                    "features": {"namespacePools": {"enabled": False}},
+                }
+            },
+            show_only=show_only,
+        )
+        houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
 
-    assert len(docs) == 2
-    assert commander_expected_result not in docs[0]["rules"]
-    assert houston_values["deployments"]["helm"].get("sccEnabled") is None
+        assert len(docs) == 2
+        assert commander_expected_result not in docs[0]["rules"]
+        assert houston_values["deployments"]["helm"].get("sccEnabled") is None
 
+    def test_scc_enabled(self, kube_version):
+        """Test all things scc related when scc is disabled."""
 
-@pytest.mark.parametrize(
-    "kube_version",
-    supported_k8s_versions,
-)
-def test_scc_enabled(kube_version):
-    """Test all things scc related when scc is disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "sccEnabled": True,
+                    "clusterRoles": True,
+                    "features": {
+                        "namespacePools": {"enabled": False},
+                    },
+                }
+            },
+            show_only=show_only,
+        )
+        houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
 
-    docs = render_chart(
-        kube_version=kube_version,
-        values={
-            "global": {
-                "sccEnabled": True,
-                "clusterRoles": True,
-                "features": {
-                    "namespacePools": {"enabled": False},
-                },
-            }
-        },
-        show_only=show_only,
-    )
-    houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
-
-    assert len(docs) == 2
-    assert commander_expected_result in docs[0]["rules"]
-    assert houston_values["deployments"]["helm"]["sccEnabled"] is True
+        assert len(docs) == 2
+        assert commander_expected_result in docs[0]["rules"]
+        assert houston_values["deployments"]["helm"]["sccEnabled"] is True

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,9 @@ global:
   # Enable security context constraints required for OpenShift
   sccEnabled: false
 
+  # Enabled nodeexporter security context constraints required for OpenShift
+  nodeExporterSccEnabled: false
+
   # Enables namespace labels for network policies
   networkNSLabels: false
 


### PR DESCRIPTION
## Description

Adds security context config for openshift to allow and run  node exporter service 

## Related Issues

https://github.com/astronomer/issues/issues/5740

## Testing

by enabling nodeExporterSccEnabled: true node exporter service should come up without any issues

## Merging

cherry-pick to release-0.33
