### PR TITLE
Update ap-base image and nat-server version 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,13 +360,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.4
                 - quay.io/astronomer/ap-auth-sidecar:1.25.4
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-7
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.23
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.13
+                - quay.io/astronomer/ap-curator:8.0.13-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.12
                 - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -377,18 +377,18 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.9-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-1
+                - quay.io/astronomer/ap-nats-exporter:0.14.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.10
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-2
                 - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
                 - quay.io/astronomer/ap-postgresql:15.6.0
                 - quay.io/astronomer/ap-prometheus:2.45.4
-                - quay.io/astronomer/ap-registry:3.18.6
+                - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - slack_team-software-infra-bot
@@ -399,13 +399,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0
                 - quay.io/astronomer/ap-astro-ui:0.34.4
                 - quay.io/astronomer/ap-auth-sidecar:1.25.4
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-7
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-6
+                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.23
                 - quay.io/astronomer/ap-commander:0.34.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.13
+                - quay.io/astronomer/ap-curator:8.0.13-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.31.12
                 - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -416,18 +416,18 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.11.4
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.9-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-1
+                - quay.io/astronomer/ap-nats-exporter:0.14.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.10
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-2
                 - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.7.0
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-10
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-4
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
                 - quay.io/astronomer/ap-postgresql:15.6.0
                 - quay.io/astronomer/ap-prometheus:2.45.4
-                - quay.io/astronomer/ap-registry:3.18.6
+                - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.32.2-4
           context:
             - twistcli

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.6
+    tag: 3.18.6-2
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.13
+    tag: 8.0.13-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-7
+    tag: 1.5.0-8
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.9-2
+    tag: 2.10.10
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0-1
+    tag: 0.14.0-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-10
+  tag: 1.17.0-11
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-6
+  tag: 0.24.0-7
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-4
+  tag: 0.15.0-5
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-1
+    tag: 0.25.6-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0-1
+    tag: 0.14.0-2
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-nats-server |2.10.9-2|2.10.10
|ap-base| 3.18.6| 3.18.6-1
|ap-awsesproxy| 1.5.0-7 | 1.5.0-8
|ap-blackbox-exporter| 0.24.0-6 | 0.24.0-7
|ap-curator | 8.0.13| 8.0.13-1
|ap-nats-exporter| 0.14.0-1| 0.14.0-2
|ap-nats-streaming| 0.25.6-1| 0.25.6-2
|ap-pgbouncer-krb| 1.17.0-10 | 1.17.0-11
|ap-postgres-exporter|0.15.0-4|0.15.0-5
|ap-registry| 3.18.6-1|3.18.6-2


## Related Issues
https://github.com/astronomer/issues/issues/6188

## Testing

NA

## Merging

cherry-pick to all valid release branches
