### PR TITLE
update vendor packages in astronomer helm chart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.7
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.4
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.7
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,25 +388,25 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
-                - quay.io/astronomer/ap-fluentd:1.16.2-1
+                - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0
-                - quay.io/astronomer/ap-nats-server:2.10.2
-                - quay.io/astronomer/ap-nats-streaming:0.25.5
+                - quay.io/astronomer/ap-nats-exporter:0.12.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.2-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.5-1
                 - quay.io/astronomer/ap-nginx-es:1.25.2-2
                 - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-11
+                - quay.io/astronomer/ap-openresty:1.21.4-12
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
-                - quay.io/astronomer/ap-vector:0.32.2
+                - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -427,25 +427,25 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
-                - quay.io/astronomer/ap-fluentd:1.16.2-1
+                - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.7
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0
-                - quay.io/astronomer/ap-nats-server:2.10.2
-                - quay.io/astronomer/ap-nats-streaming:0.25.5
+                - quay.io/astronomer/ap-nats-exporter:0.12.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.2-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.5-1
                 - quay.io/astronomer/ap-nginx-es:1.25.2-2
                 - quay.io/astronomer/ap-nginx:1.9.4
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-11
+                - quay.io/astronomer/ap-openresty:1.21.4-12
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
-                - quay.io/astronomer/ap-vector:0.32.2
+                - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - twistcli
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.6
+    tag: 0.31.7
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-11
+    tag: 1.21.4-12
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.2-1
+    tag: 1.16.2-2
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.6
+    tag: 0.31.7
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.2
+    tag: 2.10.2-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0
+    tag: 0.12.0-1
     pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.5
+    tag: 0.25.5-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0
+    tag: 0.12.0-1
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -114,7 +114,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.32.2
+    image: quay.io/astronomer/ap-vector:0.32.2-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-fluentd | 1.16.2-1 | 1.16.2-2 |
| ap-nats-exporter | 0.12.0 | 0.12.0-1 |
| ap-nats-server | 2.10.2 | 2.10.2-1 |
| ap-nats-streaming | 0.25.5 | 0.25.5-1 |
| ap-openresty | 1.21.4-11 | 1.21.4-12 | 
| ap-db-bootstrapper | 0.31.6 | 0.31.7 |

## Related Issues

https://github.com/astronomer/issues/issues/5960

## Testing

QA should able to run astronomer platform without issues

## Merging

cherry-pick to release-0.32. release-0.33
