### PR TITLE
add functional test for connection strings validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.3
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.4
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.0
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.3
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.4
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.3
+    tag: 0.35.4
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.3
+    tag: 0.35.4
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.3
+    tag: 0.35.4
     pullPolicy: IfNotPresent
 
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -43,6 +43,18 @@ def houston_api(core_v1_client):
 
 
 @pytest.fixture(scope="function")
+def grafana(core_v1_client):
+    """This is the host fixture for testinfra.
+
+    To read more, please see the testinfra documentation:
+    https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
+    """
+
+    pod = get_pod_by_label_selector(core_v1_client, "component=grafana")
+    yield testinfra.get_host(f"kubectl://{pod}?container=grafana&namespace={namespace}")
+
+
+@pytest.fixture(scope="function")
 def prometheus():
     """This is the host fixture for testinfra.
 

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -57,9 +57,8 @@ def test_houston_check_db_info(houston_api):
         print("No release_name env var, using release_name=astronomer")
         release_name = "astronomer"
 
-    data = houston_api.check_output("env | grep DATABASE_URL")
-    print(data)
-    assert f"{release_name}_houston" in data
+    houston_db_info = houston_api.check_output("env | grep DATABASE_URL")
+    assert f"{release_name}_houston" in houston_db_info
 
 
 def test_grafana_check_db_info(grafana):
@@ -68,9 +67,8 @@ def test_grafana_check_db_info(grafana):
         print("No release_name env var, using release_name=astronomer")
         release_name = "astronomer"
 
-    data = grafana.check_output("env | grep GF_DATABASE_URL")
-    print(data)
-    assert f"{release_name}_grafana" in data
+    grafana_db_info = grafana.check_output("env | grep GF_DATABASE_URL")
+    assert f"{release_name}_grafana" in grafana_db_info
 
 
 def test_houston_can_reach_prometheus(houston_api):

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -51,6 +51,28 @@ def test_houston_config(houston_api):
         ), f"Expected not to find 'localhost' in the 'servers' configuration. Found:\n\n{houston_config['nats']}"
 
 
+def test_houston_check_db_info(houston_api):
+    """Make assertions about Houston's configuration."""
+    if not (release_name := getenv("RELEASE_NAME")):
+        print("No release_name env var, using release_name=astronomer")
+        release_name = "astronomer"
+
+    data = houston_api.check_output("env | grep DATABASE_URL")
+    print(data)
+    assert f"{release_name}_houston" in data
+
+
+def test_grafana_check_db_info(grafana):
+    """Make assertions about Houston's configuration."""
+    if not (release_name := getenv("RELEASE_NAME")):
+        print("No release_name env var, using release_name=astronomer")
+        release_name = "astronomer"
+
+    data = grafana.check_output("env | grep GF_DATABASE_URL")
+    print(data)
+    assert f"{release_name}_grafana" in data
+
+
 def test_houston_can_reach_prometheus(houston_api):
     assert houston_api.check_output(
         "wget --timeout=5 -qO- http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets"


### PR DESCRIPTION
## Description

This PR updates db boostrapper service to 0.35.4 and includes various fixes
Implements funtional testing to validate connection strings assertion

## Related Issues

https://github.com/astronomer/issues/issues/6430

## Testing

funtional tests should pass and connection strings should include service specific db_name

## Merging

cherry-pick to release-0.34
