### PR TITLE
Add bin/show-docker-images.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ update-requirements: ## Update all requirements.txt files
 
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
-	@bin/show-docker-images.py
+	@bin/show-docker-images.py --with-houston
 
 .PHONY: show-docker-images-with-private-registry
 show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
-	@bin/show-docker-images.py --private-registry
+	@bin/show-docker-images.py --private-registry --with-houston

--- a/Makefile
+++ b/Makefile
@@ -75,18 +75,8 @@ update-requirements: ## Update all requirements.txt files
 
 .PHONY: show-docker-images
 show-docker-images: ## Show all docker images and versions used in the helm chart
-	@helm template . \
-		-f tests/enable_all_features.yaml \
-		--set forceIncompatibleKubernetes=true \
-		2>/dev/null \
-		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
+	@bin/show-docker-images.py
 
 .PHONY: show-docker-images-with-private-registry
 show-docker-images-with-private-registry: ## Show all docker images and versions used in the helm chart with a privateRegistry set
-	@helm template . \
-		-f tests/enable_all_features.yaml \
-		--set forceIncompatibleKubernetes=true \
-		--set global.privateRegistry.enabled=True \
-		--set global.privateRegistry.repository=example.com/the-private-registry \
-		2>/dev/null \
-		| gawk '/image: / {match($$2, /(([^"]*):[^"]*)/, a) ; printf "https://%s %s\n", a[2], a[1] ;}' | sort -u | column -t
+	@bin/show-docker-images.py --private-registry

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -31,14 +31,14 @@ def default_spec_parser(doc, args):
     item_containers = get_containers_from_spec(doc["spec"]["template"]["spec"])
 
     if args.verbose:
-        print(f"Processing {doc['kind']} {doc['metadata']['name']}")
+        print(f"Processing {doc['kind']} {doc['metadata']['name']}", file=sys.stderr)
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
         print(
-            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io'
+            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry'
         )
         if args.verbose:
-            print(json.dumps(doc["spec"]["template"]["spec"]))
+            print(json.dumps(doc["spec"]["template"]["spec"]), file=sys.stderr)
 
     return item_containers
 
@@ -47,7 +47,7 @@ def job_template_spec_parser(doc, args):
     """Parse and report on CronJobs, which have a different structure than other pod managers."""
 
     if args.verbose:
-        print(f"Processing {doc['kind']} {doc['metadata']['name']}")
+        print(f"Processing {doc['kind']} {doc['metadata']['name']}", file=sys.stderr)
 
     item_containers = get_containers_from_spec(
         doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]
@@ -55,15 +55,18 @@ def job_template_spec_parser(doc, args):
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
         print(
-            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io'
+            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry'
         )
         if args.verbose:
-            print(json.dumps(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]))
+            print(
+                json.dumps(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]),
+                file=sys.stderr,
+            )
 
     return item_containers
 
 
-def get_images_from_houston_configmap(doc):
+def get_images_from_houston_configmap(doc, args):
     """Return a list of images used in the houston configmap."""
     houston_config = yaml.safe_load(doc["data"]["production.yaml"])
     keepers = ("authSideCar", "loggingSidecar")
@@ -72,7 +75,34 @@ def get_images_from_houston_configmap(doc):
         f'{items["authSideCar"]["repository"]}:{items["authSideCar"]["tag"]}'
     )
     logging_sidecar_image = f'{items["loggingSidecar"]["image"]}'
-    return (auth_sidecar_image, logging_sidecar_image)
+    images = (auth_sidecar_image, logging_sidecar_image)
+    if args.verbose and any("quay.io" in x for x in images):
+        print(
+            "Houston configmap uses quay.io instead of private registry",
+            file=sys.stderr,
+        )
+    return images
+
+
+def helm_template(args):
+    """Run helm template and return the parsed yaml."""
+    GIT_ROOT = next(
+        iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]),
+        None,
+    )
+
+    command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
+    if args.private_registry:
+        command += (
+            " --set global.privateRegistry.repository=example.com/the-private-registry"
+            " --set global.privateRegistry.enabled=True"
+        )
+
+    if args.verbose:
+        print(f"Running command: {command}", flush=True, file=sys.stderr)
+    output = subprocess.check_output(command, shell=True, cwd=GIT_ROOT).decode("utf-8")
+
+    return list(yaml.safe_load_all(output))
 
 
 def main():
