### PR TITLE
Remove commander expire-deployments networkPolicies

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -55,11 +55,6 @@ spec:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
-          component: houston-expire-deployments
-    - podSelector:
-        matchLabels:
-          tier: astronomer
-          release: {{ .Release.Name }}
           component: houston
     - podSelector:
         matchLabels:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -44,11 +44,6 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
-          component: houston-expire-deployments
-          release: {{ .Release.Name }}
-    - podSelector:
-        matchLabels:
-          tier: astronomer
           component: houston-db-migrations
           release: {{ .Release.Name }}
     - podSelector:


### PR DESCRIPTION
## Description

Remove commander expire-deployments networkPolicies. This is a follow-up to https://github.com/astronomer/astronomer/pull/2252

## Related Issues

https://github.com/astronomer/issues/issues/6510

## Testing

No extra human testing needed. However, if we do encounter any failures related to this, it only points to an additional bug. It is unlikely we have such a bug, but if we do find one, we should fix it instead of worrying about this change. With that in mind, all we need to do is be aware that this change has been made.

## Merging

Merge everywhere that we are merging https://github.com/astronomer/astronomer/pull/2252