### PR TITLE
update curator service 8.0.8-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-2
+                - quay.io/astronomer/ap-curator:8.0.8-3
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-2
+                - quay.io/astronomer/ap-curator:8.0.8-3
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-2
+    tag: 8.0.8-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter


### PR DESCRIPTION
## Description

resolves below listed CVE in curator packages

<img width="1329" alt="image" src="https://github.com/astronomer/ap-vendor/assets/81585115/fc4685d7-b376-461d-951b-b7e54a7296d6">

## Related Issues

https://github.com/astronomer/issues/issues/5908

## Testing

QA should able to run curator service without any errors on execution 

## Merging

cherry-pick to all valid releases
