### PR TITLE
update latest vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,17 +360,17 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.17
+                - quay.io/astronomer/ap-cli-install:0.26.18
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
-                - quay.io/astronomer/ap-curator:8.0.8-1
+                - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.18
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
+                - quay.io/astronomer/ap-default-backend:0.28.19
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2
                 - quay.io/astronomer/ap-grafana:10.0.2
@@ -382,16 +382,16 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
-                - quay.io/astronomer/ap-nginx-es:1.25.1
+                - quay.io/astronomer/ap-nginx-es:1.25.2
                 - quay.io/astronomer/ap-nginx:1.8.1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-9
+                - quay.io/astronomer/ap-openresty:1.21.4-10
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
                 - quay.io/astronomer/ap-registry:3.18.3-1
-                - quay.io/astronomer/ap-vector:0.28.2-3
+                - quay.io/astronomer/ap-vector:0.32.2
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -400,17 +400,17 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.3
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.17
+                - quay.io/astronomer/ap-cli-install:0.26.18
                 - quay.io/astronomer/ap-commander:0.33.2
                 - quay.io/astronomer/ap-configmap-reloader:0.11.0
-                - quay.io/astronomer/ap-curator:8.0.8-1
+                - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.18
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.5.0-1
+                - quay.io/astronomer/ap-default-backend:0.28.19
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2
                 - quay.io/astronomer/ap-grafana:10.0.2
@@ -422,16 +422,16 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
-                - quay.io/astronomer/ap-nginx-es:1.25.1
+                - quay.io/astronomer/ap-nginx-es:1.25.2
                 - quay.io/astronomer/ap-nginx:1.8.1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-9
+                - quay.io/astronomer/ap-openresty:1.21.4-10
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.12.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
                 - quay.io/astronomer/ap-prometheus:2.45.0
                 - quay.io/astronomer/ap-registry:3.18.3-1
-                - quay.io/astronomer/ap-vector:0.28.2-3
+                - quay.io/astronomer/ap-vector:0.32.2
           context:
             - twistcli
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.17
+    tag: 0.26.18
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,15 +18,15 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-1
+    tag: 8.0.8-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.5.0-1
+    tag: 1.6.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.1
+    tag: 1.25.2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-9
+    tag: 1.21.4-10
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.18
+    tag: 0.28.19
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.12.0-1
+  tag: 0.14.0
   pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -114,7 +114,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.28.2-3
+    image: quay.io/astronomer/ap-vector:0.32.2
     customConfig: false
     indexPattern: ~
     extraEnv: []
@@ -130,7 +130,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.1
+    tag: 1.25.2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-auth-sidecar | 1.25.1 | 1.25.2 |
|ap-cli-install | 0.26.17 | 0.26.18 |
|ap-curator | 8.0.8-1 | 8.0.8-2 | 
|ap-default-backend | 0.28.18| 0.28.19| 
|ap-elasticsearch-exporter| 1.5.0-1 | 1.6.0 | 
|ap-nginx-es| 1.25.1| 1.25.2| 
|ap-openresty | 1.21.4-9 |1.21.4-10 | 
|ap-postgres-exporte | 0.12.0-1 | 0.14.0|
| ap-vector | 0.28.2-3 | 0.32.2 |

## Related Issues

https://github.com/astronomer/issues/issues/5882
https://github.com/astronomer/issues/issues/5881
https://github.com/astronomer/issues/issues/5879
https://github.com/astronomer/issues/issues/5878
https://github.com/astronomer/issues/issues/5877


## Testing

QA should able to deploy platform 

## Merging

cherry-pick to release-0.30,0.32,0.33
