### PR TITLE
add nats securityContext to jetstream job

### DIFF
--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -85,6 +85,7 @@ spec:
       containers:
       - name: jetstream-template-fixer
         image: {{ template "dbBootstrapper.image" . }}
+        securityContext: {{ template "nats.securityContext" . }}
         command:
         - /bin/sh
         - -c

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -30,26 +30,10 @@ class TestNatsJetstream:
         assert prod["nats"] == {"jetStreamEnabled": True, "tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
-
-    def test_nats_statefulset_with_jetstream_security_context_defaults(
-        self, kube_version
-    ):
-        """Test that nats statefulset is good with defaults."""
-        values = {
-            "global": {"nats": {"jetStream": {"enabled": True}}},
-        }
-        docs = render_chart(
-            kube_version=kube_version,
-            values=values,
-            show_only=[
-                "charts/nats/templates/jetstream-job.yaml",
-            ],
-        )
-
-        assert len(docs) == 4
-        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[3]["spec"]["template"][
+        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[6]["spec"]["template"][
             "spec"
         ]["containers"][0]["securityContext"]
+
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test Nats with jetstream config."""

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -31,6 +31,26 @@ class TestNatsJetstream:
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
 
+    def test_nats_statefulset_with_jetstream_security_context_defaults(
+        self, kube_version
+    ):
+        """Test that nats statefulset is good with defaults."""
+        values = {
+            "global": {"nats": {"jetStream": {"enabled": True}}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/nats/templates/jetstream-job.yaml",
+            ],
+        )
+
+        assert len(docs) == 4
+        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[3]["spec"]["template"][
+            "spec"
+        ]["containers"][0]["securityContext"]
+
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test Nats with jetstream config."""
         values = {

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -34,7 +34,6 @@ class TestNatsJetstream:
             "spec"
         ]["containers"][0]["securityContext"]
 
-
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test Nats with jetstream config."""
         values = {


### PR DESCRIPTION
## Description

currently jetstream job does not have securityContext defined , this PR adopts nats securityContext configuration to jetstream to share same securityContext

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
