### PR TITLE
add security context support for config syncer cron job

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -437,3 +437,11 @@ tlsEnabled: false
 {{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 10 }}
 {{- end -}}
 {{- end }}
+
+{{- define "configSyncer.securityContext" -}}
+{{- if .Values.configSyncer.securityContext }}
+{{ toYaml .Values.configSyncer.securityContext | indent 16 }}
+{{- else }}
+{{ toYaml .Values.securityContext | indent 16 }}
+{{- end }}
+{{- end }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -45,6 +45,7 @@ spec:
             - name: config-syncer
               image: {{ template "commander.image" . }}
               imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args:
               - "sync"

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -45,7 +45,7 @@ spec:
             - name: config-syncer
               image: {{ template "commander.image" . }}
               imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ template "configSyncer.securityContext" .  }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args:
               - "sync"

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -320,6 +320,7 @@ configSyncer:
   enabled: true
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.
   schedule: ~
+  securityContext: {}
 
 commander:
   replicas: 2

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -193,6 +193,36 @@ class TestAstronomerConfigSyncer:
         assert ",".join(namespaces) in container["args"]
         assert {"runAsNonRoot": True} == container["securityContext"]
 
+    def test_astronomer_config_syncer_cronjob_security_context_default_overrides(
+        self, kube_version
+    ):
+        """Test that  config-syncer's container is allowed to configure security context."""
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "rbacEnabled": True,
+                },
+                "astronomer": {
+                    "securityContext": {
+                        "runAsNonRoot": True,
+                        "allowPrivilegeEscalation": False,
+                    },
+                },
+            },
+            show_only=[
+                "charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml",
+            ],
+        )[0]
+
+        container = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"][
+            "containers"
+        ][0]
+
+        assert {"runAsNonRoot": True, "allowPrivilegeEscalation": False} == container[
+            "securityContext"
+        ]
+
     def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(
         self, kube_version
     ):

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -191,6 +191,7 @@ class TestAstronomerConfigSyncer:
 
         assert "--target-namespaces" in container["args"]
         assert ",".join(namespaces) in container["args"]
+        assert {'runAsNonRoot': True} == container["securityContext"]
 
     def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(
         self, kube_version

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -191,7 +191,7 @@ class TestAstronomerConfigSyncer:
 
         assert "--target-namespaces" in container["args"]
         assert ",".join(namespaces) in container["args"]
-        assert {'runAsNonRoot': True} == container["securityContext"]
+        assert {"runAsNonRoot": True} == container["securityContext"]
 
     def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(
         self, kube_version


### PR DESCRIPTION
## Description

Adds securitycontext support for config syncer job

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

QA should able to pass supported securityContext at container level for config syncer job  service

## Merging

cherry-pick to release-0.35
