### PR TITLE
update nginx ingress controller 1.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.2
-                - quay.io/astronomer/ap-nginx:1.8.1
+                - quay.io/astronomer/ap-nginx:1.9.0
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-10
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
@@ -439,7 +439,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.2
-                - quay.io/astronomer/ap-nginx:1.8.1
+                - quay.io/astronomer/ap-nginx:1.9.0
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-10
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9

--- a/charts/nginx/templates/nginx-configmap.yaml
+++ b/charts/nginx/templates/nginx-configmap.yaml
@@ -11,6 +11,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
+  allow-snippet-annotations: "{{ .Values.allowSnippetAnnotations }}"
   add-headers: {{ .Release.Namespace }}/{{ template "nginx.fullname" . }}-ingress-controller-headers
   proxy-add-original-uri-header: "true"
   proxy-connect-timeout: {{ .Values.proxyConnectTimeout | quote }}

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -52,6 +52,9 @@ spec:
             {{- if .Values.global.singleNamespace }}
             - --watch-namespace={{ .Release.Namespace }}
             {{- end }}
+            {{- if .Values.enableAnnotationValidations }}
+            - --enable-annotation-validation=true
+            {{- end }}
             - --election-id={{ .Values.electionId }}-{{ template "nginx.fullname" . }}
             - --publish-service={{ .Release.Namespace }}/{{ template "nginx.fullname" . }}
             - --http-port={{ .Values.ports.http }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.8.1
+    tag: 1.9.0
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
@@ -82,6 +82,14 @@ ports:
 # Election ID to use for status update
 electionId: ingress-controller-leader
 
+# Enables the annotation validation feature
+enableAnnotationValidations: false
+
+# -- This configuration defines if Ingress Controller should allow users to set
+# their own *-snippet annotations, otherwise this is forbidden / dropped
+# when users add those annotations.
+# Global snippets in ConfigMap are still respected
+allowSnippetAnnotations: false
 
 defaultBackend:
   resources: {}


### PR DESCRIPTION
## Description

update nginx ingress controller 1.9.0. Adds 2 new features from upstream 
* enable-annotation-validation 
* allowSnippetAnnotations 



## Related Issues

https://github.com/astronomer/issues/issues/5890

## Testing

QA should able to deploy platform 

## Merging

cherry-pick to all valid release branches
