### PR TITLE
cli-install 0.26.25, default-backend 0.28.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,12 +347,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.24
+                - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.0
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
-                - quay.io/astronomer/ap-default-backend:0.28.25
+                - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3
@@ -386,12 +386,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-9
                 - quay.io/astronomer/ap-base:3.18.7-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
-                - quay.io/astronomer/ap-cli-install:0.26.24
+                - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.0
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.15-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
-                - quay.io/astronomer/ap-default-backend:0.28.25
+                - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.16.3

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.24
+    tag: 0.26.25
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.25
+    tag: 0.28.26
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

| imageName | oldVersion | newVersion |
|--------|--------|--------|
| ap-cli-install | 0.26.24 | 0.26.25 |
| default-backend | 0.28.25 | 0.28.26 |


## Related Issues

https://github.com/astronomer/issues/issues/6533

## Testing

NA

## Merging

cherry-pick release-0.35, release-0.36
