### PR TITLE
update astro-ui image 0.30.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,7 +335,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.25.0
-                - quay.io/astronomer/ap-astro-ui:0.30.13
+                - quay.io/astronomer/ap-astro-ui:0.30.14
                 - quay.io/astronomer/ap-auth-sidecar:1.25.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-13
                 - quay.io/astronomer/ap-base:3.18.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.30.13
+    tag: 0.30.14
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update astro-ui image 0.30.14

## Related Issues

https://github.com/astronomer/issues/issues/5712

## Testing

QA should able to run UI without any issues

## Merging

cherry-pick to release-0.30
