### PR TITLE
Updating ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,6 +346,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.6-2
+                - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3
@@ -354,12 +355,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
-                - quay.io/astronomer/ap-elasticsearch:8.12.0
+                - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.5
                 - quay.io/astronomer/ap-init:3.18.7-1
-                - quay.io/astronomer/ap-kibana:8.12.0
+                - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.14-1
@@ -373,7 +374,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.6
                 - quay.io/astronomer/ap-registry:3.18.7-1
-                - quay.io/astronomer/ap-vector:0.33.1-1
+                - quay.io/astronomer/ap-vector:0.38.0-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -385,6 +386,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.6-2
+                - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3
@@ -393,12 +395,12 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
-                - quay.io/astronomer/ap-elasticsearch:8.12.0
+                - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.5
                 - quay.io/astronomer/ap-init:3.18.7-1
-                - quay.io/astronomer/ap-kibana:8.12.0
+                - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.14-1
@@ -412,7 +414,7 @@ workflows:
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.6
                 - quay.io/astronomer/ap-registry:3.18.7-1
-                - quay.io/astronomer/ap-vector:0.33.1-1
+                - quay.io/astronomer/ap-vector:0.38.0-1
           context:
             - twistcli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,6 +345,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
+                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
@@ -384,6 +385,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
+                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -341,38 +341,39 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0-1
+                - quay.io/astronomer/ap-alertmanager:0.27.0-2
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-8
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.6-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
+                - quay.io/astronomer/ap-base:3.18.7-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3
-                - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.14-1
+                - quay.io/astronomer/ap-configmap-reloader:0.13.1
+                - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.2.4
+                - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.5
-                - quay.io/astronomer/ap-init:3.18.6-2
+                - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0
-                - quay.io/astronomer/ap-nats-server:2.10.10
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-3
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.14-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.5
                 - quay.io/astronomer/ap-nginx:1.9.6
-                - quay.io/astronomer/ap-node-exporter:1.8.1
+                - quay.io/astronomer/ap-node-exporter:1.8.1-1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.5
-                - quay.io/astronomer/ap-registry:3.18.6-2
+                - quay.io/astronomer/ap-prometheus:2.45.6
+                - quay.io/astronomer/ap-registry:3.18.7-1
                 - quay.io/astronomer/ap-vector:0.33.1-1
           context:
             - slack_team-software-infra-bot
@@ -380,38 +381,39 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0-1
+                - quay.io/astronomer/ap-alertmanager:0.27.0-2
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-8
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.6-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.24.0-7
+                - quay.io/astronomer/ap-base:3.18.7-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3
-                - quay.io/astronomer/ap-configmap-reloader:0.12.0
-                - quay.io/astronomer/ap-curator:8.0.14-1
+                - quay.io/astronomer/ap-configmap-reloader:0.13.1
+                - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.25
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.0
                 - quay.io/astronomer/ap-fluentd:1.16.3
-                - quay.io/astronomer/ap-grafana:10.2.4
+                - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.5
-                - quay.io/astronomer/ap-init:3.18.6-2
+                - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.0
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0
-                - quay.io/astronomer/ap-nats-server:2.10.10
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-3
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-1
+                - quay.io/astronomer/ap-nats-server:2.10.14-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-4
                 - quay.io/astronomer/ap-nginx-es:1.25.5
                 - quay.io/astronomer/ap-nginx:1.9.6
-                - quay.io/astronomer/ap-node-exporter:1.8.1
+                - quay.io/astronomer/ap-node-exporter:1.8.1-1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-11
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-5
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.5
-                - quay.io/astronomer/ap-registry:3.18.6-2
+                - quay.io/astronomer/ap-prometheus:2.45.6
+                - quay.io/astronomer/ap-registry:3.18.7-1
                 - quay.io/astronomer/ap-vector:0.33.1-1
           context:
             - twistcli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.7-1
+                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3
@@ -384,7 +384,7 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.7-1
+                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
                 - quay.io/astronomer/ap-commander:0.35.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,6 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
@@ -385,7 +384,6 @@ workflows:
                 - quay.io/astronomer/ap-astro-ui:0.35.3
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.6-2
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.27.0-1
+    tag: 0.27.0-2
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.6-2
+    tag: 3.18.7-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.7-1
+    tag: 3.18.6-2
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 8.12.0
+    tag: 8.12.1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.6-2
+    tag: 3.18.7-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.14-1
+    tag: 8.0.15-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.6-2
+    tag: 3.18.7-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-8
+    tag: 1.5.0-9
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.2.4
+    tag: 10.4.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -5,7 +5,7 @@ tolerations: []
 images:
   kibana:
     repository: quay.io/astronomer/ap-kibana
-    tag: 8.12.0
+    tag: 8.12.1
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.6-2
+    tag: 3.18.7-1
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.10
+    tag: 2.10.14-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -10,7 +10,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0
+    tag: 0.15.0-1
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-11
+  tag: 1.17.0-12
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.24.0-7
+  tag: 0.25.0-1
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.8.1
+  tag: 1.8.1-1
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-5
+  tag: 0.15.0-6
   pullPolicy: IfNotPresent
 
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,11 +18,11 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.5
+    tag: 2.45.6
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.12.0
+    tag: 0.13.1
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.6-2
+    tag: 3.18.7-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-3
+    tag: 0.25.6-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0
+    tag: 0.15.0-1
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,7 @@ global:
     containerdnodeAffinitys: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.18.6-2
+      tag: 3.18.7-1
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
@@ -141,7 +141,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.33.1-1
+    image: quay.io/astronomer/ap-vector:0.38.0-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Image Name | Old Tag | New Tag
-- | -- | -- | 
ap-base | 3.18.6-2 | 3.18.7-1
ap-alertmanager | 0.27.0-1 | 0.27.0-2
ap-awsesproxy | 1.5.0-8 | 1.5.0-9
ap-blackbox-exporter | 0.25.0 | 0.25.0-1
ap-curator | 8.0.14 | 8.0.15-1 
ap-init | 3.18.6-2 | 3.18.7-1
ap-nats-exporter | 0.15.0 | 0.15.0-1 
ap-nats-server | 2.10.14 | 2.10.14-1
ap-nats-streaming | 0.25.6-3 |0.25.6-4 
ap-pgbouncer-krb | 1.17.0-11 | 1.17.0-12
ap-postgres-exporter| 0.15.0-5 | 0.15.0-6
ap-registry | 3.18.6-2 | 3.18.7-1 
ap-configmap-reloader | 0.12.0 | 0.13.1
ap-grafana |  10.2.4 | 10.4.5 
ap-prometheus | 2.45.5 | 2.45.6
ap-node-exporter | 1.8.1 | 1.8.1-1
ap-vector | 0.33.1-1 | 0.38.0-1
ap-kibana| 8.12.0 | 8.12.1
ap-elasticsearch| 8.12.0 | 8.12.1



## Related Issues

https://github.com/astronomer/issues/issues/6305
https://github.com/astronomer/issues/issues/6462

## Testing

generic testing to ensure all components up and running

## Merging

This should be merged/cherry-picked into releases 0.34 0.35 
