### PR TITLE
update houston api 0.35.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.9
+                - quay.io/astronomer/ap-houston-api:0.35.10
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -396,7 +396,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.9
+                - quay.io/astronomer/ap-houston-api:0.35.10
                 - quay.io/astronomer/ap-init:3.18.7-1
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.9
+    tag: 0.35.10
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.35.10

## Related Issues

https://github.com/astronomer/issues/issues/6527

## Testing

NA

## Merging


cherry-pick to master, release-0.35
