### PR TITLE
astro-ui 0.32.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,7 +358,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.32.9
+                - quay.io/astronomer/ap-astro-ui:0.32.10
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
@@ -397,7 +397,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.26.0
-                - quay.io/astronomer/ap-astro-ui:0.32.9
+                - quay.io/astronomer/ap-astro-ui:0.32.10
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.32.9
+    tag: 0.32.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

 updating astro-ui image from 0.32.9 to 0.32.10

## Related Issues

https://github.com/astronomer/astro-ui/pull/1701

## Testing

QA should able to validate above linked issue

## Merging

cherry-pick to release-0.32
