### PR TITLE
Update ap vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,32 +376,32 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.4
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.18
+                - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.19
+                - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.8
+                - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.6
-                - quay.io/astronomer/ap-init:3.18.3
                 - quay.io/astronomer/ap-init:3.18.4
+                - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
-                - quay.io/astronomer/ap-nginx-es:1.25.2
+                - quay.io/astronomer/ap-nginx-es:1.25.2-1
                 - quay.io/astronomer/ap-nginx:1.9.0
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-10
+                - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
@@ -416,32 +416,32 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.4
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.18
+                - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.19
+                - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.8
+                - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.6
-                - quay.io/astronomer/ap-init:3.18.3
                 - quay.io/astronomer/ap-init:3.18.4
+                - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.10.0-6
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
-                - quay.io/astronomer/ap-nginx-es:1.25.2
+                - quay.io/astronomer/ap-nginx-es:1.25.2-1
                 - quay.io/astronomer/ap-nginx:1.9.0
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-10
+                - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,6 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.6
-                - quay.io/astronomer/ap-init:3.18.4
                 - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
@@ -431,7 +430,6 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.6
-                - quay.io/astronomer/ap-init:3.18.4
                 - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.18
+    tag: 0.26.19
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.2
+    tag: 1.25.2-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-10
+    tag: 1.21.4-11
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.0.8
+    tag: 10.0.9
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4
+    tag: 3.18.4-1
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.19
+    tag: 0.28.20
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.3
+    tag: 3.18.4-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming

--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.2
+    tag: 1.25.2-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-auth-sidecar | 1.25.2 | 1.25.2-1 |
| ap-cli-install | 0.26.18 | 0.26.19 |
|ap-default-backend | 0.28.19 |0.28.20 |
|ap-grafana | 10.0.8 | 10.0.9 |
| ap-init | 3.18.4 | 3.18.4-1 | 
| ap-nginx-es | 1.25.2 | 1.25.2-1 |
| ap-openresty | 1.21.4-10 | 1.21.4-11|

## Related Issues

https://github.com/astronomer/issues/issues/5908

## Testing

NA

## Merging

cherry-pick to all valid release branches
