### PR TITLE
fix CVE-2023-5678 in vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,12 +364,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-4
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
-                - quay.io/astronomer/ap-cli-install:0.26.20
+                - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
-                - quay.io/astronomer/ap-default-backend:0.28.21
+                - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
@@ -403,12 +403,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-4
                 - quay.io/astronomer/ap-base:3.18.4-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
-                - quay.io/astronomer/ap-cli-install:0.26.20
+                - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
-                - quay.io/astronomer/ap-default-backend:0.28.21
+                - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,14 +360,14 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.9
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-3
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-4
                 - quay.io/astronomer/ap-base:3.18.4-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.20
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-4
+                - quay.io/astronomer/ap-curator:8.0.8-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
@@ -375,18 +375,18 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.11
-                - quay.io/astronomer/ap-init:3.18.4-2
+                - quay.io/astronomer/ap-init:3.18.4-3
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.2-1
+                - quay.io/astronomer/ap-nats-exporter:0.12.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.2-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5-1
-                - quay.io/astronomer/ap-nginx-es:1.25.2-2
-                - quay.io/astronomer/ap-nginx:1.9.4
+                - quay.io/astronomer/ap-nginx-es:1.25.2-3
+                - quay.io/astronomer/ap-nginx:1.9.4-1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-12
+                - quay.io/astronomer/ap-openresty:1.21.4-13
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-2
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1
@@ -399,14 +399,14 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.9
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-3
+                - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-4
                 - quay.io/astronomer/ap-base:3.18.4-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-3
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.20
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-4
+                - quay.io/astronomer/ap-curator:8.0.8-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.7
                 - quay.io/astronomer/ap-default-backend:0.28.21
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
@@ -414,18 +414,18 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
                 - quay.io/astronomer/ap-houston-api:0.33.11
-                - quay.io/astronomer/ap-init:3.18.4-2
+                - quay.io/astronomer/ap-init:3.18.4-3
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.2-1
+                - quay.io/astronomer/ap-nats-exporter:0.12.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.2-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.5-1
-                - quay.io/astronomer/ap-nginx-es:1.25.2-2
-                - quay.io/astronomer/ap-nginx:1.9.4
+                - quay.io/astronomer/ap-nginx-es:1.25.2-3
+                - quay.io/astronomer/ap-nginx:1.9.4-1
                 - quay.io/astronomer/ap-node-exporter:1.6.1
-                - quay.io/astronomer/ap-openresty:1.21.4-12
+                - quay.io/astronomer/ap-openresty:1.21.4-13
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-2
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.1
                 - quay.io/astronomer/ap-registry:3.16.5-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.20
+    tag: 0.26.21
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-4
+    tag: 8.0.8-5
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.2-2
+    tag: 1.25.2-3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-12
+    tag: 1.21.4-13
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-3
+    tag: 1.5.0-4
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-2
+    tag: 3.18.4-3
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.2-1
+    tag: 2.10.2-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0-1
+    tag: 0.12.0-2
     pullPolicy: IfNotPresent
 
 

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.21
+    tag: 0.28.22
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.4
+    tag: 1.9.4-1
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-3
+  tag: 0.24.0-4
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-1
+  tag: 0.15.0-2
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-2
+    tag: 3.18.4-3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0-1
+    tag: 0.12.0-2
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -133,7 +133,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.2-2
+    tag: 1.25.2-3
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-base | 3.18.4-1 | 3.18.4-2 |  
| ap-blackbox-exporter | 0.24.0-3 | 0.24.0-4 |  
| ap-nats-exporter | 0.12.0-1 |0.12.0-2 |
| ap-nats-server | 2.10.2-1 | 2.10.2-2 |
| ap-curator | 0.25.5-1 | 0.25.5-2 |
| ap-awsesproxy | 1.5.0-3 | 1.5.0-4 |
| ap-init | 3.18.4-2 | 3.18.4-3 |
| ap-openresty | 1.21.4-12 | 1.21.4-13 |
| ap-postgres-exporter | 0.15.0-1 | 0.15.0-2 | 
| ap-authsidecar | 1.25.2-2 | 1.25.2-3 |
| ap-nginx-es | 1.25.2-2 | 1.25.2-3 |
| ap-nginx | 1.9.4 | 1.9.4-1 | 
| ap-cli-install | 0.26.20 | 0.26.21 | 
| ap-default-backend | 0.28.21 | 0.28.22 |


## Related Issues

https://github.com/astronomer/issues/issues/5988

## Testing

QA basic sanity testing to be done
## Merging

cherry-pick to release-0.33
