### PR TITLE
replace cert copier image (#2116)

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -34,3 +34,21 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{ .Values.global.loggingSidecar.image }}
 {{- end }}
 {{- end }}
+
+{{ define "certCopier.image" -}}
+{{- if .Values.global.privateRegistry.enabled -}}
+{{ .Values.global.privateRegistry.repository }}/ap-base:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+{{- else -}}
+{{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the proper Docker Image Registry Secret Names
+*/}}
+{{- define "certCopier.imagePullSecrets" -}}
+{{- if and .Values.global.privateRegistry.enabled .Values.global.privateRegistry.secretName }}
+imagePullSecrets:
+  - name: {{ .Values.global.privateRegistry.secretName }}
+{{- end -}}
+{{- end -}}

--- a/templates/trust-private-ca-on-all-nodes/daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/daemonset.yaml
@@ -28,20 +28,23 @@ spec:
   template:
     metadata:
       labels:
+        app: private-ca
         tier: platform
         component: private-ca
         release: {{ .Release.Name }}
+        version: {{ .Chart.Version }}
     spec:
       serviceAccountName: {{ .Release.Name }}-private-ca
+{{- include "certCopier.imagePullSecrets" . | indent 6 }}
       containers:
       - name: cert-copy
-        image: {{ .Values.global.privateCaCertsAddToHost.certCopier.repository }}:{{ .Values.global.privateCaCertsAddToHost.certCopier.tag }}
+        image: {{ include "certCopier.image" . }}
         command:
           - "sh"
           - "-c"
         args:
           - "while true; do date; cp -v /private-ca-certs/* /host-trust-store/; sleep 10; done"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.global.privateCaCertsAddToHost.certCopier.pullPolicy }}
         volumeMounts:
         - name: hostcerts
           mountPath: /host-trust-store

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -15,6 +15,8 @@ global:
   pspEnabled: true
   taskUsageMetricsEnabled: True
   veleroEnabled: true
+  privateCaCertsAddToHost:
+    enabled: true
 prometheus-node-exporter:
   rbac:
     create: true

--- a/values.yaml
+++ b/values.yaml
@@ -20,8 +20,8 @@ global:
     enabled: false
     hostDirectory: /etc/docker/certs.d
     certCopier:
-      repository: alpine
-      tag: 3.18
+      repository: quay.io/astronomer/ap-base
+      tag: 3.18.4-2
       pullPolicy: IfNotPresent
   # Global flag to enable to user to enable/disable Astronomer platform
   # level Network Policy


### PR DESCRIPTION
## Description

move cert copier image alpine:3.18 to astronomer managed quay repo

## Related Issues

https://github.com/astronomer/issues/issues/6102

## Testing

when global private registry it should auto switch to private registry

## Merging

cherry-pick to release-0.32
