### PR TITLE
fix curator config to support es 8

### DIFF
--- a/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
@@ -45,6 +45,26 @@ data:
     ---
     # Remember, leave a key empty if there is no value.  None will be a string,
     # not a Python "NoneType"
+    {{ if semverCompare "<8" .Values.images.curator.tag -}}
+    client:
+      hosts:
+        - {{ template "elasticsearch.fullname" . }}
+      port: {{ .Values.common.ports.http }}
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']
+    {{- else -}}
     elasticsearch:
       client:
         hosts:
@@ -61,4 +81,5 @@ data:
       logfile:
       logformat: default
       blacklist: ['elasticsearch', 'urllib3']
+    {{- end }}
 {{- end }}

--- a/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
@@ -48,7 +48,7 @@ data:
     elasticsearch:
       client:
         hosts:
-          - http://{{ template "elasticsearch.fullname" . }}:{{ .Values.common.ports.http }}
+          - {{ .Values.common.protocol }}://{{ template "elasticsearch.fullname" . }}:{{ .Values.common.ports.http }}
         ca_certs:
         client_cert:
         client_key:

--- a/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
@@ -45,19 +45,17 @@ data:
     ---
     # Remember, leave a key empty if there is no value.  None will be a string,
     # not a Python "NoneType"
-    client:
-      hosts:
-        - {{ template "elasticsearch.fullname" . }}
-      port: {{ .Values.common.ports.http }}
-      url_prefix:
-      use_ssl: False
-      certificate:
-      client_cert:
-      client_key:
-      ssl_no_validate: False
-      http_auth:
-      timeout: 30
-      master_only: False
+    elasticsearch:
+      client:
+        hosts:
+          - http://{{ template "elasticsearch.fullname" . }}:{{ .Values.common.ports.http }}
+        ca_certs:
+        client_cert:
+        client_key:
+        verify_certs:
+        request_timeout: 30
+      other_settings:
+        master_only: False
     logging:
       loglevel: INFO
       logfile:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -32,6 +32,7 @@ images:
 common:
   podAnnotations: {}
   serviceType: ClusterIP
+  protocol: http
 
   env:
     CLUSTER_NAME: "astronomer"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -469,3 +469,39 @@ class TestElasticSearch:
         assert len(docs) == 1
         assert (LS := yaml.safe_load(docs[0]["data"]["action_file.yml"]))
         assert indexPattern == LS["actions"][1]["filters"][0]["timestring"]
+
+    def test_elasticsearch_curator_config_defaults(self, kube_version):
+        """Test ElasticSearch Curator IndexPattern with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
+            ],
+        )
+        assert len(docs) == 1
+        assert (LS := yaml.safe_load(docs[0]["data"]["config.yml"]))
+        print(LS["elasticsearch"])
+        assert "elasticsearch" in LS
+        assert (
+            "http://release-name-elasticsearch:9200"
+            in LS["elasticsearch"]["client"]["hosts"]
+        )
+
+    def test_elasticsearch_curator_config_overrides(self, kube_version):
+        """Test ElasticSearch Curator IndexPattern with defaults"""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"elasticsearch": {"common": {"protocol": "https"}}},
+            show_only=[
+                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
+            ],
+        )
+        assert len(docs) == 1
+        assert (LS := yaml.safe_load(docs[0]["data"]["config.yml"]))
+        print(LS["elasticsearch"])
+        assert "elasticsearch" in LS
+        assert (
+            "https://release-name-elasticsearch:9200"
+            in LS["elasticsearch"]["client"]["hosts"]
+        )


### PR DESCRIPTION
## Description

starting from elasticsearch 8.0 curator config moved to elasticearch section, this PR fixes the behavior and makes compactible with newer elastic version


8.0 curator configuration reference https://www.elastic.co/guide/en/elasticsearch/client/curator/current/configfile.html

7.0 curator configuration reference https://www.elastic.co/guide/en/elasticsearch/client/curator/7.0/configfile.html

## Related Issues

https://github.com/astronomer/issues/issues/5767

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

cherry-pick to release-0.33 and release-0.32 release-0.30
