### PR TITLE
fix kibana ui warnings

### DIFF
--- a/charts/kibana/templates/kibana-deployment.yaml
+++ b/charts/kibana/templates/kibana-deployment.yaml
@@ -50,6 +50,10 @@ spec:
           value: "http://{{ .Release.Name }}-elasticsearch:9200"
         - name: ELASTICSEARCH_REQUESTTIMEOUT
           value: "60000"
+        {{- if .Values.global.baseDomain }}
+        - name: SERVER_PUBLICBASEURL
+          value: https://{{ template "kibana.name" . }}.{{ .Values.global.baseDomain }}
+        {{- end }}
         resources: {{ toYaml .Values.resources | nindent 12 }}
         ports:
         - containerPort: {{ .Values.ports.http }}


### PR DESCRIPTION
## Description

currenly with existing kibana we see below warning 
<img width="418" alt="image" src="https://github.com/user-attachments/assets/4d7719ad-5708-4198-a2b4-0fc5b3601a2e">

with this new change the warning will go away 

## Related Issues

https://github.com/astronomer/issues/issues/6539
https://github.com/astronomer/astronomer/issues/1275

## Testing

QA should not see any warning when kibana url is opened

## Merging

cherry-pick to release-0.35 and release-0.36
