### PR TITLE
nginx ingress controller 1.9.0-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.2-1
-                - quay.io/astronomer/ap-nginx:1.9.0
+                - quay.io/astronomer/ap-nginx:1.9.0-1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
@@ -437,7 +437,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.8.4-4
                 - quay.io/astronomer/ap-nats-streaming:0.24.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.2-1
-                - quay.io/astronomer/ap-nginx:1.9.0
+                - quay.io/astronomer/ap-nginx:1.9.0-1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.0
+    tag: 1.9.0-1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

fix  CVE-2023-38545,CVE-2023-44487  in nginx service

## Related Issues

https://github.com/astronomer/issues/issues/5890
https://github.com/astronomer/issues/issues/5908

## Testing

nginx should work as expected

## Merging

cherry-pick to all valid release branches
