### PR TITLE
Fix broken scan-docker-images CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ jobs:
       - run:
           name: Install twistcli
           command: |
-            apk add --update-cache --upgrade curl
             curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
             chmod +x twistcli
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apk add --update-cache --upgrade curl rpm bash
+            apt update && apt install -y bash curl
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: set -leo pipefail
+      - run: set -euo pipefail
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ parameters:
 jobs:
   trivy-scan-docker:
     docker:
-      - image: cimg/base:stable
-    shell: /bin/sh -leo pipefail
+      - image: cimg/base:current-22.04
+    shell: /usr/bin/bash
     parameters:
       docker_image:
         type: string
@@ -48,6 +48,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - run: set -euo pipefail
       - checkout
       - run:
           name: Pull Docker image
@@ -86,14 +87,15 @@ jobs:
 
   twistcli-scan-docker:
     docker:
-      - image: cimg/base:stable
-    shell: /bin/sh -leo pipefail
+      - image: cimg/base:current-22.04
+    shell: /usr/bin/bash
     parameters:
       docker_image:
         type: string
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - run: set -leo pipefail
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -332,7 +334,7 @@ jobs:
 
   check-commander-airflow-version:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current-22.04
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,6 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apt update && apt install -y bash curl
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -54,7 +54,6 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apt update && apt install -y bash curl
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -100,7 +100,6 @@ jobs:
       - run:
           name: Install twistcli
           command: |
-            apk add --update-cache --upgrade curl
             curl -k -u $USER:$PASSWORD --output twistcli $CONSOLE_URL"/api/v1/util/twistcli"
             chmod +x twistcli
       - run:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -93,7 +93,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: set -leo pipefail
+      - run: set -euo pipefail
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:
           keys:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apk add --update-cache --upgrade curl rpm bash
+            apt update && apt install -y bash curl
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
             date +%F > date
       - restore_cache:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -27,8 +27,8 @@ parameters:
 jobs:
   trivy-scan-docker:
     docker:
-      - image: cimg/base:stable
-    shell: /bin/sh -leo pipefail
+      - image: cimg/base:current-22.04
+    shell: /usr/bin/bash
     parameters:
       docker_image:
         type: string
@@ -46,6 +46,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - run: set -euo pipefail
       - checkout
       - run:
           name: Pull Docker image
@@ -84,14 +85,15 @@ jobs:
 
   twistcli-scan-docker:
     docker:
-      - image: cimg/base:stable
-    shell: /bin/sh -leo pipefail
+      - image: cimg/base:current-22.04
+    shell: /usr/bin/bash
     parameters:
       docker_image:
         type: string
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
+      - run: set -leo pipefail
       - run:
           name: Pull Docker image
           command: docker pull << parameters.docker_image >>
@@ -267,7 +269,7 @@ jobs:
 
   check-commander-airflow-version:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current-22.04
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
## Description

- Use cimg/base:current-22.04
- use /usr/bin/bash for shell
- move shell options to their own step

## Related Issues

https://github.com/astronomer/issues/issues/6125

## Testing

This should be manually tested. It only affects dev workflows, not the product itself.

## Merging

This should be merged everywhere