### PR TITLE
add priorityclass support for containerd daemonset

### DIFF
--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -37,7 +37,7 @@ spec:
         checksum/configmap: {{ include (print $.Template.BasePath "/trust-private-ca-on-all-nodes/containerd-ca-update-script.yaml") . | sha256sum }}
     spec:
     {{- if .Values.global.privateCaCertsAddToHost.priorityClassName }}
-      priorityClassName: {{ .Values.flower.priorityClassName }}
+      priorityClassName: {{ .Values.global.privateCaCertsAddToHost.priorityClassName }}
     {{- end }}
 {{- if .Values.global.privateCaCertsAddToHost.containerdnodeAffinitys }}
       affinity:

--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -36,6 +36,9 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/trust-private-ca-on-all-nodes/containerd-ca-update-script.yaml") . | sha256sum }}
     spec:
+    {{- if .Values.global.privateCaCertsAddToHost.priorityClassName }}
+      priorityClassName: {{ .Values.flower.priorityClassName }}
+    {{- end }}
 {{- if .Values.global.privateCaCertsAddToHost.containerdnodeAffinitys }}
       affinity:
 {{ toYaml .Values.global.privateCaCertsAddToHost.containerdnodeAffinitys  | indent 8 }}

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -95,3 +95,29 @@ class TestContainerdPrivateCaDaemonset:
         ]
 
         assert volumemounts == expected_volumemounts
+
+    def test_containerd_privateca_daemonset_enabled_with_priority_class(self, kube_version):
+        """Test that the containerd daemonset is rendered with priorityClass when
+        enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "global": {
+                    "privateCaCertsAddToHost": {
+                        "enabled": True,
+                        "addToContainerd": True,
+                        "priorityClassName": "high-priority",
+                    },
+                }
+            },
+        )
+
+        assert len(docs) == 2
+        self.common_tests_daemonset(docs[0])
+        assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
+        cert_copier = docs[0]["spec"]["template"]["spec"]["containers"][0]
+        cert_copier["image"].startswith("alpine:3")
+        assert "high-priority" ==  docs[0]["spec"]["template"]["spec"]["priorityClassName"]
+
+

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -96,7 +96,9 @@ class TestContainerdPrivateCaDaemonset:
 
         assert volumemounts == expected_volumemounts
 
-    def test_containerd_privateca_daemonset_enabled_with_priority_class(self, kube_version):
+    def test_containerd_privateca_daemonset_enabled_with_priority_class(
+        self, kube_version
+    ):
         """Test that the containerd daemonset is rendered with priorityClass when
         enabled."""
         docs = render_chart(
@@ -118,6 +120,6 @@ class TestContainerdPrivateCaDaemonset:
         assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
         cert_copier = docs[0]["spec"]["template"]["spec"]["containers"][0]
         cert_copier["image"].startswith("alpine:3")
-        assert "high-priority" ==  docs[0]["spec"]["template"]["spec"]["priorityClassName"]
-
-
+        assert (
+            "high-priority" == docs[0]["spec"]["template"]["spec"]["priorityClassName"]
+        )

--- a/values.yaml
+++ b/values.yaml
@@ -28,6 +28,7 @@ global:
       repository: quay.io/astronomer/ap-base
       tag: 3.18.6-1
       pullPolicy: IfNotPresent
+    priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
   # level Network Policy
   networkPolicy:


### PR DESCRIPTION
## Description

Add priority class support for containerd daemonset service 

## Related Issues

https://github.com/astronomer/issues/issues/6366

## Testing

user should able to pass priorityclass 
```yaml
global:
   privateCaCertsAddToHost:
      enabled: true
      addToContainerd: true
      priorityClassName: xyz
```

## Merging

cherry-pick to all valid branches
