### PR TITLE
update vector image 0.32.2 -> 0.32.2-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
-                - quay.io/astronomer/ap-vector:0.32.2
+                - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -445,7 +445,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
-                - quay.io/astronomer/ap-vector:0.32.2
+                - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -114,7 +114,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.32.2
+    image: quay.io/astronomer/ap-vector:0.32.2-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

resolves CVE in ap-vector services

## Related Issues

https://github.com/astronomer/issues/issues/5960
https://github.com/astronomer/issues/issues/5873

## Testing

NA

## Merging

cherry-pick to release-0.32, release-0.33
