### PR TITLE
update nats exporter version 0.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.13.0-1
+                - quay.io/astronomer/ap-nats-exporter:0.14.0
                 - quay.io/astronomer/ap-nats-server:2.10.9-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6
                 - quay.io/astronomer/ap-nginx-es:1.25.3
@@ -417,7 +417,7 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.13.0-1
+                - quay.io/astronomer/ap-nats-exporter:0.14.0
                 - quay.io/astronomer/ap-nats-server:2.10.9-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6
                 - quay.io/astronomer/ap-nginx-es:1.25.3

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.13.0-1
+    tag: 0.14.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.13.0-1
+    tag: 0.14.0
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description


| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-nats-exporter | 0.13.0-1 | 0.14.0 |


## Related Issues

NA

## Testing

nats exporter metrics endpoint should work as expected

## Merging

cherry-pick to all valid release branches
