### PR TITLE
update astro-ui image 0.32.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,7 +351,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.32.7
+                - quay.io/astronomer/ap-astro-ui:0.32.8
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.32.7
+    tag: 0.32.8
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

resolves  CVE-2023-38545,CVE-2023-44487  , CVE-2023-38039,CVE-2023-4863 in astro-ui services

## Related Issues

https://github.com/astronomer/issues/issues/5908
https://github.com/astronomer/issues/issues/5893

## Testing

QA should able to run astro-ui

## Merging

cherry-pick to release-0.32
