### PR TITLE
update postgres exporter version 0.15.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,7 +402,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.14.0
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
@@ -441,7 +441,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.14.0
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.14.0
+  tag: 0.15.0
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description
update Postgres-exporter  version 0.14.0 -> 0.15.0

## Related Issues
release notes link: https://quay.io/repository/prometheuscommunity/postgres-exporter?tab=tags&tag=


## Testing

QA should be able to deploy  Postgres-exporter without any issues

## Merging

cherry-pick to release 0.32,0.33
