### PR TITLE
add custom ca volume on right indent

### DIFF
--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -125,6 +125,7 @@ spec:
         - name: certificate
           secret:
             secretName: {{ .Values.global.tlsSecret }}
+        {{ include "custom_ca_volumes" . | indent 8  }}
         {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}
         {{- include "registry.gcsVolume" . | indent 8 }}
         {{- end }}
@@ -132,7 +133,6 @@ spec:
         - name: data
           emptyDir: {}
   {{- else }}
-        {{ include "custom_ca_volumes" . | indent 8  }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/tests/chart_tests/test_registry_statefulset.py
+++ b/tests/chart_tests/test_registry_statefulset.py
@@ -148,7 +148,7 @@ class TestRegistryStatefulset:
             {"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}
         ]
 
-        assert docs[0]["kind"] == "Statefulset"
+        assert docs[0]["kind"] == "StatefulSet"
         assert volume_mount_search_result == expected_volume_mounts_result
         assert volume_search_result == expected_volume_result
         assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"][

--- a/tests/chart_tests/test_registry_statefulset.py
+++ b/tests/chart_tests/test_registry_statefulset.py
@@ -127,11 +127,15 @@ class TestRegistryStatefulset:
                 "charts/astronomer/templates/registry/registry-statefulset.yaml"
             ],
         )
-        search_result = jmespath.search(
+        volume_mount_search_result = jmespath.search(
             "spec.template.spec.containers[*].volumeMounts[?name == 'private-root-ca']",
             docs[0],
         )
-        expected_result = [
+        volume_search_result = jmespath.search(
+            "spec.template.spec.volumes[?name == 'private-root-ca']",
+            docs[0],
+        )
+        expected_volume_mounts_result = [
             [
                 {
                     "mountPath": "/usr/local/share/ca-certificates/private-root-ca.pem",
@@ -140,7 +144,51 @@ class TestRegistryStatefulset:
                 }
             ]
         ]
-        assert search_result == expected_result
+        expected_volume_result = [
+            {"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}
+        ]
+
+        assert docs[0]["kind"] == "Statefulset"
+        assert volume_mount_search_result == expected_volume_mounts_result
+        assert volume_search_result == expected_volume_result
+        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"][
+            "template"
+        ]["spec"]["containers"][0]["env"]
+
+    def test_registry_privateca_enabled_with_external_backend(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"privateCaCerts": ["private-root-ca"]},
+                "astronomer": {"registry": {"s3": {"enabled": True}}},
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-statefulset.yaml"
+            ],
+        )
+        volume_mount_search_result = jmespath.search(
+            "spec.template.spec.containers[*].volumeMounts[?name == 'private-root-ca']",
+            docs[0],
+        )
+        volume_search_result = jmespath.search(
+            "spec.template.spec.volumes[?name == 'private-root-ca']",
+            docs[0],
+        )
+        expected_volume_mounts_result = [
+            [
+                {
+                    "mountPath": "/usr/local/share/ca-certificates/private-root-ca.pem",
+                    "name": "private-root-ca",
+                    "subPath": "cert.pem",
+                }
+            ]
+        ]
+        expected_volume_result = [
+            {"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}
+        ]
+        assert docs[0]["kind"] == "Deployment"
+        assert volume_mount_search_result == expected_volume_mounts_result
+        assert volume_search_result == expected_volume_result
         assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"][
             "template"
         ]["spec"]["containers"][0]["env"]


### PR DESCRIPTION
## Description

fixes an issue where private ca added in wrong indent causing registry deployment not exposing ca-volumes causing deployments to not able to patch 

## Related Issues

https://github.com/astronomer/issues/issues/5939

## Testing

QA should able to see CA certs when registry type is deployment 

## Merging

cherry-pick to release-0.34
