### PR TITLE
update commander version 0.32.10 and airflow chart 1.8.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,7 +341,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.4-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
                 - quay.io/astronomer/ap-cli-install:0.26.21
-                - quay.io/astronomer/ap-commander:0.32.9
+                - quay.io/astronomer/ap-commander:0.32.10
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-5
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.9

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.8
+airflowChartVersion: 1.8.9
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.9
+    tag: 0.32.10
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander version 0.32.10 and airflow chart 1.8.9

## Related Issues

https://github.com/astronomer/issues/issues/6007
https://github.com/astronomer/issues/issues/6006

## Testing

QA should able to deploy airflow without issues

## Merging

cherry-pick to release-0.32
