### PR TITLE
update nginx ingress controller 1.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5
                 - quay.io/astronomer/ap-nginx-es:1.25.2-1
-                - quay.io/astronomer/ap-nginx:1.9.0-1
+                - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
@@ -437,7 +437,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5
                 - quay.io/astronomer/ap-nginx-es:1.25.2-1
-                - quay.io/astronomer/ap-nginx:1.9.0-1
+                - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.0-1
+    tag: 1.9.4
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

update nginx ingress controller version 1.9.0 -> 1.9.4

release notes link: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.9.4

## Related Issues

https://github.com/astronomer/issues/issues/5954

## Testing

QA should able to deploy nginx ingress controller without any issue and able to acess ingress URL

## Merging

cherry-pick to release 0.32,0.33
