### PR TITLE
segregate kibana index network policy

### DIFF
--- a/charts/kibana/templates/kibana-networkpolicy.yaml
+++ b/charts/kibana/templates/kibana-networkpolicy.yaml
@@ -33,18 +33,22 @@ spec:
           component: ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
-    {{ if .Values.createDefaultIndex }}
-    - podSelector:
-        matchLabels:
-          component: kibana-default-index
-          release: {{ .Release.Name }}
-          tier: logging
-    {{- end }}
     ports:
     {{- if .Values.global.authSidecar.enabled  }}
     - protocol: TCP
       port: {{ .Values.global.authSidecar.port }}
     {{- else }}
+    - protocol: TCP
+      port: {{ .Values.ports.http }}
+    {{- end}}
+{{ if .Values.createDefaultIndex }}
+  - from:
+    - podSelector:
+        matchLabels:
+          component: kibana-default-index
+          release: {{ .Release.Name }}
+          tier: logging
+    ports:
     - protocol: TCP
       port: {{ .Values.ports.http }}
     {{- end}}

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -122,7 +122,7 @@ class TestAuthSidecar:
                 }
             }
         ] == jmespath.search("spec.ingress[0].from", docs[3])
-        assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search(
+        assert {"port": 8084, "protocol": "TCP"} in jmespath.search(
             "spec.ingress[*].ports[0]", docs[3]
         )
 

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -120,16 +120,7 @@ class TestAuthSidecar:
                 "namespaceSelector": {
                     "matchLabels": {"network.openshift.io/policy-group": "ingress"}
                 }
-            },
-            {
-                "podSelector": {
-                    "matchLabels": {
-                        "component": "kibana-default-index",
-                        "release": "release-name",
-                        "tier": "logging",
-                    }
-                }
-            },
+            }
         ] == jmespath.search("spec.ingress[0].from", docs[3])
         assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search(
             "spec.ingress[*].ports[0]", docs[3]

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -58,3 +58,29 @@ class TestKibana:
         )
 
         assert len(docs) == 0
+
+    def test_kibana_index_network_policy_enabled(self, kube_version):
+        """Test network policy for kibana index service."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"kibana": {"createDefaultIndex": True}},
+            show_only=[
+                "charts/kibana/templates/kibana-networkpolicy.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert "NetworkPolicy" == doc["kind"]
+        assert [
+            {
+                "namespaceSelector": {"matchLabels": {"platform": "release-name"}},
+                "podSelector": {
+                    "matchLabels": {
+                        "component": "kibana-default-index",
+                        "release": "release-name",
+                        "tier": "logging",
+                    }
+                },
+            }
+        ] == [doc["spec"]["ingress"][0]["from"][2]]

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -74,7 +74,6 @@ class TestKibana:
         assert "NetworkPolicy" == doc["kind"]
         assert [
             {
-                "namespaceSelector": {"matchLabels": {"platform": "release-name"}},
                 "podSelector": {
                     "matchLabels": {
                         "component": "kibana-default-index",
@@ -83,4 +82,6 @@ class TestKibana:
                     }
                 },
             }
-        ] == [doc["spec"]["ingress"][0]["from"][1]]
+        ] == [doc["spec"]["ingress"][1]["from"][0]]
+
+        assert [{"port": 5601, "protocol": "TCP"}] == doc["spec"]["ingress"][1]["ports"]

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -83,4 +83,4 @@ class TestKibana:
                     }
                 },
             }
-        ] == [doc["spec"]["ingress"][0]["from"][2]]
+        ] == [doc["spec"]["ingress"][0]["from"][1]]


### PR DESCRIPTION
## Description

Add seperate network policy within kibana network policy template this fixes an odd behaviour when authsidecar is enabled

## Related Issues

https://github.com/astronomer/issues/issues/5912

## Testing

QA should able to validate kibana index pattern creation with authsidecar enabled

## Merging

cherry-pick to release-0.33
