### PR TITLE
add nginx electionTTL overrides

### DIFF
--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -59,6 +59,9 @@ spec:
             {{- if .Values.disableLeaderElection }}
             - --disable-leader-election=true
             {{- end }}
+            {{- if .Values.electionTTL }}
+            - --election-ttl={{ .Values.electionTTL }}
+            {{- end }}
             {{- if .Values.enableTopologyAwareRouting }}
             - --enable-topology-aware-routing=true
             {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -92,6 +92,9 @@ enableTopologyAwareRouting: false
 
 disableLeaderElection: false
 
+# -- Duration a leader election is valid before it's getting re-elected, e.g. `15s`, `10m` or `1h`. (Default: 30s)
+electionTTL: ""
+
 # -- This configuration defines if Ingress Controller should allow users to set
 # their own *-snippet annotations, otherwise this is forbidden / dropped
 # when users add those annotations.

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -226,6 +226,7 @@ class TestNginx:
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
         )[0]
 
+        electionTTL = "--election-ttl"
         electionId = "--election-id=ingress-controller-leader-release-name-nginx"
         topologyAwareRouting = "--enable-topology-aware-routing"
         annotationValidation = "--enable-annotation-validation"
@@ -235,6 +236,7 @@ class TestNginx:
 
         assert doc["spec"]["minReadySeconds"] == 0
         assert electionId in c_by_name["nginx"]["args"]
+        assert electionTTL not in c_by_name["nginx"]["args"]
         assert topologyAwareRouting not in c_by_name["nginx"]["args"]
         assert annotationValidation not in c_by_name["nginx"]["args"]
         assert disableLeaderElection not in c_by_name["nginx"]["args"]
@@ -247,6 +249,15 @@ class TestNginx:
         )[0]
 
         assert doc["spec"]["minReadySeconds"] == minReadySeconds
+
+    def test_nginx_election_ttl_overrides(self):
+        doc = render_chart(
+            values={"nginx": {"electionTTL": "30s"}},
+            show_only=["charts/nginx/templates/nginx-deployment.yaml"],
+        )[0]
+        electionTTL = "--election-ttl=30s"
+        c_by_name = get_containers_by_name(doc)
+        assert electionTTL in c_by_name["nginx"]["args"]
 
     def test_nginx_topology_aware_routing_overrides(self):
         doc = render_chart(


### PR DESCRIPTION
## Description

This PR adds electionTTL configurable args to nginx ingress controller

## Related Issues

https://github.com/astronomer/issues/issues/6600

## Testing

QA should able to validate electionTTL args in nginx deployment spec 

## Merging

cherry-pick to all valid releases which has nginx ingress >= 1.11
