### PR TITLE
update kube state metrics command args

### DIFF
--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -31,4 +31,4 @@ ports:
 replicas: 1
 
 extraArgs:
-- "--metric-labels-allowlist=namespaces=[*]"
+- "--metric-labels-allowlist=namespaces=[*],pods=[*]"

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -67,7 +67,7 @@ class TestKubeStateDeployment:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         assert (
-            "--metric-labels-allowlist=namespaces=[*]"
+            "--metric-labels-allowlist=namespaces=[*],pods=[*]"
             in c_by_name["kube-state"]["args"]
         )
         assert "--namespaces=" not in c_by_name["kube-state"]["args"]


### PR DESCRIPTION
## Description

by default kube-state-metrics 2.10.x has changed the default behaviour of exposing pod lables to reduce the memory usage and number of metrics being exposed, since we are relying on that metrics we have updated our kube-state-metrics command args to include pod label metrics to resolve this issue

## Related Issues

https://github.com/astronomer/issues/issues/6084

## Testing

QA should able to verify the metrics tab with all the necessary metrics

## Merging

cherry-pick to all valid release version
