### PR TITLE
disable kibana index pattern defaults

### DIFF
--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -40,4 +40,4 @@ serviceType: ClusterIP
 ports:
   http: 5601
 
-createDefaultIndex: true
+createDefaultIndex: false

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -9,6 +9,7 @@ from tests.chart_tests.helm_template_generator import render_chart
     supported_k8s_versions,
 )
 class TestKibana:
+    @pytest.mark.skip(reason="resrved for 0.32.5")
     def test_kibana_index_defaults(self, kube_version):
         """Test kibana Service with index defaults."""
         docs = render_chart(
@@ -27,7 +28,7 @@ class TestKibana:
             "fluentd.*"
             in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
         )
-
+    @pytest.mark.skip(reason="resrved for 0.32.5")
     def test_kibana_index_with_logging_sidecar(self, kube_version):
         """Test kibana Service with logging sidecar index."""
         docs = render_chart(

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -9,7 +9,7 @@ from tests.chart_tests.helm_template_generator import render_chart
     supported_k8s_versions,
 )
 class TestKibana:
-    @pytest.mark.skip(reason="resrved for 0.32.5")
+    @pytest.mark.skip(reason="reserved for 0.32.5")
     def test_kibana_index_defaults(self, kube_version):
         """Test kibana Service with index defaults."""
         docs = render_chart(
@@ -28,7 +28,8 @@ class TestKibana:
             "fluentd.*"
             in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
         )
-    @pytest.mark.skip(reason="resrved for 0.32.5")
+
+    @pytest.mark.skip(reason="reserved for 0.32.5")
     def test_kibana_index_with_logging_sidecar(self, kube_version):
         """Test kibana Service with logging sidecar index."""
         docs = render_chart(

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -243,7 +243,7 @@ def test_cve_2021_44228_es_master(es_master):
         "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
-
+@pytest.mark.skip(reason="resrved for 0.32.5")
 def test_kibana_index_pod(kibana_index_pod_client):
     """Check kibana index pod completed successfully"""
     command = ["kubectl -n astronomer logs -f  -lcomponent=kibana-default-index"]

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -243,7 +243,8 @@ def test_cve_2021_44228_es_master(es_master):
         "/usr/share/elasticsearch/jdk/bin/jps -lv"
     )
 
-@pytest.mark.skip(reason="resrved for 0.32.5")
+
+@pytest.mark.skip(reason="reserved for 0.32.5")
 def test_kibana_index_pod(kibana_index_pod_client):
     """Check kibana index pod completed successfully"""
     command = ["kubectl -n astronomer logs -f  -lcomponent=kibana-default-index"]


### PR DESCRIPTION
## Description

we are disabling this default behaviour in 0.32.4 and reserved for 0.32.5

## Related Issues

https://github.com/astronomer/issues/issues/5923

## Testing

QA should  not kibana index creation job

## Merging

cherry-pick to release-0.32
