### PR TITLE
Update/grafana/10.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.9
+                - quay.io/astronomer/ap-grafana:10.2.0
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.8.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.9
+                - quay.io/astronomer/ap-grafana:10.2.0
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-1
                 - quay.io/astronomer/ap-kibana:8.8.2

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.0.9
+    tag: 10.2.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update grafana version 10.0.9 > 10.2.0

release link: https://hub.docker.com/layers/grafana/grafana/10.2.0/images/sha256-b24884097937b88badf18d95c158a125a4173a650af8d82db83a4f66127c4b18?context=explore

## Related Issues

https://github.com/astronomer/issues/issues/5880

## Testing

QA should be able to deploy Grafana without any issues and able to access Grafana URL

## Merging

cherry-pick to release 0.32,0.33