### PR TITLE
format to new securitycontext configuration for blackbox exporter

### DIFF
--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -50,15 +50,9 @@ spec:
         - name: blackbox-exporter
           image: {{ template "prometheus-blackbox-exporter.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
-            {{- if .Values.allowIcmp }}
-            capabilities:
-              add: ["NET_RAW"]
-            {{- else }}
-            runAsNonRoot: {{ .Values.runAsNonRoot  }}
-            runAsUser: {{ .Values.runAsUser }}
-            {{- end }}
+          {{- with .Values.securityContext }}
+          securityContext: {{ toYaml . | nindent 12 }}
+          {{- end }}
           args:
 {{- if .Values.config }}
             - "--config.file=/config/blackbox.yaml"

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -25,9 +25,14 @@ image:
   #   - myRegistrKeySecretName
 
 ## User to run blackbox-exporter container as
-runAsUser: 1000
-readOnlyRootFilesystem: true
-runAsNonRoot: true
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+# Add NET_RAW to enable ICMP
+#    add: ["NET_RAW"]
 
 # These are set in the global values.
 # nodeSelector: {}
@@ -71,8 +76,6 @@ extraSecretMounts: []
   #   secretName: blackbox-secret-files
   #   readOnly: true
   #   defaultMode: 420
-
-allowIcmp: false
 
 # These are overridden by what is  in the global values file
 resources:

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -80,7 +80,7 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
 
         c_by_name = get_containers_by_name(doc)
-        assert c_by_name["blackbox-exporter"].get("resources"] == {
+        assert c_by_name["blackbox-exporter"].get("resources") == {
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -80,8 +80,7 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
 
         c_by_name = get_containers_by_name(doc)
-        assert c_by_name["blackbox-exporter"]
-        assert c_by_name["blackbox-exporter"]["resources"] == {
+        assert c_by_name["blackbox-exporter"].get("resources"] == {
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -49,7 +49,6 @@ class TestPrometheusBlackBoxExporterDeployment:
         )
 
         c_by_name = get_containers_by_name(doc)
-        assert c_by_name["blackbox-exporter"]
         assert c_by_name["blackbox-exporter"]["resources"] == {
             "limits": {"cpu": "100m", "memory": "200Mi"},
             "requests": {"cpu": "50m", "memory": "70Mi"},

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -1,0 +1,82 @@
+import pytest
+
+from tests import supported_k8s_versions, get_containers_by_name
+from tests.chart_tests.helm_template_generator import render_chart
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestPrometheusBlackBoxExporterDeployment:
+    def test_prometheus_blackbox_exporter_service_defaults(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/prometheus-blackbox-exporter/templates/service.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Service"
+        assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
+        assert doc["spec"]["selector"]["component"] == "blackbox-exporter"
+        assert doc["spec"]["type"] == "ClusterIP"
+        assert doc["spec"]["ports"] == [
+            {
+                "port": 9115,
+                "protocol": "TCP",
+                "name": "http",
+                "appProtocol": "http",
+            }
+        ]
+
+    def test_prometheus_blackbox_exporter_deployment_defaults(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+        assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
+        assert (
+            doc["spec"]["selector"]["matchLabels"]["component"] == "blackbox-exporter"
+        )
+        assert (
+            doc["spec"]["template"]["metadata"]["labels"]["app"]
+            == "prometheus-blackbox-exporter"
+        )
+
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["blackbox-exporter"]
+        assert c_by_name["blackbox-exporter"]["resources"] == {
+            "limits": {"cpu": "100m", "memory": "200Mi"},
+            "requests": {"cpu": "50m", "memory": "70Mi"},
+        }
+
+    def test_prometheus_blackbox_exporter_daemonset_custom_resources(
+        self, kube_version
+    ):
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus-blackbox-exporter": {
+                    "resources": {
+                        "limits": {"cpu": "777m", "memory": "999Mi"},
+                        "requests": {"cpu": "666m", "memory": "888Mi"},
+                    }
+                },
+            },
+            show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
+        )[0]
+
+        assert doc["kind"] == "Deployment"
+        assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
+
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["blackbox-exporter"]
+        assert c_by_name["blackbox-exporter"]["resources"] == {
+            "limits": {"cpu": "777m", "memory": "999Mi"},
+            "requests": {"cpu": "666m", "memory": "888Mi"},
+        }

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -54,6 +54,12 @@ class TestPrometheusBlackBoxExporterDeployment:
             "limits": {"cpu": "100m", "memory": "200Mi"},
             "requests": {"cpu": "50m", "memory": "70Mi"},
         }
+        assert c_by_name["blackbox-exporter"]["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "capabilities": {"drop": ["ALL"]},
+        }
 
     def test_prometheus_blackbox_exporter_daemonset_custom_resources(
         self, kube_version

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -61,7 +61,7 @@ class TestPrometheusBlackBoxExporterDeployment:
             "capabilities": {"drop": ["ALL"]},
         }
 
-    def test_prometheus_blackbox_exporter_daemonset_custom_resources(
+    def test_prometheus_blackbox_exporter_deployment_custom_resources(
         self, kube_version
     ):
         doc = render_chart(
@@ -85,4 +85,26 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert c_by_name["blackbox-exporter"]["resources"] == {
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
+        }
+
+    def test_prometheus_blackbox_exporter_deployment_custom_security_context(
+        self, kube_version
+    ):
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus-blackbox-exporter": {
+                    "securityContext": {"runAsUser": 1000}
+                },
+            },
+            show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
+        )[0]
+
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["blackbox-exporter"]["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
         }


### PR DESCRIPTION
## Description

convert individual security context config values to single parsable config to pass user defined custom values.
One of the improvement requirement for openshift native config

## Related Issues

https://github.com/astronomer/issues/issues/5919

## Testing

Yet to update

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
