### PR TITLE
update dbbootstrapper 0.31.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.4
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.5
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
@@ -407,7 +407,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.4
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.5
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.4
+    tag: 0.31.5
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.4
+    tag: 0.31.5
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

update dbbooststrapper image for grafana and astronomer to vesion 0.31.5

## Related Issues

https://github.com/astronomer/issues/issues/5777

## Testing

QA should able to run db bootstrapper service without issues 

## Merging

cherry-pick to release-0.30,0.32,0.33