### PR TITLE
update alertmanager version 0.27.0-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0
+                - quay.io/astronomer/ap-alertmanager:0.27.0-1
                 - quay.io/astronomer/ap-astro-ui:0.35.0
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8
@@ -412,7 +412,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0
+                - quay.io/astronomer/ap-alertmanager:0.27.0-1
                 - quay.io/astronomer/ap-astro-ui:0.35.0
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.27.0
+    tag: 0.27.0-1
     pullPolicy: IfNotPresent
 
 podSecurityContext:


### PR DESCRIPTION
## Description

update alertmanager version 0.27.0-1

## Related Issues

https://github.com/astronomer/issues/issues/6334

## Testing

refer issue ticket

## Merging

cherry-pick to release-0.35
