### PR TITLE
Make houston-db-migrations run both pre-upgrade and post-upgrade helm hooks

### DIFF
--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -14,7 +14,7 @@ metadata:
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
-    "helm.sh/hook": pre-upgrade,post-install
+    "helm.sh/hook": pre-upgrade,post-upgrade,post-install
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:


### PR DESCRIPTION
## Description

Workaround to an order-of-operations bug that we discovered. More details in the issue linked below.

## Related Issues

https://github.com/astronomer/issues/issues/6152

## Testing

This solves a problem where houston requires deploys to happen twice before picking up the AU vs resources configuration setting.

## Merging

AFAIK this would only be needed in release-0.34, but the root cause may be happening elsewhere and we haven't noticed.