### PR TITLE
update ap-registry 3.16.5-1 -> 3.18.5-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.2
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - slack_team-software-infra-bot
@@ -427,7 +427,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
                 - quay.io/astronomer/ap-postgresql:15.4.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.2
-                - quay.io/astronomer/ap-registry:3.16.5-1
+                - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.16.5-1
+    tag: 3.18.5-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:


### PR DESCRIPTION
## Description

revert upstream registry repo since aws iam role is broken in distribution repo upstream

## Related Issues

https://github.com/astronomer/issues/issues/5939
https://github.com/astronomer/issues/issues/5905

## Testing

QA should able to validate aws iam roles with new image

## Merging

cherry-pick to all valid release branches