### PR TITLE
add flag to disable jetstream job

### DIFF
--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -1,8 +1,8 @@
 ########################################################
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
-{{- if  .Values.nats.createJetStreamJob  -}}
-{{- if or  .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled  .Values.global.stan.enabled  }}
+{{- if .Values.nats.createJetStreamJob -}}
+{{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled .Values.global.stan.enabled }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -1,7 +1,8 @@
 ########################################################
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
-{{- if and (or  .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled  .Values.global.stan.enabled) ( .Values.nats.createJetStreamJob ) }}
+{{- if  .Values.nats.createJetStreamJob  -}}
+{{- if or  .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled  .Values.global.stan.enabled  }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,4 +110,5 @@ spec:
             echo "{{ .Release.Name }}-Nats is already enabled with jetstream. skipping sts cleanup"
           fi
           {{ end }}
+{{ end }}
 {{ end }}

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -1,7 +1,7 @@
 ########################################################
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
-{{- if or  .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled  .Values.global.stan.enabled }}
+{{- if and (or  .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled  .Values.global.stan.enabled) ( .Values.nats.createJetStreamJob ) }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -19,7 +19,6 @@ images:
 
 
 nats:
-
   createJetStreamJob: true
 
   # In case both external access and advertise are enabled

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -19,6 +19,9 @@ images:
 
 
 nats:
+
+  createJetStreamJob: true
+
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to
   # gather the public ip from a node.

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -146,6 +146,28 @@ class TestNatsJetstream:
 
         assert len(docs) == 4
 
+    def test_nats_with_jetstream_disabled_with_custom_flag(self, kube_version):
+        """Test that jetstream feature  is disabled completely with createJetStreamJob."""
+        values = {
+            "global": {"nats": {"jetStream": {"enabled": False}}},
+            "nats": {"nats": {"createJetStreamJob": False}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/nats/templates/statefulset.yaml",
+                "charts/nats/templates/configmap.yaml",
+                "charts/nats/templates/jetstream-job.yaml",
+                "charts/stan/templates/configmap.yaml",
+                "charts/stan/templates/service.yaml",
+                "charts/stan/templates/statefulset.yaml",
+                "charts/stan/templates/stan-networkpolicy.yaml",
+                "charts/nats/templates/nats-jetstream-tls-secret.yaml",
+            ],
+        )
+        assert len(docs) == 6
+
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
         values = {

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -145,3 +145,18 @@ class TestNatsJetstream:
         )
 
         assert len(docs) == 4
+
+    def test_jetstream_hook_job_disabled(self, kube_version):
+        """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
+        values = {
+            "nats": {"nats": {"createJetStreamJob": False}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/nats/templates/jetstream-job.yaml",
+            ],
+        )
+
+        assert len(docs) == 0


### PR DESCRIPTION
## Description

Add flag to disable jetstream job 

## Related Issues

https://github.com/astronomer/issues/issues/6245

## Testing

QA should pass to disable jetstream hook job
```
nats:
  nats:
      createJetStreamJob: false 
```

## Merging

cherry-pick to release-0.34,release-0.35
