### PR TITLE
update commander image 0.30.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.0-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0
                 - quay.io/astronomer/ap-cli-install:0.26.17
-                - quay.io/astronomer/ap-commander:0.30.10
+                - quay.io/astronomer/ap-commander:0.30.11
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.5

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.30.10
+    tag: 0.30.11
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

updates commander dependencies to latest version


## Related Issues

https://github.com/astronomer/issues/issues/5787
https://github.com/astronomer/issues/issues/5772

## Testing

QA should able to deploy airflow without any issues

## Merging

cherry-pick to release-0.30
