### PR TITLE
update airflow chart 1.11.1 and commander 0.35.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.0
+                - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.0
+                - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.11.0
+airflowChartVersion: 1.11.1
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.35.0
+    tag: 0.35.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update airflow chart 1.11.1 and commander 0.35.1

## Related Issues

https://github.com/astronomer/issues/issues/6423
https://github.com/astronomer/issues/issues/6383
https://github.com/astronomer/issues/issues/6309
https://github.com/astronomer/issues/issues/6403

## Testing

refer issue ticket 

## Merging

cherry-pick to release-0.35
