### PR TITLE
update alertmanager version 0.26.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.25.0-1
+                - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-13
@@ -397,7 +397,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.25.0-1
+                - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.1
                 - quay.io/astronomer/ap-awsesproxy:1.3-13

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.25.0-1
+    tag: 0.26.0
     pullPolicy: IfNotPresent
 
 PodSecurityContext:


### PR DESCRIPTION
## Description

update alertmanager 0.25.0 -> 0.26.0
resolves CVE-2022-41723  in alertmanager 

## Related Issues

https://github.com/astronomer/issues/issues/5797

## Testing

QA should able to validate alertmanager service works as expected

## Merging

cherry-pick to release-0.30,0.32,0.33
