### PR TITLE
update grafana version 10.1.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
-                - quay.io/astronomer/ap-grafana:10.2.2
+                - quay.io/astronomer/ap-grafana:10.1.5
                 - quay.io/astronomer/ap-houston-api:0.33.12
                 - quay.io/astronomer/ap-init:3.18.4-3
                 - quay.io/astronomer/ap-kibana:8.9.2
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
-                - quay.io/astronomer/ap-grafana:10.2.2
+                - quay.io/astronomer/ap-grafana:10.1.5
                 - quay.io/astronomer/ap-houston-api:0.33.12
                 - quay.io/astronomer/ap-init:3.18.4-3
                 - quay.io/astronomer/ap-kibana:8.9.2

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.2.2
+    tag: 10.1.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update grafana version 10.1.5
resolves permission issue caused by newer grafana version

## Related Issues

https://github.com/astronomer/issues/issues/5775

## Testing

QA should able to see all dashboards for fresh install

## Merging

cherry-pick to all release branches
