### PR TITLE
modify commander role to get job name in rbac

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -94,7 +94,7 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["list", "watch", "create", "delete"]
+  verbs: ["list", "watch", "create", "delete", "get"]
 - apiGroups: ["batch"]
   resources: ["cronjobs"]
   verbs: ["create", "delete", "get", "list", "patch", "watch"]


### PR DESCRIPTION
## Description

Add role to get kubernetes job details from commander

## Related Issues

https://github.com/astronomer/issues/issues/6309

## Testing

while making downgrade  our internal service should downgrade the airflow deployments sucessfully

## Merging

cherry-pick to release-0.35
