### PR TITLE
update base and circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,13 +360,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-6
-                - quay.io/astronomer/ap-base:3.18.5
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-7
+                - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-6
+                - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.10
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -374,12 +374,12 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.3
                 - quay.io/astronomer/ap-houston-api:0.34.4
-                - quay.io/astronomer/ap-init:3.18.5
+                - quay.io/astronomer/ap-init:3.18.6
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0
-                - quay.io/astronomer/ap-nats-server:2.10.9-1
-                - quay.io/astronomer/ap-nats-streaming:0.25.6
+                - quay.io/astronomer/ap-nats-exporter:0.14.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.9-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-1
                 - quay.io/astronomer/ap-nginx-es:1.25.3
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
-                - quay.io/astronomer/ap-vector:0.32.2-3
+                - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -399,13 +399,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-6
-                - quay.io/astronomer/ap-base:3.18.5
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-7
+                - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
                 - quay.io/astronomer/ap-cli-install:0.26.21
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-6
+                - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.10
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -413,12 +413,12 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.3
                 - quay.io/astronomer/ap-houston-api:0.34.4
-                - quay.io/astronomer/ap-init:3.18.5
+                - quay.io/astronomer/ap-init:3.18.6
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0
-                - quay.io/astronomer/ap-nats-server:2.10.9-1
-                - quay.io/astronomer/ap-nats-streaming:0.25.6
+                - quay.io/astronomer/ap-nats-exporter:0.14.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.9-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-1
                 - quay.io/astronomer/ap-nginx-es:1.25.3
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.5.0
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
-                - quay.io/astronomer/ap-vector:0.32.2-3
+                - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - twistcli
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.5
+    tag: 3.18.6
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-6
+    tag: 8.0.8-7
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-6
+    tag: 1.5.0-7
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.5
+    tag: 3.18.6
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.9-1
+    tag: 2.10.9-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0
+    tag: 0.14.0-1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.5
+    tag: 3.18.6
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6
+    tag: 0.25.6-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0
+    tag: 0.14.0-1
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -26,7 +26,7 @@ global:
     containerdnodeAffinitys: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.18.5
+      tag: 3.18.6
       pullPolicy: IfNotPresent
   # Global flag to enable to user to enable/disable Astronomer platform
   # level Network Policy
@@ -136,7 +136,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.32.2-3
+    image: quay.io/astronomer/ap-vector:0.32.2-4
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Update AP base image from 3.18.5 --> 3.18.6

imageName | oldTag | newTag | CVE-UPDATES
-- | -- | -- | --
ap-base | 3.18.5 | 3.18.6
ap-awsesproxy | 1.5.0-6 | 1.5.0-7 | CVE-2023-6129, CVE-2023-6237
ap-blackbox-exporter | 0.24.0-5 | 0.24.0-6  | CVE-2023-6129, CVE-2023-6237
ap-curator | 8.0.8-6 |8.0.8-7 | CVE-2023-6129, CVE-2023-6237
ap-git-daemon | 3.18.5 | 3.18.6 | CVE-2023-6129, CVE-2023-6237
ap-git-sync-relay | 0.0.3-1 | 0.0.3-2
ap-init | 3.18.5 | 3.18.6 | CVE-2023-6129, CVE-2023-6237
ap-nats-exporter | 0.14.0 | 0.14.0-1 | CVE-2023-6129, CVE-2023-6237
ap-nats-server | 2.10.9-1 | 2.10.9-2
ap-nats-streaming | 0.25.6 | 0.25.6-1 | CVE-2023-29406, CVE-2023-29409, <br /> CVE-2023-39318,  CVE-2023-39319 , <br /> CVE-2023-39323, CVE-2023-46129, <br /> CVE-2023-47090, CVE-2023-46129
ap-pgbouncer-exporter | 0.15.0-5 |0.15.0-6 | CVE-2023-6129, CVE-2023-6237
ap-postgres-exporter | 0.15.0-3 | 0.15.0-4 | CVE-2023-6129, CVE-2023-6237
ap-vector | 0.32.2-3 | 0.32.2-4 | CVE-2024-0684, CVE-2024-0684

## Related Issues

https://github.com/astronomer/issues/issues/6159

## Testing

NA

## Merging

cherry-pick to all valid branches
