### PR TITLE
update awsesproxy version 1.15.0-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
-                - quay.io/astronomer/ap-awsesproxy:1.5
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-1
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.19
@@ -416,7 +416,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
-                - quay.io/astronomer/ap-awsesproxy:1.5
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-1
                 - quay.io/astronomer/ap-base:3.18.4
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.19

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5
+    tag: 1.5.0-1
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description

update awsesproxy version 1.15.0 --> 1.15.0-1

## Related Issues



## Testing

QA should be able to deploy awsesproxy without any issues. 

## Merging
cherry-pick to release 0.32,0.33

