### PR TITLE
Fix CVE-2024-7646 by bumping nginx to 1.11.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.14-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-5
                 - quay.io/astronomer/ap-nginx-es:1.27.0
-                - quay.io/astronomer/ap-nginx:1.9.6
+                - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
@@ -404,7 +404,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.14-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-5
                 - quay.io/astronomer/ap-nginx-es:1.27.0
-                - quay.io/astronomer/ap-nginx:1.9.6
+                - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.9.6
+    tag: 1.11.2
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

This is a yolo attempt at blindly bumping the version of nginx from 1.9.x to 1.11.x to see if it works. There may be changes between these two versions that cause this to break, so we'll have to pay attention to all nginx-ingress related things. Looking at the [list of breaking changes](https://github.com/kubernetes/ingress-nginx/issues/10186) between 1.9 and 1.11, I think we should be good with 1.11.

## Related Issues

- https://github.com/astronomer/issues/issues/6591

## Testing

All nginx-ingress related features should be tested.

## Merging

This should be cherry-picked into all supported versions to fix CVE-2024-7646.