### PR TITLE
houston-api 0.35.9, dag-server 0.5.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.8
+                - quay.io/astronomer/ap-houston-api:0.35.9
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -396,7 +396,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.8
+                - quay.io/astronomer/ap-houston-api:0.35.9
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -23,9 +23,9 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston-cleanup
+            component: houston
             release: {{ .Release.Name }}
-            app: houston-cleanup
+            app: houston
             version: {{ .Chart.Version }}
           {{- if .Values.global.istio.enabled }}
           annotations:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.8
+    tag: 0.35.9
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/values.yaml
+++ b/values.yaml
@@ -128,7 +128,7 @@ global:
 
   dagOnlyDeployment:
     enabled: false
-    image: quay.io/astronomer/ap-dag-deploy:0.5.2
+    image: quay.io/astronomer/ap-dag-deploy:0.5.3
     securityContext:
       fsGroup: 50000
     resources: {}


### PR DESCRIPTION
## Description

update houston api 0.35.9 and dag server with 0.5.3

## Related Issues

Related https://github.com/astronomer/issues/issues/6531 
Related https://github.com/astronomer/issues/issues/6455
Related https://github.com/astronomer/issues/issues/6529
Related https://github.com/astronomer/issues/issues/6451


## Testing

refer issue ticket

## Merging

cherry-pick to release-0.35
