### PR TITLE
Add check for Calico CRDs for each tested k8s version

### DIFF
--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -30,6 +30,14 @@ def list_docker_images():
 
 def main():
     """Render the Jinja2 template file."""
+    for version in kube_versions:
+        maj_min = version.rpartition(".")[0]
+        if not Path(
+            git_root_dir / "bin" / "kind" / f"calico-crds-v{maj_min}.yaml"
+        ).exists():
+            raise SystemExit(
+                f"ERROR: calico-crds-v{maj_min}.yaml is required for for CircleCI to succeed but it does not exist!"
+            )
     config_file_template_path = git_root_dir / ".circleci" / "config.yml.j2"
     config_file_path = git_root_dir / ".circleci" / "config.yml"
 


### PR DESCRIPTION
## Description

Abort `bin/generate_circleci_config.py` if Calico CRDs are not found for k8s versions that are being added to `.circleci/config.yml`. This has bitten us before, and it's not a huge deal, but it is wasteful and time consuming to have to go through that iteration.

I canceled CI because no CI-facing code changed. This is strictly a developer local-workstation change.

## Related Issues

https://github.com/astronomer/issues/issues/6240

## Testing

This is strictly a dev workflow improvement, not customer facing, and does not change the shipped product in any way, so no QA is needed.

## Merging

Merge everywhere.