### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,14 +337,14 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
                 - quay.io/astronomer/ap-astro-ui:0.30.13
                 - quay.io/astronomer/ap-auth-sidecar:1.25.1
-                - quay.io/astronomer/ap-awsesproxy:1.3-12
+                - quay.io/astronomer/ap-awsesproxy:1.3-13
                 - quay.io/astronomer/ap-base:3.18.0-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-4
+                - quay.io/astronomer/ap-blackbox-exporter:0.23.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.17
                 - quay.io/astronomer/ap-commander:0.30.10
                 - quay.io/astronomer/ap-configmap-reloader:0.8.0
-                - quay.io/astronomer/ap-curator:7.0.0-4
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.2
+                - quay.io/astronomer/ap-curator:7.0.0-6
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.4
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0
                 - quay.io/astronomer/ap-elasticsearch:7.17.10
@@ -354,19 +354,19 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:7.17.10
                 - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.10.0-5
-                - quay.io/astronomer/ap-nats-server:2.8.4-3
-                - quay.io/astronomer/ap-nats-streaming:0.24.6-3
+                - quay.io/astronomer/ap-nats-exporter:0.10.0-6
+                - quay.io/astronomer/ap-nats-server:2.8.4-4
+                - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.1
                 - quay.io/astronomer/ap-nginx:1.7.0
                 - quay.io/astronomer/ap-node-exporter:1.5.0
                 - quay.io/astronomer/ap-openresty:1.21.4-9
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-7
-                - quay.io/astronomer/ap-postgres-exporter:0.12.0
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
+                - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:11.18.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.0
-                - quay.io/astronomer/ap-registry:3.16.5
-                - quay.io/astronomer/ap-vector:0.28.2-1
+                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - slack_team-software-infra-bot
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.5
+    tag: 3.16.5-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.2
+    tag: 0.31.4
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 7.0.0-4
+    tag: 7.0.0-6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.3-12
+    tag: 1.3-13
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.2
+    tag: 0.31.4
     pullPolicy: IfNotPresent
 
 backendSecretName: ~

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.8.4-3
+    tag: 2.8.4-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-5
+    tag: 0.10.0-6
     pullPolicy: IfNotPresent
 
 nats:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-7
+  tag: 1.17.0-9
   pullPolicy: IfNotPresent
 
 internalPort: 5432

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -13,7 +13,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.23.0-4
+  tag: 0.23.0-5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.12.0
+  tag: 0.12.0-1
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.24.6-3
+    tag: 0.24.6-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.10.0-5
+    tag: 0.10.0-6
     pullPolicy: IfNotPresent
 
 stan:

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -46,12 +46,6 @@ class TestAllPodSpecContainers:
             assert container["image"], f"container {name} does not have an image: {doc}"
             assert container["imagePullPolicy"] == "IfNotPresent"
 
-            resources = c_by_name[name]["resources"]
-            assert "cpu" in resources.get("limits")
-            assert "memory" in resources.get("limits")
-            assert "cpu" in resources.get("requests")
-            assert "memory" in resources.get("requests")
-
     private_repo = "example.com/the-private-registry-repository"
     private_values = chart_tests.get_all_features()
     private_values["global"]["privateRegistry"] = {

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -13,8 +13,10 @@ pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 class TestAllPodSpecContainers:
     """Test pod spec containers for some defaults."""
 
-    default_docs = render_chart()
-    default_docs_trimmed = [doc for doc in default_docs if doc["kind"] in pod_managers]
+    chart_values = chart_tests.get_all_features()
+
+    default_docs = render_chart(values=chart_values)
+    pod_manager_docs = [doc for doc in default_docs if doc["kind"] in pod_managers]
     annotated = [x for x in default_docs if x["metadata"].get("annotations")]
 
     @pytest.mark.parametrize(
@@ -33,15 +35,22 @@ class TestAllPodSpecContainers:
 
     @pytest.mark.parametrize(
         "doc",
-        default_docs_trimmed,
-        ids=[f"{x['kind']}/{x['metadata']['name']}" for x in default_docs_trimmed],
+        pod_manager_docs,
+        ids=[f"{x['kind']}/{x['metadata']['name']}" for x in pod_manager_docs],
     )
     def test_default_chart_with_basedomain(self, doc):
-        """Test that each container in each pod spec renders."""
+        """Test that each container in each pod spec renders and has some
+        required fields."""
         c_by_name = get_containers_by_name(doc, include_init_containers=True)
         for name, container in c_by_name.items():
             assert container["image"], f"container {name} does not have an image: {doc}"
-            assert container["imagePullPolicy"]
+            assert container["imagePullPolicy"] == "IfNotPresent"
+
+            resources = c_by_name[name]["resources"]
+            assert "cpu" in resources.get("limits")
+            assert "memory" in resources.get("limits")
+            assert "cpu" in resources.get("requests")
+            assert "memory" in resources.get("requests")
 
     private_repo = "example.com/the-private-registry-repository"
     private_values = chart_tests.get_all_features()

--- a/values.yaml
+++ b/values.yaml
@@ -108,7 +108,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.28.2-1
+    image: quay.io/astronomer/ap-vector:0.28.2-3
     customConfig: false
     extraEnv: []
     resources: {}


### PR DESCRIPTION
## Description

resolves CVE 2023 2650 in below list of services
| imageName | oldTag | newTag |
|--------|--------|--------|
| awsesproxy | 1.3-12 | 1.3-13 | 
| blackbox-exporter  | 0.23.0-4| 0.23.0-5 | 
| curator | 7.0.0-5| 7.0.0-6 | 
| nats-exporter | 0.10.0-5 | 0.10.0-6 | 
| nats-server | 2.8.4-3 | 2.8.4-4 | 
|  nats-streaming                    |    0.24.6-3          |  0.24.6-4             |
| postgres-exporter| 0.12.0 | 0.12.0-1|
| registry | 3.16.5 | 3.16.5-1 |
| ap-db-bootstrapper | 0.31.3 | 0.31.4 |
| ap-cli-install | 0.26.15 |  0.26.16 | 
| ap-pgbouncer-krb | 1.17.0-8 | 1.17.0-9 |
| ap-vector | 0.28.2-2 |  0.28.2-3 |



PS : while backporting some test cases were breaking inrelease 0.30 the changes added in this commit will resolves those and allows to run unit tests without any issues

## Related Issues

https://github.com/astronomer/issues/issues/5659

## Testing

QA should able to deploy platform without any issues

## Merging

cherry-pick to release-0.30
