### PR TITLE
update commander 0.36.2 with airflow chart 1.11.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,7 +348,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.8
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.25
-                - quay.io/astronomer/ap-commander:0.36.0
+                - quay.io/astronomer/ap-commander:0.36.2
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
@@ -387,7 +387,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.8
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
                 - quay.io/astronomer/ap-cli-install:0.26.25
-                - quay.io/astronomer/ap-commander:0.36.0
+                - quay.io/astronomer/ap-commander:0.36.2
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.11.2
+airflowChartVersion: 1.11.4
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.36.0
+    tag: 0.36.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander 0.36.2 with airflow chart 1.11.4

## Related Issues

https://github.com/astronomer/issues/issues/6401
https://github.com/astronomer/issues/issues/6547
https://github.com/astronomer/issues/issues/6523
https://github.com/astronomer/issues/issues/6401

## Testing

refer issue tickets

## Merging

cherry-pick to release-0.36
