### PR TITLE
update houston api 0.32.17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.8.1
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
                 - quay.io/astronomer/ap-grafana:8.5.26
-                - quay.io/astronomer/ap-houston-api:0.32.16
+                - quay.io/astronomer/ap-houston-api:0.32.17
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:8.8.1
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.32.16
+    tag: 0.32.17
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.32.17

## Related Issues

https://github.com/astronomer/issues/issues/3954
https://github.com/astronomer/issues/issues/5647
https://github.com/astronomer/issues/issues/5594

## Testing

QA should validate all marked features for 0.32

## Merging

cherry-pick to release-0.32
