### PR TITLE
update aws-es-proxy version 1.5.0-3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,7 +361,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-2
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.20
@@ -400,7 +400,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-2
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.20

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-2
+    tag: 1.5.0-3
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
## Description

updates aws-es-proxy go modules to resolve x/net CVE

## Related Issues

https://github.com/astronomer/issues/issues/5960

## Testing

NA

## Merging

cherry-pick to release-0.32, release-0.33
