### PR TITLE
update elasticsearch version 8.9.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,7 +387,7 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
-                - quay.io/astronomer/ap-elasticsearch:8.8.2
+                - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
@@ -426,7 +426,7 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
-                - quay.io/astronomer/ap-elasticsearch:8.8.2
+                - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ workflows:
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
-                - quay.io/astronomer/ap-kibana:8.8.2
+                - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2
@@ -431,7 +431,7 @@ workflows:
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
-                - quay.io/astronomer/ap-kibana:8.8.2
+                - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 8.8.2
+    tag: 8.9.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 8.8.2
+    tag: 8.9.2
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |      release notes    |
|--------|--------|--------|--------|
| ap-elasticsearch | 8.8.2 | 8.9.2 | https://www.elastic.co/guide/en/elasticsearch/reference/8.9/release-notes-8.9.2.html
| ap-kibana  | 8.8.2 | 8.9.2 | https://www.elastic.co/guide/en/kibana/8.9/release-notes-8.9.2.html




## Related Issues
https://github.com/astronomer/issues/issues/5776

## Testing

QA should able to deploy elastic search without any issue

## Merging

cherry-pick to release 0.32,0.33
