### PR TITLE
enable dag server persistance spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.5
+                - quay.io/astronomer/ap-houston-api:0.35.7
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -396,7 +396,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.5
+                - quay.io/astronomer/ap-houston-api:0.35.7
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -165,7 +165,7 @@ data:
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.persistence }}
-        persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 12 }}
+        persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -164,6 +164,9 @@ data:
         client:
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.persistence }}
+        persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 12 }}
+        {{- end }}
       {{- end }}
 
       # These values get passed directly into the airflow helm deployments

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.5
+    tag: 0.35.7
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -125,3 +125,56 @@ class TestDagOnlyDeploy:
         assert prod["deployments"]["dagOnlyDeployment"] is True
 
         assert {} == prod["deployments"]["dagDeploy"]["securityContext"]
+
+    def test_dagonlydeploy_config_enabled_with_persistence_retain(self, kube_version):
+        """Test dagonlydeploy to validate persistence policy retain."""
+        persistenceRetain = {
+            "persistentVolumeClaimRetentionPolicy": {
+                "whenDeleted": "Retain",
+                "whenScaled": "Retain",
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "persistence": persistenceRetain,
+                    },
+                },
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["dagOnlyDeployment"] is True
+
+        assert persistenceRetain == prod["deployments"]["dagDeploy"]["persistence"]
+
+    def test_dagonlydeploy_config_enabled_with_persistence_delete(self, kube_version):
+        """Test dagonlydeploy to validate persistence policy delete."""
+        persistenceRetain = {
+            "persistentVolumeClaimRetentionPolicy": {
+                "whenDeleted": "Delete",
+                "whenScaled": "Retain",
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "persistence": persistenceRetain,
+                    },
+                },
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["dagOnlyDeployment"] is True
+        assert persistenceRetain == prod["deployments"]["dagDeploy"]["persistence"]

--- a/values.yaml
+++ b/values.yaml
@@ -132,6 +132,7 @@ global:
     securityContext:
       fsGroup: 50000
     resources: {}
+    persistence: {}
 
   logging:
     indexNamePrefix: ~


### PR DESCRIPTION
## Description

enable dag server persistance spec 

## Related Issues

https://github.com/astronomer/issues/issues/6436

## Testing

```
global:
  dagOnlyDeployment:
    enabled: true
    persistence:
      persistentVolumeClaimRetentionPolicy:
        whenDeleted: Delete
        whenScaled: Retain
```

Action explanation:

whenDeleted: Delete - this means once the statefulset template is deleted kubernetes will automatically delete the pvc as well
whenScaled: Retain. - his means once the statefulset scaled up or down pvc is retained

## Merging

cherry-pick to release-0.35
