### PR TITLE
Replace cert copier image

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -48,7 +48,7 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{- end }}
 {{- end }}
 
-{{ define "certCopied.image" -}}
+{{ define "certCopier.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
 {{- else -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -55,3 +55,13 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
 {{- end }}
 {{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "certCopier.imagePullSecrets" -}}
+{{- if and .Values.global.privateRegistry.enabled .Values.global.privateRegistry.secretName }}
+imagePullSecrets:
+  - name: {{ .Values.global.privateRegistry.secretName }}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -47,3 +47,11 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{ .Values.global.loggingSidecar.image }}
 {{- end }}
 {{- end }}
+
+{{ define "certCopied.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+{{- else -}}
+{{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+{{- end }}
+{{- end }}

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -22,12 +22,14 @@ spec:
       maxUnavailable: "100%"
   selector:
     matchLabels:
+      app: containerd-private-ca
       tier: platform
       component: containerd-private-ca
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
+        app: containerd-private-ca
         tier: platform
         component: containerd-private-ca
         release: {{ .Release.Name }}

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
 {{ end }}
       containers:
       - name: cert-copy-and-toml-update
-        image: {{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+        image: {{ include "certCopied.image" . }}
         command:
           - "sh"
           - "-c"

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -40,6 +40,7 @@ spec:
       affinity:
 {{ toYaml .Values.global.privateCaCertsAddToHost.containerdnodeAffinitys  | indent 8 }}
 {{ end }}
+{{- include "certCopier.imagePullSecrets" . | indent 6 }}
       containers:
       - name: cert-copy-and-toml-update
         image: {{ include "certCopier.image" . }}

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -46,7 +46,7 @@ spec:
           - "-c"
         args:
           - sh /cert-copy-and-toml-update.sh
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.privateCaCertsAddToHost.certCopier.pullPolicy }}
         securityContext:
           runAsUser: 0
           privileged: true

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
 {{ end }}
       containers:
       - name: cert-copy-and-toml-update
-        image: {{ include "certCopied.image" . }}
+        image: {{ include "certCopier.image" . }}
         command:
           - "sh"
           - "-c"

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -22,7 +22,6 @@ spec:
       maxUnavailable: "100%"
   selector:
     matchLabels:
-      app: containerd-private-ca
       tier: platform
       component: containerd-private-ca
       release: {{ .Release.Name }}
@@ -33,6 +32,7 @@ spec:
         tier: platform
         component: containerd-private-ca
         release: {{ .Release.Name }}
+        version: {{ .Chart.Version }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/trust-private-ca-on-all-nodes/containerd-ca-update-script.yaml") . | sha256sum }}
     spec:

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:
       - name: cert-copy
-        image: {{ include "certCopied.image" . }}
+        image: {{ include "certCopier.image" . }}
         command:
           - "sh"
           - "-c"

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:
       - name: cert-copy
-        image: {{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+        image: {{ include "certCopied.image" . }}
         command:
           - "sh"
           - "-c"

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -22,12 +22,14 @@ spec:
       maxUnavailable: "100%"
   selector:
     matchLabels:
+      app: private-ca
       tier: platform
       component: private-ca
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
+        app: private-ca
         tier: platform
         component: private-ca
         release: {{ .Release.Name }}

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -22,7 +22,6 @@ spec:
       maxUnavailable: "100%"
   selector:
     matchLabels:
-      app: private-ca
       tier: platform
       component: private-ca
       release: {{ .Release.Name }}
@@ -33,6 +32,7 @@ spec:
         tier: platform
         component: private-ca
         release: {{ .Release.Name }}
+        version: {{ .Chart.Version }}
     spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
       containers:

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -35,6 +35,7 @@ spec:
         version: {{ .Chart.Version }}
     spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
+{{- include "certCopier.imagePullSecrets" . | indent 6 }}
       containers:
       - name: cert-copy
         image: {{ include "certCopier.image" . }}

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
           - "-c"
         args:
           - "while true; do date; cp -v /private-ca-certs/* /host-trust-store/; sleep 10; done"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.privateCaCertsAddToHost.certCopier.pullPolicy }}
         volumeMounts:
         - name: hostcerts
           mountPath: /host-trust-store

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -15,6 +15,9 @@ global:
   pspEnabled: true
   taskUsageMetricsEnabled: True
   veleroEnabled: true
+  privateCaCertsAddToHost:
+    enabled: true
+    addToContainerd: true
 prometheus-node-exporter:
   rbac:
     create: true

--- a/values.yaml
+++ b/values.yaml
@@ -25,8 +25,8 @@ global:
     containerdConfigToml: ~
     containerdnodeAffinitys: []
     certCopier:
-      repository: alpine
-      tag: 3.18
+      repository: quay.io/astronomer/ap-base
+      tag: 3.18.5
       pullPolicy: IfNotPresent
   # Global flag to enable to user to enable/disable Astronomer platform
   # level Network Policy


### PR DESCRIPTION
## Description

move cert copier image alpine:3.18 to astronomer managed quay repo 
alpine:3.18 -> quay.io/astronomer/ap-base:3.18 


## Related Issues

https://github.com/astronomer/issues/issues/6102

## Testing

when global private registry it should auto switch to private registry

## Merging

cherry-pick to all valid branches
