### PR TITLE
fix jetstream client certificate mount path

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -278,7 +278,7 @@ s3:
 - name: nats-jetstream-client-tls-volume
   mountPath: {{ include "houston.jetStreamSSLCertificateDir" . }}/{{ $secretName }}
 - name: nats-jetstream-client-tls-volume
-  mountPath: /usr/local/share/ca-certificates/{{ $secretName }}/ca.crt
+  mountPath: /usr/local/share/ca-certificates/{{ $secretName }}.crt
   subPath: ca.crt
 {{- end }}
 {{- end }}

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -66,7 +66,7 @@ imagePullSecrets:
 
 
 {{ define "nats.jestreamTLSSecret" -}}
-{{ default (printf "%s-jetstream-tls-certificate" .Release.Name) .Values.global.nats.jetstreamSSLSecretName }}
+{{ default (printf "%s-jetstream-tls-certificate" .Release.Name)}}
 {{- end }}
 
 {{- define "nats.securityContext" -}}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -54,7 +54,6 @@ nats:
     lameDuckDuration:
 
   regenerateCaEachUpgrade: false
-  jetstreamSSLSecretName: ~
 
   jetstream:
     enabled: false

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -99,7 +99,7 @@ class TestNatsJetstream:
         } in docs[10]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
         assert {
             "name": "nats-jetstream-client-tls-volume",
-            "mountPath": "/usr/local/share/ca-certificates/release-name-jetstream-tls-certificate-client/ca.crt",
+            "mountPath": "/usr/local/share/ca-certificates/release-name-jetstream-tls-certificate-client.crt",
             "subPath": "ca.crt",
         } in docs[10]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
         assert {


### PR DESCRIPTION
## Description

This PR fixes an issue where mounted client side tls are not respected by the system path due long nested path. 

## Related Issues
https://github.com/astronomer/issues/issues/6259
## Testing

QA should not see any TLS error in nats service

## Merging

cherry-pick to release-0.34
