### PR TITLE
update security context for missing exporters

### DIFF
--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -13,8 +13,8 @@ images:
     pullPolicy: IfNotPresent
 
 securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
+  runAsNonRoot: true
+  runAsUser: 1000
 
 clusterName: "astronomer"
 

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -35,8 +35,7 @@ spec:
         - name: node-exporter
           image: {{ template "image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            runAsNonRoot: {{ toYaml .Values.securityContext.runAsNonRoot }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           args:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -110,7 +110,7 @@ spec:
 {{ tpl . $ | indent 8 }}
 {{- end }}
       securityContext:
-{{ toYaml .Values.securityContext | indent 8 }}
+{{ toYaml .Values.podSecurityContext | indent 8 }}
      {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -39,6 +39,7 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+podSecurityContext: {}
 securityContext:
   runAsNonRoot: true
   # The securityContext this Pod should use. See https://kubernetes.io/docs/concepts/policy/security-context/ for more.

--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -105,5 +105,5 @@ class TestPrometheusNodeExporterDaemonset:
         assert c_by_name["node-exporter"]["securityContext"] == {
             "allowPrivilegeEscalation": False,
             "readOnlyRootFilesystem": True,
-            "runAsNonRoot": True
+            "runAsNonRoot": True,
         }

--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -79,3 +79,30 @@ class TestPrometheusNodeExporterDaemonset:
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }
+        assert c_by_name["node-exporter"]["securityContext"] == {"runAsNonRoot": True}
+
+    def test_prometheus_node_exporter_daemonset_with_security_context_overrides(
+        self, kube_version
+    ):
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus-node-exporter": {
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False,
+                        "readOnlyRootFilesystem": True,
+                    }
+                },
+            },
+            show_only=["charts/prometheus-node-exporter/templates/daemonset.yaml"],
+        )[0]
+
+        assert doc["kind"] == "DaemonSet"
+        assert doc["metadata"]["name"] == "release-name-prometheus-node-exporter"
+
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["node-exporter"]
+        assert c_by_name["node-exporter"]["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+        }

--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -105,4 +105,5 @@ class TestPrometheusNodeExporterDaemonset:
         assert c_by_name["node-exporter"]["securityContext"] == {
             "allowPrivilegeEscalation": False,
             "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True
         }

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -1,0 +1,52 @@
+import pytest
+
+from tests import supported_k8s_versions, get_containers_by_name
+from tests.chart_tests.helm_template_generator import render_chart
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestPrometheusPostgresExporter:
+
+    def test_prometheus_postgres_exporter_service_enabled(self, kube_version):
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "prometheusPostgresExporterEnabled": True,
+                },
+            },
+            show_only=[
+                "charts/prometheus-postgres-exporter/templates/service.yaml",
+                "charts/prometheus-postgres-exporter/templates/deployment.yaml",
+                "charts/prometheus-postgres-exporter/templates/configmap.yaml",
+                "charts/prometheus-postgres-exporter/templates/serviceaccount.yaml",
+            ],
+        )
+        assert len(docs) == 4
+        doc = docs[0]
+        assert doc["kind"] == "Service"
+        assert doc["metadata"]["name"] == "release-name-postgresql-exporter"
+        assert doc["spec"]["selector"]["app"] == "prometheus-postgres-exporter"
+        assert doc["spec"]["type"] == "ClusterIP"
+        assert doc["spec"]["ports"] == [
+            {
+                "port": 80,
+                "targetPort": "http",
+                "protocol": "TCP",
+                "name": "http",
+                "appProtocol": "tcp",
+            }
+        ]
+        c_by_name = get_containers_by_name(docs[1])
+        assert c_by_name["prometheus-postgres-exporter"]
+        assert c_by_name["prometheus-postgres-exporter"]["resources"] == {
+            "limits": {"cpu": "100m", "memory": "128Mi"},
+            "requests": {"cpu": "10m", "memory": "128Mi"},
+        }
+        assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {
+            "runAsNonRoot": True
+        }


### PR DESCRIPTION
## Description

rework securityContext config for prometheus-node-exporter and postgres-exporter

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

QA should able to pass multiple securityContext config for above mentioned services

## Merging

cherry-pick to release-0.35