@@ -92,23 +122,7 @@ def main():
     )
     args = parser.parse_args()
 
-    GIT_ROOT = next(
-        iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]),
-        None,
-    )
-
-    command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
-
-    if args.private_registry:
-        command += (
-            " --set global.privateRegistry.repository=example.com/the-private-registry"
-            " --set global.privateRegistry.enabled=True"
-        )
-
-    if args.verbose:
-        print(f"Running: {command}", flush=True, file=sys.stderr)
-    output = subprocess.check_output(command, shell=True, cwd=GIT_ROOT).decode("utf-8")
-    docs = list(yaml.safe_load_all(output))
+    docs = helm_template(args)
 
     containers = set()
 
@@ -122,7 +136,7 @@ def main():
                 containers.update(job_template_spec_parser(doc, args))
             case {"metadata": {"name": "release-name-houston-config"}}:
                 if args.with_houston:
-                    containers.update(get_images_from_houston_configmap(doc))
+                    containers.update(get_images_from_houston_configmap(doc, args))
             case _:
                 pass
 

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -62,7 +62,9 @@ def main():
                 )
                 containers.update(item_containers)
                 if args.private_registry and "quay.io" in yaml.dump(item_containers):
-                    print(f'{doc["kind"]} {doc["metadata"]["name"]} uses quay.io')
+                    print(
+                        f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io'
+                    )
                     if args.verbose:
                         print(json.dumps(doc["spec"]["template"]["spec"]))
             case {"spec": {"jobTemplate": {"spec": {"template": {"spec": _}}}}}:
@@ -71,7 +73,9 @@ def main():
                 )
                 containers.update(item_containers)
                 if args.private_registry and "quay.io" in yaml.dump(item_containers):
