### PR TITLE
update db bootstrapper image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.34.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.13-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.12
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.0
                 - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
@@ -406,7 +406,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.34.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.13-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.31.12
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.0
                 - quay.io/astronomer/ap-default-backend:0.28.24
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.12
+    tag: 0.35.0
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.12
+    tag: 0.35.0
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.31.12
+    tag: 0.35.0
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

update db bootstrapper image to support mysql and postgresql

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

## Testing

QA should validate that bootstrapper recognises the connection string and creates secret if any of supported db are found

## Merging

cherry-pick to release-0.35
