### PR TITLE
update airflow chart and commander version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.0-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0
                 - quay.io/astronomer/ap-cli-install:0.26.17
-                - quay.io/astronomer/ap-commander:0.33.1
+                - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.9.1
+airflowChartVersion: 1.9.2
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.33.1
+    tag: 0.33.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander version 0.33.2 
update airflowchartversion 1.9.2

## Related Issues

https://github.com/astronomer/issues/issues/5742

## Testing

QA should able to deploy airflow instance without any issues

## Merging

cherry-pick to release-0.33
