### PR TITLE
update houston-api and astro-ui images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.33.5
+                - quay.io/astronomer/ap-astro-ui:0.33.6
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
@@ -374,7 +374,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.7
+                - quay.io/astronomer/ap-houston-api:0.33.8
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
@@ -398,7 +398,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.33.5
+                - quay.io/astronomer/ap-astro-ui:0.33.6
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
@@ -413,7 +413,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.7
+                - quay.io/astronomer/ap-houston-api:0.33.8
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.33.7
+    tag: 0.33.8
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.33.5
+    tag: 0.33.6
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 0.33.7 | 0.33.8 |
| ap-astro-ui | 0.33.5 | 0.33.6 |


## Related Issues

houston-api
Related https://github.com/astronomer/issues/issues/5977
Related https://github.com/astronomer/issues/issues/5966
Related https://github.com/astronomer/issues/issues/5942
Related https://github.com/astronomer/issues/issues/5950
Related https://github.com/astronomer/issues/issues/5942
Related https://github.com/astronomer/issues/issues/5948
Related https://github.com/astronomer/issues/issues/5922
Related https://github.com/astronomer/issues/issues/5953

astro-ui
Related https://github.com/astronomer/issues/issues/5948
Related https://github.com/astronomer/issues/issues/5914

## Testing

QA should able to verify above link issues

## Merging

cherry-pick to release-0.33
