### PR TITLE
add configurable security context for stan service

### DIFF
--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -70,8 +70,7 @@ spec:
       {{- end }}
       initContainers:
         - name: wait-for-nats-server
-          securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot}}
+          securityContext: {{toYaml .Values.securityContext | nindent 12 }}
           command:
             - "dockerize"
           args:
@@ -89,8 +88,7 @@ spec:
       containers:
         - name: stan
           image: {{ include "stan.image" . }}
-          securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+          securityContext: {{toYaml .Values.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.images.stan.pullPolicy }}
           args:
           - -sc

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -67,12 +67,7 @@ assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.val
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
         assert len(c_by_name) == 3
-        assert (
-            c_by_name["wait-for-nats-server"]["securityContext"]
-            == securityContextResponse
-        )
-        assert c_by_name["stan"]["securityContext"] == securityContextResponse
-        assert c_by_name["metrics"]["securityContext"] == securityContextResponse
+        assert all(c["securityContext"] == securityContextResponse for c in c_by_name.values())
 
     def test_stan_statefulset_with_metrics_and_resources(self, kube_version):
         """Test that stan statefulset renders good metrics exporter."""

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -59,7 +59,7 @@ class TestStanStatefulSet:
 
         securityContextResponse = {
             "runAsNonRoot": True,
-            "allowPrivilegeEscalation": False
+            "allowPrivilegeEscalation": False,
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -68,7 +68,7 @@ class TestStanStatefulSet:
                 "stan": {
                     "securityContext": {
                         "runAsNonRoot": True,
-                        "allowPrivilegeEscalation": False ,
+                        "allowPrivilegeEscalation": False,
                     },
                 },
             },
@@ -77,7 +77,10 @@ class TestStanStatefulSet:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
         assert len(c_by_name) == 3
-        assert c_by_name["wait-for-nats-server"]["securityContext"] == securityContextResponse
+        assert (
+            c_by_name["wait-for-nats-server"]["securityContext"]
+            == securityContextResponse
+        )
         assert c_by_name["stan"]["securityContext"] == securityContextResponse
         assert c_by_name["metrics"]["securityContext"] == securityContextResponse
 

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -18,7 +18,7 @@ class TestStanStatefulSet:
 
         assert len(docs) == 1
         doc = docs[0]
-        c_by_name = get_containers_by_name(doc)
+        c_by_name = get_containers_by_name(doc, include_init_containers=True)
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-stan"
@@ -37,6 +37,13 @@ class TestStanStatefulSet:
             "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
             "initialDelaySeconds": 10,
             "timeoutSeconds": 5,
+        }
+
+        assert c_by_name["wait-for-nats-server"]["securityContext"] == {
+            "runAsNonRoot": True,
+        }
+        assert c_by_name["stan"]["securityContext"] == {
+            "runAsNonRoot": True,
         }
 
         assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -39,17 +39,7 @@ class TestStanStatefulSet:
             "timeoutSeconds": 5,
         }
 
-        assert c_by_name["wait-for-nats-server"]["securityContext"] == {
-            "runAsNonRoot": True,
-        }
-        assert c_by_name["stan"]["securityContext"] == {
-            "runAsNonRoot": True,
-        }
-
-        assert c_by_name["metrics"]["securityContext"] == {
-            "runAsNonRoot": True,
-        }
-
+assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values())
         assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
         assert doc["spec"]["template"]["spec"]["affinity"] == {}
         assert doc["spec"]["template"]["spec"]["tolerations"] == []

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -39,7 +39,9 @@ class TestStanStatefulSet:
             "timeoutSeconds": 5,
         }
 
-assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values())
+        assert all(
+            c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values()
+        )
         assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
         assert doc["spec"]["template"]["spec"]["affinity"] == {}
         assert doc["spec"]["template"]["spec"]["tolerations"] == []
@@ -67,7 +69,9 @@ assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.val
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
         assert len(c_by_name) == 3
-        assert all(c["securityContext"] == securityContextResponse for c in c_by_name.values())
+        assert all(
+            c["securityContext"] == securityContextResponse for c in c_by_name.values()
+        )
 
     def test_stan_statefulset_with_metrics_and_resources(self, kube_version):
         """Test that stan statefulset renders good metrics exporter."""


### PR DESCRIPTION
## Description

This PR adds support for configurable securityContext for stan service to support passing securityContext from values 

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

QA should able to pass supported securityContext at container level for stan service

## Merging

cherry-pick to release-0.35
