### PR TITLE
Update prometheus and  fluentd packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.3
+                - quay.io/astronomer/ap-fluentd:1.16.5
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8
@@ -394,7 +394,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.3
+                - quay.io/astronomer/ap-fluentd:1.16.5
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.5
+                - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8
@@ -394,7 +394,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.5
+                - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.17.0
+                - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8
@@ -394,7 +394,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.17.0
+                - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,7 +355,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.3
+                - quay.io/astronomer/ap-fluentd:1.17.0
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.7-1
@@ -371,7 +371,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.6
+                - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.7-1
                 - quay.io/astronomer/ap-vector:0.38.0-1
           context:
@@ -394,7 +394,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
-                - quay.io/astronomer/ap-fluentd:1.16.3
+                - quay.io/astronomer/ap-fluentd:1.17.0
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
                 - quay.io/astronomer/ap-init:3.18.7-1
@@ -410,7 +410,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
-                - quay.io/astronomer/ap-prometheus:2.45.6
+                - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.7-1
                 - quay.io/astronomer/ap-vector:0.38.0-1
           context:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,11 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/psf/black
-    rev: 24.4.2
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.4.10"
+    rev: "v0.5.7"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --ignore, E501]

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 .PHONY: help
 help: ## Print Makefile help.
-	@grep -Eh '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-41s\033[0m %s\n", $$1, $$2}'
+	@grep -Eh '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[1;36m%-41s\033[0m %s\n", $$1, $$2}'
 
 # List of charts to build
 CHARTS := astronomer nginx grafana prometheus alertmanager elasticsearch kibana fluentd kube-state postgresql

--- a/bin/test-ap
+++ b/bin/test-ap
@@ -18,5 +18,5 @@ export RELEASE_NAME=astronomer
 echo "Sleeping for 100 seconds to allow metrics to be collected so we can test against them"
 
 mkdir -p "test-results"
-pytest -v "--junitxml=test-results/junit.xml" -s "$GIT_ROOT/tests/functional_tests/"
+pytest --maxfail=1 -v "--junitxml=test-results/junit.xml" -s "$GIT_ROOT/tests/functional_tests/"
 deactivate

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.5
+    tag: 1.17.0-1
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.3
+    tag: 1.17.0
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.17.0
+    tag: 1.16.3
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.16.3
+    tag: 1.16.5
     pullPolicy: IfNotPresent
 
 elasticsearch:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.45.6
+    tag: 2.53.1
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader


### PR DESCRIPTION
## Description
| Image Name    | Old-tag | New-tag  |
| ------------- | ------- | -------- |
| ap-prometheus | 2.45.6  | 2.53.1   |
| ap-fluentd    | 1.16.5  | 1.17.0-1 |

## Related Issues

https://github.com/astronomer/issues/issues/6557
https://github.com/astronomer/issues/issues/6514

## Testing

Due to the huge fluentd changes we will need to test this one quite a bit and make sure all fluentd logging scenarios are working as expected. @pgvishnuram is the SME on what edge cases may pop up due to these changes.

## Merging

 cherry-pick to 0.35,0.36 and 0.34 branches 
