### PR TITLE
update commander image 0.35.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,7 +380,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.2
+                - quay.io/astronomer/ap-commander:0.35.3
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.2
+                - quay.io/astronomer/ap-commander:0.35.3
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.35.2
+    tag: 0.35.3
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

rename dag server annotation to correct naming to fix reuse values bug

## Related Issues

https://github.com/astronomer/issues/issues/6459

## Testing

refer issue ticket

## Merging

cherry-pick to release-0.35
