### PR TITLE
Add configurable container securityContext for curator cronjob

### DIFF
--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -43,6 +43,7 @@ spec:
             imagePullPolicy: {{ .Values.images.curator.pullPolicy }}
             command: ["/bin/sh", "-c"]
             args: ["sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"]
+            securityContext: {{ toYaml .Values.curator.securityContext | nindent 16 }}
             volumeMounts:
               - name: config-volume
                 mountPath: /etc/config

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -188,6 +188,7 @@ curator:
   podAnnotations: {}
   enabled: true
   schedule: "0 1 * * *"
+  securityContext: {}
 
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in


### PR DESCRIPTION
## Description

Add support for allowing security context to elasticsearch curator cronjob

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

QA should able to override or add security context for elasticsearch cron jon

## Merging

cherry-pick to release-0.35
