### PR TITLE
update houston-api and astro-ui images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.33.9
+                - quay.io/astronomer/ap-astro-ui:0.33.10
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-4
                 - quay.io/astronomer/ap-base:3.18.4-2
@@ -342,7 +342,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.9.2
                 - quay.io/astronomer/ap-fluentd:1.16.2-2
                 - quay.io/astronomer/ap-grafana:10.0.9
-                - quay.io/astronomer/ap-houston-api:0.33.12
+                - quay.io/astronomer/ap-houston-api:0.33.14
                 - quay.io/astronomer/ap-init:3.18.4-3
                 - quay.io/astronomer/ap-kibana:8.9.2
                 - quay.io/astronomer/ap-kube-state:2.8.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.33.12
+    tag: 0.33.14
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.33.9
+    tag: 0.33.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update ap-houston-api and ap-astro-ui images 

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 0.33.12 | 0.33.14 |
| ap-astro-ui | 0.33.9 | 0.33.10 |


## Related Issues
ap-astro-ui tagged tickets for release-0.33
Related https://github.com/astronomer/issues/issues/6039
Related https://github.com/astronomer/issues/issues/5977
Related https://github.com/astronomer/issues/issues/5977

ap-houston-api tagged tickets for release-0.33
Related https://github.com/astronomer/issues/issues/6081
Related https://github.com/astronomer/issues/issues/5992
Related https://github.com/astronomer/issues/issues/6018
Related https://github.com/astronomer/issues/issues/6073
## Testing

QA should able to validate all tagged houston and astro-ui issues

## Merging

cherry-pick to release-0.33
