### PR TITLE
db-bootstrapper 0.35.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.4
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.5
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.4
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.5
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.5
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.35.1
                 - quay.io/astronomer/ap-configmap-reloader:0.12.0
                 - quay.io/astronomer/ap-curator:8.0.14-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.5
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.5
+    tag: 0.35.6
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.4
+    tag: 0.35.5
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.5
+    tag: 0.35.6
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.4
+    tag: 0.35.5
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.5
+    tag: 0.35.6
     pullPolicy: IfNotPresent
 
 

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.4
+    tag: 0.35.5
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

db-bootstrapper 0.35.5

## Related Issues

https://github.com/astronomer/issues/issues/6430

## Testing

We need to test both mysql and postgres with underscores and hyphens to make sure the behavior is consistent and does not throw db connection errors.

## Merging

This should be merged everywhere because it is a bugfix for db-bootstrapper and is not specific to the 0.35 release.