### PR TITLE
6233 networkpolicy for dag deploy rollback

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -22,7 +22,7 @@ spec:
   - Ingress
   ingress:
   - from:
-    {{- if .Values.global.authSidecar.enabled  }}
+    {{- if .Values.global.authSidecar.enabled }}
     - namespaceSelector:
         matchLabels:
           network.openshift.io/policy-group: ingress
@@ -63,18 +63,25 @@ spec:
           tier: elasticsearch
           component: es-ingress-controller
           release: {{ .Release.Name }}
-    {{- if .Values.global.customLogging.enabled  }}
+    {{- if .Values.global.customLogging.enabled }}
     - podSelector:
         matchLabels:
           tier: external-logging
           component: external-es-proxy
           release: {{ .Release.Name }}
     {{- end }}
-    {{- if or .Values.houston.enableHoustonInternalAuthorization .Values.global.enableHoustonInternalAuthorization  }}
+    {{- if or .Values.houston.enableHoustonInternalAuthorization .Values.global.enableHoustonInternalAuthorization }}
     - namespaceSelector: {}
       podSelector:
         matchLabels:
           component: webserver
+          tier: airflow
+    {{- end }}
+    {{- if .Values.global.dagOnlyDeployment.enabled }}
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: dag-server
           tier: airflow
     {{- end }}
     ports:


### PR DESCRIPTION
## Description

Add a NetworkPolicy to be used with dag-deploy server to communicate with houston about new files that are uploaded.

## Related Issues

https://github.com/astronomer/issues/issues/6233

## Testing

Tests are included. I have also manually tested this. QA doesn't need to do any testing specific to this PR because it will be quite obvious if it's not working as intended.

## Merging

Merge only to release-0.35 because rollback feature is only intended for 0.35.