### PR TITLE
update commander and houston api images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.1
+                - quay.io/astronomer/ap-commander:0.35.2
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4
@@ -389,7 +389,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.35.4
+                - quay.io/astronomer/ap-houston-api:0.35.5
                 - quay.io/astronomer/ap-init:3.18.6-2
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.1
+                - quay.io/astronomer/ap-commander:0.35.2
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4
@@ -428,7 +428,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.2.4
-                - quay.io/astronomer/ap-houston-api:0.35.4
+                - quay.io/astronomer/ap-houston-api:0.35.5
                 - quay.io/astronomer/ap-init:3.18.6-2
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.35.1
+    tag: 0.35.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.4
+    tag: 0.35.5
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update commander and houston api images

| Header | Header | Header |
|--------|--------|--------|
| quay.io/astronomer/ap-commander | 0.35.1 | 0.35.2 |
| quay.io/astronomer/ap-houston-api | 0.35.4 | 0.35.5 |

## Related Issues

Related https://github.com/astronomer/issues/issues/6456
Related https://github.com/astronomer/issues/issues/6459
Related https://github.com/astronomer/issues/issues/6309
Related https://github.com/astronomer/issues/issues/6403

## Testing

refer linked tickets

## Merging

cherry-pick to release-0.35
