### PR TITLE
update registry version 3.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
-                - quay.io/astronomer/ap-registry:3.18.3
+                - quay.io/astronomer/ap-registry:3.18.3-1
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - slack_team-software-infra-bot
@@ -430,7 +430,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
-                - quay.io/astronomer/ap-registry:3.18.3
+                - quay.io/astronomer/ap-registry:3.18.3-1
                 - quay.io/astronomer/ap-vector:0.28.2-3
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.3
+    tag: 3.18.3-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION
## Description

Add support for GCS backend

## Related Issues

https://github.com/astronomer/issues/issues/5772

## Testing

QA should now able to deploy registry with GCS backend

## Merging

cherry-pick to release-0.30,0.32,0.33
