### PR TITLE
update vector image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
-                - quay.io/astronomer/ap-vector:0.32.2-1
+                - quay.io/astronomer/ap-vector:0.32.2-3
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
-                - quay.io/astronomer/ap-vector:0.32.2-1
+                - quay.io/astronomer/ap-vector:0.32.2-3
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -136,7 +136,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.32.2-1
+    image: quay.io/astronomer/ap-vector:0.32.2-3
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

update vector image with latest ap-base 
resolves CVE-2023-7104  
## Related Issues

https://github.com/astronomer/issues/issues/5984

## Testing

basic sanity testing is okay 

## Merging

cherry-pick to all valid release branches
