### PR TITLE
update houston api version 0.34.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.3
-                - quay.io/astronomer/ap-houston-api:0.34.2
+                - quay.io/astronomer/ap-houston-api:0.34.3
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.3
-                - quay.io/astronomer/ap-houston-api:0.34.2
+                - quay.io/astronomer/ap-houston-api:0.34.3
                 - quay.io/astronomer/ap-init:3.18.5
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.34.2
+    tag: 0.34.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api version 0.34.3

## Related Issues

Related https://github.com/astronomer/issues/issues/6109
Related https://github.com/astronomer/issues/issues/6131

## Testing

QA should validate above tagged issues

## Merging

cherry-pick to release-0.34
