### PR TITLE
update ap vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.32.7
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
-                - quay.io/astronomer/ap-base:3.18.3
+                - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.32.8
@@ -364,7 +364,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
-                - quay.io/astronomer/ap-fluentd:1.16.2
+                - quay.io/astronomer/ap-fluentd:1.16.2-1
                 - quay.io/astronomer/ap-grafana:8.5.26
                 - quay.io/astronomer/ap-houston-api:0.32.22
                 - quay.io/astronomer/ap-init:3.18.4-1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.14.0
-                - quay.io/astronomer/ap-postgresql:15.2.0-3
+                - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.32.2

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.3
+    tag: 3.18.4
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.2
+    tag: 1.16.2-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.2.0-3
+  tag: 15.4.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

resolves CVE in fluentd and ap-base packages

## Related Issues

https://github.com/astronomer/issues/issues/5894

## Testing

QA should be able to verify the scan passing successfully.

## Merging

cherry-pick to release-0.32
