### PR TITLE
update postgresql base image version 15.6.0-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,7 +386,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
-                - quay.io/astronomer/ap-postgresql:15.6.0
+                - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.32.2-4
@@ -425,7 +425,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
-                - quay.io/astronomer/ap-postgresql:15.6.0
+                - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.32.2-4

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.6.0
+  tag: 15.6.0-1
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

update postgresql base image version 15.6.0-1

## Related Issues

https://github.com/astronomer/issues/issues/6248

## Testing

NA

## Merging

cherry-pick to release-0.34