### PR TITLE
update astro-ui image to 0.35.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,7 +374,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-1
-                - quay.io/astronomer/ap-astro-ui:0.35.1
+                - quay.io/astronomer/ap-astro-ui:0.35.2
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-2
@@ -413,7 +413,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-1
-                - quay.io/astronomer/ap-astro-ui:0.35.1
+                - quay.io/astronomer/ap-astro-ui:0.35.2
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-8
                 - quay.io/astronomer/ap-base:3.18.6-2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.35.1
+    tag: 0.35.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update astro-ui image to 0.35.2

## Related Issues

Related https://github.com/astronomer/issues/issues/6456

## Testing

refer issue ticket
## Merging

cherry-pick to release-0.35
