### PR TITLE
support internal houston authorization (#1964)

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -70,6 +70,13 @@ spec:
           component: external-es-proxy
           release: {{ .Release.Name }}
     {{- end }}
+    {{- if .Values.houston.enableHoustonInternalAuthorization  }}
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: webserver
+          tier: airflow
+    {{- end }}
     ports:
     - protocol: TCP
       port: {{ .Values.ports.houstonHTTP }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -57,6 +57,7 @@ data:
 
     # Airflow deployment configuration
     deployments:
+      enableHoustonInternalAuthorization: {{ .Values.houston.enableHoustonInternalAuthorization }}
       namespaceFreeFormEntry: {{ .Values.global.namespaceFreeFormEntry }}
       # Airflow chart settings
       # Static helm configurations for this chart are found below.

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -314,6 +314,7 @@ houston:
   # Add custom annotation for houston ingress
   ingress:
     annotation: {}
+  enableHoustonInternalAuthorization: false
 
 configSyncer:
   enabled: true

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -505,3 +505,31 @@ def test_houston_configmap_with_cleanup_airflow_db_disabled():
 
     prod = yaml.safe_load(doc["data"]["production.yaml"])
     assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
+
+
+def test_houston_configmap_with_internal_authorization_flag_defaults():
+    """Validate the houston configmap to internal authorization."""
+    docs = render_chart(
+        values={},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
+
+
+def test_houston_configmap_with_internal_authorization_flag_enabled():
+    """Validate the houston configmap to internal authorization."""
+    docs = render_chart(
+        values={
+            "astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["enableHoustonInternalAuthorization"] is True


### PR DESCRIPTION
## Description

Introducing a change to switch to internal url when enableHoustonInternalAuthorization: true is enabled.

## Related Issues

https://github.com/astronomer/issues/issues/5733
## Testing

QA should able to verify airflow  ingress auth url should use internal service

## Merging

cherry-pick to release-0.33
