### PR TITLE
Update ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,12 +379,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
-                - quay.io/astronomer/ap-cli-install:0.26.23
+                - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.34.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.13-1
+                - quay.io/astronomer/ap-curator:8.0.14
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.0
-                - quay.io/astronomer/ap-default-backend:0.28.24
+                - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
@@ -393,17 +393,17 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0-2
+                - quay.io/astronomer/ap-nats-exporter:0.15.0
                 - quay.io/astronomer/ap-nats-server:2.10.10
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-3
                 - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.6
-                - quay.io/astronomer/ap-node-exporter:1.7.0
+                - quay.io/astronomer/ap-node-exporter:1.8.1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.4
+                - quay.io/astronomer/ap-prometheus:2.45.5
                 - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.33.1-1
           context:
@@ -418,12 +418,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
-                - quay.io/astronomer/ap-cli-install:0.26.23
+                - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.34.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.13-1
+                - quay.io/astronomer/ap-curator:8.0.14
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.0
-                - quay.io/astronomer/ap-default-backend:0.28.24
+                - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
@@ -432,17 +432,17 @@ workflows:
                 - quay.io/astronomer/ap-init:3.18.6-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.14.0-2
+                - quay.io/astronomer/ap-nats-exporter:0.15.0
                 - quay.io/astronomer/ap-nats-server:2.10.10
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-3
                 - quay.io/astronomer/ap-nginx-es:1.25.4
                 - quay.io/astronomer/ap-nginx:1.9.6
-                - quay.io/astronomer/ap-node-exporter:1.7.0
+                - quay.io/astronomer/ap-node-exporter:1.8.1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.4
+                - quay.io/astronomer/ap-prometheus:2.45.5
                 - quay.io/astronomer/ap-registry:3.18.6-2
                 - quay.io/astronomer/ap-vector:0.33.1-1
           context:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.23
+    tag: 0.26.24
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.13-1
+    tag: 8.0.14
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0-2
+    tag: 0.15.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.24
+    tag: 0.28.25
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.7.0
+  tag: 1.8.1
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.4
+    tag: 2.45.5
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -10,11 +10,11 @@ images:
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-2
+    tag: 0.25.6-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.14.0-2
+    tag: 0.15.0
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION

## Description

update ap-vendor and platform packages

| imagName | oldTag | newTag |
|--------|--------|--------|
| ap-cli-install | 0.26.23 | 0.26.24 |
| ap-default-backend | 0.28.24 | 0.28.25 |
| ap-curator | 8.0.13-1 | 8.0.14 |
| ap-nats-exporter | 0.14.0-2 | 0.15.0 |
| ap-node-exporter | 1.7.0 | 1.8.1 |
| ap-prometheus | 2.45.4 | 2.45.5 |
| ap-nats-streaming | 0.25.6-2| 0.25.6-3 |

## Related Issues

https://github.com/astronomer/issues/issues/6379

## Testing

NA

## Merging

cherry-pick to all valid release branches