### PR TITLE
update grafana version 10.0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
-                - quay.io/astronomer/ap-grafana:10.0.2
+                - quay.io/astronomer/ap-grafana:10.0.3
                 - quay.io/astronomer/ap-houston-api:0.33.4
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:8.8.2
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.1-1
-                - quay.io/astronomer/ap-grafana:10.0.2
+                - quay.io/astronomer/ap-grafana:10.0.3
                 - quay.io/astronomer/ap-houston-api:0.33.4
                 - quay.io/astronomer/ap-init:3.18.0
                 - quay.io/astronomer/ap-kibana:8.8.2

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.0.2
+    tag: 10.0.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Generic dashboard enhancements in grafana image 

## Related Issues

NA

## Testing

QA should able to see grafana up and running

## Merging

cherry-pick to release-0.30,0.32,0.33
