### PR TITLE
add scc flag for registry service when custom name is defined

### DIFF
--- a/charts/astronomer/templates/registry/registry-scc.yaml
+++ b/charts/astronomer/templates/registry/registry-scc.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.registry.serviceAccount.create .Values.registry.serviceAccount.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  name: {{ template "registry.ServiceAccount" . }}-anyuid
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "registry.ServiceAccount" . }}
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+{{- end }}

--- a/charts/astronomer/templates/registry/registry-scc.yaml
+++ b/charts/astronomer/templates/registry/registry-scc.yaml
@@ -1,3 +1,6 @@
+#################################
+### Astronomer Registry Scc   ###
+#################################
 {{- if and .Values.registry.serviceAccount.create .Values.registry.serviceAccount.sccEnabled }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -366,6 +366,8 @@ registry:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+    # Specifies whether a scc privilege should be created for custom sa
+    sccEnabled: false
 
   persistence:
     # Enable persistent storage

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -143,3 +143,17 @@ class TestRegistryStatefulset:
         )
         assert len(docs) == 1
         assert "serviceAccountName" not in docs[0]["spec"]["template"]["spec"]
+
+    def test_astronomer_registry_statefulset_with_scc_disabled(
+        self, kube_version
+    ):
+        """Test that helm renders statefulset template for astronomer
+        registry with SA disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/astronomer/templates/registry/registry-scc.yaml",
+            ],
+        )
+        assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -144,9 +144,7 @@ class TestRegistryStatefulset:
         assert len(docs) == 1
         assert "serviceAccountName" not in docs[0]["spec"]["template"]["spec"]
 
-    def test_astronomer_registry_statefulset_with_scc_disabled(
-        self, kube_version
-    ):
+    def test_astronomer_registry_statefulset_with_scc_disabled(self, kube_version):
         """Test that helm renders statefulset template for astronomer
         registry with SA disabled."""
         docs = render_chart(


### PR DESCRIPTION
## Description

Add scc template to registry service when custom service account or release based service account generated

## Related Issues

https://github.com/astronomer/issues/issues/5765

## Testing

QA should able to run registry with custom service account with ``` .Values.registry.serviceAccount.create .Values.registry.serviceAccount.sccEnabled ```

## Merging

cherry-pick to release-0.32 release-0.30 release-0.33
