### PR TITLE
enable nginx allow snippet annotation by default

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -89,7 +89,7 @@ enableAnnotationValidations: false
 # their own *-snippet annotations, otherwise this is forbidden / dropped
 # when users add those annotations.
 # Global snippets in ConfigMap are still respected
-allowSnippetAnnotations: false
+allowSnippetAnnotations: true
 
 defaultBackend:
   resources: {}

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -198,3 +198,30 @@ class TestNginx:
             show_only=["charts/nginx/templates/nginx-service.yaml"],
         )[0]
         assert "Local" == doc["spec"]["externalTrafficPolicy"]
+
+    def test_nginx_allowSnippetAnnotations_defaults(self):
+        doc = render_chart(
+            show_only=["charts/nginx/templates/nginx-configmap.yaml"],
+        )[0]
+        assert doc["data"]["allow-snippet-annotations"] == "true"
+
+    def test_nginx_enableAnnotationValidations_defaults(self):
+        doc = render_chart(
+            show_only=["charts/nginx/templates/nginx-deployment.yaml"],
+        )[0]
+        annotationValidation = "--enable-annotation-validation"
+        assert (
+            annotationValidation
+            not in doc["spec"]["template"]["spec"]["containers"][0]["args"]
+        )
+
+    def test_nginx_enableAnnotationValidations_overrides(self):
+        doc = render_chart(
+            values={"nginx": {"enableAnnotationValidations": True}},
+            show_only=["charts/nginx/templates/nginx-deployment.yaml"],
+        )[0]
+        annotationValidation = "--enable-annotation-validation=true"
+        assert (
+            annotationValidation
+            in doc["spec"]["template"]["spec"]["containers"][0]["args"]
+        )


### PR DESCRIPTION
## Description

Enable allowSnippetAnnotations by default. This allows user configured snipped annotation to work.

## Related Issues

https://github.com/astronomer/issues/issues/5909

## Testing

QA should able to access ingress URL which has user configured snipped 

## Merging

cherry-pick to release-0.33
