### PR TITLE
blackbox-exporter: respect .global.networkPolicy.enabled

### DIFF
--- a/charts/prometheus-blackbox-exporter/templates/blackbox-networkpolicy.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/blackbox-networkpolicy.yaml
@@ -2,7 +2,7 @@
 # Using this method it allows us to selectively include a policy
 # or Not based on other variables. The templates with the actually policies
 # start with "_" and are named bb-<service it is affecting>-policy.yaml
-
+{{- if .Values.global.networkPolicy.enabled }}
 {{- if .Values.astroServices.commander.enabled}}
 ---
 {{- include "blackbox.commanderNetPol" .}}
@@ -42,3 +42,4 @@
 # This one is unconditionally enabled because blackbox exporter is
 # only useful when Prometheus is enabled.
 {{- include "blackbox.prometheusPolicy" . }}
+{{- end }}

--- a/tests/chart_tests/test_global_network_policy_flag.py
+++ b/tests/chart_tests/test_global_network_policy_flag.py
@@ -31,10 +31,11 @@ show_only = [
     "charts/elasticsearch/templates/data/es-data-networkpolicy.yaml",
     "charts/elasticsearch/templates/client/es-client-networkpolicy.yaml",
     "templates/default-deny-network-policy/networkpolicy.yaml",
+    "charts/prometheus-blackbox-exporter/templates/blackbox-networkpolicy.yaml",
 ]
 
 
-@pytest.mark.parametrize("np_enabled, num_of_docs", [(True, 24), (False, 0)])
+@pytest.mark.parametrize("np_enabled, num_of_docs", [(True, 32), (False, 0)])
 def test_render_global_network_policy(np_enabled, num_of_docs):
     """Test some things that should apply to all cases."""
     docs = render_chart(


### PR DESCRIPTION
## Description

Black box exporter service applies network policies while global.networkPolicy  is set to false. This PR fixes the behaviour and respects the  global.networkPolicy flag

## Related Issues

https://github.com/astronomer/issues/issues/5843

## Testing

QA should able to validate with no network policies when global.networkPolicy  set to false

## Merging

cherry-pick to release-0.30,0.32,0.33
