### PR TITLE
Prevent multiple component versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ parameters:
 jobs:
   trivy-scan-docker:
     docker:
-      - image: docker:20.10.24-git
+      - image: cimg/base:stable
     shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
@@ -47,7 +47,7 @@ jobs:
       ASTRO_SEC_ENDPOINT: << parameters.report_url >>
     steps:
       - setup_remote_docker:
-          version: 20.10.24
+          docker_layer_caching: true
       - checkout
       - run:
           name: Pull Docker image
@@ -86,14 +86,14 @@ jobs:
 
   twistcli-scan-docker:
     docker:
-      - image: docker:20.10.24-git
+      - image: cimg/base:stable
     shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
         type: string
     steps:
       - setup_remote_docker:
-          version: 20.10.24
+          docker_layer_caching: true
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -151,7 +151,6 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.24
       - checkout
       - run:
           name: Create chart-tests-cache-key.txt
@@ -333,11 +332,11 @@ jobs:
 
   check-commander-airflow-version:
     docker:
-      - image: cimg/base:2022.09
+      - image: cimg/base:stable
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.24
+          docker_layer_caching: true
       - run:
           name: Check that commander image uses same Airflow chart version
           command: make validate-commander-airflow-version
@@ -587,7 +586,6 @@ commands:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.24
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -641,7 +639,6 @@ commands:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 20.10.24
       - run:
           name: Build the Docker image
           command: |

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -27,7 +27,7 @@ parameters:
 jobs:
   trivy-scan-docker:
     docker:
-      - image: docker:{{ remote_docker_version }}-git
+      - image: cimg/base:stable
     shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
@@ -45,7 +45,7 @@ jobs:
       ASTRO_SEC_ENDPOINT: << parameters.report_url >>
     steps:
       - setup_remote_docker:
-          version: {{ remote_docker_version }}
+          docker_layer_caching: true
       - checkout
       - run:
           name: Pull Docker image
@@ -84,14 +84,14 @@ jobs:
 
   twistcli-scan-docker:
     docker:
-      - image: docker:{{ remote_docker_version }}-git
+      - image: cimg/base:stable
     shell: /bin/sh -leo pipefail
     parameters:
       docker_image:
         type: string
     steps:
       - setup_remote_docker:
-          version: {{ remote_docker_version }}
+          docker_layer_caching: true
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -149,7 +149,6 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: {{ remote_docker_version }}
       - checkout
       - run:
           name: Create chart-tests-cache-key.txt
@@ -268,11 +267,11 @@ jobs:
 
   check-commander-airflow-version:
     docker:
-      - image: cimg/base:2022.09
+      - image: cimg/base:stable
     steps:
       - checkout
       - setup_remote_docker:
-          version: {{ remote_docker_version }}
+          docker_layer_caching: true
       - run:
           name: Check that commander image uses same Airflow chart version
           command: make validate-commander-airflow-version
@@ -448,7 +447,6 @@ commands:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: {{ remote_docker_version }}
       - attach_workspace:
           at: /tmp/workspace
       - run:
@@ -502,7 +500,6 @@ commands:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: {{ remote_docker_version }}
       - run:
           name: Build the Docker image
           command: |

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -11,9 +11,6 @@ from jinja2 import Template
 metadata = yaml.safe_load((Path(__file__).parents[1] / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
-# https://circleci.com/docs/2.0/building-docker-images/#docker-version
-ci_remote_docker_version = "20.10.24"
-
 # https://circleci.com/developer/machine/image/ubuntu-2204
 machine_image_version = "ubuntu-2204:2023.07.2"
 ci_runner_version = "2023-11"
@@ -42,7 +39,6 @@ def main():
         kube_versions=kube_versions,
         docker_images=docker_images,
         machine_image_version=machine_image_version,
-        remote_docker_version=ci_remote_docker_version,
         ci_runner_version=ci_runner_version,
     )
     with open(config_path, "w") as circle_ci_config_file:

--- a/.circleci/generate_circleci_config.py
+++ b/.circleci/generate_circleci_config.py
@@ -20,7 +20,7 @@ ci_runner_version = "2023-11"
 
 
 def list_docker_images(path):
-    command = f"cd {path} && helm template . -f tests/enable_all_features.yaml 2>/dev/null | awk '/image: / {{print $2}}' | sed 's/\"//g' | sort -u"
+    command = f"cd {path} && helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml 2>/dev/null | awk '/image: / {{print $2}}' | sed 's/\"//g' | sort -u"
     docker_images_output = subprocess.check_output(command, shell=True)
     docker_image_list = docker_images_output.decode("utf-8").strip().split("\n")
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@ exclude: '(venv|\.vscode|tests/k8s_schema)' # regex
 repos:
   - repo: local
     hooks:
+      - id: verify-image-tags
+        name: Verify image tags
+        entry: python3
+        args: [bin/verify_image_tags.py]
+        language: system
+        files: ^.*\.(tpl|yaml)$
       - id: circle-config-yaml
         name: Checks for consistency between config.yml and config.yml.j2
         language: python

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ update-requirements: ## Update all requirements.txt files
 show-docker-images: ## Show all docker images and versions used in the helm chart
 	@helm template . \
 		-f tests/enable_all_features.yaml \
+		--set forceIncompatibleKubernetes=true \
 		2>/dev/null \
 		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
 
@@ -84,6 +85,7 @@ show-docker-images: ## Show all docker images and versions used in the helm char
 show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
 	@helm template . \
 		-f tests/enable_all_features.yaml \
+		--set forceIncompatibleKubernetes=true \
 		--set global.privateRegistry.enabled=True \
 		--set global.privateRegistry.repository=example.com/the-private-registry \
 		2>/dev/null \

--- a/bin/verify_image_tags.py
+++ b/bin/verify_image_tags.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""Verify that every image has only one tag version."""
+
+import subprocess
+from pathlib import Path
+
+
+GIT_ROOT = next(
+    iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None
+)
+command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml | grep -o 'quay.io/astronomer[^\"]*' | sort -u"
+
+result = subprocess.run(
+    command,
+    shell=True,
+    cwd=GIT_ROOT,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+)
+
+if result.returncode != 0:
+    print(f"Error running the command:\n{result.stderr}")
+    raise SystemExit(1)
+
+output_lines = result.stdout.strip().split("\n")
+
+image_dict = {}
+images_with_multiple_tags = []
+
+for line in output_lines:
+    if ":" not in line:
+        continue
+
+    image = line.strip()
+    parts = image.rsplit(":", 1)
+    image_name = parts[0]
+    tag = parts[1].strip(" \"'\t\n\r")
+
+    if image_name not in image_dict:
+        image_dict[image_name] = []
+
+    if tag and tag not in image_dict[image_name]:
+        image_dict[image_name].append(tag)
+
+for image, tags in image_dict.items():
+    if len(tags) > 1:
+        print(f"ERROR: image {image} has multiple tags: {', '.join(tags)}")
+
+if any(len(tags) > 1 for tags in image_dict.values()):
+    raise SystemExit(1)


### PR DESCRIPTION
## Description

- Add `bin/verify_image_tags.py` which ensures that there is only one tag version for every docker image
- Add verify-image-tags pre-commit hook that runs `bin/verify_image_tags.py` when tpl or yaml files are changed.
- Modernize the .circleci config by removing deprecated fields
- Use `--set forceIncompatibleKubernetes=true` so that `make show-docker-images` will always succeed.

## Related Issues

https://github.com/astronomer/issues/issues/6115

## Testing

I've tested this manually on my computer. These are only dev workflow changes, so there are no production concerns here.

## Merging

This should be merged everywhere.