### PR TITLE
Update ap-vendor-packages 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.2
-                - quay.io/astronomer/ap-registry:3.18.5
+                - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - slack_team-software-infra-bot
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.2
-                - quay.io/astronomer/ap-registry:3.18.5
+                - quay.io/astronomer/ap-registry:3.16.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - twistcli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,35 +361,35 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.9
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-4
-                - quay.io/astronomer/ap-base:3.18.4-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-6
+                - quay.io/astronomer/ap-base:3.18.5
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-5
+                - quay.io/astronomer/ap-curator:8.0.8-6
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.9
                 - quay.io/astronomer/ap-default-backend:0.28.22
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
-                - quay.io/astronomer/ap-elasticsearch:8.9.2
-                - quay.io/astronomer/ap-fluentd:1.16.2-2
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
+                - quay.io/astronomer/ap-elasticsearch:8.11.4
+                - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.1.5
                 - quay.io/astronomer/ap-houston-api:0.33.12
-                - quay.io/astronomer/ap-init:3.18.4-3
-                - quay.io/astronomer/ap-kibana:8.9.2
-                - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0-2
-                - quay.io/astronomer/ap-nats-server:2.10.2-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.5-1
-                - quay.io/astronomer/ap-nginx-es:1.25.2-3
-                - quay.io/astronomer/ap-nginx:1.9.4-1
+                - quay.io/astronomer/ap-init:3.18.5
+                - quay.io/astronomer/ap-kibana:8.11.4
+                - quay.io/astronomer/ap-kube-state:2.10.1
+                - quay.io/astronomer/ap-nats-exporter:0.13.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.9-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6
+                - quay.io/astronomer/ap-nginx-es:1.25.3
+                - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
-                - quay.io/astronomer/ap-openresty:1.21.4-13
+                - quay.io/astronomer/ap-openresty:1.25.3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-2
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.1
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-prometheus:2.45.2
+                - quay.io/astronomer/ap-registry:3.18.5
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - slack_team-software-infra-bot
@@ -400,35 +400,35 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.33.9
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-4
-                - quay.io/astronomer/ap-base:3.18.4-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-4
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-6
+                - quay.io/astronomer/ap-base:3.18.5
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.33.7
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-5
+                - quay.io/astronomer/ap-curator:8.0.8-6
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.9
                 - quay.io/astronomer/ap-default-backend:0.28.22
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.6.0
-                - quay.io/astronomer/ap-elasticsearch:8.9.2
-                - quay.io/astronomer/ap-fluentd:1.16.2-2
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
+                - quay.io/astronomer/ap-elasticsearch:8.11.4
+                - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.1.5
                 - quay.io/astronomer/ap-houston-api:0.33.12
-                - quay.io/astronomer/ap-init:3.18.4-3
-                - quay.io/astronomer/ap-kibana:8.9.2
-                - quay.io/astronomer/ap-kube-state:2.8.2
-                - quay.io/astronomer/ap-nats-exporter:0.12.0-2
-                - quay.io/astronomer/ap-nats-server:2.10.2-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.5-1
-                - quay.io/astronomer/ap-nginx-es:1.25.2-3
-                - quay.io/astronomer/ap-nginx:1.9.4-1
+                - quay.io/astronomer/ap-init:3.18.5
+                - quay.io/astronomer/ap-kibana:8.11.4
+                - quay.io/astronomer/ap-kube-state:2.10.1
+                - quay.io/astronomer/ap-nats-exporter:0.13.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.9-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6
+                - quay.io/astronomer/ap-nginx-es:1.25.3
+                - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
-                - quay.io/astronomer/ap-openresty:1.21.4-13
+                - quay.io/astronomer/ap-openresty:1.25.3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-2
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.1
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-prometheus:2.45.2
+                - quay.io/astronomer/ap-registry:3.18.5
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.5-1
+    tag: 3.18.5
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.5
+    tag: 3.16.5-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.4-2
+    tag: 3.18.5
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-5
+    tag: 8.0.8-6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.2-3
+    tag: 1.25.3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 8.9.2
+    tag: 8.11.4
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.6.0
+    tag: 1.7.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-4
+    tag: 1.5.0-6
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.21.4-13
+    tag: 1.25.3
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.2-2
+    tag: 1.16.3
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-3
+    tag: 3.18.5
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 8.9.2
+    tag: 8.11.4
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.8.2
+    tag: 2.10.1
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.2-2
+    tag: 2.10.9
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0-2
+    tag: 0.13.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.13.0
+    tag: 0.13.0-1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.9
+    tag: 2.10.9-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.4-1
+    tag: 1.9.5
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-4
+  tag: 0.24.0-5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-2
+  tag: 0.15.0-3
   pullPolicy: IfNotPresent
 
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.1
+    tag: 2.45.2
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.5-1
+    tag: 0.25.6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.12.0-2
+    tag: 0.13.0
     pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,7 +6,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.4-3
+    tag: 3.18.5
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.13.0
+    tag: 0.13.0-1
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

imageName | oldTag | newTag
-- | -- | --
ap-base | 3.18.4-2 | 3.18.5
ap-blackbox-exporter | 0.24.0-4 | 0.24.0-5
ap-nats-exporter | 0.13.0 | 0.13.0-1
ap-nats-server | 2.10.9 | 2.10.9-1
ap-curator | 8.0.8-5 | 8.0.8-6
ap-awsesproxy | 1.5.0-5 | 1.5.0-6
ap-init | 3.18.4-3 | 3.18.5
ap-postgres-exporter | 0.15.0-2 | 0.15.0-3
ap-fluentd | 1.16.2-2 | 1.16.3 
ap-kibana | 8.9.2 | 8.11.4 
ap-nginx | 1.9.4-1 | 1.9.5 
ap-kubesate | 2.8.2 | 2.10.1 
ap-openresty | 1.21.4-13 | 1.25.3
ap-prometheus | 2.45.1 | 2.45.2
ap-nats-streaming | 0.25.5-1 | 0.25.6

## Related Issues

https://github.com/astronomer/ap-vendor/pull/669
https://github.com/astronomer/ap-vendor/pull/666
https://github.com/astronomer/ap-vendor/pull/677
https://github.com/astronomer/ap-vendor/pull/676
https://github.com/astronomer/ap-vendor/pull/667
https://github.com/astronomer/ap-vendor/pull/670
https://github.com/astronomer/ap-vendor/pull/671
https://github.com/astronomer/ap-vendor/pull/672
https://github.com/astronomer/ap-vendor/pull/674
https://github.com/astronomer/ap-vendor/pull/675
https://github.com/astronomer/ap-vendor/pull/678

## Testing

QA basic sanity testing to be done

## Merging
cherry-pick to release-0.33 release-0.34 release-0.32

