### PR TITLE
update houston 0.33.11 and astro-ui 0.33.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.33.8
+                - quay.io/astronomer/ap-astro-ui:0.33.9
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
@@ -374,7 +374,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.10
+                - quay.io/astronomer/ap-houston-api:0.33.11
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
@@ -398,7 +398,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.33.8
+                - quay.io/astronomer/ap-astro-ui:0.33.9
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-3
                 - quay.io/astronomer/ap-base:3.18.4-1
@@ -413,7 +413,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.10
+                - quay.io/astronomer/ap-houston-api:0.33.11
                 - quay.io/astronomer/ap-init:3.18.4-2
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.33.10
+    tag: 0.33.11
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.33.8
+    tag: 0.33.9
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Add supports for triggerer pod status

## Related Issues

https://github.com/astronomer/issues/issues/5722
https://github.com/astronomer/issues/issues/5977

## Testing

QA should able to validate triggerer pod status 

## Merging

cherry-pick to release-0.33
