### PR TITLE
update platform images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.20
-                - quay.io/astronomer/ap-commander:0.33.6
+                - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
@@ -374,7 +374,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.9
+                - quay.io/astronomer/ap-houston-api:0.33.10
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
@@ -404,7 +404,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.20
-                - quay.io/astronomer/ap-commander:0.33.6
+                - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-4
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
@@ -413,7 +413,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.9
+                - quay.io/astronomer/ap-houston-api:0.33.10
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.9.4
+airflowChartVersion: 1.9.5
 
 nodeSelector: {}
 affinity: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.33.6
+    tag: 0.33.7
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.33.9
+    tag: 0.33.10
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description
Update houston api and commander service to support index overrides and airflow chart improvements 
updates commander image 0.33.6 -> 0.33.7
updates houston image   0.33.9 -> 0.33.10

## Related Issues

https://github.com/astronomer/issues/issues/5947

## Testing

Updated in the issue

## Merging

cherry-picl to release-0.33
