### PR TITLE
commander 0.33.4, airflowChartVersion 1.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.18
-                - quay.io/astronomer/ap-commander:0.33.3
+                - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
@@ -421,7 +421,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.18
-                - quay.io/astronomer/ap-commander:0.33.3
+                - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.9.3
+airflowChartVersion: 1.9.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.33.3
+    tag: 0.33.4
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander with airflow chart 1.9.4

## Related Issues

https://github.com/astronomer/issues/issues/5904

## Testing

QA should able to deploy airflow instances without any issues

## Merging

cherry-pick to release-0.33
