### PR TITLE
update promethes-blackbox-exporter version 0.24.0-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.4
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
@@ -418,7 +418,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
                 - quay.io/astronomer/ap-awsesproxy:1.5
                 - quay.io/astronomer/ap-base:3.18.4
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-1
+  tag: 0.24.0-2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Description

Update promethes blackbox exporter version 0.24.0-1 > 0.24.0-2

## Related Issues
https://github.com/astronomer/issues/issues/5958

## Testing

QA should be able to deploy the Prometheus Blackbox exporter without any issues.

## Merging 
cherry-pick to release 0.32,0.33