### PR TITLE
ap-houston-api 0.34.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.34.5
+                - quay.io/astronomer/ap-houston-api:0.34.6
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.34.5
+                - quay.io/astronomer/ap-houston-api:0.34.6
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.34.5
+    tag: 0.34.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.34.6

## Related Issues

https://github.com/astronomer/issues/issues/6335
https://github.com/astronomer/houston-api/pull/1664
https://github.com/astronomer/issues/issues/6216

## Testing

Updated more info on ticket

## Merging

cherry-pick to release-0;34
