### PR TITLE
update airflow commander version 1.8.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.22
-                - quay.io/astronomer/ap-commander:0.32.11
+                - quay.io/astronomer/ap-commander:0.32.12
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
@@ -403,7 +403,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.22
-                - quay.io/astronomer/ap-commander:0.32.11
+                - quay.io/astronomer/ap-commander:0.32.12
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.8-7
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.8.9
+airflowChartVersion: 1.8.10
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.32.11
+    tag: 0.32.12
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update airflow commander version 1.8.10

## Related Issues

NA

## Testing

QA should verify generic flow

## Merging

cherry-pick to release-0.32
