### PR TITLE
ap-dag-deploy:0.5.2

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -128,7 +128,7 @@ global:
 
   dagOnlyDeployment:
     enabled: false
-    image: quay.io/astronomer/ap-dag-deploy:0.5.1
+    image: quay.io/astronomer/ap-dag-deploy:0.5.2
     securityContext:
       fsGroup: 50000
     resources: {}


### PR DESCRIPTION
## Description

ap-dag-deploy 0.5.2 makes rollbacks and dag-deploy work well together.

## Related Issues

https://github.com/astronomer/issues/issues/6393

## Testing

This will need a lot of testing.

## Merging

Merge to 0.35, 0.36.