### PR TITLE
Disable the Slack notifications for Docker Image scans v0.32 (#1956)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ jobs:
       report_url:
         type: string
         default: ""
+      slack_notify:
+        type: boolean
+        default: false
     environment:
       SCAN_IMAGE: << parameters.docker_image >>
       SCAN_TOOL: Trivy
@@ -61,16 +64,21 @@ jobs:
       - run:
           name: Scan the local image with trivy
           command: bin/trivy-scan.sh "<< parameters.docker_image >>" ".circleci/trivyignore"
-      - run:
-          name: Slack Init
-          command: |
-            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
-            source $BASH_ENV
-          when: on_fail
-      - slack/notify:
-          event: fail
-          template: SLACK_MSG_TEMPLATE
-          channel: C03HS1H9G1E
+      - when:
+          condition:
+            or:
+              - << parameters.slack_notify >>
+          steps:
+            - run:
+                name: Slack Init
+                command: |
+                  echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+                  source $BASH_ENV
+                when: on_fail
+            - slack/notify:
+                event: fail
+                template: SLACK_MSG_TEMPLATE
+                channel: C03HS1H9G1E
       - save_cache:
           key: trivy-cache-{{ checksum "date" }}
           paths:
@@ -322,6 +330,7 @@ workflows:
     jobs:
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
+          slack_notify: false
           matrix:
             parameters:
               docker_image:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -35,6 +35,9 @@ jobs:
       report_url:
         type: string
         default: ""
+      slack_notify:
+        type: boolean
+        default: false
     environment:
       SCAN_IMAGE: << parameters.docker_image >>
       SCAN_TOOL: Trivy
@@ -59,16 +62,21 @@ jobs:
       - run:
           name: Scan the local image with trivy
           command: bin/trivy-scan.sh "<< parameters.docker_image >>" ".circleci/trivyignore"
-      - run:
-          name: Slack Init
-          command: |
-            echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
-            source $BASH_ENV
-          when: on_fail
-      - slack/notify:
-          event: fail
-          template: SLACK_MSG_TEMPLATE
-          channel: C03HS1H9G1E
+      - when:
+          condition:
+            or:
+              - << parameters.slack_notify >>
+          steps:
+            - run:
+                name: Slack Init
+                command: |
+                  echo 'export SLACK_MSG_TEMPLATE=$(cat ./.circleci/slack_message_templates/security_scan_fail.json)' >> $BASH_ENV
+                  source $BASH_ENV
+                when: on_fail
+            - slack/notify:
+                event: fail
+                template: SLACK_MSG_TEMPLATE
+                channel: C03HS1H9G1E
       - save_cache:
           {% raw %}key: trivy-cache-{{ checksum "date" }}{% endraw %}
           paths:
@@ -257,6 +265,7 @@ workflows:
     jobs:
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
+          slack_notify: false
           matrix:
             parameters:
               docker_image:


### PR DESCRIPTION
Making slack notification optional for docker image scan.

(cherry picked from commit a6bc2db91f670425ea30c7114d9561dff4191148)

## Description

N/A

## Related Issues

N/A

## Testing

N/A

## Master PR

https://github.com/astronomer/astronomer/pull/1956
