### PR TITLE
update registry version 2.8.2 and image 3.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-registry:3.18.3
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - slack_team-software-infra-bot
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-registry:3.18.3
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.5-1
+    tag: 3.18.3
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION
## Description

update registry version to 2.8.2 and tag to 3.18.3

## Related Issues

https://github.com/astronomer/issues/issues/5772

## Testing

QA should able to verify registry service should work as expected

## Merging

cherry-pick to all valid branches once QA verified in release-0.30
