### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
+                - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
@@ -380,13 +380,13 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.14.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
-                - quay.io/astronomer/ap-nginx-es:1.25.3
+                - quay.io/astronomer/ap-nginx-es:1.25.3-1
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
-                - quay.io/astronomer/ap-postgresql:15.5.0
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
+                - quay.io/astronomer/ap-postgresql:15.5.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-4
@@ -398,7 +398,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.2-3
+                - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
@@ -419,13 +419,13 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.14.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
-                - quay.io/astronomer/ap-nginx-es:1.25.3
+                - quay.io/astronomer/ap-nginx-es:1.25.3-1
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-9
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-3
-                - quay.io/astronomer/ap-postgresql:15.5.0
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
+                - quay.io/astronomer/ap-postgresql:15.5.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.3
                 - quay.io/astronomer/ap-registry:3.18.5-1
                 - quay.io/astronomer/ap-vector:0.32.2-4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
-                - quay.io/astronomer/ap-cli-install:0.26.21
+                - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
@@ -402,7 +402,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
-                - quay.io/astronomer/ap-cli-install:0.26.21
+                - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
@@ -388,7 +388,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
                 - quay.io/astronomer/ap-postgresql:15.5.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.3
-                - quay.io/astronomer/ap-registry:3.18.5-1
+                - quay.io/astronomer/ap-registry:3.18.6
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - slack_team-software-infra-bot
@@ -401,7 +401,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-5
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
@@ -427,7 +427,7 @@ workflows:
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
                 - quay.io/astronomer/ap-postgresql:15.5.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.3
-                - quay.io/astronomer/ap-registry:3.18.5-1
+                - quay.io/astronomer/ap-registry:3.18.6
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - twistcli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.10
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.11
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
@@ -406,7 +406,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.10
+                - quay.io/astronomer/ap-db-bootstrapper:0.31.11
                 - quay.io/astronomer/ap-default-backend:0.28.22
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -368,7 +368,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
-                - quay.io/astronomer/ap-default-backend:0.28.22
+                - quay.io/astronomer/ap-default-backend:0.28.23
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
@@ -407,7 +407,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
-                - quay.io/astronomer/ap-default-backend:0.28.22
+                - quay.io/astronomer/ap-default-backend:0.28.23
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.25.3-1
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
-                - quay.io/astronomer/ap-openresty:1.25.3
+                - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
                 - quay.io/astronomer/ap-postgresql:15.5.0-1
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.25.3-1
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
-                - quay.io/astronomer/ap-openresty:1.25.3
+                - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
                 - quay.io/astronomer/ap-postgresql:15.5.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.5-1
+    tag: 3.18.6
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.10
+    tag: 0.31.11
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.21
+    tag: 0.26.22
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.3
+    tag: 1.25.3-1
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.25.3
+    tag: 1.25.3-1
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.10
+    tag: 0.31.11
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.10
+    tag: 0.31.11
     pullPolicy: IfNotPresent
 
 

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.22
+    tag: 0.28.23
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-9
+  tag: 1.17.0-10
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.5.0
+  tag: 15.5.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-5
+  tag: 0.24.0-6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-3
+  tag: 0.15.0-4
   pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -152,7 +152,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.2-3
+    tag: 1.25.3-1
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-auth-sidecar | 1.25.2-3 | 1.25.3-1 |
| ap-blackbox-exporter| 0.24.0-5 | 0.24.0-6 |
| ap-cli-install | 0.26.21 | 0.26.22 |
| ap-db-bootstrapper | 0.31.10 | 0.31.11 |
| ap-default-backend | 0.28.22 | 0.28.23 | 
|ap-nginx-es| 1.25.3|1.25.3-1|
|ap-pgbouncer-krb| 1.17.0-9 | 1.17.0-10 |
| ap-postgres-exporter| 0.15.0-3 | 0.15.0-4
|ap-postgresql|15.5.0|15.5.0-1

## Related Issues

https://github.com/astronomer/issues/issues/6159

## Testing

NA

## Merging

cherry-pick to all valid release branches
