### PR TITLE
revert to ap-registry 3.16.5-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
-                - quay.io/astronomer/ap-registry:3.18.3-1
+                - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.32.2
           context:
             - slack_team-software-infra-bot
@@ -446,7 +446,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
-                - quay.io/astronomer/ap-registry:3.18.3-1
+                - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.32.2
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.3-1
+    tag: 3.16.5-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION
## Description

revert registry service version to 3.16.5-1

## Related Issues

https://github.com/astronomer/issues/issues/5905

## Testing

if configured with AWS IAM roles it should work as expected 

## Merging

cherry-pick to release-0.33
