### PR TITLE
add dagOnlyDeployment feature flag in astronomer helm chart

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -135,7 +135,7 @@ data:
       {{- end }}
 
       {{- if .Values.global.dagOnlyDeployment.enabled }}
-      # enables sidecar logging for airflow deployments
+      # enables dag only deployment for airflow deployments
       dagDeploy:
         enabled: {{ .Values.global.dagOnlyDeployment.enabled }}
         images:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -143,10 +143,10 @@ data:
             repository: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | first | quote }}
             tag: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | last  }}
         {{- if .Values.global.dagOnlyDeployment.enabled }}
-        securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 12 }}
+        securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 10 }}
         {{- end }}
-        {{- if .Values.global.dagOnlyDeployment.resources}}
-        resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
+        {{- if .Values.global.dagOnlyDeployment.resources }}
+        resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -146,7 +146,20 @@ data:
       {{- if .Values.global.networkNSLabels }}
         networkNSLabels: true
       {{- end }}
-
+      {{- if .Values.global.dagOnlyDeployment.enabled }}
+        dagDeploy:
+          enabled: {{ .Values.global.dagOnlyDeployment.enabled }}
+          images:
+            dagServer:
+              repository: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | first | quote }}
+              tag: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | last  }}
+        {{- if .Values.global.dagOnlyDeployment.enabled }}
+          securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.resources}}
+          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
+        {{- end }}
+      {{- end }}
         airflow:
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -134,6 +134,22 @@ data:
         {{- end }}
       {{- end }}
 
+      {{- if .Values.global.dagOnlyDeployment.enabled }}
+      # enables sidecar logging for airflow deployments
+      dagDeploy:
+        enabled: {{ .Values.global.dagOnlyDeployment.enabled }}
+        images:
+          dagServer:
+            repository: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | first | quote }}
+            tag: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | last  }}
+        {{- if .Values.global.dagOnlyDeployment.enabled }}
+        securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.resources}}
+        resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
+        {{- end }}
+      {{- end }}
+
       # These values get passed directly into the airflow helm deployments
       helm:
       {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
@@ -147,20 +163,7 @@ data:
       {{- if .Values.global.networkNSLabels }}
         networkNSLabels: true
       {{- end }}
-      {{- if .Values.global.dagOnlyDeployment.enabled }}
-        dagDeploy:
-          enabled: {{ .Values.global.dagOnlyDeployment.enabled }}
-          images:
-            dagServer:
-              repository: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | first | quote }}
-              tag: {{ (splitList ":"  .Values.global.dagOnlyDeployment.image ) | last  }}
-        {{- if .Values.global.dagOnlyDeployment.enabled }}
-          securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 12 }}
-        {{- end }}
-        {{- if .Values.global.dagOnlyDeployment.resources}}
-          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
-        {{- end }}
-      {{- end }}
+
         airflow:
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -66,6 +66,7 @@ data:
     deployments:
       fluentdIndexPrefix: {{ include "fluentd.IndexPattern" .}}
       enableHoustonInternalAuthorization: {{ include "houston.InternalAuthorization" . }}
+      dagOnlyDeployment: {{ .Values.global.dagOnlyDeployment.enabled }}
       namespaceFreeFormEntry: {{ .Values.global.namespaceFreeFormEntry }}
       # Airflow chart settings
       # Static helm configurations for this chart are found below.

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -1,0 +1,60 @@
+import pytest
+import yaml
+from tests import supported_k8s_versions
+from tests.chart_tests.helm_template_generator import render_chart
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestDagOnlyDeploy:
+    def test_dagonlydeploy_with_defaults(self, kube_version):
+        """Test dagonlydeploy Service defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["dagOnlyDeployment"] is False
+
+    def test_dagonlydeploy_config_enabled(self, kube_version):
+        """Test dagonlydeploy Service defaults."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "image": "someregistry.io/my-custom-image:my-custom-tag",
+                        "securityContext": {"fsGroup": 50000},
+                        "resources": {
+                            "requests": {"memory": "386Mi", "cpu": "100m"},
+                            "limits": {"memory": "386Mi", "cpu": "100m"},
+                        },
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["dagOnlyDeployment"] is True
+        assert prod["deployments"]["helm"]["dagDeploy"] == {
+            "enabled": True,
+            "images": {
+                "dagServer": {
+                    "repository": "someregistry.io/my-custom-image",
+                    "tag": "my-custom-tag",
+                }
+            },
+            "securityContext": {"fsGroup": 50000},
+            "resources": {
+                "requests": {"memory": "386Mi", "cpu": "100m"},
+                "limits": {"memory": "386Mi", "cpu": "100m"},
+            },
+        }

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -17,12 +17,15 @@ class TestDagOnlyDeploy:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is False
 
     def test_dagonlydeploy_config_enabled(self, kube_version):
         """Test dagonlydeploy Service defaults."""
+        resources = {
+            "requests": {"memory": "888Mi", "cpu": "666m"},
+            "limits": {"memory": "999Mi", "cpu": "777m"},
+        }
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -30,11 +33,8 @@ class TestDagOnlyDeploy:
                     "dagOnlyDeployment": {
                         "enabled": True,
                         "image": "someregistry.io/my-custom-image:my-custom-tag",
-                        "securityContext": {"fsGroup": 50000},
-                        "resources": {
-                            "requests": {"memory": "386Mi", "cpu": "100m"},
-                            "limits": {"memory": "386Mi", "cpu": "100m"},
-                        },
+                        "securityContext": {"fsGroup": 55555},
+                        "resources": resources,
                     }
                 }
             },
@@ -52,9 +52,6 @@ class TestDagOnlyDeploy:
                     "tag": "my-custom-tag",
                 }
             },
-            "securityContext": {"fsGroup": 50000},
-            "resources": {
-                "requests": {"memory": "386Mi", "cpu": "100m"},
-                "limits": {"memory": "386Mi", "cpu": "100m"},
-            },
+            "securityContext": {"fsGroup": 55555},
+            "resources": resources,
         }

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -44,7 +44,7 @@ class TestDagOnlyDeploy:
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
-        assert prod["deployments"]["helm"]["dagDeploy"] == {
+        assert prod["deployments"]["dagDeploy"] == {
             "enabled": True,
             "images": {
                 "dagServer": {

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,13 @@ global:
 
   enableHoustonInternalAuthorization: false
 
+  dagOnlyDeployment:
+    enabled: false
+    image: quay.io/astronomer/ap-dag-deploy:0.3.1
+    securityContext:
+      fsGroup: 50000
+    resources: {}
+
   logging:
     indexNamePrefix: ~
 


### PR DESCRIPTION
## Description

- Adding functionality to enable dag only deployment controls from global values
- Add security context default and override

## Related Issues

https://github.com/astronomer/issues/issues/5969

## Testing

unit tests are included, but we'll need testing from QA.

## Merging

This is only for release-0.34