### PR TITLE
Update ap verdor packages 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.26.0
+                - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
@@ -366,13 +366,13 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-7
+                - quay.io/astronomer/ap-curator:8.0.9
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
                 - quay.io/astronomer/ap-default-backend:0.28.23
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.2.3
+                - quay.io/astronomer/ap-grafana:10.2.4
                 - quay.io/astronomer/ap-houston-api:0.34.4
                 - quay.io/astronomer/ap-init:3.18.6
                 - quay.io/astronomer/ap-kibana:8.11.4
@@ -380,14 +380,14 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.14.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
-                - quay.io/astronomer/ap-nginx-es:1.25.3-1
+                - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
-                - quay.io/astronomer/ap-postgresql:15.5.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.3
+                - quay.io/astronomer/ap-postgresql:15.6.0
+                - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:
@@ -396,7 +396,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.26.0
+                - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
@@ -405,13 +405,13 @@ workflows:
                 - quay.io/astronomer/ap-cli-install:0.26.22
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.8-7
+                - quay.io/astronomer/ap-curator:8.0.9
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
                 - quay.io/astronomer/ap-default-backend:0.28.23
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.2.3
+                - quay.io/astronomer/ap-grafana:10.2.4
                 - quay.io/astronomer/ap-houston-api:0.34.4
                 - quay.io/astronomer/ap-init:3.18.6
                 - quay.io/astronomer/ap-kibana:8.11.4
@@ -419,14 +419,14 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.14.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
-                - quay.io/astronomer/ap-nginx-es:1.25.3-1
+                - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.5
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
-                - quay.io/astronomer/ap-postgresql:15.5.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.3
+                - quay.io/astronomer/ap-postgresql:15.6.0
+                - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.26.0
+    tag: 0.27.0
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.8-7
+    tag: 8.0.9
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.25.3-1
+    tag: 1.25.4
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.2.3
+    tag: 10.2.4
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.5.0-1
+  tag: 15.6.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.3
+    tag: 2.45.4
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-postgresql|15.5.0-1|15.6.0
|ap-curator|8.0.8-7|8.0.9
|ap-grafana|10.2.3|10.2.4
|ap-alertmanager|0.26.0|0.27.0
|ap-prometheus|2.45.3|2.45.4
|ap-nginx-es|1.25.3-1|1.25.4


## Related Issues
https://github.com/astronomer/issues/issues/6188

## Testing

NA

## Merging

cherry-pick to all valid release branches
