### PR TITLE
fix external es search configuration

### DIFF
--- a/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
@@ -43,10 +43,10 @@ data:
           {{- include "external-es-proxy-nginx-location-common" . | indent 10 }}
         }
 
-        location = /_search {
+        location ~* /_search$ {
           # This combined with disabling explicit index searching downstream
           # prevents any deployment from being able to query any other indexes.
-          rewrite ^/(.*) /{{ include "logging.indexNamePrefix" . }}.$remote_user.*/$1 break;
+          rewrite /_search(.*) /{{ include "logging.indexNamePrefix" . }}.$remote_user.*/_search$1 break;
           {{- include "external-es-proxy-nginx-location-common" . | indent 10 }}
         }
 

--- a/tests/chart_tests/test_data/default-external-es-nginx.conf
+++ b/tests/chart_tests/test_data/default-external-es-nginx.conf
@@ -32,10 +32,10 @@ http {
       proxy_ssl_verify              off;
     }
 
-    location = /_search {
+    location ~* /_search$ {
       # This combined with disabling explicit index searching downstream
       # prevents any deployment from being able to query any other indexes.
-      rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;          
+      rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;          
       access_by_lua_file  /usr/local/openresty/nginx/conf/setenv.lua;
       proxy_pass https://esdemo.example.com:;
       proxy_ssl_verify              off;

--- a/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
+++ b/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
@@ -31,7 +31,7 @@ http {
     location ~* /_search$ {
       # This combined with disabling explicit index searching downstream
       # prevents any deployment from being able to query any other indexes.
-      rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;           
+      rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;          
       proxy_pass http://localhost:9203;
     }
 

--- a/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
+++ b/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
@@ -28,7 +28,7 @@ http {
       proxy_pass http://localhost:9203;
     }
 
-    location = /_search {
+    location ~* /_search$ {
       # This combined with disabling explicit index searching downstream
       # prevents any deployment from being able to query any other indexes.
       rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;           

--- a/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
+++ b/tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf
@@ -31,7 +31,7 @@ http {
     location = /_search {
       # This combined with disabling explicit index searching downstream
       # prevents any deployment from being able to query any other indexes.
-      rewrite ^/(.*) /fluentd.$remote_user.*/$1 break;          
+      rewrite /_search(.*) /fluentd.$remote_user.*/_search$1 break;           
       proxy_pass http://localhost:9203;
     }
 

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -405,7 +405,7 @@ class TestExternalElasticSearch:
         doc = docs[0]
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
-        assert "fluentd.$remote_user.*/$1" in es_index
+        assert "fluentd.$remote_user.*" in es_index
 
     def test_external_es_index_pattern_overrides(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -173,6 +173,7 @@ class TestExternalElasticSearch:
         nginx_conf = pathlib.Path(
             "tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf"
         ).read_text()
+        print(docs[2]["data"]["nginx.conf"])
         assert nginx_conf in docs[2]["data"]["nginx.conf"]
 
     def test_externalelasticsearch_with_awsIAMRole(self, kube_version):
@@ -459,7 +460,7 @@ class TestExternalElasticSearch:
         doc = docs[0]
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
-        assert "astronomer.$remote_user.*/$1" in es_index
+        assert "astronomer.$remote_user.*" in es_index
 
     def test_external_es_index_pattern_sidecar_logging_defaults(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search
@@ -486,7 +487,7 @@ class TestExternalElasticSearch:
         doc = docs[0]
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
-        assert "vector.$remote_user.*/$1" in es_index
+        assert "vector.$remote_user.*" in es_index
 
     def test_external_es_index_pattern_with_sidecar_logging_enabled(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search with
@@ -513,7 +514,7 @@ class TestExternalElasticSearch:
         doc = docs[0]
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
-        assert "vector.$remote_user.*/$1" in es_index
+        assert "vector.$remote_user.*" in es_index
 
     def test_external_es_with_private_registry_enabled(self, kube_version):
         """Test External Elasticsearch Service with Private Registry

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -173,7 +173,6 @@ class TestExternalElasticSearch:
         nginx_conf = pathlib.Path(
             "tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf"
         ).read_text()
-        print(docs[2]["data"]["nginx.conf"])
         assert nginx_conf in docs[2]["data"]["nginx.conf"]
 
     def test_externalelasticsearch_with_awsIAMRole(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -432,7 +432,7 @@ class TestExternalElasticSearch:
         doc = docs[0]
         es_index = doc["data"]["nginx.conf"]
         assert doc["kind"] == "ConfigMap"
-        assert "astronomer.$remote_user.*/$1" in es_index
+        assert "astronomer.$remote_user.*" in es_index
 
     def test_external_es_index_pattern_sidecar_logging_overrides(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search


### PR DESCRIPTION
## Description

Fixes log search in search endpoint to its own indexes

## Related Issues

https://github.com/astronomer/issues/issues/6339

## Testing

QA should able to see task logs in webserver

## Merging

cherry-pick to release-0.34, release-0.35
