### PR TITLE
update nginx base packages in astronomer 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-2
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
@@ -397,7 +397,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5
-                - quay.io/astronomer/ap-nginx-es:1.25.2-1
+                - quay.io/astronomer/ap-nginx-es:1.25.2-2
                 - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11
@@ -415,7 +415,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-2
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
@@ -436,7 +436,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.12.0
                 - quay.io/astronomer/ap-nats-server:2.10.2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5
-                - quay.io/astronomer/ap-nginx-es:1.25.2-1
+                - quay.io/astronomer/ap-nginx-es:1.25.2-2
                 - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
                 - quay.io/astronomer/ap-openresty:1.21.4-11

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.2-1
+    tag: 1.25.2-2
     pullPolicy: IfNotPresent
 
 common:

--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.2-1
+    tag: 1.25.2-2
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description



imageName | oldTag | newTag | extraInfo
-- | -- | -- | --
ap-auth-sidecar | 1.25.2-1 | 1.25.2-2 | resolves CVE-2023-43787
ap-nginx-es | 1.25.2-1 | 1.25.2-2 | resolves CVE-2023-43787


## Related Issues

https://github.com/astronomer/issues/issues/5974

## Testing

QA should be able to deploy ap-auth-sidecar and ap-nginx-es without any issues. 
## Merging
cherry-pick to release 0.32,0.33

