### PR TITLE
add grafana db-bootstrapper securityContext

### DIFF
--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -59,6 +59,7 @@ spec:
         - name: bootstrapper
           image: {{ template "grafana.bootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -78,6 +78,12 @@ class TestGrafanaDeployment:
         assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
             "runAsNonRoot": True
         }
+        assert doc["spec"]["template"]["spec"]["initContainers"][0][
+            "securityContext"
+        ] == {"runAsNonRoot": True}
+        assert doc["spec"]["template"]["spec"]["initContainers"][1][
+            "securityContext"
+        ] == {"runAsNonRoot": True}
 
     def test_deployment_with_securitycontext_overrides(self, kube_version):
         """Test that the grafana-deployment renders with the expected securityContext."""
@@ -93,6 +99,18 @@ class TestGrafanaDeployment:
         doc = docs[0]
         assert doc["kind"] == "Deployment"
         assert doc["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "runAsNonRoot": True,
+            "runAsUser": 467,
+        }
+        assert doc["spec"]["template"]["spec"]["initContainers"][0][
+            "securityContext"
+        ] == {
+            "runAsNonRoot": True,
+            "runAsUser": 467,
+        }
+        assert doc["spec"]["template"]["spec"]["initContainers"][1][
+            "securityContext"
+        ] == {
             "runAsNonRoot": True,
             "runAsUser": 467,
         }


### PR DESCRIPTION
## Description

Adds support for securityContext for db-bootstrapper init container configuredin grafana  service.

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

QA should able to validate securityContext in db-boostrapper initContainer in grafana service

## Merging

Not decided yet which release it will be mapped for so leaving it on master
