### PR TITLE
Update ap base packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -344,13 +344,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-2
                 - quay.io/astronomer/ap-astro-ui:0.35.8
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.7-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-10
+                - quay.io/astronomer/ap-base:3.18.8
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.0
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
-                - quay.io/astronomer/ap-curator:8.0.15-1
+                - quay.io/astronomer/ap-curator:8.0.16-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -358,22 +358,22 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
-                - quay.io/astronomer/ap-init:3.18.7-1
+                - quay.io/astronomer/ap-init:3.18.8
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.14-1
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-4
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.14-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-5
                 - quay.io/astronomer/ap-nginx-es:1.25.5
                 - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.8.1-1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.6
-                - quay.io/astronomer/ap-registry:3.18.7-1
-                - quay.io/astronomer/ap-vector:0.38.0-1
+                - quay.io/astronomer/ap-registry:3.18.8
+                - quay.io/astronomer/ap-vector:0.40.0-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -383,13 +383,13 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-2
                 - quay.io/astronomer/ap-astro-ui:0.35.8
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-9
-                - quay.io/astronomer/ap-base:3.18.7-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-1
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-10
+                - quay.io/astronomer/ap-base:3.18.8
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.0
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
-                - quay.io/astronomer/ap-curator:8.0.15-1
+                - quay.io/astronomer/ap-curator:8.0.16-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -397,22 +397,22 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.16.3
                 - quay.io/astronomer/ap-grafana:10.4.5
                 - quay.io/astronomer/ap-houston-api:0.35.11
-                - quay.io/astronomer/ap-init:3.18.7-1
+                - quay.io/astronomer/ap-init:3.18.8
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.14-1
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-4
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.14-2
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-5
                 - quay.io/astronomer/ap-nginx-es:1.25.5
                 - quay.io/astronomer/ap-nginx:1.9.6
                 - quay.io/astronomer/ap-node-exporter:1.8.1-1
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-12
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-6
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
                 - quay.io/astronomer/ap-postgresql:15.6.0-1
                 - quay.io/astronomer/ap-prometheus:2.45.6
-                - quay.io/astronomer/ap-registry:3.18.7-1
-                - quay.io/astronomer/ap-vector:0.38.0-1
+                - quay.io/astronomer/ap-registry:3.18.8
+                - quay.io/astronomer/ap-vector:0.40.0-1
           context:
             - twistcli
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.7-1
+    tag: 3.18.8
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.7-1
+    tag: 3.18.8
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.15-1
+    tag: 8.0.16-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-9
+    tag: 1.5.0-10
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.7-1
+    tag: 3.18.8
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.14-1
+    tag: 2.10.14-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-1
+    tag: 0.15.0-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-12
+  tag: 1.17.0-13
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-1
+  tag: 0.25.0-2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-6
+  tag: 0.15.0-7
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.7-1
+    tag: 3.18.8
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-4
+    tag: 0.25.6-5
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-1
+    tag: 0.15.0-2
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,7 @@ global:
     containerdnodeAffinitys: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.18.7-1
+      tag: 3.18.8
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
@@ -141,7 +141,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.38.0-1
+    image: quay.io/astronomer/ap-vector:0.40.0-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Update ap-base packages with 3.18.8

Image Name |  old  Tag| New tag |
-- | -- | -- |
ap-blackbox-exporter | 0.25.0-1| 0.25.0-2
ap-registry| 3.18.7-1 | 3.18.8
ap-postgres-exporter|0.15.0-6 |  0.15.0-7
ap-nats-streaming| 0.25.6-4 | 0.25.6-5
ap-nats-server| 2.10.14-1 | 2.10.14-2
ap-nats-exporter| 0.15.0-1 | 0.15.0-2
ap-init | 3.18.7-1 | 3.18.8
ap-curator | 8.0.15-1 |  8.0.16-1
ap-awsesproxy| 1.5.0-9 | 1.5.0-10
ap-vector | 0.48.0| 0.48.0-1
ap-pgbouncer-krb |1.17.0-12 | 1.17.0-13
ap-base | 3.18.7-1 | 3.18.3 

## Related Issues

https://github.com/astronomer/issues/issues/6557

## Testing

All components should run without any issues 

## Merging

Need to Cherry-pic release-0.34,0.35,0.36
