### PR TITLE
add configurable containerd host path

### DIFF
--- a/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
+++ b/templates/trust-private-ca-on-all-nodes/containerd-daemonset.yaml
@@ -82,7 +82,7 @@ spec:
       hostPID: true
       volumes:
       - hostPath:
-          path: /etc/containerd
+          path: {{ .Values.global.privateCaCertsAddToHost.containerdHostPath }}
           type: ""
         name: hostcontainerd
       - name: hostcerts

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -132,7 +132,7 @@ class TestContainerdPrivateCaDaemonset:
                     "privateCaCertsAddToHost": {
                         "enabled": True,
                         "addToContainerd": True,
-                        "containerdHostPath": "/etc/astronomer"
+                        "containerdHostPath": "/etc/astronomer",
                     },
                 }
             },

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -69,6 +69,9 @@ class TestContainerdPrivateCaDaemonset:
         cert_copier["image"].startswith("alpine:3")
 
         volumemounts = cert_copier["volumeMounts"]
+        volumes = docs[0]["spec"]["template"]["spec"]["volumes"]
+
+        expected_volumes = [{'hostPath': {'path': '/etc/containerd', 'type': ''}, 'name': 'hostcontainerd'}, {'name': 'hostcerts', 'hostPath': {'path': '/etc/containerd/certs.d/registry.example.com/'}}, {'name': 'cert-copy-and-toml-update', 'configMap': {'name': 'release-name-cert-copy-and-toml-update'}}, {'name': 'private-ca-cert-foo', 'secret': {'secretName': 'private-ca-cert-foo'}}, {'name': 'private-ca-cert-bar', 'secret': {'secretName': 'private-ca-cert-bar'}}]
 
         expected_volumemounts = [
             {"name": "hostcerts", "mountPath": "/host-trust-store"},
@@ -95,6 +98,7 @@ class TestContainerdPrivateCaDaemonset:
         ]
 
         assert volumemounts == expected_volumemounts
+        assert volumes == expected_volumes
 
     def test_containerd_privateca_daemonset_enabled_with_priority_class(
         self, kube_version

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -71,7 +71,28 @@ class TestContainerdPrivateCaDaemonset:
         volumemounts = cert_copier["volumeMounts"]
         volumes = docs[0]["spec"]["template"]["spec"]["volumes"]
 
-        expected_volumes = [{'hostPath': {'path': '/etc/containerd', 'type': ''}, 'name': 'hostcontainerd'}, {'name': 'hostcerts', 'hostPath': {'path': '/etc/containerd/certs.d/registry.example.com/'}}, {'name': 'cert-copy-and-toml-update', 'configMap': {'name': 'release-name-cert-copy-and-toml-update'}}, {'name': 'private-ca-cert-foo', 'secret': {'secretName': 'private-ca-cert-foo'}}, {'name': 'private-ca-cert-bar', 'secret': {'secretName': 'private-ca-cert-bar'}}]
+        expected_volumes = [
+            {
+                "hostPath": {"path": "/etc/containerd", "type": ""},
+                "name": "hostcontainerd",
+            },
+            {
+                "name": "hostcerts",
+                "hostPath": {"path": "/etc/containerd/certs.d/registry.example.com/"},
+            },
+            {
+                "name": "cert-copy-and-toml-update",
+                "configMap": {"name": "release-name-cert-copy-and-toml-update"},
+            },
+            {
+                "name": "private-ca-cert-foo",
+                "secret": {"secretName": "private-ca-cert-foo"},
+            },
+            {
+                "name": "private-ca-cert-bar",
+                "secret": {"secretName": "private-ca-cert-bar"},
+            },
+        ]
 
         expected_volumemounts = [
             {"name": "hostcerts", "mountPath": "/host-trust-store"},

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -121,6 +121,82 @@ class TestContainerdPrivateCaDaemonset:
         assert volumemounts == expected_volumemounts
         assert volumes == expected_volumes
 
+    def test_containerd_privateca_daemonset_host_path_overrides(self, kube_version):
+        """Test that the daemonset is rendered with custom hostPath."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            values={
+                "global": {
+                    "privateCaCerts": ["private-ca-cert-foo", "private-ca-cert-bar"],
+                    "privateCaCertsAddToHost": {
+                        "enabled": True,
+                        "addToContainerd": True,
+                        "containerdHostPath": "/etc/astronomer"
+                    },
+                }
+            },
+        )
+
+        assert len(docs) == 2
+        self.common_tests_daemonset(docs[0])
+        assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
+        cert_copier = docs[0]["spec"]["template"]["spec"]["containers"][0]
+        cert_copier["image"].startswith("alpine:3")
+
+        volumemounts = cert_copier["volumeMounts"]
+        volumes = docs[0]["spec"]["template"]["spec"]["volumes"]
+
+        expected_volumes = [
+            {
+                "hostPath": {"path": "/etc/astronomer", "type": ""},
+                "name": "hostcontainerd",
+            },
+            {
+                "name": "hostcerts",
+                "hostPath": {"path": "/etc/containerd/certs.d/registry.example.com/"},
+            },
+            {
+                "name": "cert-copy-and-toml-update",
+                "configMap": {"name": "release-name-cert-copy-and-toml-update"},
+            },
+            {
+                "name": "private-ca-cert-foo",
+                "secret": {"secretName": "private-ca-cert-foo"},
+            },
+            {
+                "name": "private-ca-cert-bar",
+                "secret": {"secretName": "private-ca-cert-bar"},
+            },
+        ]
+
+        expected_volumemounts = [
+            {"name": "hostcerts", "mountPath": "/host-trust-store"},
+            {
+                "mountPath": "/hostcontainerd",
+                "name": "hostcontainerd",
+                "readOnly": False,
+            },
+            {
+                "mountPath": "/cert-copy-and-toml-update.sh",
+                "name": "cert-copy-and-toml-update",
+                "subPath": "update-containerd-certs.sh",
+            },
+            {
+                "name": "private-ca-cert-foo",
+                "mountPath": "/private-ca-certs/private-ca-cert-foo/private-ca-cert-foo.pem",
+                "subPath": "cert.pem",
+            },
+            {
+                "name": "private-ca-cert-bar",
+                "mountPath": "/private-ca-certs/private-ca-cert-bar/private-ca-cert-bar.pem",
+                "subPath": "cert.pem",
+            },
+        ]
+
+        assert volumemounts == expected_volumemounts
+        assert volumes == expected_volumes
+
     def test_containerd_privateca_daemonset_enabled_with_priority_class(
         self, kube_version
     ):

--- a/values.yaml
+++ b/values.yaml
@@ -22,6 +22,7 @@ global:
     addToContainerd: false
     addToDockerd: true
     containerdCertConfigPath: /etc/containerd/certs.d
+    containerdHostPath: /etc/containerd
     containerdConfigToml: ~
     containerdnodeAffinitys: []
     certCopier:


### PR DESCRIPTION
## Description

Add support for configurable containerd hostPath

## Related Issues

https://github.com/astronomer/issues/issues/6341

## Testing

QA should able to override the containerd hostpath

## Merging

cherry-pick to release-0.34 and release-0.35
