### PR TITLE
upgrade grafana version 10.2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.1.5
+                - quay.io/astronomer/ap-grafana:10.2.3
                 - quay.io/astronomer/ap-houston-api:0.33.12
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.1.5
+                - quay.io/astronomer/ap-grafana:10.2.3
                 - quay.io/astronomer/ap-houston-api:0.33.12
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.1.5
+    tag: 10.2.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

upgrade grafana version 10.2.3

## Related Issues

https://github.com/astronomer/issues/issues/6060
https://github.com/astronomer/issues/issues/5880

## Testing

QA should able to validate grafana dashboard without auth when logged in with SYS_ADMIN 

## Merging

cherry-pick to release-0.34
