### PR TITLE
node-exporter 1.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.5-1
                 - quay.io/astronomer/ap-nginx-es:1.25.2-3
                 - quay.io/astronomer/ap-nginx:1.9.4-1
-                - quay.io/astronomer/ap-node-exporter:1.6.1
+                - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.21.4-13
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-2
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.5-1
                 - quay.io/astronomer/ap-nginx-es:1.25.2-3
                 - quay.io/astronomer/ap-nginx:1.9.4-1
-                - quay.io/astronomer/ap-node-exporter:1.6.1
+                - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.21.4-13
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-2

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.6.1
+  tag: 1.7.0
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Description

Update  node_expoter version from 1.6.1 to 1.7.0

imageName | oldTag | newTag
-- | -- | --
node_expoter | 1.6.1 | 1.7.0

## Related Issues

https://github.com/astronomer/issues/issues/6008

## Testing
QA should be able to deploy without any issues.

## Merging
cherry-pick to release 0.32, 0.33

