### PR TITLE
update commander 0.32.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.19
-                - quay.io/astronomer/ap-commander:0.32.8
+                - quay.io/astronomer/ap-commander:0.32.9
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-3
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.8
+    tag: 0.32.9
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

 updates all the old go modules of registry distribution and docker packages to resolve CVE's.

## Related Issues

https://github.com/astronomer/issues/issues/5787
https://github.com/astronomer/issues/issues/5772

## Testing

QA should able to validate commander service 

## Merging

cherry-pick to release-0.32