-                    print(f'{doc["kind"]} {doc["metadata"]["name"]} uses quay.io')
+                    print(
+                        f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io'
+                    )
                     if args.verbose:
                         print(
                             json.dumps(

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -9,11 +9,6 @@ import sys
 import json
 
 
-GIT_ROOT = next(
-    iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None
-)
-
-
 def get_containers_from_spec(spec):
     """Return a list of images used in a kubernetes pod spec."""
     return [
@@ -75,6 +70,11 @@ def main():
     parser.add_argument("--private-registry", action="store_true")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()
+
+    GIT_ROOT = next(
+        iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]),
+        None,
+    )
 
     command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
 

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Show a list of docker images that are deployed by the astronomer platform."""
+
+import subprocess
+from pathlib import Path
+import yaml
+import argparse
+import sys
+import json
+
+
+GIT_ROOT = next(
+    iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None
+)
+
+
+def get_containers_from_spec(spec):
+    """Return a list of images used in a kubernetes pod spec."""
+    return [
+        container["image"]
+        for container in spec.get("containers", []) + spec.get("initContainers", [])
+    ]
+
+
+def print_results(items):
+    """Print an HTTPS url and the docker pull URL for every image in the list."""
+    splits = [image_tag.split(":") for image_tag in items]
+    max_length = max(len(x[0]) for x in splits)
+    for image, tag in splits:
+        print(f"https://{image:{max_length}}  {image}:{tag}")
+
+
+def main():
+    """Parse the helm output and print the images."""
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--private-registry", action="store_true")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
+
+    if args.private_registry:
+        command += (
+            " --set global.privateRegistry.repository=example.com/the-private-registry"
+            " --set global.privateRegistry.enabled=True"
+        )
+
+    if args.verbose:
+        print(f"Running: {command}", flush=True, file=sys.stderr)
+    output = subprocess.check_output(command, shell=True, cwd=GIT_ROOT).decode("utf-8")
+
+    containers = set()
+
+    for doc in yaml.safe_load_all(output):
+        if doc is None:
+            continue
+        match doc:
+            case {"spec": {"template": {"spec": _}}}:
+                item_containers = get_containers_from_spec(
+                    doc["spec"]["template"]["spec"]
+                )
+                containers.update(item_containers)
+                if args.private_registry and "quay.io" in yaml.dump(item_containers):
+                    print(f'{doc["kind"]} {doc["metadata"]["name"]} uses quay.io')
+                    if args.verbose:
+                        print(json.dumps(doc["spec"]["template"]["spec"]))
+            case {"spec": {"jobTemplate": {"spec": {"template": {"spec": _}}}}}:
+                item_containers = get_containers_from_spec(
+                    doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+                )
+                containers.update(item_containers)
+                if args.private_registry and "quay.io" in yaml.dump(item_containers):
+                    print(f'{doc["kind"]} {doc["metadata"]["name"]} uses quay.io')
+                    if args.verbose:
+                        print(
+                            json.dumps(
+                                doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+                            )
+                        )
+
+            case _:
+                pass
+
+    print_results(sorted(containers))
+
+
+if __name__ == "__main__":
+    main()

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
             {{- end }}
         {{- if .Values.global.authSidecar.enabled  }}
         - name: auth-proxy
-          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
+          image: {{ include "authSidecar.image" . }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -100,10 +100,11 @@ data:
 
       {{- if .Values.global.authSidecar.enabled }}
       # enables nginx auth sidecar for airflow deployments
+      {{- $authSidecar := include "authSidecar.image" . }}
       authSideCar:
         enabled: true
-        repository: {{ .Values.global.authSidecar.repository }}
-        tag: {{ .Values.global.authSidecar.tag }}
+        repository: {{ (splitList ":"  $authSidecar ) | first  }}
+        tag: {{ (splitList ":"  $authSidecar ) | last  }}
         port: {{ .Values.global.authSidecar.port }}
         pullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
         annotations: {
@@ -118,7 +119,7 @@ data:
       loggingSidecar:
         enabled: true
         name: {{ .Values.global.loggingSidecar.name }}
-        image: {{ .Values.global.loggingSidecar.image }}
+        image: {{ include "loggingSidecar.image" . }}
         customConfig: {{ .Values.global.loggingSidecar.customConfig }}
         {{- if .Values.global.loggingSidecar.extraEnv}}
         extraEnv: {{- .Values.global.loggingSidecar.extraEnv | toYaml | nindent 8 }}

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -133,7 +133,7 @@ spec:
 {{- end }}
         {{- if .Values.global.authSidecar.enabled }}
         - name: auth-proxy
-          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
+          image: {{ include "authSidecar.image" . }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}

--- a/charts/kibana/templates/kibana-deployment.yaml
+++ b/charts/kibana/templates/kibana-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           protocol: TCP
       {{- if .Values.global.authSidecar.enabled  }}
       - name: auth-proxy
-        image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
+        image: {{ include "authSidecar.image" . }}
         securityContext: {{ template "kibana.securityContext" . }}
         imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
         {{- if .Values.global.authSidecar.resources }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
       containers:
         {{- if .Values.global.authSidecar.enabled  }}
         - name: auth-proxy
-          image: "{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}"
+          image: {{ include "authSidecar.image" . }}
           securityContext: {{ template "prometheus.securityContext" . }}
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,3 +23,19 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{ define "containerd.configToml" -}}
 {{- .Values.global.privateCaCertsAddToHost.containerdConfigToml -}}
 {{- end }}
+
+{{ define "authSidecar.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-auth-sidecar:{{ .Values.global.authSidecar.tag }}
+{{- else -}}
+{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}
+{{- end }}
+{{- end }}
+
+{{ define "loggingSidecar.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-vector:{{ (splitList ":"  .Values.global.loggingSidecar.image ) | last  }}
+{{- else -}}
+{{ .Values.global.loggingSidecar.image }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
## Description

Add a python script that parses the output of `helm template` and finds all the container specs and prints the images that are used in them. This avoids printing containers that are inside of nested yaml like the houston configmap.

```
$ bin/show-docker-images.py --help
usage: show-docker-images.py [-h] [--private-registry] [-v]

options:
  -h, --help          show this help message and exit
  --private-registry
  -v, --verbose
```

## Related Issues

https://github.com/astronomer/issues/issues/6113
https://github.com/astronomer/issues/issues/4862 - fixing this issue as well with this PR

## Testing

I've tested this extensively while developing, which is enough. This is not a product feature and is not customer facing so no QA is needed.

## Merging

This should be merged everywhere.