### PR TITLE
move dag server resource to new supported format

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -155,9 +155,9 @@ data:
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.resources }}
         server:
-          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
+          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         client:
-          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
+          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         {{- end }}
       {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -154,7 +154,10 @@ data:
         securityContext: {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 10 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.resources }}
-        resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
+        server:
+          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
+        client:
+          resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -53,12 +53,8 @@ class TestDagOnlyDeploy:
                 }
             },
             "securityContext": {"fsGroup": 55555},
-            "server": {
-              "resources": resources
-            },
-            "client": {
-              "resources": resources
-            }
+            "server": {"resources": resources},
+            "client": {"resources": resources},
         }
 
     def test_dagonlydeploy_config_enabled_with_private_registry(self, kube_version):

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -53,7 +53,12 @@ class TestDagOnlyDeploy:
                 }
             },
             "securityContext": {"fsGroup": 55555},
-            "resources": resources,
+            "server": {
+              "resources": resources
+            },
+            "client": {
+              "resources": resources
+            }
         }
 
     def test_dagonlydeploy_config_enabled_with_private_registry(self, kube_version):


### PR DESCRIPTION
## Description

Fixes a behaviours where dag server resources are not formatted to newly configured resource spec.
This PR addresses the issue to pass the resources properly back to dag server and client

## Related Issues

https://github.com/astronomer/issues/issues/6348

## Testing

QA should able to override resource from global dagServer values
```
global:
  dagOnlyDeployment:
    enabled: true
    image: quay.io/astronomer/ap-dag-deploy:0.3.2
    securityContext:
      fsGroup: 50000
    resources:
      limits:
        cpu: 100m
        memory: 400Mi
      requests:
        cpu: 100m
        memory: 400Mi
```

## Merging

cherry-pick to release-0.34, 0.35
