### PR TITLE
Add pdb patch permissions to commander role

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -133,7 +133,7 @@ rules:
   verbs: ["create", "delete", "list", "watch"]
 - apiGroups: ["policy"]
   resources: ["poddisruptionbudgets"]
-  verbs: ["create", "delete", "get", "list", "watch"]
+  verbs: ["create", "delete", "get", "list", "patch", "watch"]
 {{- if $useClusterRoles }}
 # permissions for "nonResourceURLs" can only be applied on ClusterRoles
 - nonResourceURLs: ["/metrics"]


### PR DESCRIPTION
## Description

Add PodDisruptionBudget permissions to commander role

## Related Issues

https://github.com/astronomer/issues/issues/6295

## Testing

Unfortunately I do not know of a good way to test this automatically without writing a bunch of involved functional test code.

QA can test this by:
1. Install this version of the astronomer chart with pdb enabled (`global.podDisruptionBudgetsEnabled=true`)
2. Create a new airflow deployment
3. Upgrade the airflow deployment by creating a new env var or something
4. Verify that the upgrade succeeded and no `patch` error occurred.

## Merging

This should be merged everywhere since it is a permission bug that will affect all of our versions and the fix is small and easy.