### PR TITLE
update houston-api 0.35.3 -> 0.35.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.35.3
+                - quay.io/astronomer/ap-houston-api:0.35.4
                 - quay.io/astronomer/ap-init:3.18.6-2
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.35.3
+                - quay.io/astronomer/ap-houston-api:0.35.4
                 - quay.io/astronomer/ap-init:3.18.6-2
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.3
+    tag: 0.35.4
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston-api 0.35.3 -> 0.35.4

## Related Issues

Related https://github.com/astronomer/issues/issues/6452
Related https://github.com/astronomer/issues/issues/6394
Related https://github.com/astronomer/issues/issues/6404
Related https://github.com/astronomer/issues/issues/6446

## Testing

refer above linked issues

## Merging

cherry-pick to release-0.35
