### PR TITLE
add additional scrape jobs for prometheus

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -723,3 +723,13 @@ data:
             regex: ([^:]+)(?::\d+)?;(\d+)
             replacement: $1:$2
             target_label: __address__
+
+    {{- if .Values.additionalScrapeJobs }}
+    {{- range .Values.additionalScrapeJobs }}
+      - job_name: '{{ .job_name }}'
+        kubernetes_sd_configs:
+    {{ toYaml .kubernetes_sd_configs | indent 8 }}
+        relabel_configs:
+    {{ toYaml .relabel_configs | indent 8 }}
+    {{- end }}
+    {{- end }}

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -724,12 +724,6 @@ data:
             replacement: $1:$2
             target_label: __address__
 
-    {{- if .Values.additionalScrapeJobs }}
-    {{- range .Values.additionalScrapeJobs }}
-      - job_name: '{{ .job_name }}'
-        kubernetes_sd_configs:
-    {{ toYaml .kubernetes_sd_configs | indent 8 }}
-        relabel_configs:
-    {{ toYaml .relabel_configs | indent 8 }}
-    {{- end }}
+    {{- with .Values.additionalScrapeJobs }}
+    {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -138,6 +138,23 @@ additionalAlerts:
 #     annotations:
 #       summary: "The Astronomer Helm release {{ .Release.Name }} is failing task instances {{ printf \"%.2f\" $value }}% of the time over the past 30 minutes"
 #       description: Task instances failing above threshold
+additionalScrapeJobs: {}
+# Example:
+# additionalScrapeJobs:
+#   - job_name: 'my-job'
+#     kubernetes_sd_configs:
+#       - role: endpoints
+#     relabel_configs:
+#       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+#         action: keep
+#         regex: true
+#       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+#         action: replace
+#         target_label: __scheme__
+#         regex: (https?)
+#       - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+#         action: replace
+#
 
 # Prometheus config file remote_write stanza
 # https://prometheus.io/docs/prometheus/latest/configuration/configuration/

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -313,7 +313,7 @@ class TestPrometheusConfigConfigmap:
             name="astronomer",
             values={
                 "prometheus": {
-                    "extraScrapeJobs": [
+                    "additionalScrapeJobs": [
                         {
                             "job_name": "example-static-job",
                             "static_configs": [{"targets": ["localhost:9090"]}],
@@ -330,10 +330,8 @@ class TestPrometheusConfigConfigmap:
                     ]
                 }
             },
-        )
-
-        config_map = yaml.safe_load(doc[0])
-        prometheus_config = yaml.safe_load(config_map["data"]["prometheus.yml"])
+        )[0]
+        prometheus_config = yaml.safe_load(doc["data"]["config"])
 
         found_static_job = False
         found_kubernetes_job = False


### PR DESCRIPTION
## Description

We want to scrape other services like ie: Push gateway running on the same cluster and we need to be able to modify the Prometheus configuration. 


is this something that could be supported by Astronomer? 

