### PR TITLE
update airflow chart 1.11.4 and commander version 0.35.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.5
+                - quay.io/astronomer/ap-commander:0.35.6
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
@@ -387,7 +387,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
                 - quay.io/astronomer/ap-cli-install:0.26.24
-                - quay.io/astronomer/ap-commander:0.35.5
+                - quay.io/astronomer/ap-commander:0.35.6
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.11.3
+airflowChartVersion: 1.11.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.35.5
+    tag: 0.35.6
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update airflow chart 1.11.4 and commander version 0.35.6

## Related Issues

https://github.com/astronomer/issues/issues/6487
https://github.com/astronomer/issues/issues/6506
https://github.com/astronomer/issues/issues/6518

## Testing

refer issue tickets

## Merging

cherry-pick to release-0.35
