### PR TITLE
update fluentd version 1.6.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
-                - quay.io/astronomer/ap-fluentd:1.16.1-1
+                - quay.io/astronomer/ap-fluentd:1.16.2
                 - quay.io/astronomer/ap-grafana:10.0.2
                 - quay.io/astronomer/ap-houston-api:0.33.4
                 - quay.io/astronomer/ap-init:3.18.0
@@ -411,7 +411,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
-                - quay.io/astronomer/ap-fluentd:1.16.1-1
+                - quay.io/astronomer/ap-fluentd:1.16.2
                 - quay.io/astronomer/ap-grafana:10.0.2
                 - quay.io/astronomer/ap-houston-api:0.33.4
                 - quay.io/astronomer/ap-init:3.18.0

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.1-1
+    tag: 1.16.2
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
## Description

update fluentd version to 1.16.2

link to release notes https://github.com/fluent/fluentd/releases/tag/v1.16.2

## Related Issues

https://github.com/astronomer/issues/issues/5798

## Testing

QA should validate fluentd service should run without any issues

## Merging

cherry-pick to release-0.30,0.32,0.33
