### PR TITLE
Update vendor packages in astronomer/astronomer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.2.0
+                - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.2.0
+                - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,21 +377,21 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
-                - quay.io/astronomer/ap-awsesproxy:1.5
-                - quay.io/astronomer/ap-base:3.18.4
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-2
+                - quay.io/astronomer/ap-base:3.18.4-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-3
+                - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.9
+                - quay.io/astronomer/ap-grafana:10.2.0
                 - quay.io/astronomer/ap-houston-api:0.33.7
-                - quay.io/astronomer/ap-init:3.18.4-1
+                - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
@@ -402,7 +402,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.14.0
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
@@ -416,21 +416,21 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
-                - quay.io/astronomer/ap-awsesproxy:1.5
-                - quay.io/astronomer/ap-base:3.18.4
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-1
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-2
+                - quay.io/astronomer/ap-base:3.18.4-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.19
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-3
+                - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
                 - quay.io/astronomer/ap-default-backend:0.28.20
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
-                - quay.io/astronomer/ap-grafana:10.0.9
+                - quay.io/astronomer/ap-grafana:10.2.0
                 - quay.io/astronomer/ap-houston-api:0.33.7
-                - quay.io/astronomer/ap-init:3.18.4-1
+                - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
@@ -441,7 +441,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.14.0
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.4
+    tag: 3.18.4-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-3
+    tag: 8.0.8-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5
+    tag: 1.5.0-1
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-1
+    tag: 1.5.0-2
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.2.0
+    tag: 10.0.9
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.0.9
+    tag: 10.2.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-1
+    tag: 3.18.4-2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-1
+  tag: 0.24.0-3
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.14.0
+  tag: 0.15.0-1
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-1
+    tag: 3.18.4-2
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming


### PR DESCRIPTION
## Description

update  ap-vendor images with ap-base image 3.18.4-1 to resolve the CVE in the dockerize package

imageName | oldTag | newTag
-- | -- | --
ap-postgres-exporter | 0.15.0 | 0.15.0-1
ap-curator | 8.0.8-3 | 8.0.8-4
ap-blackbox-exporter | 0.24.0-2 | 0.24.0-3
ap-awsesproxy | 1.5.0-1 | 1.5.0-2
ap-init | 3.18.4-1 | 3.18.4-2
ap-base| 3.18.4 | 3.18.4-1


<br class="Apple-interchange-newline">

## Related Issues

https://github.com/astronomer/issues/issues/5960
https://github.com/astronomer/issues/issues/5866
https://github.com/astronomer/issues/issues/5873

## Testing

QA should be able to deploy all the components without any issues 

## Merging

cherry-pick to release 0.32,0.33
