### PR TITLE
Add debug port for nginx-ingress

### DIFF
--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -73,6 +73,8 @@ spec:
               containerPort: {{ .Values.ports.https }}
             - name: metrics
               containerPort: {{ .Values.ports.metrics }}
+            - name: debug
+              containerPort: 10245
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Description

Exposes the debug port on the nginx-ingress controller. This is already running in the container but is not currently exposed to be able to port-forward and see the heap dump from a browser

## Related Issues

Fixes: https://github.com/astronomer/issues/issues/6579

## Testing

Manually edited the deployment configuration to add it. You can then port forward the port from each pod and run `go tool pprof -http=:8082 localhost:10245/debug/pprof` to view the heap

## Merging

Ship in next release