### PR TITLE
Update airflow chart 1.8.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,7 +350,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
                 - quay.io/astronomer/ap-grafana:8.5.26
-                - quay.io/astronomer/ap-houston-api:0.32.17
+                - quay.io/astronomer/ap-houston-api:0.32.18
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.0-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0
                 - quay.io/astronomer/ap-cli-install:0.26.17
-                - quay.io/astronomer/ap-commander:0.32.7
+                - quay.io/astronomer/ap-commander:0.32.8
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.4

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -360,7 +360,7 @@ data:
             the minute field of the cron schedule. This is effectively a splay seeded by the release name.
             This is used to spread the load of this job away from high-use minutes 0,15,30,45.
             */}}
-            schedule: "{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *"
+            schedule: {{`'{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'`}}
             command:
             - airflow-cleanup-pods
             - --namespace={{`{{ .Release.Namespace }}`}}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.7
+airflowChartVersion: 1.8.8
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.7
+    tag: 0.32.8
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.32.17
+    tag: 0.32.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -452,28 +452,6 @@ cron_test_data = [
 ]
 
 
-@pytest.mark.parametrize(
-    "test_data", cron_test_data, ids=[x[0] for x in cron_test_data]
-)
-def test_cron_splay(test_data):
-    """Test that our adler32sum method of generating deterministic random
-    numbers works."""
-    doc = render_chart(
-        name=test_data[0],
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )[0]
-
-    production_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    cron_schedule = production_yaml["deployments"]["helm"]["airflow"]["cleanup"][
-        "schedule"
-    ]
-    cron_minute = cron_schedule.split("-")[0]
-    # We are comparing after the addition of 3, which happens in the configmap template
-    assert (
-        str(test_data[1]) == cron_minute
-    ), f'test_data should be: ("{test_data[0]}", {cron_minute}),'
-
-
 def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
     """Validate the houston configmap and its embedded data with
     updateAirflowCheck and updateRuntimeCheck."""

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -25,6 +25,11 @@ def common_test_cases(docs):
         "airflowLocalSettings"
     ]
 
+    assert (
+        prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
+        == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
+    )
+
     # validate yaml-embedded python
     ast.parse(airflow_local_settings.encode())
 


### PR DESCRIPTION
## Description

update commander service with airflow chart 1.8.8

## Related Issues

https://github.com/astronomer/issues/issues/5670
https://github.com/astronomer/issues/issues/5762

## Testing

QA should able to create and deploy airflow instance

## Merging

cherry-pick to release-0.32
