### PR TITLE
update houston api 0.35.8 and astro-ui 0.35.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-2
-                - quay.io/astronomer/ap-astro-ui:0.35.3
+                - quay.io/astronomer/ap-astro-ui:0.35.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.7-1
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.7
+                - quay.io/astronomer/ap-houston-api:0.35.8
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -381,7 +381,7 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-2
-                - quay.io/astronomer/ap-astro-ui:0.35.3
+                - quay.io/astronomer/ap-astro-ui:0.35.5
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.7-1
@@ -396,7 +396,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.7
+                - quay.io/astronomer/ap-houston-api:0.35.8
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.7
+    tag: 0.35.8
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.35.3
+    tag: 0.35.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update houston api 0.35.8 and astro-ui 0.35.5

## Related Issues

Related https://github.com/astronomer/issues/issues/6422
Related https://github.com/astronomer/issues/issues/6498
Related https://github.com/astronomer/issues/issues/6393
Related https://github.com/astronomer/issues/issues/6513

## Testing

refer issue tickets 

## Merging

cherry-pick to release-0.35
