### PR TITLE
update configmap reload 0.11.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0
                 - quay.io/astronomer/ap-cli-install:0.26.17
                 - quay.io/astronomer/ap-commander:0.30.10
-                - quay.io/astronomer/ap-configmap-reloader:0.8.0
+                - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.5
                 - quay.io/astronomer/ap-default-backend:0.28.18

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -41,7 +41,7 @@ images:
   configReloader:
     # repository: astronomerinc/ap-config-reloader
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.8.0
+    tag: 0.11.0
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
## Description

update configmap release 0.11.0

## Related Issues

https://github.com/astronomer/issues/issues/5649

## Testing

QA should able to validate configmap syncer reloads prometheus 

## Merging


cherry-pick to release-0.30
