### PR TITLE
add support for authsidecar security context

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -107,6 +107,9 @@ data:
         tag: {{ (splitList ":"  $authSidecar ) | last  }}
         port: {{ .Values.global.authSidecar.port }}
         pullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
+        {{- if .Values.global.authSidecar.securityContext}}
+        securityContext: {{- .Values.global.authSidecar.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         annotations: {
           {{- range $key, $value := .Values.global.extraAnnotations}}
           {{ $key }}: {{ $value | quote }},

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -5,6 +5,15 @@ import yaml
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
+def common_houston_config_test_cases(docs):
+    """Test some things that should apply to all cases."""
+    assert len(docs) == 1
+    doc = docs[0]
+    assert doc["kind"] == "ConfigMap"
+    assert doc["apiVersion"] == "v1"
+    assert doc["metadata"]["name"] == "release-name-houston-config"
+
+
 
 @pytest.mark.parametrize(
     "kube_version",
@@ -144,14 +153,9 @@ class TestAuthSidecar:
             ],
         )
 
-        assert len(docs) == 1
-        doc = docs[0]
+        common_houston_config_test_cases(docs)
 
-        assert doc["kind"] == "ConfigMap"
-        assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "release-name-houston-config"
-
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         expected_output = {
             "enabled": True,
             "repository": "someregistry.io/my-custom-image",
@@ -184,12 +188,9 @@ class TestAuthSidecar:
             ],
         )
 
-        assert len(docs) == 1
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert doc["kind"] == "ConfigMap"
-        assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "release-name-houston-config"
+        common_houston_config_test_cases(docs)
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        
 
         expected_output = {
             "enabled": True,
@@ -225,13 +226,8 @@ class TestAuthSidecar:
             ],
         )
 
-        assert len(docs) == 1
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert doc["kind"] == "ConfigMap"
-        assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "release-name-houston-config"
-
+        common_houston_config_test_cases(docs)
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         expected_output = {
             "enabled": True,
             "repository": "someregistry.io/my-custom-image",

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -203,3 +203,44 @@ class TestAuthSidecar:
             },
         }
         assert expected_output == prod["deployments"]["authSideCar"]
+
+    def test_authSidecar_houston_configmap_with_securityContext(self, kube_version):
+        """Test Houston Configmap with authSidecar securityContext."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "authSidecar": {
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "securityContext": {
+                            "runAsUser": 1000,
+                        },
+                    },
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/houston/houston-configmap.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-houston-config"
+
+        expected_output = {
+            "enabled": True,
+            "repository": "someregistry.io/my-custom-image",
+            "tag": "my-custom-tag",
+            "port": 8084,
+            "pullPolicy": "IfNotPresent",
+            "securityContext": {
+                "runAsUser": 1000,
+            },
+            "annotations": {}
+        }
+        assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -5,6 +5,7 @@ import yaml
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
+
 def common_houston_config_test_cases(docs):
     """Test some things that should apply to all cases."""
     assert len(docs) == 1
@@ -12,7 +13,6 @@ def common_houston_config_test_cases(docs):
     assert doc["kind"] == "ConfigMap"
     assert doc["apiVersion"] == "v1"
     assert doc["metadata"]["name"] == "release-name-houston-config"
-
 
 
 @pytest.mark.parametrize(
@@ -190,7 +190,6 @@ class TestAuthSidecar:
 
         common_houston_config_test_cases(docs)
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-        
 
         expected_output = {
             "enabled": True,

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -241,6 +241,6 @@ class TestAuthSidecar:
             "securityContext": {
                 "runAsUser": 1000,
             },
-            "annotations": {}
+            "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/values.yaml
+++ b/values.yaml
@@ -155,6 +155,8 @@ global:
     tag: 1.25.4
     pullPolicy: IfNotPresent
     port: 8084
+    securityContext:
+      runAsUser: 1000
     default_nginx_settings: |
       internal;
       proxy_pass_request_body     off;

--- a/values.yaml
+++ b/values.yaml
@@ -156,8 +156,7 @@ global:
     tag: 1.25.4
     pullPolicy: IfNotPresent
     port: 8084
-    securityContext:
-      runAsUser: 1000
+    securityContext: {}
     default_nginx_settings: |
       internal;
       proxy_pass_request_body     off;


### PR DESCRIPTION
## Description

add security context support for auth sidecar service

## Related Issues

https://github.com/astronomer/issues/issues/6328

## Testing

QA should validate passing securityContext from helm values to see if it gets interpretted to airflow components for more info on testing check the issues

## Merging

cherry-pick to release-0.35
