### PR TITLE
remove duplicate annotation in nats statefulset

### DIFF
--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -33,6 +33,10 @@ spec:
         {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
+      {{- if and  .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
+        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
+      {{- end }}
+        checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         tier: astronomer
         app: {{ template "nats.name" . }}
@@ -40,11 +44,6 @@ spec:
         release: {{ .Release.Name }}
         component: nats
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-      annotations:
-        {{- if and  .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
-        {{- end }}
-        checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
 {{- include "nats.imagePullSecrets" . | indent 6 }}
 {{- if eq .Values.global.openshiftEnabled false }}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -22,8 +22,11 @@ spec:
   serviceName: {{ template "nats.name" . }}
   template:
     metadata:
-      {{- if or .Values.podAnnotations .Values.exporter.enabled }}
       annotations:
+        checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if and  .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
+        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
+      {{- end }}
       {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "7777"
@@ -32,11 +35,6 @@ spec:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- end }}
-      {{- if and  .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
-      {{- end }}
-        checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         tier: astronomer
         app: {{ template "nats.name" . }}

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -203,3 +203,38 @@ class TestNatsStatefulSet:
 
         nats_cm = docs[0]["data"]["nats.conf"]
         assert "release-name-astronats" in nats_cm
+
+    def test_nats_statefulset_template_annotation_defaults(self, kube_version):
+        """Test that nats template default annotations."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/nats/templates/statefulset.yaml"],
+        )
+        doc = docs[0]
+        assert {
+            "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
+            "prometheus.io/path": "/metrics",
+            "prometheus.io/port": "7777",
+            "prometheus.io/scrape": "true",
+        } == doc["spec"]["template"]["metadata"]["annotations"]
+
+    def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(
+        self, kube_version
+    ):
+        """Test that nats template default annotations."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/nats/templates/statefulset.yaml"],
+            values={
+                "nats": {
+                    "podAnnotations": {
+                        "app.test.io": "sampleannotation",
+                    }
+                }
+            },
+        )
+        doc = docs[0]
+        assert (
+            "sampleannotation"
+            in doc["spec"]["template"]["metadata"]["annotations"]["app.test.io"]
+        )

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -211,12 +211,12 @@ class TestNatsStatefulSet:
             show_only=["charts/nats/templates/statefulset.yaml"],
         )
         doc = docs[0]
-        assert {
+        assert set({
             "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
             "prometheus.io/path": "/metrics",
             "prometheus.io/port": "7777",
             "prometheus.io/scrape": "true",
-        } == doc["spec"]["template"]["metadata"]["annotations"]
+        }.keys()) == set(doc["spec"]["template"]["metadata"]["annotations"]).keys()
 
     def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(
         self, kube_version

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -211,17 +211,14 @@ class TestNatsStatefulSet:
             show_only=["charts/nats/templates/statefulset.yaml"],
         )
         doc = docs[0]
-        assert (
-            set(
-                {
-                    "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
-                    "prometheus.io/path": "/metrics",
-                    "prometheus.io/port": "7777",
-                    "prometheus.io/scrape": "true",
-                }.keys()
-            )
-            == set(doc["spec"]["template"]["metadata"]["annotations"]).keys()
-        )
+        assert set(
+            {
+                "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "7777",
+                "prometheus.io/scrape": "true",
+            }.keys()
+        ) == set(doc["spec"]["template"]["metadata"]["annotations"].keys())
 
     def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(
         self, kube_version

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -211,12 +211,17 @@ class TestNatsStatefulSet:
             show_only=["charts/nats/templates/statefulset.yaml"],
         )
         doc = docs[0]
-        assert set({
-            "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
-            "prometheus.io/path": "/metrics",
-            "prometheus.io/port": "7777",
-            "prometheus.io/scrape": "true",
-        }.keys()) == set(doc["spec"]["template"]["metadata"]["annotations"]).keys()
+        assert (
+            set(
+                {
+                    "checksum/nats-config": "8173240e8d81e0c797b3ce1c4a97b3031176e057483524bc185419df1d52b54a",
+                    "prometheus.io/path": "/metrics",
+                    "prometheus.io/port": "7777",
+                    "prometheus.io/scrape": "true",
+                }.keys()
+            )
+            == set(doc["spec"]["template"]["metadata"]["annotations"]).keys()
+        )
 
     def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(
         self, kube_version


### PR DESCRIPTION
combined config from two metadata.annotations

## Description

There are two annotation sections in the NATS statefulsets, 

## Related Issues

fixes: https://github.com/astronomer/issues/issues/6284

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
