### PR TITLE
add persistance policy for platform components

### DIFF
--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -12,6 +12,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   replicas: {{ .Values.replicas }}
   serviceName: {{ template "alertmanager.fullname" . }}
   selector:

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   replicas: {{ .Values.replicas }}
   serviceName: {{ template "alertmanager.fullname" . }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -36,6 +36,7 @@ persistence:
   size: 2Gi
   storageClassName: ~
   annotations: {}
+  persistentVolumeClaimRetentionPolicy: ~
 
 env: {}
 

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     role: data
 spec:
   {{- if and .Values.common.persistence.enabled .Values.common.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-data
   replicas: {{ .Values.data.replicas }}

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -13,8 +13,8 @@ metadata:
     heritage: {{ .Release.Service }}
     role: data
 spec:
-  {{- if and .Values.commmon.persistence.enabled .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{- if and .Values.common.persistence.enabled .Values.common.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-data
   replicas: {{ .Values.data.replicas }}

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
     heritage: {{ .Release.Service }}
     role: data
 spec:
+  {{- if and .Values.commmon.persistence.enabled .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-data
   replicas: {{ .Values.data.replicas }}
   selector:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     role: master
 spec:
   {{- if and .Values.common.persistence.enabled .Values.common.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-master
   replicas: {{ .Values.master.replicas }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -13,8 +13,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
     role: master
 spec:
-  {{- if and .Values.commmon.persistence.enabled .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{- if and .Values.common.persistence.enabled .Values.common.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.common.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
   {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-master
   replicas: {{ .Values.master.replicas }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -13,6 +13,9 @@ metadata:
     heritage: "{{ .Release.Service }}"
     role: master
 spec:
+  {{- if and .Values.commmon.persistence.enabled .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.commmon.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   serviceName: {{ template "elasticsearch.fullname" . }}-master
   replicas: {{ .Values.master.replicas }}
   selector:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -52,6 +52,7 @@ common:
   persistence:
     enabled: true
     annotations: {}
+    persistentVolumeClaimRetentionPolicy: ~
 
     # The PVC storage class that backs the persistent volume claims. On AWS
     # "gp2" would be appropriate.

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service | quote }}
 spec:
   {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: {{ .Values.replication.slaveReplicas }}

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -9,6 +9,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
+  {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: {{ .Values.replication.slaveReplicas }}
   selector:

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -12,6 +12,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
 spec:
+  {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: 1
   updateStrategy:

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
   {{- end }}
 spec:
   {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   serviceName: {{ template "postgresql.fullname" . }}-headless
   replicas: 1

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -248,6 +248,7 @@ persistence:
     - ReadWriteOnce
   size: 8Gi
   annotations: {}
+  persistentVolumeClaimRetentionPolicy: ~
 
 ## updateStrategy for PostgreSQL StatefulSet and its slaves StatefulSets
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -12,6 +12,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   replicas: {{ .Values.replicas }}
   serviceName: {{ template "prometheus.fullname" . }}
   selector:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -13,7 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   {{- if and .Values.persistence.enabled .Values.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   replicas: {{ .Values.replicas }}
   serviceName: {{ template "prometheus.fullname" . }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -72,6 +72,7 @@ persistence:
   size: 100Gi
   storageClassName: ~
   annotations: {}
+  persistentVolumeClaimRetentionPolicy: ~
 
 ports:
   http: 9090

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -16,7 +16,7 @@ metadata:
   {{- end }}
 spec:
   {{- if and .Values.store.volume.enabled  .Values.persistence.persistentVolumeClaimRetentionPolicy }}
-  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy | nindent 4 }}
   {{ end }}
   selector:
     matchLabels:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -15,6 +15,9 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
 spec:
+  {{- if and .Values.store.volume.enabled  .Values.persistence.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy: {{- toYaml .Values.persistence.persistentVolumeClaimRetentionPolicy  | nindent 4 }}
+  {{ end }}
   selector:
     matchLabels:
       app: {{ template "stan.name" . }}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -183,3 +183,4 @@ exporter:
 # nats chart values.
 persistence:
   annotations: {}
+  persistentVolumeClaimRetentionPolicy: ~

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -32,11 +32,13 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "StatefulSet"
         esm_containers = get_containers_by_name(docs[0], include_init_containers=True)
         assert vm_max_map_count in esm_containers["sysctl"]["command"]
+        assert "persistentVolumeClaimRetentionPolicy" not in docs[0]["spec"]
 
         # elasticsearch data
         assert docs[1]["kind"] == "StatefulSet"
         esd_containers = get_containers_by_name(docs[1], include_init_containers=True)
         assert vm_max_map_count in esd_containers["sysctl"]["command"]
+        assert "persistentVolumeClaimRetentionPolicy" not in docs[1]["spec"]
 
         # elasticsearch client
         assert docs[2]["kind"] == "Deployment"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -650,3 +650,34 @@ class TestElasticSearch:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["nginx"]["securityContext"] == {"runAsNonRoot": True}
+
+    def test_elasticsearch_persistentVolumeClaimRetentionPolicy(self, kube_version):
+        test_persistentVolumeClaimRetentionPolicy = {
+            "whenDeleted": "Delete",
+            "whenScaled": "Retain",
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "elasticsearch": {
+                    "common": {
+                        "persistence": {
+                            "persistentVolumeClaimRetentionPolicy": test_persistentVolumeClaimRetentionPolicy,
+                        },
+                    },
+                },
+            },
+            show_only=[
+                "charts/elasticsearch/templates/master/es-master-statefulset.yaml",
+                "charts/elasticsearch/templates/data/es-data-statefulset.yaml",
+            ],
+        )
+
+        assert len(docs) == 2
+
+        for doc in docs:
+            assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
+            assert (
+                test_persistentVolumeClaimRetentionPolicy
+                == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+            )

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -70,3 +70,64 @@ class TestPostgresql:
                 assert container["image"].startswith(
                     repository
                 ), f"Container named '{name}' does not use registry '{repository}': {container}"
+
+    def test_postgresql_persistentVolumeClaimRetentionPolicy(self, kube_version):
+        test_persistentVolumeClaimRetentionPolicy = {
+            "whenDeleted": "Delete",
+            "whenScaled": "Retain",
+        }
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"postgresqlEnabled": True},
+                "postgresql": {
+                    "persistence": {
+                        "persistentVolumeClaimRetentionPolicy": test_persistentVolumeClaimRetentionPolicy,
+                    },
+                },
+            },
+            show_only=[
+                "charts/postgresql/templates/statefulset.yaml",
+            ],
+        )
+
+        assert len(doc) == 1
+
+        assert "persistentVolumeClaimRetentionPolicy" in doc[0]["spec"]
+        assert (
+            test_persistentVolumeClaimRetentionPolicy
+            == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
+        )
+
+    def test_postgresql_replication_persistentVolumeClaimRetentionPolicy(
+        self, kube_version
+    ):
+        test_persistentVolumeClaimRetentionPolicy = {
+            "whenDeleted": "Delete",
+            "whenScaled": "Retain",
+        }
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"postgresqlEnabled": True},
+                "postgresql": {
+                    "replication": {
+                        "enabled": True,
+                    },
+                    "persistence": {
+                        "persistentVolumeClaimRetentionPolicy": test_persistentVolumeClaimRetentionPolicy,
+                    },
+                },
+            },
+            show_only=[
+                "charts/postgresql/templates/statefulset-slaves.yaml",
+            ],
+        )
+
+        assert len(doc) == 1
+
+        assert "persistentVolumeClaimRetentionPolicy" in doc[0]["spec"]
+        assert (
+            test_persistentVolumeClaimRetentionPolicy
+            == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
+        )

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -22,6 +22,7 @@ class TestPostgresql:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-postgresql"
         assert "initContainers" not in doc["spec"]["template"]["spec"]
+        assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
 
     def test_postgresql_statefulset_with_volumePermissions_enabled(self, kube_version):
         """Test postgresql statefulset when volumePermissions init container is

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -127,3 +127,26 @@ class TestPrometheusStatefulset:
             "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
         )
         assert "--enable-feature=agent" in c_by_name["prometheus"]["args"]
+
+    def test_prometheus_persistentVolumeClaimRetentionPolicy(self, kube_version):
+        test_persistentVolumeClaimRetentionPolicy = {
+            "whenDeleted": "Delete",
+            "whenScaled": "Retain",
+        }
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus": {
+                    "persistence": {
+                        "persistentVolumeClaimRetentionPolicy": test_persistentVolumeClaimRetentionPolicy,
+                    },
+                },
+            },
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
+        )[0]
+
+        assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
+        assert (
+            test_persistentVolumeClaimRetentionPolicy
+            == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+        )

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -46,6 +46,7 @@ class TestPrometheusStatefulset:
             {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
             {"mountPath": "/prometheus", "name": "data"},
         ]
+        assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
         # check default liveness probe values
         assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10
         assert c_by_name["prometheus"]["livenessProbe"]["periodSeconds"] == 5


### PR DESCRIPTION
## Description

Adds persistance policy support for below components
alertmanager
prometheus
elasticsearch
postgresql
stan

scope: for POC adding these policy cleans up the pvc after the uninstallation of platform

## Related Issues

https://github.com/astronomer/astronomer/issues/1974

## Testing



## Merging

cherry-pick to release-0.35 and release-0.36
