### PR TITLE
update prometheus and configmap reloader service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,7 +382,7 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.18
                 - quay.io/astronomer/ap-commander:0.33.2
-                - quay.io/astronomer/ap-configmap-reloader:0.11.0
+                - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.19
@@ -405,7 +405,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
-                - quay.io/astronomer/ap-prometheus:2.45.0
+                - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.18.3-1
                 - quay.io/astronomer/ap-vector:0.32.2
           context:
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.18
                 - quay.io/astronomer/ap-commander:0.33.2
-                - quay.io/astronomer/ap-configmap-reloader:0.11.0
+                - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.19
@@ -445,7 +445,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.2.0-3
-                - quay.io/astronomer/ap-prometheus:2.45.0
+                - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.18.3-1
                 - quay.io/astronomer/ap-vector:0.32.2
           context:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,11 +18,11 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.0
+    tag: 2.45.1
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.11.0
+    tag: 0.12.0
     pullPolicy: IfNotPresent
 
 resources: {}


### PR DESCRIPTION
## Description

update prometheus and configmap reloader service

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-configmap-reloader| 0.11.0  | 0.12.0  |
| ap-prometheus | 2.45.0 | 2.45.1 |

## Related Issues

NA

## Testing

QA should able to validate prometheus service 

## Merging

cherry-pick to all valid release branches
