### PR TITLE
updating kibana version 8.9.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ workflows:
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
-                - quay.io/astronomer/ap-kibana:8.8.2
+                - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2
@@ -431,7 +431,7 @@ workflows:
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
-                - quay.io/astronomer/ap-kibana:8.8.2
+                - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 8.8.2
+    tag: 8.9.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init


### PR DESCRIPTION
## Description

update kibana version 8.8.2 > 8.9.2
Release Notes link: https://www.elastic.co/guide/en/kibana/8.9/release-notes-8.9.2.html 

## Related Issues
https://github.com/astronomer/issues/issues/5774

## Testing

QA should able to deploy kibana without any issue and able to acess kibana UI 

## Merging

cherry-pick to release 0.32,0.33
