### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,16 +359,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.4
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
-                - quay.io/astronomer/ap-cli-install:0.26.22
+                - quay.io/astronomer/ap-cli-install:0.26.23
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.9
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
-                - quay.io/astronomer/ap-default-backend:0.28.23
+                - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3
@@ -398,16 +398,16 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.3
-                - quay.io/astronomer/ap-auth-sidecar:1.25.3-1
+                - quay.io/astronomer/ap-auth-sidecar:1.25.4
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-7
                 - quay.io/astronomer/ap-base:3.18.6
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
-                - quay.io/astronomer/ap-cli-install:0.26.22
+                - quay.io/astronomer/ap-cli-install:0.26.23
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.9
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.11
-                - quay.io/astronomer/ap-default-backend:0.28.23
+                - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.11.4
                 - quay.io/astronomer/ap-fluentd:1.16.3

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.22
+    tag: 0.26.23
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.23
+    tag: 0.28.24
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -152,7 +152,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.3-1
+    tag: 1.25.4
     pullPolicy: IfNotPresent
     port: 8084
     default_nginx_settings: |


### PR DESCRIPTION
## Description

update ap-vendor and platform packages

| imagName | oldTag | newTag |
|--------|--------|--------|
| ap-auth-sidecar  | 1.25.3-1 | 1.25.4 |
| ap-cli-install | 0.26.22 | 0.26.23 |
| ap-default-backend | 0.28.23 | 0.28.24 |
## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
