### PR TITLE
update postgresql version 15.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
-                - quay.io/astronomer/ap-postgresql:15.4.0-1
+                - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1
@@ -425,7 +425,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
-                - quay.io/astronomer/ap-postgresql:15.4.0-1
+                - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-1

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.4.0-1
+  tag: 15.5.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

update postgresql version 15.5.0

## Related Issues

https://github.com/astronomer/issues/issues/6134

## Testing

since we are upgrading from 15.4.0 -> 15.5.0 basic upgrade sanity should be fine

## Merging

cherry-pick to release branches
