### PR TITLE
add es security context for missing components

### DIFF
--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -52,7 +52,7 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: {{ .Values.exporter.restartPolicy }}
       securityContext:
-{{ toYaml .Values.exporter.securityContext | indent 8 }}
+{{ toYaml .Values.exporter.podSecurityContext | indent 8 }}
 {{- include "elasticsearch.imagePullSecrets" . | indent 6 }}
       containers:
         - name: metrics-exporter
@@ -66,23 +66,7 @@ spec:
                     "--web.listen-address=:{{ .Values.exporter.service.httpPort }}",
                     "--web.telemetry-path={{ .Values.exporter.web.path }}"]
           securityContext:
-            capabilities:
-              drop:
-                - SETPCAP
-                - MKNOD
-                - AUDIT_WRITE
-                - CHOWN
-                - NET_RAW
-                - DAC_OVERRIDE
-                - FOWNER
-                - FSETID
-                - KILL
-                - SETGID
-                - SETUID
-                - NET_BIND_SERVICE
-                - SYS_CHROOT
-                - SETFCAP
-            readOnlyRootFilesystem: true
+{{ toYaml .Values.exporter.securityContext | indent 12 }}
           resources:
 {{ toYaml .Values.exporter.resources | indent 12 }}
           ports:

--- a/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - name: nginx
           image: {{ template "nginx-es.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
+          securityContext:
+{{ toYaml .Values.nginx.securityContext | indent 12 }}
           resources:
 {{ toYaml .Values.nginx.resources | indent 12 }}
           volumeMounts:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -205,6 +205,13 @@ exporter:
   # Restart policy for all containers
   restartPolicy: Always
 
+  podSecurityContext: {}
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+
   resources: {}
   # requests:
   #   cpu: 100m

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -236,6 +236,7 @@ nginx:
   fullnameOverride: ~
   ingressClass: ~
   resources: {}
+  securityContext: {}
 
 # sysctl init container
 # Warning: sysctl changes affect the kernel, and thus, all containers running on the same node.

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -626,3 +626,27 @@ class TestElasticSearch:
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
         ]
         assert c_by_name["curator"]["securityContext"] == {"runAsNonRoot": True}
+
+    def test_elasticsearch_nginx_deployment_defaults(self, kube_version):
+        """Test ElasticSearch Nginx deployment default values."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=["charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["nginx"]["securityContext"] == {}
+
+    def test_elasticsearch_nginx_deployment_overrides(self, kube_version):
+        """Test ElasticSearch Nginx deployment default overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "elasticsearch": {"nginx": {"securityContext": {"runAsNonRoot": True}}},
+            },
+            show_only=["charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["nginx"]["securityContext"] == {"runAsNonRoot": True}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -425,8 +425,8 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
-        assert pod_data["securityContext"]["runAsNonRoot"] is True
-        assert pod_data["securityContext"]["runAsUser"] == 2000
+        assert pod_data["containers"][0]["securityContext"]["runAsNonRoot"] is True
+        assert pod_data["containers"][0]["securityContext"]["runAsUser"] == 2000
 
     def test_elasticsearch_role_defaults(self, kube_version):
         """Test ElasticSearch master, data and client with default roles"""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -414,7 +414,8 @@ class TestElasticSearch:
             values={
                 "elasticsearch": {
                     "exporter": {
-                        "securityContext": {"runAsNonRoot": True, "runAsUser": 2000}
+                        "podSecurityContext": {"runAsNonRoot": True},
+                        "securityContext": {"runAsNonRoot": True, "runAsUser": 2000},
                     }
                 }
             },
@@ -425,6 +426,7 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
+        assert pod_data["securityContext"]["runAsNonRoot"] is True
         assert pod_data["containers"][0]["securityContext"]["runAsNonRoot"] is True
         assert pod_data["containers"][0]["securityContext"]["runAsUser"] == 2000
 

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -402,7 +402,10 @@ class TestElasticSearch:
 
         assert pod_data["securityContext"] == {}
 
-        assert pod_data["containers"][0]["securityContext"] ==  {'capabilities': {'drop': ['ALL']},'readOnlyRootFilesystem': True}
+        assert pod_data["containers"][0]["securityContext"] == {
+            "capabilities": {"drop": ["ALL"]},
+            "readOnlyRootFilesystem": True,
+        }
 
     def test_elasticsearch_exporter_securitycontext_overrides(self, kube_version):
         """Test ElasticSearch Exporter with securityContext default values."""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -400,7 +400,9 @@ class TestElasticSearch:
         doc = docs[0]
         pod_data = doc["spec"]["template"]["spec"]
 
-        assert pod_data["securityContext"] is None
+        assert pod_data["securityContext"] == {}
+
+        assert pod_data["containers"][0]["securityContext"] ==  {'capabilities': {'drop': ['ALL']},'readOnlyRootFilesystem': True}
 
     def test_elasticsearch_exporter_securitycontext_overrides(self, kube_version):
         """Test ElasticSearch Exporter with securityContext default values."""


### PR DESCRIPTION
## Description

removed hardcoded security context from elasticsearch exported and reworked it support both pod and container security context and tweaked default privilges

## Related Issues

https://github.com/astronomer/issues/issues/6363

## Testing

elasticsearch exporter should able to expose metrics

## Merging

cherry-pick to releaase-0.35
