### PR TITLE
update ap-db-bootstrapper version 0.31.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,8 +368,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-5
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.7
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.8
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.9
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
@@ -408,8 +407,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-5
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.7
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.8
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.9
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.8
+    tag: 0.31.9
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.7
+    tag: 0.31.9
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

update ap-db-bootstrapper version 0.31.9

## Related Issues

https://github.com/astronomer/issues/issues/5976

## Testing

NA

## Merging

cherry-pick to release-0.32,0.33
