### PR TITLE
update nginx base in vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,12 +380,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-2
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.19
+                - quay.io/astronomer/ap-cli-install:0.26.20
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.20
+                - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1
@@ -419,12 +419,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-2
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.19
+                - quay.io/astronomer/ap-cli-install:0.26.20
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.6
-                - quay.io/astronomer/ap-default-backend:0.28.20
+                - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.19
+    tag: 0.26.20
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.20
+    tag: 0.28.21
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

resolves CVE-2023-43787 in below services

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-cli-install | 0.26.19 |0.26.20 |
| ap-default-backend |0.28.20 |0.28.21 |


## Related Issues

https://github.com/astronomer/issues/issues/5974

## Testing

NA

## Merging

cherry-pick to release-0.32, release-0.33
