### PR TITLE
update dbbootstrapper 0.31.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.5
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
                 - quay.io/astronomer/ap-curator:8.0.8-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.5
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.18
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.5
+    tag: 0.31.6
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.5
+    tag: 0.31.6
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

Resolves CVE-2023-38325 in dbbootstrapper

## Related Issues

https://github.com/astronomer/issues/issues/5822

## Testing

QA should able to deploy db-boostrapper 

## Merging

cherry-pick to release-0.30,0.32,0.33
