### PR TITLE
Update ap-vector version 0.32.2-4 -> 0.33.1-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6-2
-                - quay.io/astronomer/ap-vector:0.32.2-4
+                - quay.io/astronomer/ap-vector:0.33.1-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.4
                 - quay.io/astronomer/ap-registry:3.18.6-2
-                - quay.io/astronomer/ap-vector:0.32.2-4
+                - quay.io/astronomer/ap-vector:0.33.1-1
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -136,7 +136,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.32.2-4
+    image: quay.io/astronomer/ap-vector:0.33.1-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

imageName | oldTag |new tag | 
-- | -- | -- |
ap-vector| 0.32.2-4 | 0.33.1-1

## Related Issues
https://github.com/astronomer/issues/issues/6188


## Testing
After enabling sidecar with create deployments with previous version of sidecar , after deployment comes up update to newer version of sidecar to see if it still works fine and able to view and query logs in the UI and kibana.

## Merging
cherry-pick to all valid release branches