### PR TITLE
Update nginx version 1.9.5 -> 1.9.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
                 - quay.io/astronomer/ap-nginx-es:1.25.3-1
-                - quay.io/astronomer/ap-nginx:1.9.5
+                - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.9-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-1
                 - quay.io/astronomer/ap-nginx-es:1.25.3-1
-                - quay.io/astronomer/ap-nginx:1.9.5
+                - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.5
+    tag: 1.9.6
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -62,6 +62,11 @@ def test_nginx_can_reach_default_backend(nginx):
         "curl -s --max-time 1 http://astronomer-nginx-default-backend:8080"
     )
 
+def test_nginx_ssl_cache(nginx):
+    """Ensure default nginx cache size if 10m."""
+    assert "ssl_session_cache shared:SSL:10m;" == nginx.check_output(
+        "cat nginx.conf | grep ssl_session_cache"
+    ).replace('\t',"")
 
 @pytest.mark.flaky(reruns=20, reruns_delay=10)
 def test_prometheus_targets(prometheus):

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -62,11 +62,13 @@ def test_nginx_can_reach_default_backend(nginx):
         "curl -s --max-time 1 http://astronomer-nginx-default-backend:8080"
     )
 
+
 def test_nginx_ssl_cache(nginx):
-    """Ensure default nginx cache size if 10m."""
+    """Ensure nginx default ssl cache size is 10m."""
     assert "ssl_session_cache shared:SSL:10m;" == nginx.check_output(
         "cat nginx.conf | grep ssl_session_cache"
-    ).replace('\t',"")
+    ).replace("\t", "")
+
 
 @pytest.mark.flaky(reruns=20, reruns_delay=10)
 def test_prometheus_targets(prometheus):


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-nginx|1.9.5|1.9.6

## Related Issues
https://github.com/astronomer/issues/issues/6188

## Testing

NA

## Merging

cherry-pick to all valid release branches
