### PR TITLE
Expand and configure linting. Fix ruff complaints.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,10 @@ repos:
     rev: "v0.5.7"
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --ignore, E501]
+        args:
+          - "--fix"
+          - "--exit-non-zero-on-fix"
+          # - "--unsafe-fixes"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -7,9 +7,7 @@ import yaml
 
 from jinja2 import Template
 
-git_root_dir = next(
-    iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None
-)
+git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
 metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
@@ -21,9 +19,7 @@ ci_runner_version = "2024-07"
 def list_docker_images():
     command = f"{git_root_dir}/bin/show-docker-images.py --with-houston"
     docker_images_output = subprocess.check_output(command, shell=True)
-    docker_image_list = [
-        x.split()[1] for x in docker_images_output.decode("utf-8").strip().split("\n")
-    ]
+    docker_image_list = [x.split()[1] for x in docker_images_output.decode("utf-8").strip().split("\n")]
 
     return sorted(set(docker_image_list))
 
@@ -32,12 +28,8 @@ def main():
     """Render the Jinja2 template file."""
     for version in kube_versions:
         maj_min = version.rpartition(".")[0]
-        if not Path(
-            git_root_dir / "bin" / "kind" / f"calico-crds-v{maj_min}.yaml"
-        ).exists():
-            raise SystemExit(
-                f"ERROR: calico-crds-v{maj_min}.yaml is required for for CircleCI to succeed but it does not exist!"
-            )
+        if not Path(git_root_dir / "bin" / "kind" / f"calico-crds-v{maj_min}.yaml").exists():
+            raise SystemExit(f"ERROR: calico-crds-v{maj_min}.yaml is required for for CircleCI to succeed but it does not exist!")
     config_file_template_path = git_root_dir / ".circleci" / "config.yml.j2"
     config_file_path = git_root_dir / ".circleci" / "config.yml"
 

--- a/bin/get-k8s-versions.py
+++ b/bin/get-k8s-versions.py
@@ -7,14 +7,14 @@ import yaml
 
 def get_latest_versions(repository, num_versions):
     url = f"https://hub.docker.com/v2/repositories/{repository}/tags/"
-    response = requests.get(url)
+    response = requests.get(url, timeout=30)
     data = response.json()
 
     versions = {}
     for tag in data["results"]:
         version = tag["name"]
         # Split version string into major, minor, and patch
-        major, minor, patch = [int(x.removeprefix("v")) for x in version.split(".")]
+        major, minor, patch = (int(x.removeprefix("v")) for x in version.split("."))
         key = f"{major}.{minor}"
         # Only keep the highest patch version for each major.minor
         if key not in versions or versions[key] < patch:
@@ -29,9 +29,7 @@ def generate_yaml(versions):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Generate a YAML list of latest Docker image versions"
-    )
+    parser = argparse.ArgumentParser(description="Generate a YAML list of latest Docker image versions")
     parser.add_argument("-n", type=int, default=5, help="Number of versions to include")
     parser.add_argument(
         "--repo",

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -13,10 +13,7 @@ from collections import defaultdict
 
 def get_containers_from_spec(spec):
     """Return a list of images used in a kubernetes pod spec."""
-    return [
-        container["image"]
-        for container in spec.get("containers", []) + spec.get("initContainers", [])
-    ]
+    return [container["image"] for container in spec.get("containers", []) + spec.get("initContainers", [])]
 
 
 def print_results(items):
@@ -36,9 +33,7 @@ def default_spec_parser(doc, args):
         print(f"Processing {doc['kind']} {doc['metadata']['name']}", file=sys.stderr)
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
-        print(
-            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry'
-        )
+        print(f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry')
         if args.verbose:
             print(json.dumps(doc["spec"]["template"]["spec"]), file=sys.stderr)
 
@@ -51,14 +46,10 @@ def job_template_spec_parser(doc, args):
     if args.verbose:
         print(f"Processing {doc['kind']} {doc['metadata']['name']}", file=sys.stderr)
 
-    item_containers = get_containers_from_spec(
-        doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]
-    )
+    item_containers = get_containers_from_spec(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"])
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
-        print(
-            f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry'
-        )
+        print(f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry')
         if args.verbose:
             print(
                 json.dumps(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]),
@@ -73,9 +64,7 @@ def get_images_from_houston_configmap(doc, args):
     houston_config = yaml.safe_load(doc["data"]["production.yaml"])
     keepers = ("authSideCar", "loggingSidecar")
     items = {k: v for k, v in houston_config["deployments"].items() if k in keepers}
-    auth_sidecar_image = (
-        f'{items["authSideCar"]["repository"]}:{items["authSideCar"]["tag"]}'
-    )
+    auth_sidecar_image = f'{items["authSideCar"]["repository"]}:{items["authSideCar"]["tag"]}'
     logging_sidecar_image = f'{items["loggingSidecar"]["image"]}'
     images = (auth_sidecar_image, logging_sidecar_image)
     if args.verbose and any("quay.io" in x for x in images):
@@ -96,8 +85,7 @@ def helm_template(args):
     command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
     if args.private_registry:
         command += (
-            " --set global.privateRegistry.repository=example.com/the-private-registry"
-            " --set global.privateRegistry.enabled=True"
+            " --set global.privateRegistry.repository=example.com/the-private-registry" " --set global.privateRegistry.enabled=True"
         )
 
     if args.verbose:
@@ -150,9 +138,7 @@ def main():
 
     if args.check_tags:
         image_tag_counts = defaultdict(int)
-        for x, y in [
-            (tag.rpartition(":")[0], tag.rpartition(":")[2]) for tag in containers
-        ]:
+        for x, y in [(tag.rpartition(":")[0], tag.rpartition(":")[2]) for tag in containers]:
             image_tag_counts[x] += 1
         for image, count in image_tag_counts.items():
             if count > 1:

--- a/bin/trigger_rc_tests.py
+++ b/bin/trigger_rc_tests.py
@@ -10,6 +10,7 @@ import os
 import re
 import time
 from pathlib import Path
+from typing import Optional
 
 CHECK_PIPELINE_STATUES_TIMER_MIN = 5
 GITHUB_ORG = "astronomer"
@@ -21,7 +22,7 @@ parent_directory = Path(__file__).parent.parent
 circleci_directory = parent_directory / ".circleci"
 
 
-def run_workflow(circleci_token: str, parameters: dict = None):
+def run_workflow(circleci_token: str, parameters: Optional[dict] = None):
     circle_ci_conn = http.client.HTTPSConnection(CIRCLECI_URL, timeout=15)
     api_endpoint = f"/api/v2/project/github/{GITHUB_ORG}/{REPO}/pipeline"
 
@@ -32,9 +33,7 @@ def run_workflow(circleci_token: str, parameters: dict = None):
     if parameters is not None:
         payload["parameters"] = parameters
 
-    circle_ci_conn.request(
-        method="POST", url=api_endpoint, body=json.dumps(payload), headers=headers
-    )
+    circle_ci_conn.request(method="POST", url=api_endpoint, body=json.dumps(payload), headers=headers)
     resp = circle_ci_conn.getresponse().read().decode("utf-8")
     circle_ci_conn.close()
     return resp
@@ -85,26 +84,20 @@ def main(circleci_token: str, astro_path: str):
     print(json.dumps(parameters, indent=1))
 
     # Run Workflow
-    run_workflow_resp = run_workflow(
-        circleci_token=circleci_token, parameters=parameters
-    )
+    run_workflow_resp = run_workflow(circleci_token=circleci_token, parameters=parameters)
 
     pipeline_id = json.loads(run_workflow_resp)["id"]
     pipeline_number = json.loads(run_workflow_resp)["number"]
 
     # Printing Info
-    print(
-        f"CircleCI JOB URL = https://app.circleci.com/pipelines/github/{GITHUB_ORG}/{REPO}/{pipeline_number}"
-    )
+    print(f"CircleCI JOB URL = https://app.circleci.com/pipelines/github/{GITHUB_ORG}/{REPO}/{pipeline_number}")
 
     print("INFO: Waiting until pipeline starts running. It will wait for 5 min.")
     pipeline_state = "pending"
     counter = 0
     while "pending" == pipeline_state:
         time.sleep(10)
-        job_state_resp = get_job_state(
-            circleci_token=circleci_token, pipeline_id=pipeline_id
-        )
+        job_state_resp = get_job_state(circleci_token=circleci_token, pipeline_id=pipeline_id)
         pipeline_state = json.loads(job_state_resp)["items"][0]["status"]
         counter = counter + 1
 

--- a/bin/validate-helm-unittest-templates.py
+++ b/bin/validate-helm-unittest-templates.py
@@ -31,9 +31,7 @@ def validate_test_suite(test_suite: dict, file: PosixPath) -> None:
 
     for test in test_suite["tests"]:
         if "template" in test:
-            validate_template_file(
-                Path(file.parent.parent) / "templates" / test["template"]
-            )
+            validate_template_file(Path(file.parent.parent) / "templates" / test["template"])
 
 
 def validate_template_file(file: PosixPath) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[tool.black]
+line-length = 132
+
+[tool.ruff.lint]
+fixable = ["ALL"]
+
+# https://docs.astral.sh/ruff/rules/
+select = [
+  "ASYNC",
+  "C",
+  "E",
+  "F",
+  "FURB",
+  "PERF",
+  "Q",
+  "RUF",
+  "S",
+  "UP",
+  "W",
+]
+ignore = [
+  "E501",
+  "RUF012",
+  "S311",
+  "S314",
+  "S602",
+  "S603",
+  "S607",
+  "S608",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+  "S101",
+  "S105",
+  "S602",
+  ]
+"tests/functional_tests/test_network_security.py" = ["C901"]
+"tests/chart_tests/test_private_registry.py" = ["UP031"]
+"tests/chart_tests/test_pods.py" = ["UP031"]
+
+[tool.ruff.lint.mccabe]
+# TODO: reduce this
+max-complexity = 14

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,17 +3,13 @@ from pathlib import Path
 import yaml
 
 # The top-level path of this repository
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][
-    -1
-]
+git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
 
 metadata = yaml.safe_load((Path(git_root_dir) / "metadata.yaml").read_text())
 # replace all patch versions with 0 so we end up with ['a.b.0', 'x.y.0']
-supported_k8s_versions = [
-    ".".join(x.split(".")[:-1] + ["0"]) for x in metadata["test_k8s_versions"]
-]
-k8s_version_too_old = f'1.{str(int(supported_k8s_versions[0].split(".")[1]) - 1)}.0'
-k8s_version_too_new = f'1.{str(int(supported_k8s_versions[-1].split(".")[1]) + 1)}.0'
+supported_k8s_versions = [".".join(x.split(".")[:-1] + ["0"]) for x in metadata["test_k8s_versions"]]
+k8s_version_too_old = f'1.{int(supported_k8s_versions[0].split(".")[1]) - 1!s}.0'
+k8s_version_too_new = f'1.{int(supported_k8s_versions[-1].split(".")[1]) + 1!s}.0'
 
 
 def get_containers_by_name(doc, include_init_containers=False) -> dict:
@@ -24,15 +20,8 @@ def get_containers_by_name(doc, include_init_containers=False) -> dict:
 
     c_by_name = {c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]}
 
-    if include_init_containers and doc["spec"]["template"]["spec"].get(
-        "initContainers"
-    ):
-        c_by_name.update(
-            {
-                c["name"]: c
-                for c in doc["spec"]["template"]["spec"].get("initContainers")
-            }
-        )
+    if include_init_containers and doc["spec"]["template"]["spec"].get("initContainers"):
+        c_by_name.update({c["name"]: c for c in doc["spec"]["template"]["spec"].get("initContainers")})
 
     return c_by_name
 
@@ -43,9 +32,6 @@ def get_cronjob_containerspec_by_name(doc) -> dict:
     doc must be a valid spec for a CronJob.
     """
 
-    c_by_name = {
-        c["name"]: c
-        for c in doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"]
-    }
+    c_by_name = {c["name"]: c for c in doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"]}
 
     return c_by_name

--- a/tests/chart_tests/__init__.py
+++ b/tests/chart_tests/__init__.py
@@ -7,9 +7,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 
 
 def get_all_features():
-    return yaml.safe_load(
-        (Path(__file__).parent.parent / "enable_all_features.yaml").read_text()
-    )
+    return yaml.safe_load((Path(__file__).parent.parent / "enable_all_features.yaml").read_text())
 
 
 def get_chart_containers(k8s_version, chart_values, ignore_kind_list=None) -> dict:

--- a/tests/chart_tests/conftest.py
+++ b/tests/chart_tests/conftest.py
@@ -30,9 +30,7 @@ def upgrade_helm(tmp_path_factory, worker_id):
 
     def _upgrade_helm():
         try:
-            subprocess.check_output(
-                "helm repo add stable --force-update https://charts.helm.sh/stable/".split()
-            )
+            subprocess.check_output("helm repo add stable --force-update https://charts.helm.sh/stable/".split())
             # The following command may modify any requirements.yaml with updated metadata
             subprocess.check_output(
                 f"find {git_root_dir} -type f -name requirements.yaml -print -execdir helm dep update ;".split()

--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -54,7 +54,7 @@ def get_schema_k8s(api_version, kind, kube_version=default_version):
     if not local_sp.exists():
         if not local_sp.parent.is_dir():
             local_sp.parent.mkdir()
-        request = requests.get(f"{BASE_URL_SPEC}/{schema_path}")
+        request = requests.get(f"{BASE_URL_SPEC}/{schema_path}", timeout=30)
         request.raise_for_status()
         local_sp.write_text(request.text)
 
@@ -71,9 +71,7 @@ def create_validator(api_version, kind, kube_version=default_version):
 
 def validate_k8s_object(instance, kube_version=default_version):
     """Validate the k8s object."""
-    validate = create_validator(
-        instance.get("apiVersion"), instance.get("kind"), kube_version=kube_version
-    )
+    validate = create_validator(instance.get("apiVersion"), instance.get("kind"), kube_version=kube_version)
     validate.validate(instance)
 
 
@@ -125,9 +123,7 @@ def render_chart(
             if DEBUG:
                 print("ERROR: subprocess.CalledProcessError:")
                 print(f"helm command: {' '.join(command)}")
-                print(
-                    f"Values file contents:\n{'-' * 21}\n{yaml.dump(values)}{'-' * 21}"
-                )
+                print(f"Values file contents:\n{'-' * 21}\n{yaml.dump(values)}{'-' * 21}")
                 print(f"{error.output=}\n{error.stderr=}")
 
                 if "could not find template" in error.stderr.decode("utf-8"):
@@ -152,10 +148,7 @@ def prepare_k8s_lookup_dict(k8s_objects) -> dict[tuple[str, str], dict[str, Any]
 
     The keys of the dict are the k8s object's kind and name
     """
-    return {
-        (k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object
-        for k8s_object in k8s_objects
-    }
+    return {(k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object for k8s_object in k8s_objects}
 
 
 def render_k8s_object(obj, type_to_render):

--- a/tests/chart_tests/test_alertmanager.py
+++ b/tests/chart_tests/test_alertmanager.py
@@ -32,9 +32,7 @@ class TestAlertmanager:
         assert (
             any(
                 "--cluster.advertise-address=" in arg
-                for args in jmespath.search(
-                    "spec.template.spec.containers[*].args", doc
-                )
+                for args in jmespath.search("spec.template.spec.containers[*].args", doc)
                 for arg in args
             )
             is False
@@ -125,12 +123,8 @@ class TestAlertmanager:
 
         c_by_name = get_containers_by_name(doc, include_init_containers=False)
 
-        assert "webhook-alert-secret" in [
-            x["name"] for x in doc["spec"]["template"]["spec"]["volumes"]
-        ]
-        assert "webhook-alert-secret" in [
-            x["name"] for x in c_by_name["alertmanager"]["volumeMounts"]
-        ]
+        assert "webhook-alert-secret" in [x["name"] for x in doc["spec"]["template"]["spec"]["volumes"]]
+        assert "webhook-alert-secret" in [x["name"] for x in c_by_name["alertmanager"]["volumeMounts"]]
 
     def test_alertmanager_global_private_ca(self, kube_version):
         values = {
@@ -157,9 +151,7 @@ class TestAlertmanager:
                 "name": "config-volume",
                 "configMap": {
                     "name": "release-name-alertmanager",
-                    "items": [
-                        {"key": "alertmanager.yaml", "path": "alertmanager.yaml"}
-                    ],
+                    "items": [{"key": "alertmanager.yaml", "path": "alertmanager.yaml"}],
                 },
             },
             {
@@ -189,9 +181,7 @@ class TestAlertmanager:
 
         assert volumemounts == expected_volumemounts
         assert volumes == expected_volumes
-        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in c_by_name[
-            "alertmanager"
-        ]["env"]
+        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in c_by_name["alertmanager"]["env"]
 
     def test_alertmanager_persistentVolumeClaimRetentionPolicy(self, kube_version):
         test_persistentVolumeClaimRetentionPolicy = {
@@ -211,7 +201,4 @@ class TestAlertmanager:
         )[0]
 
         assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
-        assert (
-            test_persistentVolumeClaimRetentionPolicy
-            == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
-        )
+        assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]

--- a/tests/chart_tests/test_argo_sync-wave.py
+++ b/tests/chart_tests/test_argo_sync-wave.py
@@ -50,22 +50,8 @@ def test_argo_sync_wave():
 
     docs = render_argo_charts(argo_enabled=True)
     assert len(docs) == 26
-    assert (
-        len(
-            jmespath.search(
-                '[*].metadata.annotations."argocd.argoproj.io/sync-wave"', docs
-            )
-        )
-        == 26
-    )
+    assert len(jmespath.search('[*].metadata.annotations."argocd.argoproj.io/sync-wave"', docs)) == 26
 
     docs = render_argo_charts(argo_enabled=False)
     assert len(docs) == 26
-    assert (
-        len(
-            jmespath.search(
-                '[*].metadata.annotations."argocd.argoproj.io/sync-wave"', docs
-            )
-        )
-        == 0
-    )
+    assert len(jmespath.search('[*].metadata.annotations."argocd.argoproj.io/sync-wave"', docs)) == 0

--- a/tests/chart_tests/test_astro_ui_deployment.py
+++ b/tests/chart_tests/test_astro_ui_deployment.py
@@ -27,9 +27,5 @@ class TestIngress:
 
         assert "Deployment" == jmespath.search("kind", docs[0])
         assert "release-name-astro-ui" == jmespath.search("metadata.name", docs[0])
-        assert "astro-ui" == jmespath.search(
-            "spec.template.spec.containers[0].name", docs[0]
-        )
-        assert "500m" == jmespath.search(
-            "spec.template.spec.containers[0].resources.limits.cpu", docs[0]
-        )
+        assert "astro-ui" == jmespath.search("spec.template.spec.containers[0].name", docs[0])
+        assert "500m" == jmespath.search("spec.template.spec.containers[0].resources.limits.cpu", docs[0])

--- a/tests/chart_tests/test_astronomer_bootstrap_secret.py
+++ b/tests/chart_tests/test_astronomer_bootstrap_secret.py
@@ -6,9 +6,7 @@ from subprocess import CalledProcessError
 def test_astronomer_bootstrap_secret_defaults():
     """Test the astronomer-bootstrap secret with defaults."""
     with pytest.raises(CalledProcessError):
-        render_chart(
-            show_only="charts/postgresql/templates/astronomer-bootstrap-secret.yaml"
-        )
+        render_chart(show_only="charts/postgresql/templates/astronomer-bootstrap-secret.yaml")
 
 
 def test_astronomer_bootstrap_secret_postgres_enabled():

--- a/tests/chart_tests/test_astronomer_cli_install.py
+++ b/tests/chart_tests/test_astronomer_cli_install.py
@@ -47,9 +47,7 @@ class TestAstronomerCliInstall:
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"install": {"cliEnabled": False}}},
-            show_only=[
-                "charts/astronomer/templates/cli-install/cli-install-ingress.yaml"
-            ],
+            show_only=["charts/astronomer/templates/cli-install/cli-install-ingress.yaml"],
         )
 
         assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -13,9 +13,7 @@ class TestAstronomerCommander:
         astronomer/commander."""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -25,9 +23,7 @@ class TestAstronomerCommander:
         assert doc["metadata"]["name"] == "release-name-commander"
         c_by_name = get_containers_by_name(doc)
         assert len(c_by_name) == 1
-        assert c_by_name["commander"]["image"].startswith(
-            "quay.io/astronomer/ap-commander:"
-        )
+        assert c_by_name["commander"]["image"].startswith("quay.io/astronomer/ap-commander:")
         assert c_by_name["commander"]["resources"]["limits"]["memory"] == "2Gi"
         assert c_by_name["commander"]["resources"]["requests"]["memory"] == "1Gi"
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
@@ -43,9 +39,7 @@ class TestAstronomerCommander:
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"commander": {"upgradeTimeout": 997}}},
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -55,9 +49,7 @@ class TestAstronomerCommander:
         assert doc["metadata"]["name"] == "release-name-commander"
         c_by_name = get_containers_by_name(doc)
         assert len(c_by_name) == 1
-        assert c_by_name["commander"]["image"].startswith(
-            "quay.io/astronomer/ap-commander:"
-        )
+        assert c_by_name["commander"]["image"].startswith("quay.io/astronomer/ap-commander:")
 
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "997"
@@ -108,9 +100,7 @@ class TestAstronomerCommander:
         assert cluster_role_binding["roleRef"] == expected_role_ref
         assert cluster_role_binding["subjects"] == expected_subjects
 
-    def test_astronomer_commander_rbac_cluster_roles_disabled_rbac_enabled(
-        self, kube_version
-    ):
+    def test_astronomer_commander_rbac_cluster_roles_disabled_rbac_enabled(self, kube_version):
         """Test that if rbacEnabled set to true, but clusterRoles and
         namespacePools are disabled, we do not create any RBAC resources."""
         docs = render_chart(
@@ -179,35 +169,18 @@ class TestAstronomerCommander:
         permissions to manage Cluster-level RBAC resources."""
         doc = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "houston": {
-                        "config": {
-                            "deployments": {
-                                "helm": {"airflow": {"multiNamespaceMode": False}}
-                            }
-                        }
-                    }
-                }
-            },
+            values={"astronomer": {"houston": {"config": {"deployments": {"helm": {"airflow": {"multiNamespaceMode": False}}}}}}},
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
         )[0]
 
         cluster_resources = ["clusterrolebindings", "clusterroles"]
 
         # check that there is no rules regarding ClusterRoles and ClusterRolesBinding
-        generated_resources = [
-            resource
-            for rule in doc["rules"]
-            if "resources" in rule
-            for resource in rule["resources"]
-        ]
+        generated_resources = [resource for rule in doc["rules"] if "resources" in rule for resource in rule["resources"]]
         for resource in generated_resources:
             assert resource not in cluster_resources
 
-    def test_astronomer_commander_rbac_multinamespace_mode_undefined(
-        self, kube_version
-    ):
+    def test_astronomer_commander_rbac_multinamespace_mode_undefined(self, kube_version):
         """Test that if Houston's configuration for Airflow chart is not
         defined, the rendered commander role doesn't have permissions to manage
         Cluster-level RBAC resources."""
@@ -220,12 +193,7 @@ class TestAstronomerCommander:
         cluster_resources = ["clusterrolebindings", "clusterroles"]
 
         # check that there is no rules regarding ClusterRoles and ClusterRolesBinding
-        generated_resources = [
-            resource
-            for rule in doc["rules"]
-            if "resources" in rule
-            for resource in rule["resources"]
-        ]
+        generated_resources = [resource for rule in doc["rules"] if "resources" in rule for resource in rule["resources"]]
         for resource in generated_resources:
             assert resource not in cluster_resources
 
@@ -235,29 +203,14 @@ class TestAstronomerCommander:
         to manage Cluster-level RBAC resources."""
         doc = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "houston": {
-                        "config": {
-                            "deployments": {
-                                "helm": {"airflow": {"multiNamespaceMode": True}}
-                            }
-                        }
-                    }
-                }
-            },
+            values={"astronomer": {"houston": {"config": {"deployments": {"helm": {"airflow": {"multiNamespaceMode": True}}}}}}},
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
         )[0]
 
         cluster_resources = ["clusterrolebindings", "clusterroles"]
 
         # check that there are rules for cluterroles and clusterrolebindings
-        generated_resources = [
-            resource
-            for rule in doc["rules"]
-            if "resources" in rule
-            for resource in rule["resources"]
-        ]
+        generated_resources = [resource for rule in doc["rules"] if "resources" in rule for resource in rule["resources"]]
         for resource in cluster_resources:
             assert resource in generated_resources
 
@@ -379,17 +332,13 @@ class TestAstronomerCommander:
 
         assert cluster_role_binding["roleRef"] == expected_cluster_role
 
-    def test_astronomer_commander_disable_manage_clusterscopedresources_overrides(
-        self, kube_version
-    ):
+    def test_astronomer_commander_disable_manage_clusterscopedresources_overrides(self, kube_version):
         """Test that helm renders a good deployment template for
         astronomer/commander."""
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"disableManageClusterScopedResources": True}},
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -401,9 +350,7 @@ class TestAstronomerCommander:
         env_vars = {x["name"]: x["value"] for x in c_by_name["commander"]["env"]}
         assert env_vars["COMMANDER_MANAGE_NAMESPACE_RESOURCE"] == "false"
 
-    def test_astronomer_commander_clusterscopedresources_overrides_with_custom_flags(
-        self, kube_version
-    ):
+    def test_astronomer_commander_clusterscopedresources_overrides_with_custom_flags(self, kube_version):
         """Test that helm renders a good deployment template for
         astronomer/commander."""
         docs = render_chart(
@@ -420,9 +367,7 @@ class TestAstronomerCommander:
                     }
                 },
             },
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )
 
         assert len(docs) == 1

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -161,9 +161,7 @@ class TestAstronomerConfigSyncer:
         )
         assert len(docs) == 0
 
-    def test_astronomer_config_syncer_cronjob_namespace_pool_enabled(
-        self, kube_version
-    ):
+    def test_astronomer_config_syncer_cronjob_namespace_pool_enabled(self, kube_version):
         """Test that when namespace pool is enabled, config-syncer's container
         is configured to use namespaces from the pool."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
@@ -187,13 +185,9 @@ class TestAstronomerConfigSyncer:
         job_container_by_name = get_cronjob_containerspec_by_name(doc)
         assert "--target-namespaces" in job_container_by_name["config-syncer"]["args"]
         assert ",".join(namespaces) in job_container_by_name["config-syncer"]["args"]
-        assert {"runAsNonRoot": True} == job_container_by_name["config-syncer"][
-            "securityContext"
-        ]
+        assert {"runAsNonRoot": True} == job_container_by_name["config-syncer"]["securityContext"]
 
-    def test_astronomer_config_syncer_cronjob_security_context_default_overrides(
-        self, kube_version
-    ):
+    def test_astronomer_config_syncer_cronjob_security_context_default_overrides(self, kube_version):
         """Test that  config-syncer's container is allowed to configure security context."""
         doc = render_chart(
             kube_version=kube_version,
@@ -218,11 +212,11 @@ class TestAstronomerConfigSyncer:
         assert {
             "runAsNonRoot": True,
             "allowPrivilegeEscalation": False,
-        } == job_container_by_name["config-syncer"]["securityContext"]
+        } == job_container_by_name[
+            "config-syncer"
+        ]["securityContext"]
 
-    def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(
-        self, kube_version
-    ):
+    def test_astronomer_config_syncer_cronjob_namespace_pool_disabled(self, kube_version):
         """Test that when namespacePools is disabled, config-syncer cronjob is
         configured not to target any namespace."""
         namespaces = ["my-namespace-1", "my-namespace-2"]
@@ -245,19 +239,11 @@ class TestAstronomerConfigSyncer:
 
         job_container_by_name = get_cronjob_containerspec_by_name(doc)
 
-        assert (
-            "--target-namespaces" not in job_container_by_name["config-syncer"]["args"]
-        )
-        assert (
-            ",".join(namespaces) not in job_container_by_name["config-syncer"]["args"]
-        )
+        assert "--target-namespaces" not in job_container_by_name["config-syncer"]["args"]
+        assert ",".join(namespaces) not in job_container_by_name["config-syncer"]["args"]
 
-    @pytest.mark.parametrize(
-        "test_data", cron_test_data, ids=[x[0] for x in cron_test_data]
-    )
-    def test_astronomer_config_syncer_cronjob_default_schedule(
-        self, test_data, kube_version
-    ):
+    @pytest.mark.parametrize("test_data", cron_test_data, ids=[x[0] for x in cron_test_data])
+    def test_astronomer_config_syncer_cronjob_default_schedule(self, test_data, kube_version):
         """Test that if no schedule is provided for configSyncer, helm
         automatically generates a random one."""
 

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -80,9 +80,7 @@ class TestDagOnlyDeploy:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
 
-        assert prod["deployments"]["dagDeploy"]["images"]["dagServer"][
-            "repository"
-        ].startswith(private_registry)
+        assert prod["deployments"]["dagDeploy"]["images"]["dagServer"]["repository"].startswith(private_registry)
 
     def test_dagonlydeploy_config_enabled_with_openshift_enabled(self, kube_version):
         """Test dagonlydeploy with openshift enabled to validate fsGroup removal."""

--- a/tests/chart_tests/test_astronomer_houston_Internal_authorization.py
+++ b/tests/chart_tests/test_astronomer_houston_Internal_authorization.py
@@ -28,9 +28,7 @@ class TestHoustonInternalAuthorization:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert (
                 "https://houston.example.com/v1/authorization"
-                in doc["metadata"]["annotations"][
-                    "nginx.ingress.kubernetes.io/auth-url"
-                ]
+                in doc["metadata"]["annotations"]["nginx.ingress.kubernetes.io/auth-url"]
             )
 
     def test_ingress_with_internal_authorization(self, kube_version):
@@ -52,7 +50,5 @@ class TestHoustonInternalAuthorization:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert (
                 "http://release-name-houston.default.svc.cluster.local:8871/v1/authorization"
-                in doc["metadata"]["annotations"][
-                    "nginx.ingress.kubernetes.io/auth-url"
-                ]
+                in doc["metadata"]["annotations"]["nginx.ingress.kubernetes.io/auth-url"]
             )

--- a/tests/chart_tests/test_astronomer_houston_airflow_db_cleanup.py
+++ b/tests/chart_tests/test_astronomer_houston_airflow_db_cleanup.py
@@ -28,13 +28,7 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
     def test_astronomer_airflow_db_cleanup_cron_feature_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "houston": {
-                        "cleanupAirflowDb": {"enabled": True, "schedule": "23 5 * * *"}
-                    }
-                }
-            },
+            values={"astronomer": {"houston": {"cleanupAirflowDb": {"enabled": True, "schedule": "23 5 * * *"}}}},
             show_only=[
                 "charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml",
             ],
@@ -43,14 +37,9 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
         assert len(docs) == 1
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-airflow-db-data"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-airflow-db-data"
         assert docs[0]["spec"]["schedule"] == "23 5 * * *"
-        assert job_container_by_name["cleanup"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert job_container_by_name["cleanup"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_astronomer_airflow_db_cleanup_cron_custom_schedule(self, kube_version):
         docs = render_chart(
@@ -58,9 +47,7 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
             values={
                 "astronomer": {
                     "securityContext": {"allowPriviledgeEscalation": False},
-                    "houston": {
-                        "cleanupAirflowDb": {"enabled": True, "schedule": "22 5 * * *"}
-                    },
+                    "houston": {"cleanupAirflowDb": {"enabled": True, "schedule": "22 5 * * *"}},
                 }
             },
             show_only=[
@@ -71,10 +58,7 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
         assert len(docs) == 1
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-airflow-db-data"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-airflow-db-data"
         assert docs[0]["spec"]["schedule"] == "22 5 * * *"
         assert job_container_by_name["cleanup"]["securityContext"] == {
             "runAsNonRoot": True,

--- a/tests/chart_tests/test_astronomer_houston_cronjob.py
+++ b/tests/chart_tests/test_astronomer_houston_cronjob.py
@@ -13,9 +13,7 @@ class TestHoustonCronjobJob:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_cronjob_containerspec_by_name(docs[0])
@@ -50,9 +48,7 @@ class TestHoustonCronjobJob:
                     },
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_cronjob_containerspec_by_name(docs[0])
@@ -85,8 +81,6 @@ class TestHoustonCronjobJob:
                     }
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"],
         )
         assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_houston_deploy_revisions.py
+++ b/tests/chart_tests/test_astronomer_houston_deploy_revisions.py
@@ -11,25 +11,17 @@ class TestAstronomerHoustonDeployRevisionsCronjobs:
     def test_astronomer_cleanup_deploy_revisons_cron_defaults(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "houston": {"cleanupDeployRevisions": {"enabled": False}}
-                }
-            },
+            values={"astronomer": {"houston": {"cleanupDeployRevisions": {"enabled": False}}}},
             show_only=[
                 "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml",
             ],
         )
         assert len(docs) == 0
 
-    def test_astronomer_cleanup_deploy_revisons_cron_feature_enabled(
-        self, kube_version
-    ):
+    def test_astronomer_cleanup_deploy_revisons_cron_feature_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"cleanupDeployRevisions": {"enabled": True}}}
-            },
+            values={"astronomer": {"houston": {"cleanupDeployRevisions": {"enabled": True}}}},
             show_only=[
                 "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml",
             ],
@@ -37,18 +29,13 @@ class TestAstronomerHoustonDeployRevisionsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-deploy-revisions"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-deploy-revisions"
         assert docs[0]["spec"]["schedule"] == "11 23 * * *"
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][
-            0
-        ]["securityContext"] == {"runAsNonRoot": True}
+        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "runAsNonRoot": True
+        }
 
-    def test_astronomer_cleanup_deploy_revisons_cron_custom_schedule(
-        self, kube_version
-    ):
+    def test_astronomer_cleanup_deploy_revisons_cron_custom_schedule(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -68,8 +55,5 @@ class TestAstronomerHoustonDeployRevisionsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-deploy-revisions"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-deploy-revisions"
         assert docs[0]["spec"]["schedule"] == "1 2 3 4 5"

--- a/tests/chart_tests/test_astronomer_houston_hook_job.py
+++ b/tests/chart_tests/test_astronomer_houston_hook_job.py
@@ -13,31 +13,23 @@ class TestHoustonHookJob:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "Job"
         assert docs[0]["metadata"]["name"] == "release-name-update-resource-strategy"
 
-        assert c_by_name["post-upgrade-update-resource-strategy"]["args"] == [
-            "update-deployments-resource-mode"
-        ]
+        assert c_by_name["post-upgrade-update-resource-strategy"]["args"] == ["update-deployments-resource-mode"]
 
-        assert c_by_name["post-upgrade-update-resource-strategy"][
-            "securityContext"
-        ] == {"runAsNonRoot": True}
+        assert c_by_name["post-upgrade-update-resource-strategy"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_upgrade_deployments_job_defaults(self, kube_version):
         """Test Upgrade Deployments Job defaults."""
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
@@ -46,9 +38,7 @@ class TestHoustonHookJob:
 
         assert c_by_name["wait-for-db"]["securityContext"] == {"runAsNonRoot": True}
 
-        assert c_by_name["houston-bootstrapper"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert c_by_name["houston-bootstrapper"]["securityContext"] == {"runAsNonRoot": True}
 
         assert c_by_name["post-upgrade-job"]["args"] == [
             "yarn",
@@ -57,20 +47,14 @@ class TestHoustonHookJob:
             "--canary=false",
         ]
 
-        assert c_by_name["post-upgrade-job"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert c_by_name["post-upgrade-job"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_upgrade_deployments_job_disabled(self, kube_version):
         """Test Upgrade Deployments Job when disabled."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"upgradeDeployments": {"enabled": False}}}
-            },
-            show_only=[
-                "charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml"
-            ],
+            values={"astronomer": {"houston": {"upgradeDeployments": {"enabled": False}}}},
+            show_only=["charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml"],
         )
         assert len(docs) == 0
 
@@ -79,9 +63,7 @@ class TestHoustonHookJob:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
@@ -90,15 +72,11 @@ class TestHoustonHookJob:
 
         assert c_by_name["wait-for-db"]["securityContext"] == {"runAsNonRoot": True}
 
-        assert c_by_name["houston-bootstrapper"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert c_by_name["houston-bootstrapper"]["securityContext"] == {"runAsNonRoot": True}
 
         assert c_by_name["houston-db-migrations-job"]["args"] == [
             "yarn",
             "migrate",
         ]
 
-        assert c_by_name["houston-db-migrations-job"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert c_by_name["houston-db-migrations-job"]["securityContext"] == {"runAsNonRoot": True}

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -17,9 +17,7 @@ chart_values = {
                     "name": "fluentd",
                     "image": "ap-fluentd:0.5",
                     "imagePullPolicy": "Never",
-                    "volumeMounts": [
-                        {"name": "logvol", "mountPath": "/var/log/file_logs/"}
-                    ],
+                    "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/file_logs/"}],
                 }
             ],
             "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
@@ -29,17 +27,13 @@ chart_values = {
                     "-c",
                     "yarn worker 1> >( tee -a /var/log/houston_worker/data.out.log ) 2> >( tee -a /var/log/houston_worker/data.err.log >&2 )",
                 ],
-                "volumeMounts": [
-                    {"name": "logvol", "mountPath": "/var/log/houston_worker"}
-                ],
+                "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/houston_worker"}],
                 "extraContainers": [
                     {
                         "name": "fluentd",
                         "image": "ap-fluentd:0.5",
                         "imagePullPolicy": "Never",
-                        "volumeMounts": [
-                            {"name": "logvol", "mountPath": "/var/log/file_logs/"}
-                        ],
+                        "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/file_logs/"}],
                     }
                 ],
                 "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
@@ -57,9 +51,7 @@ chart_values = {
                     "name": "fluentd",
                     "image": "ap-fluentd:0.5",
                     "imagePullPolicy": "Never",
-                    "volumeMounts": [
-                        {"name": "logvol", "mountPath": "/var/log/file_logs/"}
-                    ],
+                    "volumeMounts": [{"name": "logvol", "mountPath": "/var/log/file_logs/"}],
                 }
             ],
             "extraVolumes": [{"name": "logvol", "emptyDir": {}}],
@@ -81,8 +73,7 @@ class TestAstronomerFileLogs:
         assert container["command"] == ["/bin/sh"]
         assert container["args"] == [
             "-c",
-            "yarn serve"
-            + " 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
+            "yarn serve" + " 1> >( tee -a /var/log/houston/data.out.log ) 2> >( tee -a /var/log/houston/data.err.log >&2 )",
         ]
 
         volume_mounts = container["volumeMounts"]

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -31,14 +31,9 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-task-usage-data"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
         assert docs[0]["spec"]["schedule"] == "40 23 * * *"
-        assert job_container_by_name["cleanup"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert job_container_by_name["cleanup"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_astronomer_cleanup_task_usage_cron_custom_schedule(self, kube_version):
         docs = render_chart(
@@ -58,19 +53,14 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-cleanup-task-usage-data"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
         assert docs[0]["spec"]["schedule"] == "0 23 * * *"
         assert job_container_by_name["cleanup"]["securityContext"] == {
             "runAsNonRoot": True,
             "allowPriviledgeEscalation": False,
         }
 
-    def test_astronomer_populate_hourly_task_audit_metrics_cron_defaults(
-        self, kube_version
-    ):
+    def test_astronomer_populate_hourly_task_audit_metrics_cron_defaults(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"taskUsageMetricsEnabled": False}},
@@ -80,9 +70,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         )
         assert len(docs) == 0
 
-    def test_astronomer_populate_hourly_task_audit_metrics_cron_feature_enabled(
-        self, kube_version
-    ):
+    def test_astronomer_populate_hourly_task_audit_metrics_cron_feature_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"taskUsageMetricsEnabled": True}},
@@ -94,27 +82,16 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-hourly-ta-metrics"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-populate-hourly-ta-metrics"
         assert docs[0]["spec"]["schedule"] == "57 * * * *"
-        assert job_container_by_name["populate-daily-task-metrics"][
-            "securityContext"
-        ] == {"runAsNonRoot": True}
+        assert job_container_by_name["populate-daily-task-metrics"]["securityContext"] == {"runAsNonRoot": True}
 
-    def test_astronomer_populate_hourly_task_audit_metrics_cron_custom_schedule(
-        self, kube_version
-    ):
+    def test_astronomer_populate_hourly_task_audit_metrics_cron_custom_schedule(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={
                 "global": {"taskUsageMetricsEnabled": True},
-                "astronomer": {
-                    "houston": {
-                        "populateHourlyTaskAuditMetrics": {"schedule": "90 * * * *"}
-                    }
-                },
+                "astronomer": {"houston": {"populateHourlyTaskAuditMetrics": {"schedule": "90 * * * *"}}},
             },
             show_only=[
                 "charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml",
@@ -123,10 +100,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-hourly-ta-metrics"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-populate-hourly-ta-metrics"
         assert docs[0]["spec"]["schedule"] == "90 * * * *"
 
     def test_astronomer_populate_daily_task_metrics_defaults(self, kube_version):
@@ -151,23 +125,16 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
         job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-daily-task-metrics"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-populate-daily-task-metrics"
         assert docs[0]["spec"]["schedule"] == "8 0 * * *"
-        assert job_container_by_name["populate-daily-task-metrics"][
-            "securityContext"
-        ] == {"runAsNonRoot": True}
+        assert job_container_by_name["populate-daily-task-metrics"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_astronomer_populate_daily_task_metrics_custom_schedule(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={
                 "global": {"taskUsageMetricsEnabled": True},
-                "astronomer": {
-                    "houston": {"populateDailyTaskMetrics": {"schedule": "0 23 * * *"}}
-                },
+                "astronomer": {"houston": {"populateDailyTaskMetrics": {"schedule": "0 23 * * *"}}},
             },
             show_only=[
                 "charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml",
@@ -176,10 +143,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        assert (
-            docs[0]["metadata"]["name"]
-            == "release-name-houston-populate-daily-task-metrics"
-        )
+        assert docs[0]["metadata"]["name"] == "release-name-houston-populate-daily-task-metrics"
         assert docs[0]["spec"]["schedule"] == "0 23 * * *"
 
     def test_houston_configmap_with_taskusagemetrics_enabled(self, kube_version):
@@ -193,7 +157,4 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        assert (
-            prod_yaml["deployments"]["taskUsageReport"]["taskUsageMetricsEnabled"]
-            is True
-        )
+        assert prod_yaml["deployments"]["taskUsageReport"]["taskUsageMetricsEnabled"] is True

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -127,9 +127,7 @@ class TestAstronomerNamespacePools:
         )
         assert len(docs) == 0
 
-    def test_astronomer_namespace_pools_commander_deployment_configuration(
-        self, kube_version
-    ):
+    def test_astronomer_namespace_pools_commander_deployment_configuration(self, kube_version):
         """Test that commander deployment is configured properly when enabling
         namespace pools."""
 
@@ -146,9 +144,7 @@ class TestAstronomerNamespacePools:
                     }
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )[0]
 
         # Check that by enabling global.features.namespacePools, the environment variable COMMANDER_MANUAL_NAMESPACE_NAMES
@@ -157,10 +153,7 @@ class TestAstronomerNamespacePools:
 
         manual_ns_env_found = False
         for env in c_by_name["commander"]["env"]:
-            if (
-                env["name"] == "COMMANDER_MANUAL_NAMESPACE_NAMES"
-                and env["value"] == "true"
-            ):
+            if env["name"] == "COMMANDER_MANUAL_NAMESPACE_NAMES" and env["value"] == "true":
                 manual_ns_env_found = True
 
         assert manual_ns_env_found
@@ -178,9 +171,7 @@ class TestAstronomerNamespacePools:
                     }
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/commander/commander-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
         )[0]
 
         # Check that by enabling global.features.namespacePools, the environment variable COMMANDER_MANUAL_NAMESPACE_NAMES
@@ -189,10 +180,7 @@ class TestAstronomerNamespacePools:
 
         manual_ns_env_found = False
         for env in c_by_name["commander"]["env"]:
-            if (
-                env["name"] == "COMMANDER_MANUAL_NAMESPACE_NAMES"
-                and env["value"] == "true"
-            ):
+            if env["name"] == "COMMANDER_MANUAL_NAMESPACE_NAMES" and env["value"] == "true":
                 manual_ns_env_found = True
 
         assert not manual_ns_env_found
@@ -220,9 +208,7 @@ class TestAstronomerNamespacePools:
 
         assert deployments_config["deployments"]["hardDeleteDeployment"]
         assert deployments_config["deployments"]["manualNamespaceNames"]
-        assert deployments_config["deployments"]["preCreatedNamespaces"] == [
-            {"name": namespace} for namespace in namespaces
-        ]
+        assert deployments_config["deployments"]["preCreatedNamespaces"] == [{"name": namespace} for namespace in namespaces]
 
         # test configuration when namespacePools is disabled -> should not add configuration parameters
         doc = render_chart(
@@ -266,7 +252,5 @@ class TestAstronomerNamespacePools:
             show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
         )[0]
 
-        expected_rule = "key $.kubernetes.namespace_name\n    pattern ^({}|{})$".format(
-            namespaces[0], namespaces[1]
-        )
+        expected_rule = f"key $.kubernetes.namespace_name\n    pattern ^({namespaces[0]}|{namespaces[1]})$"
         assert expected_rule in doc["data"]["output.conf"]

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -14,9 +14,7 @@ class TestRegistryStatefulset:
         registry."""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/registry/registry-statefulset.yaml"
-            ],
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
 
         assert len(docs) == 1
@@ -25,8 +23,7 @@ class TestRegistryStatefulset:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
         assert any(
-            "quay.io/astronomer/ap-registry:" in item
-            for item in jmespath.search("spec.template.spec.containers[*].image", doc)
+            "quay.io/astronomer/ap-registry:" in item for item in jmespath.search("spec.template.spec.containers[*].image", doc)
         )
         assert docs[0]["spec"]["template"]["spec"]["securityContext"] == {
             "fsGroup": 1000,
@@ -41,9 +38,7 @@ class TestRegistryStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"registry": {"extraEnv": [extra_env]}}},
-            show_only=[
-                "charts/astronomer/templates/registry/registry-statefulset.yaml"
-            ],
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
 
         assert len(docs) == 1
@@ -53,9 +48,7 @@ class TestRegistryStatefulset:
         assert doc["metadata"]["name"] == "release-name-registry"
         assert extra_env in doc["spec"]["template"]["spec"]["containers"][0]["env"]
 
-    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_defaults(
-        self, kube_version
-    ):
+    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_defaults(self, kube_version):
         """Test that helm renders statefulset and serviceAccount template for astronomer
         registry with SA enabled."""
         annotation = {
@@ -63,13 +56,7 @@ class TestRegistryStatefulset:
         }
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "registry": {
-                        "serviceAccount": {"create": True, "annotations": annotation}
-                    }
-                }
-            },
+            values={"astronomer": {"registry": {"serviceAccount": {"create": True, "annotations": annotation}}}},
             show_only=[
                 "charts/astronomer/templates/registry/registry-statefulset.yaml",
                 "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
@@ -80,10 +67,7 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert (
-            doc["spec"]["template"]["spec"]["serviceAccountName"]
-            == "release-name-registry"
-        )
+        assert doc["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-registry"
 
         doc = docs[1]
         assert doc["kind"] == "ServiceAccount"
@@ -91,9 +75,7 @@ class TestRegistryStatefulset:
         assert doc["metadata"]["name"] == "release-name-registry"
         assert annotation == doc["metadata"]["annotations"]
 
-    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_with_custom_name(
-        self, kube_version
-    ):
+    def test_astronomer_registry_statefulset_with_serviceaccount_enabled_with_custom_name(self, kube_version):
         """Test that helm renders statefulset and serviceAccount template for astronomer
         registry with SA enabled with custom name."""
         annotation = {
@@ -122,10 +104,7 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert (
-            doc["spec"]["template"]["spec"]["serviceAccountName"]
-            == "release-name-customregistrysa"
-        )
+        assert doc["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-customregistrysa"
 
         doc = docs[1]
         assert doc["kind"] == "ServiceAccount"
@@ -133,9 +112,7 @@ class TestRegistryStatefulset:
         assert doc["metadata"]["name"] == "release-name-customregistrysa"
         assert annotation == doc["metadata"]["annotations"]
 
-    def test_astronomer_registry_statefulset_with_serviceaccount_disabled(
-        self, kube_version
-    ):
+    def test_astronomer_registry_statefulset_with_serviceaccount_disabled(self, kube_version):
         """Test that helm renders statefulset template for astronomer
         registry with SA disabled."""
         docs = render_chart(
@@ -162,9 +139,7 @@ class TestRegistryStatefulset:
         assert len(docs) == 0
 
     @pytest.mark.skip(reason="This test needs rework")
-    def test_astronomer_registry_statefulset_with_podSecurityContext_disabled(
-        self, kube_version
-    ):
+    def test_astronomer_registry_statefulset_with_podSecurityContext_disabled(self, kube_version):
         """Test that helm renders statefulset template for astronomer
         registry with podSecurityContext disabled."""
         docs = render_chart(

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -52,9 +52,7 @@ class TestAuthSidecar:
         } in jmespath.search("spec.ports", docs[2])
 
         assert "NetworkPolicy" == docs[3]["kind"]
-        assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search(
-            "spec.ingress[*].ports[1]", docs[3]
-        )
+        assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search("spec.ingress[*].ports[1]", docs[3])
 
     def test_authSidecar_prometheus(self, kube_version):
         """Test Prometheus Service with authSidecar."""
@@ -88,9 +86,7 @@ class TestAuthSidecar:
         } in jmespath.search("spec.ports", docs[2])
 
         assert "NetworkPolicy" == docs[3]["kind"]
-        assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search(
-            "spec.ingress[*].ports[1]", docs[3]
-        )
+        assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search("spec.ingress[*].ports[1]", docs[3])
 
     def test_authSidecar_kibana(self, kube_version):
         """Test Kibana Service with authSidecar."""
@@ -124,16 +120,10 @@ class TestAuthSidecar:
         } in jmespath.search("spec.ports", docs[2])
 
         assert "NetworkPolicy" == docs[3]["kind"]
-        assert [
-            {
-                "namespaceSelector": {
-                    "matchLabels": {"network.openshift.io/policy-group": "ingress"}
-                }
-            }
-        ] == jmespath.search("spec.ingress[0].from", docs[3])
-        assert {"port": 8084, "protocol": "TCP"} in jmespath.search(
-            "spec.ingress[*].ports[0]", docs[3]
+        assert [{"namespaceSelector": {"matchLabels": {"network.openshift.io/policy-group": "ingress"}}}] == jmespath.search(
+            "spec.ingress[0].from", docs[3]
         )
+        assert {"port": 8084, "protocol": "TCP"} in jmespath.search("spec.ingress[*].ports[0]", docs[3])
 
     def test_authSidecar_houston_configmap_without_annotation(self, kube_version):
         """Test Houston Configmap with authSidecar."""

--- a/tests/chart_tests/test_check_platform_updates.py
+++ b/tests/chart_tests/test_check_platform_updates.py
@@ -12,9 +12,7 @@ class TestHoustonCronJobPlatformUpdates:
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"houston": {"updateCheck": {"enabled": True}}}},
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 1
@@ -29,9 +27,7 @@ class TestHoustonCronJobPlatformUpdates:
             "--",
             " --url=https://updates.astronomer.io/astronomer-platform",
         ]
-        assert job_container_by_name["update-check"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert job_container_by_name["update-check"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_cronjob_platform_updates_enabled_with_overrides(self, kube_version):
         docs = render_chart(
@@ -39,14 +35,10 @@ class TestHoustonCronJobPlatformUpdates:
             values={
                 "astronomer": {
                     "securityContext": {"allowPriviledgeEscalation": False},
-                    "houston": {
-                        "updateCheck": {"enabled": True, "schedule": "57 * * * *"}
-                    },
+                    "houston": {"updateCheck": {"enabled": True, "schedule": "57 * * * *"}},
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 1
@@ -70,9 +62,7 @@ class TestHoustonCronJobPlatformUpdates:
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"houston": {"updateCheck": {"enabled": False}}}},
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 0

--- a/tests/chart_tests/test_containerd_privateca.py
+++ b/tests/chart_tests/test_containerd_privateca.py
@@ -19,10 +19,7 @@ class TestContainerdPrivateCaDaemonset:
         """Test things common to all daemonsets."""
         assert doc["kind"] == "DaemonSet"
         assert doc["metadata"]["name"] == "release-name-containerd-ca-update"
-        assert (
-            doc["spec"]["template"]["spec"]["containers"][0]["name"]
-            == "cert-copy-and-toml-update"
-        )
+        assert doc["spec"]["template"]["spec"]["containers"][0]["name"] == "cert-copy-and-toml-update"
 
     def test_privateca_daemonset_disabled(self, kube_version):
         """Test that no daemonset is rendered when privateCaCertsAddToHost is
@@ -197,9 +194,7 @@ class TestContainerdPrivateCaDaemonset:
         assert volumemounts == expected_volumemounts
         assert volumes == expected_volumes
 
-    def test_containerd_privateca_daemonset_enabled_with_priority_class(
-        self, kube_version
-    ):
+    def test_containerd_privateca_daemonset_enabled_with_priority_class(self, kube_version):
         """Test that the containerd daemonset is rendered with priorityClass when
         enabled."""
         docs = render_chart(
@@ -221,6 +216,4 @@ class TestContainerdPrivateCaDaemonset:
         assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
         cert_copier = docs[0]["spec"]["template"]["spec"]["containers"][0]
         cert_copier["image"].startswith("alpine:3")
-        assert (
-            "high-priority" == docs[0]["spec"]["template"]["spec"]["priorityClassName"]
-        )
+        assert "high-priority" == docs[0]["spec"]["template"]["spec"]["priorityClassName"]

--- a/tests/chart_tests/test_cronjob_check_airflow_updates.py
+++ b/tests/chart_tests/test_cronjob_check_airflow_updates.py
@@ -11,12 +11,8 @@ class TestHoustonCronJobAirflowUpdates:
     def test_cronjob_airflow_updates_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"updateAirflowCheck": {"enabled": True}}}
-            },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"
-            ],
+            values={"astronomer": {"houston": {"updateAirflowCheck": {"enabled": True}}}},
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 1
@@ -30,13 +26,9 @@ class TestHoustonCronJobAirflowUpdates:
             "check-airflow-updates",
             "--url=https://updates.astronomer.io/astronomer-certified",
         ]
-        assert job_container_by_name["update-check"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert job_container_by_name["update-check"]["securityContext"] == {"runAsNonRoot": True}
 
-    def test_cronjob_airflow_updates_enabled_with_securityContext_overrides(
-        self, kube_version
-    ):
+    def test_cronjob_airflow_updates_enabled_with_securityContext_overrides(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -45,9 +37,7 @@ class TestHoustonCronJobAirflowUpdates:
                     "houston": {"updateAirflowCheck": {"enabled": True}},
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 1
@@ -69,12 +59,8 @@ class TestHoustonCronJobAirflowUpdates:
     def test_cronjob_airflow_updates_disabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"updateAirflowCheck": {"enabled": False}}}
-            },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"
-            ],
+            values={"astronomer": {"houston": {"updateAirflowCheck": {"enabled": False}}}},
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml"],
         )
 
         assert len(docs) == 0

--- a/tests/chart_tests/test_cronjob_check_runtime_updates.py
+++ b/tests/chart_tests/test_cronjob_check_runtime_updates.py
@@ -11,12 +11,8 @@ class TestHoustonCronJobAstroRuntimeUpdates:
     def test_cronjob_runtime_updates_enabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"updateRuntimeCheck": {"enabled": True}}}
-            },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"
-            ],
+            values={"astronomer": {"houston": {"updateRuntimeCheck": {"enabled": True}}}},
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"],
         )
 
         assert len(docs) == 1
@@ -30,13 +26,9 @@ class TestHoustonCronJobAstroRuntimeUpdates:
             "check-runtime-updates",
             "--url=https://updates.astronomer.io/astronomer-runtime",
         ]
-        assert job_container_by_name["update-check"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert job_container_by_name["update-check"]["securityContext"] == {"runAsNonRoot": True}
 
-    def test_cronjob_runtime_updates_enabled_with_securityContext_overrides(
-        self, kube_version
-    ):
+    def test_cronjob_runtime_updates_enabled_with_securityContext_overrides(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -45,9 +37,7 @@ class TestHoustonCronJobAstroRuntimeUpdates:
                     "houston": {"updateRuntimeCheck": {"enabled": True}},
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"],
         )
 
         assert len(docs) == 1
@@ -69,12 +59,8 @@ class TestHoustonCronJobAstroRuntimeUpdates:
     def test_cronjob_runtime_updates_disabled(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {"houston": {"updateRuntimeCheck": {"enabled": False}}}
-            },
-            show_only=[
-                "charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"
-            ],
+            values={"astronomer": {"houston": {"updateRuntimeCheck": {"enabled": False}}}},
+            show_only=["charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml"],
         )
 
         assert len(docs) == 0

--- a/tests/chart_tests/test_cves.py
+++ b/tests/chart_tests/test_cves.py
@@ -24,15 +24,10 @@ def test_log4shell(kube_version):
         ],
     )
 
-    containers = [
-        c for doc in docs for c in doc["spec"]["template"]["spec"]["containers"]
-    ]
+    containers = [c for doc in docs for c in doc["spec"]["template"]["spec"]["containers"]]
 
     # Assert that all containers contain at least one ES_JAVA_OPTS env var
-    assert all(
-        any(env_var["name"] == "ES_JAVA_OPTS" for env_var in c["env"])
-        for c in containers
-    )
+    assert all(any(env_var["name"] == "ES_JAVA_OPTS" for env_var in c["env"]) for c in containers)
 
     # Assert that all ES_JAVA_OPTS env vars in all containers have the string -Dlog4j2.formatMsgNoLookups=true
     assert all(

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -6,9 +6,7 @@ import tests.chart_tests as chart_tests
 from tests import get_containers_by_name, k8s_version_too_old, k8s_version_too_new
 from tests.chart_tests.helm_template_generator import render_chart
 
-annotation_validator = re.compile(
-    "^([^/]+/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
-)
+annotation_validator = re.compile("^([^/]+/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$")
 pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 
 
@@ -50,15 +48,11 @@ class TestAllCronJobs:
     def test_ensure_cronjob_names_are_max_52_chars(self):
         """Cronjob names must be DNS_MAX_LEN - TIMESTAMP_LEN, which is 52 chars."""
         default_docs = render_chart(values=self.chart_values)
-        cronjobs = [
-            doc for doc in default_docs if doc["kind"].lower() == "CronJob".lower()
-        ]
+        cronjobs = [doc for doc in default_docs if doc["kind"].lower() == "CronJob".lower()]
 
         for doc in cronjobs:
             name_len = len(doc["metadata"]["name"])
-            assert (
-                name_len <= 52
-            ), f'{doc["metadata"]["name"]} is too long at {name_len} characters'
+            assert name_len <= 52, f'{doc["metadata"]["name"]} is too long at {name_len} characters'
 
 
 class TestAllPodSpecContainers:
@@ -77,12 +71,8 @@ class TestAllPodSpecContainers:
     )
     def test_annotation_keys_are_valid(self, doc):
         """Test that our annotation keys are valid."""
-        annotation_results = [
-            bool(annotation_validator.match(a)) for a in doc["metadata"]["annotations"]
-        ]
-        assert all(
-            annotation_results
-        ), f"One of the annotation keys in {doc['kind']} {doc['metadata']['name']} is invalid."
+        annotation_results = [bool(annotation_validator.match(a)) for a in doc["metadata"]["annotations"]]
+        assert all(annotation_results), f"One of the annotation keys in {doc['kind']} {doc['metadata']['name']} is invalid."
 
     @pytest.mark.parametrize(
         "doc",
@@ -114,19 +104,13 @@ class TestAllPodSpecContainers:
         "repository": f"{private_repo}/ap-auth-sidecar",
     }
     private_repo_docs = render_chart(values=private_values)
-    pod_manager_docs_private = [
-        doc for doc in private_repo_docs if doc["kind"] in pod_managers
-    ]
-    pod_manager_docs_private_ids = [
-        f"{doc['kind']}/{doc['metadata']['name']}" for doc in pod_manager_docs_private
-    ]
+    pod_manager_docs_private = [doc for doc in private_repo_docs if doc["kind"] in pod_managers]
+    pod_manager_docs_private_ids = [f"{doc['kind']}/{doc['metadata']['name']}" for doc in pod_manager_docs_private]
 
     pod_manager_containers_public = {
         f"{doc['kind']}/{doc['metadata']['name']}/{name}": container
         for doc in pod_manager_docs
-        for name, container in get_containers_by_name(
-            doc, include_init_containers=True
-        ).items()
+        for name, container in get_containers_by_name(doc, include_init_containers=True).items()
     }
 
     @pytest.mark.parametrize(
@@ -145,19 +129,14 @@ class TestAllPodSpecContainers:
         for name, container in c_by_name.items():
             pod_container = f"{doc['kind']}/{doc['metadata']['name']}/{name}"
             assert (
-                container["image"].split("/")[-1:]
-                == self.pod_manager_containers_public[pod_container]["image"].split(
-                    "/"
-                )[-1:]
+                container["image"].split("/")[-1:] == self.pod_manager_containers_public[pod_container]["image"].split("/")[-1:]
             ), f"The spec for '{pod_container}' does not use the same image for public and private registry configurations."
             assert container["image"].startswith(
                 self.private_repo
             ), f"The spec for '{pod_container}' does not use the privateRegistry repo '{self.private_repo}': {container}"
 
 
-@pytest.mark.skip(
-    "See issue https://github.com/astronomer/issues/issues/5227 for details about when to reenabling this."
-)
+@pytest.mark.skip("See issue https://github.com/astronomer/issues/issues/5227 for details about when to reenabling this.")
 class TestDuplicateEnvironment:
     """Parametrize all the docs that have container specs and test them for
     duplicate env vars."""
@@ -165,7 +144,7 @@ class TestDuplicateEnvironment:
     values = chart_tests.get_all_features()
 
     docs = render_chart(values=values)
-    trimmed_docs = [x for x in docs if x["kind"] in pod_managers + ["CronJob"]]
+    trimmed_docs = [x for x in docs if x["kind"] in [*pod_managers, "CronJob"]]
 
     @staticmethod
     def check_env_vars_are_unique(container):
@@ -182,32 +161,14 @@ class TestDuplicateEnvironment:
         """Test that there are no duplicate env vars."""
         if doc["kind"] in pod_managers:
             for container in doc["spec"]["template"]["spec"].get("containers") or []:
-                assert (
-                    self.check_env_vars_are_unique(container) == []
-                ), "container has duplicate env vars"
+                assert self.check_env_vars_are_unique(container) == [], "container has duplicate env vars"
 
-            for container in (
-                doc["spec"]["template"]["spec"].get("initContainers") or []
-            ):
-                assert (
-                    self.check_env_vars_are_unique(container) == []
-                ), "initContainer has duplicate env vars"
+            for container in doc["spec"]["template"]["spec"].get("initContainers") or []:
+                assert self.check_env_vars_are_unique(container) == [], "initContainer has duplicate env vars"
 
         elif doc["kind"] == "CronJob":
-            for container in (
-                doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("containers")
-                or []
-            ):
-                assert (
-                    self.check_env_vars_are_unique(container) == []
-                ), "container has duplicate env vars"
+            for container in doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("containers") or []:
+                assert self.check_env_vars_are_unique(container) == [], "container has duplicate env vars"
 
-            for container in (
-                doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get(
-                    "initContainers"
-                )
-                or []
-            ):
-                assert (
-                    self.check_env_vars_are_unique(container) == []
-                ), "initContainer has duplicate env vars"
+            for container in doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("initContainers") or []:
+                assert self.check_env_vars_are_unique(container) == [], "initContainer has duplicate env vars"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -76,9 +76,7 @@ class TestElasticSearch:
         )
         assert len(docs) == 3
         for doc in docs:
-            assert doc["spec"]["template"]["spec"]["securityContext"] == {
-                "fsGroup": 1000
-            }
+            assert doc["spec"]["template"]["spec"]["securityContext"] == {"fsGroup": 1000}
 
     def test_elasticsearch_securitycontext_defaults(self, kube_version):
         """Test ElasticSearch master, data with securityContext default
@@ -215,15 +213,13 @@ class TestElasticSearch:
         assert [
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
+                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
             },
-        ] == doc["spec"]["ingress"][0]["from"]
+        ] == doc[
+            "spec"
+        ]["ingress"][0]["from"]
 
-    def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(
-        self, kube_version
-    ):
+    def test_nginx_es_client_network_selector_with_logging_sidecar_enabled(self, kube_version):
         """Test Nginx ES Service with NetworkPolicies."""
         docs = render_chart(
             kube_version=kube_version,
@@ -239,33 +235,23 @@ class TestElasticSearch:
         assert [
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
+                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "scheduler", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "scheduler", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "worker", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "worker", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "triggerer", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "triggerer", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
         ] == doc["spec"]["ingress"][0]["from"]
 
@@ -297,9 +283,7 @@ class TestElasticSearch:
             ]
         )
 
-    def test_elastic_nginx_config_pattern_defaults_and_index_prefix_overrides(
-        self, kube_version
-    ):
+    def test_elastic_nginx_config_pattern_defaults_and_index_prefix_overrides(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search with index prefix overrides."""
         docs = render_chart(
             kube_version=kube_version,
@@ -326,9 +310,7 @@ class TestElasticSearch:
             ]
         )
 
-    def test_elasticsearch_nginx_config_pattern_with_sidecar_logging_enabled(
-        self, kube_version
-    ):
+    def test_elasticsearch_nginx_config_pattern_with_sidecar_logging_enabled(self, kube_version):
         """Test Nginx ES Service Index Pattern Search with sidecar logging."""
         docs = render_chart(
             kube_version=kube_version,
@@ -355,9 +337,7 @@ class TestElasticSearch:
             ]
         )
 
-    def test_elasticsearch_nginx_config_pattern_with_sidecar_logging_enabled_and_index_prefix_overrides(
-        self, kube_version
-    ):
+    def test_elasticsearch_nginx_config_pattern_with_sidecar_logging_enabled_and_index_prefix_overrides(self, kube_version):
         """Test Nginx ES Service Index Pattern Search with sidecar logging."""
         docs = render_chart(
             kube_version=kube_version,
@@ -394,9 +374,7 @@ class TestElasticSearch:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
@@ -421,9 +399,7 @@ class TestElasticSearch:
                     }
                 }
             },
-            show_only=[
-                "charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
@@ -448,26 +424,17 @@ class TestElasticSearch:
             "name": "node.roles",
             "value": "master,ml,remote_cluster_client,",
         }
-        assert (
-            node_master_roles_env
-            in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_master_roles_env in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
         node_data_roles_env = {
             "name": "node.roles",
             "value": "data,data_cold,data_content,data_frozen,data_hot,data_warm,ml,remote_cluster_client,transform,",
         }
-        assert (
-            node_data_roles_env
-            in docs[1]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_data_roles_env in docs[1]["spec"]["template"]["spec"]["containers"][0]["env"]
         node_client_roles_env = {
             "name": "node.roles",
             "value": "ingest,ml,remote_cluster_client,",
         }
-        assert (
-            node_client_roles_env
-            in docs[2]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_client_roles_env in docs[2]["spec"]["template"]["spec"]["containers"][0]["env"]
 
     def test_elasticsearch_role_overrides(self, kube_version):
         """Test ElasticSearch master, data and client with custom roles"""
@@ -491,45 +458,28 @@ class TestElasticSearch:
             "name": "node.roles",
             "value": "master,",
         }
-        assert (
-            node_master_roles_env
-            in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_master_roles_env in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
         node_data_roles_env = {
             "name": "node.roles",
             "value": "data,",
         }
-        assert (
-            node_data_roles_env
-            in docs[1]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_data_roles_env in docs[1]["spec"]["template"]["spec"]["containers"][0]["env"]
         node_client_roles_env = {
             "name": "node.roles",
             "value": "ingest,",
         }
-        assert (
-            node_client_roles_env
-            in docs[2]["spec"]["template"]["spec"]["containers"][0]["env"]
-        )
+        assert node_client_roles_env in docs[2]["spec"]["template"]["spec"]["containers"][0]["env"]
 
-    def test_elasticsearch_curator_indexPatterns_override_with_loggingSidecar(
-        self, kube_version
-    ):
+    def test_elasticsearch_curator_indexPatterns_override_with_loggingSidecar(self, kube_version):
         """Test ElasticSearch Curator IndexPattern Override with loggingSidecar"""
         indexPattern = "%Y.%m"
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "global": {
-                    "loggingSidecar": {"enabled": True, "indexPattern": indexPattern}
-                }
-            },
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
-            ],
+            values={"global": {"loggingSidecar": {"enabled": True, "indexPattern": indexPattern}}},
+            show_only=["charts/elasticsearch/templates/curator/es-curator-configmap.yaml"],
         )
         assert len(docs) == 1
-        assert (LS := yaml.safe_load(docs[0]["data"]["action_file.yml"]))
+        LS = yaml.safe_load(docs[0]["data"]["action_file.yml"])
         assert indexPattern == LS["actions"][1]["filters"][0]["timestring"]
 
     def test_elasticsearch_curator_with_indexPatterns_defaults(self, kube_version):
@@ -538,12 +488,10 @@ class TestElasticSearch:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/curator/es-curator-configmap.yaml"],
         )
         assert len(docs) == 1
-        assert (LS := yaml.safe_load(docs[0]["data"]["action_file.yml"]))
+        LS = yaml.safe_load(docs[0]["data"]["action_file.yml"])
         assert indexPattern == LS["actions"][1]["filters"][0]["timestring"]
 
     def test_elasticsearch_curator_config_defaults(self, kube_version):
@@ -551,45 +499,31 @@ class TestElasticSearch:
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/curator/es-curator-configmap.yaml"],
         )
         assert len(docs) == 1
-        assert (LS := yaml.safe_load(docs[0]["data"]["config.yml"]))
-        print(LS["elasticsearch"])
+        LS = yaml.safe_load(docs[0]["data"]["config.yml"])
         assert "elasticsearch" in LS
-        assert (
-            "http://release-name-elasticsearch:9200"
-            in LS["elasticsearch"]["client"]["hosts"]
-        )
+        assert "http://release-name-elasticsearch:9200" in LS["elasticsearch"]["client"]["hosts"]
 
     def test_elasticsearch_curator_config_overrides(self, kube_version):
         """Test ElasticSearch Curator IndexPattern with defaults"""
         docs = render_chart(
             kube_version=kube_version,
             values={"elasticsearch": {"common": {"protocol": "https"}}},
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-configmap.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/curator/es-curator-configmap.yaml"],
         )
         assert len(docs) == 1
-        assert (LS := yaml.safe_load(docs[0]["data"]["config.yml"]))
-        print(LS["elasticsearch"])
+        LS = yaml.safe_load(docs[0]["data"]["config.yml"])
         assert "elasticsearch" in LS
-        assert (
-            "https://release-name-elasticsearch:9200"
-            in LS["elasticsearch"]["client"]["hosts"]
-        )
+        assert "https://release-name-elasticsearch:9200" in LS["elasticsearch"]["client"]["hosts"]
 
     def test_elasticsearch_curator_cronjob_defaults(self, kube_version):
         """Test ElasticSearch Curator cron job with defaults"""
         docs = render_chart(
             kube_version=kube_version,
             values={},
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_cronjob_containerspec_by_name(docs[0])
@@ -614,9 +548,7 @@ class TestElasticSearch:
                     }
                 }
             },
-            show_only=[
-                "charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"
-            ],
+            show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
         )
         assert len(docs) == 1
         c_by_name = get_cronjob_containerspec_by_name(docs[0])
@@ -679,7 +611,4 @@ class TestElasticSearch:
 
         for doc in docs:
             assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
-            assert (
-                test_persistentVolumeClaimRetentionPolicy
-                == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
-            )
+            assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -39,9 +39,7 @@ class TestExternalElasticSearch:
         assert expected_env == doc["spec"]["template"]["spec"]["containers"][0]["env"]
 
         assert "Service" == jmespath.search("kind", docs[3])
-        assert "release-name-external-es-proxy" == jmespath.search(
-            "metadata.name", docs[3]
-        )
+        assert "release-name-external-es-proxy" == jmespath.search("metadata.name", docs[3])
         assert "ClusterIP" == jmespath.search("spec.type", docs[3])
         assert {
             "name": "secure-http",
@@ -61,9 +59,7 @@ class TestExternalElasticSearch:
         secrets."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "global": {"customLogging": {"enabled": True, "secretName": "essecret"}}
-            },
+            values={"global": {"customLogging": {"enabled": True, "secretName": "essecret"}}},
             show_only=[
                 "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
                 "charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml",
@@ -91,9 +87,7 @@ class TestExternalElasticSearch:
         assert expected_env == doc["spec"]["template"]["spec"]["containers"][0]["env"]
 
         assert "Service" == jmespath.search("kind", docs[3])
-        assert "release-name-external-es-proxy" == jmespath.search(
-            "metadata.name", docs[3]
-        )
+        assert "release-name-external-es-proxy" == jmespath.search("metadata.name", docs[3])
         assert "ClusterIP" == jmespath.search("spec.type", docs[3])
         assert {
             "name": "secure-http",
@@ -138,24 +132,18 @@ class TestExternalElasticSearch:
         expected_env = [
             {
                 "name": "AWS_ACCESS_KEY_ID",
-                "valueFrom": {
-                    "secretKeyRef": {"name": "awssecret", "key": "aws_access_key"}
-                },
+                "valueFrom": {"secretKeyRef": {"name": "awssecret", "key": "aws_access_key"}},
             },
             {
                 "name": "AWS_SECRET_ACCESS_KEY",
-                "valueFrom": {
-                    "secretKeyRef": {"name": "awssecret", "key": "aws_secret_key"}
-                },
+                "valueFrom": {"secretKeyRef": {"name": "awssecret", "key": "aws_secret_key"}},
             },
             {"name": "ENDPOINT", "value": "https://esdemo.example.com"},
         ]
         assert expected_env == doc["spec"]["template"]["spec"]["containers"][1]["env"]
 
         assert "Service" == jmespath.search("kind", docs[1])
-        assert "release-name-external-es-proxy" == jmespath.search(
-            "metadata.name", docs[1]
-        )
+        assert "release-name-external-es-proxy" == jmespath.search("metadata.name", docs[1])
         assert "ClusterIP" == jmespath.search("spec.type", docs[1])
         assert {
             "name": "secure-http",
@@ -170,9 +158,7 @@ class TestExternalElasticSearch:
             "appProtocol": "http",
         } in jmespath.search("spec.ports", docs[1])
 
-        nginx_conf = pathlib.Path(
-            "tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf"
-        ).read_text()
+        nginx_conf = pathlib.Path("tests/chart_tests/test_data/external-es-nginx-with-aws-secrets.conf").read_text()
         assert nginx_conf in docs[2]["data"]["nginx.conf"]
 
     def test_externalelasticsearch_with_awsIAMRole(self, kube_version):
@@ -207,9 +193,7 @@ class TestExternalElasticSearch:
         )
 
         assert "Service" == jmespath.search("kind", docs[1])
-        assert "release-name-external-es-proxy" == jmespath.search(
-            "metadata.name", docs[1]
-        )
+        assert "release-name-external-es-proxy" == jmespath.search("metadata.name", docs[1])
         assert "ClusterIP" == jmespath.search("spec.type", docs[1])
         assert {
             "name": "secure-http",
@@ -254,14 +238,10 @@ class TestExternalElasticSearch:
 
         doc = docs[1]
 
-        assert "arn:aws:iam::xxxxxxxx:role/customrole" == jmespath.search(
-            'metadata.annotations."eks.amazonaws.com/role-arn"', doc
-        )
+        assert "arn:aws:iam::xxxxxxxx:role/customrole" == jmespath.search('metadata.annotations."eks.amazonaws.com/role-arn"', doc)
 
         assert "Service" == jmespath.search("kind", docs[2])
-        assert "release-name-external-es-proxy" == jmespath.search(
-            "metadata.name", docs[2]
-        )
+        assert "release-name-external-es-proxy" == jmespath.search("metadata.name", docs[2])
         assert "ClusterIP" == jmespath.search("spec.type", docs[2])
         assert {
             "name": "secure-http",
@@ -276,9 +256,7 @@ class TestExternalElasticSearch:
             "appProtocol": "http",
         } in jmespath.search("spec.ports", docs[2])
 
-    def test_externalelasticsearch_houston_configmap_with_disabled_kibanaUIFlag(
-        self, kube_version
-    ):
+    def test_externalelasticsearch_houston_configmap_with_disabled_kibanaUIFlag(self, kube_version):
         """Test Houston Configmap with kibanaUIFlag."""
         docs = render_chart(
             kube_version=kube_version,
@@ -316,15 +294,13 @@ class TestExternalElasticSearch:
         assert [
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
+                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
             },
-        ] == doc["spec"]["ingress"][0]["from"]
+        ] == doc[
+            "spec"
+        ]["ingress"][0]["from"]
 
-    def test_external_es_network_selector_with_logging_sidecar_enabled(
-        self, kube_version
-    ):
+    def test_external_es_network_selector_with_logging_sidecar_enabled(self, kube_version):
         """Test External Elasticsearch Service with NetworkPolicy Defaults."""
         docs = render_chart(
             kube_version=kube_version,
@@ -350,33 +326,23 @@ class TestExternalElasticSearch:
         assert [
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"tier": "airflow", "component": "webserver"}
-                },
+                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "scheduler", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "scheduler", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "worker", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "worker", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "triggerer", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "triggerer", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {
-                    "matchLabels": {"component": "git-sync-relay", "tier": "airflow"}
-                },
+                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
         ] == doc["spec"]["ingress"][0]["from"]
 
@@ -578,9 +544,7 @@ class TestExternalElasticSearch:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-external-es-proxy"
-        assert {"name": "TEST_VAR_NAME", "value": "test_var_value"} in doc["spec"][
-            "template"
-        ]["spec"]["containers"][0]["env"]
+        assert {"name": "TEST_VAR_NAME", "value": "test_var_value"} in doc["spec"]["template"]["spec"]["containers"][0]["env"]
 
     def test_external_elasticsearch_nginx_defaults_config(self, kube_version):
         """Test External ElasticSearch with nginx defaults."""
@@ -602,8 +566,6 @@ class TestExternalElasticSearch:
 
         assert len(docs) == 1
         doc = docs[0]
-        nginx_conf = pathlib.Path(
-            "tests/chart_tests/test_data/default-external-es-nginx.conf"
-        ).read_text()
+        nginx_conf = pathlib.Path("tests/chart_tests/test_data/default-external-es-nginx.conf").read_text()
         assert doc["kind"] == "ConfigMap"
         assert nginx_conf in doc["data"]["nginx.conf"]

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -55,10 +55,7 @@ class TestFluentd:
             ]
         ]
 
-        assert (
-            search_result_es_index_template_volume_mount
-            == expected_result_es_index_template_volume_mount
-        )
+        assert search_result_es_index_template_volume_mount == expected_result_es_index_template_volume_mount
 
         search_result_es_index_template_volume = jmespath.search(
             "spec.template.spec.volumes[?name == 'release-name-fluentd-index-template-volume']",
@@ -72,10 +69,7 @@ class TestFluentd:
             }
         ]
 
-        assert (
-            search_result_es_index_template_volume
-            == expected_result_es_index_template_volume
-        )
+        assert search_result_es_index_template_volume == expected_result_es_index_template_volume
 
     def test_fluentd_clusterrolebinding(self, kube_version):
         """Test that helm renders a good ClusterRoleBinding template for fluentd
@@ -122,9 +116,7 @@ class TestFluentd:
         expected_rule = "key $.kubernetes.namespace_name\n    # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled"
         assert expected_rule in doc["data"]["output.conf"]
 
-    def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(
-        self, kube_version
-    ):
+    def test_fluentd_configmap_manual_namespaces_and_namespacepools_disabled(self, kube_version):
         """Test that when namespace Pools and manualNamespaceNamesEnabled are
         disabled, helm renders a default fluentd configmap looking at an
         environment variable."""
@@ -143,9 +135,7 @@ class TestFluentd:
             show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
         )[0]
 
-        expected_rule = (
-            'key $.kubernetes.namespace_labels.platform\n    pattern "release-name"'
-        )
+        expected_rule = 'key $.kubernetes.namespace_labels.platform\n    pattern "release-name"'
         assert expected_rule in doc["data"]["output.conf"]
 
     def test_fluentd_configmap_configure_extra_log_stores(self, kube_version):
@@ -257,16 +247,11 @@ class TestFluentd:
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-fluentd"
-        assert (
-            'fluentd.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}'
-            in doc["data"]["output.conf"]
-        )
+        assert 'fluentd.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}' in doc["data"]["output.conf"]
         doc = docs[1]
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
-        assert (
-            doc["metadata"]["name"] == "release-name-fluentd-index-template-configmap"
-        )
+        assert doc["metadata"]["name"] == "release-name-fluentd-index-template-configmap"
         index_cm = yaml.safe_load(doc["data"]["index_template.json"])
         assert index_cm == {
             "index_patterns": ["fluentd.*"],
@@ -291,16 +276,13 @@ class TestFluentd:
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-fluentd"
         assert (
-            'astronomer.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}'
-            in doc["data"]["output.conf"]
+            'astronomer.${record["release"]}.${Time.at(time).getutc.strftime(@logstash_dateformat)}' in doc["data"]["output.conf"]
         )
 
         doc = docs[1]
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
-        assert (
-            doc["metadata"]["name"] == "release-name-fluentd-index-template-configmap"
-        )
+        assert doc["metadata"]["name"] == "release-name-fluentd-index-template-configmap"
         index_cm = yaml.safe_load(doc["data"]["index_template.json"])
         assert index_cm == {
             "index_patterns": ["astronomer.*"],
@@ -330,10 +312,7 @@ class TestFluentd:
         doc = docs[0]
         self.fluentd_common_tests(doc)
         assert "priorityClassName" in doc["spec"]["template"]["spec"]
-        assert (
-            "fluentd-priority-pod"
-            == doc["spec"]["template"]["spec"]["priorityClassName"]
-        )
+        assert "fluentd-priority-pod" == doc["spec"]["template"]["spec"]["priorityClassName"]
 
     def test_fluentd_with_custom_env(self, kube_version):
         """Test to validate fluentd extraEnv configured."""
@@ -353,4 +332,6 @@ class TestFluentd:
         assert {
             "name": "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR",
             "value": "1",
-        } in c_by_name["fluentd"]["env"]
+        } in c_by_name[
+            "fluentd"
+        ]["env"]

--- a/tests/chart_tests/test_global_network_policy_flag.py
+++ b/tests/chart_tests/test_global_network_policy_flag.py
@@ -65,10 +65,7 @@ def test_networkpolicy_enabled(np_enabled, num_of_docs):
 
     assert len(docs) == num_of_docs
     if docs:
-        components = [
-            x["podSelector"]["matchLabels"].get("component")
-            for x in docs[0]["spec"]["ingress"][0]["from"]
-        ]
+        components = [x["podSelector"]["matchLabels"].get("component") for x in docs[0]["spec"]["ingress"][0]["from"]]
         assert "dag-server" not in components
 
 
@@ -87,9 +84,6 @@ def test_networkpolicy_dag_deploy_enabled(kube_version):
 
     assert len(docs) == 1
 
-    components = [
-        x["podSelector"]["matchLabels"].get("component")
-        for x in docs[0]["spec"]["ingress"][0]["from"]
-    ]
+    components = [x["podSelector"]["matchLabels"].get("component") for x in docs[0]["spec"]["ingress"][0]["from"]]
     assert len(components) == 8
     assert "dag-server" in components

--- a/tests/chart_tests/test_global_storageclass.py
+++ b/tests/chart_tests/test_global_storageclass.py
@@ -28,7 +28,5 @@ def test_global_storageclass(supported_types, expected_output):
 
     assert all(
         expected_output in storageClassNames
-        for storageClassNames in jmespath.search(
-            "[*].spec.volumeClaimTemplates[*].spec.storageClassName", docs
-        )
+        for storageClassNames in jmespath.search("[*].spec.volumeClaimTemplates[*].spec.storageClassName", docs)
     )

--- a/tests/chart_tests/test_grafana.py
+++ b/tests/chart_tests/test_grafana.py
@@ -84,9 +84,7 @@ class TestGrafanaDeployment:
         """Test that the grafana-deployment renders with the expected securityContext."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "grafana": {"securityContext": {"runAsNonRoot": True, "runAsUser": 467}}
-            },
+            values={"grafana": {"securityContext": {"runAsNonRoot": True, "runAsUser": 467}}},
             show_only=[DEPLOYMENT_FILE],
         )
 

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -13,9 +13,7 @@ class TestHoustonApiDeployment:
     def test_houston_api_deployment(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -26,15 +24,14 @@ class TestHoustonApiDeployment:
             "tier": "astronomer",
             "component": "houston",
             "release": "release-name",
-        } == doc["spec"]["selector"]["matchLabels"]
+        } == doc["spec"][
+            "selector"
+        ]["matchLabels"]
 
         assert doc["spec"]["template"]["metadata"]["labels"].get("app") == "houston"
         assert doc["spec"]["template"]["metadata"]["labels"].get("app") == "houston"
         assert doc["spec"]["template"]["metadata"]["labels"].get("tier") == "astronomer"
-        assert (
-            doc["spec"]["template"]["metadata"]["labels"].get("release")
-            == "release-name"
-        )
+        assert doc["spec"]["template"]["metadata"]["labels"].get("release") == "release-name"
 
         labels = doc["spec"]["template"]["metadata"]["labels"]
         assert {
@@ -45,38 +42,18 @@ class TestHoustonApiDeployment:
         } == {x: labels[x] for x in labels if x != "version"}
 
         c_by_name = get_containers_by_name(doc, include_init_containers=True)
-        assert c_by_name["houston-bootstrapper"]["image"].startswith(
-            "quay.io/astronomer/ap-db-bootstrapper:"
-        )
-        assert c_by_name["houston"]["image"].startswith(
-            "quay.io/astronomer/ap-houston-api:"
-        )
-        assert c_by_name["wait-for-db"]["image"].startswith(
-            "quay.io/astronomer/ap-houston-api:"
-        )
+        assert c_by_name["houston-bootstrapper"]["image"].startswith("quay.io/astronomer/ap-db-bootstrapper:")
+        assert c_by_name["houston"]["image"].startswith("quay.io/astronomer/ap-houston-api:")
+        assert c_by_name["wait-for-db"]["image"].startswith("quay.io/astronomer/ap-houston-api:")
         houston_env = c_by_name["houston"]["env"]
-        deployments_database_connection_env = next(
-            x for x in houston_env if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION"
-        )
+        deployments_database_connection_env = next(x for x in houston_env if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION")
         assert deployments_database_connection_env is not None
 
     def test_houston_api_deployment_with_helm_set_database(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
-            values={
-                "astronomer": {
-                    "houston": {
-                        "config": {
-                            "deployments": {
-                                "database": {"connection": {"host": "1.1.1.1"}}
-                            }
-                        }
-                    }
-                }
-            },
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
+            values={"astronomer": {"houston": {"config": {"deployments": {"database": {"connection": {"host": "1.1.1.1"}}}}}}},
         )
 
         assert len(docs) == 1
@@ -86,23 +63,15 @@ class TestHoustonApiDeployment:
         houston_env = c_by_name["houston"]["env"]
 
         deployments_database_connection_env = next(
-            (
-                x
-                for x in houston_env
-                if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION"
-            ),
+            (x for x in houston_env if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION"),
             None,
         )
         assert deployments_database_connection_env is None
 
-    def test_houston_api_deployment_private_registry_with_secret_name_undefined(
-        self, kube_version
-    ):
+    def test_houston_api_deployment_private_registry_with_secret_name_undefined(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
             values={
                 "global": {
                     "privateRegistry": {
@@ -115,25 +84,14 @@ class TestHoustonApiDeployment:
 
         assert not jmespath.search("spec.template.spec.imagePullSecrets", docs[0])
 
-    def test_houston_api_deployment_private_registry_with_secret_name_defined(
-        self, kube_version
-    ):
+    def test_houston_api_deployment_private_registry_with_secret_name_defined(self, kube_version):
         secretName = "shhhhh"
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
-            values={
-                "global": {
-                    "privateRegistry": {"enabled": True, "secretName": secretName}
-                }
-            },
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
+            values={"global": {"privateRegistry": {"enabled": True, "secretName": secretName}}},
         )
-        assert (
-            jmespath.search("spec.template.spec.imagePullSecrets[0].name", docs[0])
-            == secretName
-        )
+        assert jmespath.search("spec.template.spec.imagePullSecrets[0].name", docs[0]) == secretName
 
     def test_houston_api_deployment_with_updates_url_enabled(self, kube_version):
         docs = render_chart(
@@ -146,9 +104,7 @@ class TestHoustonApiDeployment:
                     }
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -188,9 +144,7 @@ class TestHoustonApiDeployment:
                     }
                 }
             },
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
         )
 
         assert len(docs) == 1
@@ -212,14 +166,10 @@ class TestHoustonApiDeployment:
 
         assert expected_airflow_env in houston_env
 
-    def test_houston_api_deployment_passing_in_base_houston_host_in_env(
-        self, kube_version
-    ):
+    def test_houston_api_deployment_passing_in_base_houston_host_in_env(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
@@ -239,9 +189,7 @@ class TestHoustonApiDeployment:
         docs = render_chart(
             name="custom-name",
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
         )
         assert all(
             env["value"].startswith("custom-name-")

--- a/tests/chart_tests/test_houston_bootstrap_serviceaccount.py
+++ b/tests/chart_tests/test_houston_bootstrap_serviceaccount.py
@@ -11,9 +11,7 @@ class TestHoustonBootstrapServiceAccount:
     def test_houston_bootstrap_serviceaccount_defaults(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml"
-            ],
+            show_only=["charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml"],
         )
 
         assert len(docs) == 1

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -22,9 +22,7 @@ def common_test_cases(docs):
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
     assert prod["deployments"]["disableManageClusterScopedResources"] is False
-    airflow_local_settings = prod["deployments"]["helm"]["airflow"][
-        "airflowLocalSettings"
-    ]
+    airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
 
     assert (
         prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
@@ -163,13 +161,8 @@ def test_houston_configmap_with_config_syncer_disabled():
     common_test_cases(docs)
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert (
-        "extraVolumeMounts"
-        not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    )
-    assert (
-        "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    )
+    assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+    assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
     assert not prod_yaml["deployments"].get("loggingSidecar")
 
 
@@ -220,9 +213,7 @@ def test_houston_configmap_with_loggingsidecar_enabled():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": "sidecar-log-consumer",
@@ -253,9 +244,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrid
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": "sidecar-log-consumer",
@@ -288,9 +277,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -324,9 +311,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -359,9 +344,7 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -412,9 +395,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -423,15 +404,11 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
         "extraEnv": [
             {
                 "name": "ES_USER",
-                "valueFrom": {
-                    "secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}
-                },
+                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
             },
             {
                 "name": "ES_PASS",
-                "valueFrom": {
-                    "secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}
-                },
+                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
             },
         ],
     }
@@ -464,9 +441,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides()
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -506,9 +481,7 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_conf
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert (
-        log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    )
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     assert prod_yaml["deployments"]["loggingSidecar"] == {
         "enabled": True,
         "name": sidecar_container_name,
@@ -625,9 +598,7 @@ def test_houston_configmap_with_internal_authorization_flag_defaults():
 def test_houston_configmap_with_internal_authorization_flag_enabled():
     """Validate the houston configmap to internal authorization."""
     docs = render_chart(
-        values={
-            "astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}
-        },
+        values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     common_test_cases(docs)

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -29,32 +29,18 @@ class TestIngress:
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert "release-name-houston" in [
-                name[0]
-                for name in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.service.name", doc
-                )
+                name[0] for name in jmespath.search("spec.rules[*].http.paths[*].backend.service.name", doc)
             ]
             assert "houston-http" in [
-                port[0]
-                for port in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.service.port.name", doc
-                )
+                port[0] for port in jmespath.search("spec.rules[*].http.paths[*].backend.service.port.name", doc)
             ]
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
             assert "release-name-houston" in [
-                name[0]
-                for name in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.serviceName", doc
-                )
+                name[0] for name in jmespath.search("spec.rules[*].http.paths[*].backend.serviceName", doc)
             ]
-            assert "houston-http" in [
-                port[0]
-                for port in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.servicePort", doc
-                )
-            ]
+            assert "houston-http" in [port[0] for port in jmespath.search("spec.rules[*].http.paths[*].backend.servicePort", doc)]
 
     def test_protect_houston_internal_urls(self, kube_version):
         docs = render_chart(
@@ -80,21 +66,11 @@ class TestIngress:
         }
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "astronomer": {
-                    "houston": {"ingress": {"annotation": custom_annotations}}
-                }
-            },
+            values={"astronomer": {"houston": {"ingress": {"annotation": custom_annotations}}}},
             show_only=["charts/astronomer/templates/houston/ingress.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
         annotations = jmespath.search("metadata.annotations", doc)
-        assert (
-            annotations["nginx.ingress.kubernetes.io/upstream-keepalive-connections"]
-            == "9999"
-        )
-        assert (
-            annotations["nginx.ingress.kubernetes.io/upstream-keepalive-timeout"]
-            == "7777"
-        )
+        assert annotations["nginx.ingress.kubernetes.io/upstream-keepalive-connections"] == "9999"
+        assert annotations["nginx.ingress.kubernetes.io/upstream-keepalive-timeout"] == "7777"

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -75,20 +75,11 @@ class TestIngress:
 
     def test_single_ingress_per_host(self, kube_version):
         default_docs = render_chart(values={"global": {"enablePerHostIngress": True}})
-        ingresses = [
-            doc for doc in default_docs if doc["kind"].lower() == "Ingress".lower()
-        ]
+        ingresses = [doc for doc in default_docs if doc["kind"].lower() == "Ingress".lower()]
         assert len(ingresses) == 9
         assert all(len(doc["spec"]["rules"]) == 1 for doc in ingresses)
         assert all(len(doc["spec"]["tls"][0]["hosts"]) == 1 for doc in ingresses)
         assert all(doc["apiVersion"] == "networking.k8s.io/v1" for doc in ingresses)
         assert all(doc["kind"] == "Ingress" for doc in ingresses)
-        assert all(
-            doc["metadata"]["annotations"]["kubernetes.io/ingress.class"]
-            == "release-name-nginx"
-            for doc in ingresses
-        )
-        assert all(
-            doc["metadata"]["annotations"]["kubernetes.io/tls-acme"] == "false"
-            for doc in ingresses
-        )
+        assert all(doc["metadata"]["annotations"]["kubernetes.io/ingress.class"] == "release-name-nginx" for doc in ingresses)
+        assert all(doc["metadata"]["annotations"]["kubernetes.io/tls-acme"] == "false" for doc in ingresses)

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -40,7 +40,9 @@ class TestKibana:
         assert {
             "name": "SERVER_PUBLICBASEURL",
             "value": "https://kibana.example.com",
-        } in c_by_name["kibana"]["env"]
+        } in c_by_name[
+            "kibana"
+        ]["env"]
 
     def test_kibana_index_defaults(self, kube_version):
         """Test kibana Service with index defaults."""
@@ -53,10 +55,7 @@ class TestKibana:
         )
         common_kibana_cronjob_test(docs)
         doc = docs[0]
-        assert (
-            "fluentd.*"
-            in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
-        )
+        assert "fluentd.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
 
     def test_kibana_index_with_logging_sidecar(self, kube_version):
         """Test kibana Service with logging sidecar index."""
@@ -69,9 +68,7 @@ class TestKibana:
         )
         common_kibana_cronjob_test(docs)
         doc = docs[0]
-        assert (
-            "vector.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
-        )
+        assert "vector.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
 
     def test_kibana_index_disabled(self, kube_version):
         """Test kibana Service with index creation disabled."""
@@ -123,9 +120,7 @@ class TestKibana:
         )
         common_kibana_cronjob_test(docs)
         doc = docs[0]
-        assert {"runAsNonRoot": True, "runAsUser": 1000} == doc["spec"]["template"][
-            "spec"
-        ]["containers"][0]["securityContext"]
+        assert {"runAsNonRoot": True, "runAsUser": 1000} == doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]
 
     def test_kibana_index_securitycontext_with_openshiftEnabled(self, kube_version):
         """Test kibana Service with index defaults."""
@@ -138,6 +133,4 @@ class TestKibana:
         )
         common_kibana_cronjob_test(docs)
         doc = docs[0]
-        assert {"runAsNonRoot": True} == doc["spec"]["template"]["spec"]["containers"][
-            0
-        ]["securityContext"]
+        assert {"runAsNonRoot": True} == doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -66,10 +66,7 @@ class TestKubeStateDeployment:
 
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
-        assert (
-            "--metric-labels-allowlist=namespaces=[*],pods=[*],configmaps=[*]"
-            in c_by_name["kube-state"]["args"]
-        )
+        assert "--metric-labels-allowlist=namespaces=[*],pods=[*],configmaps=[*]" in c_by_name["kube-state"]["args"]
         assert "--namespaces=" not in c_by_name["kube-state"]["args"]
         assert "--namespace=" not in c_by_name["kube-state"]["args"]
 
@@ -131,10 +128,7 @@ class TestKubeStateDeployment:
 
         assert len(docs) == 9
         c_by_name = get_containers_by_name(docs[0])
-        assert (
-            "--namespaces=test-1,test-2,test-3,test_namespace"
-            in c_by_name["kube-state"]["args"]
-        )
+        assert "--namespaces=test-1,test-2,test-3,test_namespace" in c_by_name["kube-state"]["args"]
         roles_namespace_pools_list = ["test-1", "test-2", "test-3", "test_namespace"]
         for i in range(1, 5):
             role_binding = docs[i]
@@ -149,10 +143,7 @@ class TestKubeStateDeployment:
                 "name": "release-name-kube-state",
             }
             assert role_binding["kind"] == "RoleBinding"
-            assert (
-                role_binding["metadata"]["namespace"]
-                == roles_namespace_pools_list[i - 5]
-            )
+            assert role_binding["metadata"]["namespace"] == roles_namespace_pools_list[i - 5]
             assert role_binding["roleRef"] == expected_role
             assert role_binding["subjects"][0] == expected_subject
 
@@ -232,7 +223,4 @@ class TestKubeStateDeployment:
         assert len(docs) == 1
         doc = docs[0]
         assert "priorityClassName" in doc["spec"]["template"]["spec"]
-        assert (
-            "kube-state-priority-pod"
-            == doc["spec"]["template"]["spec"]["priorityClassName"]
-        )
+        assert "kube-state-priority-pod" == doc["spec"]["template"]["spec"]["priorityClassName"]

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -30,9 +30,7 @@ class TestNatsJetstream:
         assert prod["nats"] == {"jetStreamEnabled": True, "tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
-        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[6]["spec"]["template"][
-            "spec"
-        ]["containers"][0]["securityContext"]
+        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[6]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test Nats with jetstream config."""
@@ -58,14 +56,8 @@ class TestNatsJetstream:
 
         obj_by_name = {f"{x['kind']}-{x['metadata']['name']}": x for x in docs}
 
-        jetStreamCertPrefix = (
-            "/etc/houston/jetstream/tls/release-name-jetstream-tls-certificate"
-        )
-        prod = yaml.safe_load(
-            obj_by_name["ConfigMap-release-name-houston-config"]["data"][
-                "production.yaml"
-            ]
-        )
+        jetStreamCertPrefix = "/etc/houston/jetstream/tls/release-name-jetstream-tls-certificate"
+        prod = yaml.safe_load(obj_by_name["ConfigMap-release-name-houston-config"]["data"]["production.yaml"])
         assert prod["nats"] == {
             "jetStreamEnabled": True,
             "tlsEnabled": True,
@@ -79,51 +71,31 @@ class TestNatsJetstream:
         assert {
             "name": "release-name-jetstream-tls-certificate-client-volume",
             "mountPath": "/etc/nats-certs/client/release-name-jetstream-tls-certificate-client",
-        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"][
-            "containers"
-        ][
-            0
-        ][
-            "volumeMounts"
-        ]
+        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
 
         assert {
             "name": "release-name-jetstream-tls-certificate-server-volume",
             "mountPath": "/etc/nats-certs/server/release-name-jetstream-tls-certificate",
-        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"][
-            "containers"
-        ][
-            0
-        ][
-            "volumeMounts"
-        ]
+        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
 
         assert {
             "name": "release-name-jetstream-tls-certificate-client-volume",
             "secret": {"secretName": "release-name-jetstream-tls-certificate-client"},
-        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"]["volumes"]
 
         assert {
             "name": "release-name-jetstream-tls-certificate-server-volume",
             "secret": {"secretName": "release-name-jetstream-tls-certificate"},
-        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        } in obj_by_name["StatefulSet-release-name-nats"]["spec"]["template"]["spec"]["volumes"]
 
         nats_cm = obj_by_name["ConfigMap-release-name-nats-config"]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
         assert (
-            obj_by_name["Secret-release-name-jetstream-tls-certificate"]["metadata"][
-                "name"
-            ]
+            obj_by_name["Secret-release-name-jetstream-tls-certificate"]["metadata"]["name"]
             == "release-name-jetstream-tls-certificate"
         )
         assert (
-            obj_by_name["Secret-release-name-jetstream-tls-certificate-client"][
-                "metadata"
-            ]["name"]
+            obj_by_name["Secret-release-name-jetstream-tls-certificate-client"]["metadata"]["name"]
             == "release-name-jetstream-tls-certificate-client"
         )
 
@@ -134,21 +106,17 @@ class TestNatsJetstream:
             assert {
                 "name": "nats-jetstream-client-tls-volume",
                 "mountPath": f"{jetStreamCertPrefix}-client",
-            } in obj_by_name[item]["spec"]["template"]["spec"]["containers"][0][
-                "volumeMounts"
-            ]
+            } in obj_by_name[item][
+                "spec"
+            ]["template"]["spec"]["containers"][0]["volumeMounts"]
             assert {
                 "name": "nats-jetstream-client-tls-volume",
                 "mountPath": "/usr/local/share/ca-certificates/release-name-jetstream-tls-certificate-client.crt",
                 "subPath": "ca.crt",
-            } in obj_by_name[item]["spec"]["template"]["spec"]["containers"][0][
-                "volumeMounts"
-            ]
+            } in obj_by_name[item]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
             assert {
                 "name": "nats-jetstream-client-tls-volume",
-                "secret": {
-                    "secretName": "release-name-jetstream-tls-certificate-client"
-                },
+                "secret": {"secretName": "release-name-jetstream-tls-certificate-client"},
             } in obj_by_name[item]["spec"]["template"]["spec"]["volumes"]
 
     def test_stan_with_jetstream_enabled(self, kube_version):

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -24,12 +24,8 @@ class TestNatsStatefulSet:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-nats"
-        assert c_by_name["metrics"]["image"].startswith(
-            "quay.io/astronomer/ap-nats-exporter:"
-        )
-        assert c_by_name["nats"]["image"].startswith(
-            "quay.io/astronomer/ap-nats-server:"
-        )
+        assert c_by_name["metrics"]["image"].startswith("quay.io/astronomer/ap-nats-exporter:")
+        assert c_by_name["nats"]["image"].startswith("quay.io/astronomer/ap-nats-server:")
         assert c_by_name["nats"]["livenessProbe"] == {
             "httpGet": {"path": "/", "port": 8222},
             "initialDelaySeconds": 10,
@@ -116,14 +112,7 @@ class TestNatsStatefulSet:
         assert spec["nodeSelector"] != {}
         assert spec["nodeSelector"]["role"] == "astro"
         assert spec["affinity"] != {}
-        assert (
-            len(
-                spec["affinity"]["nodeAffinity"][
-                    "requiredDuringSchedulingIgnoredDuringExecution"
-                ]["nodeSelectorTerms"]
-            )
-            == 1
-        )
+        assert len(spec["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"]) == 1
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["nats"]["tolerations"]
 
@@ -175,18 +164,9 @@ class TestNatsStatefulSet:
         assert spec["nodeSelector"] != {}
         assert spec["nodeSelector"]["role"] == "astro"
         assert spec["affinity"] != {}
-        assert (
-            len(
-                spec["affinity"]["nodeAffinity"][
-                    "requiredDuringSchedulingIgnoredDuringExecution"
-                ]["nodeSelectorTerms"]
-            )
-            == 1
-        )
+        assert len(spec["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"]) == 1
         assert len(spec["tolerations"]) > 0
-        assert (
-            spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
-        )
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
     def test_nats_statefulset_with_default_cluster_name(self, kube_version):
         """Test that nats configmap has cluster name defined."""
@@ -244,9 +224,7 @@ class TestNatsStatefulSet:
             }.keys()
         ) == set(doc["spec"]["template"]["metadata"]["annotations"].keys())
 
-    def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(
-        self, kube_version
-    ):
+    def test_nats_statefulset_template_annotation_with_podAnnotations_overrides(self, kube_version):
         """Test that nats template default annotations."""
         docs = render_chart(
             kube_version=kube_version,
@@ -264,7 +242,4 @@ class TestNatsStatefulSet:
         )
         assert len(docs) == 1
         doc = docs[0]
-        assert (
-            "sampleannotation"
-            in doc["spec"]["template"]["metadata"]["annotations"]["app.test.io"]
-        )
+        assert "sampleannotation" in doc["spec"]["template"]["metadata"]["annotations"]["app.test.io"]

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -32,9 +32,7 @@ class TestNginx:
             ("ExternalName", "Local", True),
         ],
     )
-    def test_nginx_service_servicetype(
-        self, service_type, external_traffic_policy, preserve_source_ip
-    ):
+    def test_nginx_service_servicetype(self, service_type, external_traffic_policy, preserve_source_ip):
         """Verify that ClusterIP never has an externalTrafficPolicy, and other
         configurations are correct according to spec.
 
@@ -58,19 +56,12 @@ class TestNginx:
         """Deployment should contain the given ingress annotations when they
         are specified."""
         doc = render_chart(
-            values={
-                "nginx": {
-                    "ingressAnnotations": {"foo1": "foo", "foo2": "foo", "foo3": "foo"}
-                }
-            },
+            values={"nginx": {"ingressAnnotations": {"foo1": "foo", "foo2": "foo", "foo3": "foo"}}},
             show_only=["charts/nginx/templates/nginx-service.yaml"],
         )[0]
 
         expected_annotations = {"foo1": "foo", "foo2": "foo", "foo3": "foo"}
-        assert all(
-            doc["metadata"]["annotations"][x] == y
-            for x, y in expected_annotations.items()
-        )
+        assert all(doc["metadata"]["annotations"][x] == y for x, y in expected_annotations.items())
 
     def test_nginx_type_loadbalancer(self):
         """Deployment works with type LoadBalancer and some LB
@@ -205,17 +196,12 @@ class TestNginx:
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
         )[0]
         annotationValidation = "--enable-annotation-validation=true"
-        assert (
-            annotationValidation
-            in doc["spec"]["template"]["spec"]["containers"][0]["args"]
-        )
+        assert annotationValidation in doc["spec"]["template"]["spec"]["containers"][0]["args"]
 
     def test_nginx_backend_serviceaccount_defaults(self):
         doc = render_chart(
             values={},
-            show_only=[
-                "charts/nginx/templates/nginx-default-backend-serviceaccount.yaml"
-            ],
+            show_only=["charts/nginx/templates/nginx-default-backend-serviceaccount.yaml"],
         )[0]
 
         assert "release-name-nginx-default-backend" == doc["metadata"]["name"]

--- a/tests/chart_tests/test_non_root_user.py
+++ b/tests/chart_tests/test_non_root_user.py
@@ -19,9 +19,7 @@ class TestProbes:
     def test_container_runasnonroot(self, kube_version):
         """Ensure all containers have runAsNonRoot."""
 
-        containers = chart_tests.get_chart_containers(
-            kube_version, chart_tests.get_all_features(), ignore_kind_list
-        )
+        containers = chart_tests.get_chart_containers(kube_version, chart_tests.get_all_features(), ignore_kind_list)
 
         for container in containers.values():
             if container["key"].split("release-name-")[-1] in ignore_list:

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -39,9 +39,7 @@ non_airflow_components_list = [
     supported_k8s_versions,
 )
 class TestOpenshift:
-    def test_openshift_flag_defaults_with_enabled_and_validate_podsecuritycontext(
-        self, kube_version
-    ):
+    def test_openshift_flag_defaults_with_enabled_and_validate_podsecuritycontext(self, kube_version):
         "Validate podSecurityContext is not set when openshiftEnabled is True"
         docs = render_chart(
             kube_version=kube_version,
@@ -55,9 +53,7 @@ class TestOpenshift:
         for doc in docs:
             assert "securityContext" not in doc["spec"]["template"]["spec"]
 
-    def test_openshift_flag_defaults_with_enabled_and_validate_container_securitycontext(
-        self, kube_version
-    ):
+    def test_openshift_flag_defaults_with_enabled_and_validate_container_securitycontext(self, kube_version):
         "Validate containerSecurityContext when openshiftEnabled is Enabled"
         docs = render_chart(
             kube_version=kube_version,
@@ -76,13 +72,9 @@ class TestOpenshift:
 
         assert len(docs) == 6
         for doc in docs:
-            assert "runAsUser" not in jmespath.search(
-                "spec.template.spec.containers[*].securityContext", doc
-            )
+            assert "runAsUser" not in jmespath.search("spec.template.spec.containers[*].securityContext", doc)
 
-    def test_openshift_flag_defaults_with_enabled_and_validate_houston_configmap(
-        self, kube_version
-    ):
+    def test_openshift_flag_defaults_with_enabled_and_validate_houston_configmap(self, kube_version):
         "Validate houston config when openshiftEnabled is Enabled"
         docs = render_chart(
             values={
@@ -97,11 +89,7 @@ class TestOpenshift:
         airflowConfig = prod["deployments"]["helm"]["airflow"]
 
         for component in airflow_components_list:
-            assert {"runAsNonRoot": False} == airflowConfig[component][
-                "securityContexts"
-            ]["pod"]
+            assert {"runAsNonRoot": False} == airflowConfig[component]["securityContexts"]["pod"]
 
         for component in non_airflow_components_list:
-            assert {"runAsNonRoot": True} == airflowConfig[component][
-                "securityContexts"
-            ]["pod"]
+            assert {"runAsNonRoot": True} == airflowConfig[component]["securityContexts"]["pod"]

--- a/tests/chart_tests/test_poddisruptionbudget.py
+++ b/tests/chart_tests/test_poddisruptionbudget.py
@@ -16,45 +16,33 @@ class TestHoustonPDB:
             labels = render_chart(
                 show_only=[show_only],
                 values={},
-            )[
-                0
-            ]["spec"][
-                "jobTemplate"
-            ]["spec"]["template"]["metadata"]["labels"]
-            assert (
-                labels["component"] != "houston"
-            ), f"ERROR: tempplate '{show_only}' matched houston"
+            )[0][
+                "spec"
+            ]["jobTemplate"][
+                "spec"
+            ]["template"][
+                "metadata"
+            ]["labels"]
+            assert labels["component"] != "houston", f"ERROR: tempplate '{show_only}' matched houston"
 
     def test_houston_pdb_workers(self):
         """Test that pdbs do not touch houston cronjobs or workers."""
-        template = (
-            "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml"
-        )
-        match_labels = render_chart(show_only=[template])[0]["spec"]["selector"][
-            "matchLabels"
-        ]
-        assert (
-            match_labels["component"] != "houston"
-        ), f"ERROR: tempplate '{template}' matched houston"
+        template = "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml"
+        match_labels = render_chart(show_only=[template])[0]["spec"]["selector"]["matchLabels"]
+        assert match_labels["component"] != "houston", f"ERROR: tempplate '{template}' matched houston"
 
     def test_houston_api_pdb_match_labels(self):
         # sourcery skip: class-extract-method
         """Houston pdb should have the right matchLabels."""
-        template = (
-            "charts/astronomer/templates/houston/api/houston-pod-disruption-budget.yaml"
-        )
-        match_labels = render_chart(show_only=[template])[0]["spec"]["selector"][
-            "matchLabels"
-        ]
+        template = "charts/astronomer/templates/houston/api/houston-pod-disruption-budget.yaml"
+        match_labels = render_chart(show_only=[template])[0]["spec"]["selector"]["matchLabels"]
         assert match_labels["tier"] == "astronomer"
         assert match_labels["component"] == "houston"
 
     def test_houston_api_pdb_deployment(self):
         """Houston pdb should have the right matchLabels."""
         template = "charts/astronomer/templates/houston/api/houston-deployment.yaml"
-        labels = render_chart(show_only=[template])[0]["spec"]["template"]["metadata"][
-            "labels"
-        ]
+        labels = render_chart(show_only=[template])[0]["spec"]["template"]["metadata"]["labels"]
         assert labels["tier"] == "astronomer"
         assert labels["component"] == "houston"
 
@@ -65,9 +53,7 @@ class TestHoustonPDB:
 )
 class TestPDB:
     show_only = [
-        str(path.relative_to(git_root_dir))
-        for path in git_root_dir.rglob("charts/**/*")
-        if "pod-disruption-budget" in str(path)
+        str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "pod-disruption-budget" in str(path)
     ]
 
     def test_pod_disruption_budgets_default(self, kube_version):

--- a/tests/chart_tests/test_pods.py
+++ b/tests/chart_tests/test_pods.py
@@ -22,14 +22,11 @@ def init_test_pod_labels_configs():
     pod_docs = []
     for key, val in kubernetes_objects.items():
         pod_docs += jmespath.search(
-            "[?kind == `%s`].{name: metadata.name, kind: kind, chart: metadata.labels.chart, labels: %s}"
-            % (key, val),
+            "[?kind == `%s`].{name: metadata.name, kind: kind, chart: metadata.labels.chart, labels: %s}" % (key, val),
             docs,
         )
 
-    return {
-        f'{doc["chart"]}_{doc["kind"]}_{doc["name"]}': doc["labels"] for doc in pod_docs
-    }
+    return {f'{doc["chart"]}_{doc["kind"]}_{doc["name"]}': doc["labels"] for doc in pod_docs}
 
 
 test_pod_labels_configs_data = init_test_pod_labels_configs()

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -95,14 +95,9 @@ class TestPostgresql:
         assert len(doc) == 1
 
         assert "persistentVolumeClaimRetentionPolicy" in doc[0]["spec"]
-        assert (
-            test_persistentVolumeClaimRetentionPolicy
-            == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
-        )
+        assert test_persistentVolumeClaimRetentionPolicy == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
 
-    def test_postgresql_replication_persistentVolumeClaimRetentionPolicy(
-        self, kube_version
-    ):
+    def test_postgresql_replication_persistentVolumeClaimRetentionPolicy(self, kube_version):
         test_persistentVolumeClaimRetentionPolicy = {
             "whenDeleted": "Delete",
             "whenScaled": "Retain",
@@ -128,7 +123,4 @@ class TestPostgresql:
         assert len(doc) == 1
 
         assert "persistentVolumeClaimRetentionPolicy" in doc[0]["spec"]
-        assert (
-            test_persistentVolumeClaimRetentionPolicy
-            == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
-        )
+        assert test_persistentVolumeClaimRetentionPolicy == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]

--- a/tests/chart_tests/test_private_registry.py
+++ b/tests/chart_tests/test_private_registry.py
@@ -37,16 +37,12 @@ def test_private_registry_repository_image_names_the_same_as_public_ones():
         private_repo_images = jmespath.search(search_string, private_repo_doc)
         if public_repo_images is not None or private_repo_images is not None:
             assert len(public_repo_images) == len(private_repo_images)
-            for public_repo_image, private_repo_image in zip(
-                public_repo_images, private_repo_images
-            ):
+            for public_repo_image, private_repo_image in zip(public_repo_images, private_repo_images):
                 if public_repo_image != private_repo_image:
                     print(
                         f"image name differs when using a private repo named same as public - {public_repo_image} vs {private_repo_image}"
                     )
-                    differently_named_images.append(
-                        (public_repo_image, private_repo_image)
-                    )
+                    differently_named_images.append((public_repo_image, private_repo_image))
     assert not differently_named_images, differently_named_images
 
 
@@ -55,9 +51,7 @@ def test_private_registry_repository_overrides_work():
     specified."""
     repository = "bob-the-registry"
     docs = render_chart(
-        values={
-            "global": {"privateRegistry": {"enabled": True, "repository": repository}}
-        },
+        values={"global": {"privateRegistry": {"enabled": True, "repository": repository}}},
     )
     # there should be lots of image hits
     assert len(docs) > 50
@@ -67,9 +61,7 @@ def test_private_registry_repository_overrides_work():
         if doc_images is not None:
             for image in doc_images:
                 if not image.startswith(repository):
-                    print(
-                        f"{image} did not begin with specified repository - {repository}"
-                    )
+                    print(f"{image} did not begin with specified repository - {repository}")
                     differently_named_images.append(image)
     assert not differently_named_images, differently_named_images
 
@@ -102,20 +94,14 @@ def get_private_registry_docs_image_pull_secrets():
     searched_docs = []
     for key, val in kubernetes_objects.items():
         searched_docs += jmespath.search(
-            "[?kind == `%s`].{name: metadata.name, kind: kind, image_pull_secrets: %s}"
-            % (key, val),
+            "[?kind == `%s`].{name: metadata.name, kind: kind, image_pull_secrets: %s}" % (key, val),
             docs,
         )
 
-    return {
-        f'{doc["name"]}_{doc["kind"]}': doc["image_pull_secrets"]
-        for doc in searched_docs
-    }
+    return {f'{doc["name"]}_{doc["kind"]}': doc["image_pull_secrets"] for doc in searched_docs}
 
 
-private_registry_docs_image_pull_secrets = (
-    get_private_registry_docs_image_pull_secrets()
-)
+private_registry_docs_image_pull_secrets = get_private_registry_docs_image_pull_secrets()
 
 
 @pytest.mark.parametrize(

--- a/tests/chart_tests/test_privateca.py
+++ b/tests/chart_tests/test_privateca.py
@@ -99,10 +99,7 @@ class TestPrivateCaDaemonset:
         doc = docs[0]
         self.common_tests_daemonset(doc)
         assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
-        assert (
-            doc["spec"]["template"]["spec"]["containers"][0]["image"]
-            == "snarks:boojums"
-        )
+        assert doc["spec"]["template"]["spec"]["containers"][0]["image"] == "snarks:boojums"
 
 
 @pytest.mark.parametrize(

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -12,9 +12,7 @@ def init_test_probes():
 
     containers = {}
     for k8s_version in supported_k8s_versions:
-        k8s_version_containers = chart_tests.get_chart_containers(
-            k8s_version, chart_values, ignore_kind_list
-        )
+        k8s_version_containers = chart_tests.get_chart_containers(k8s_version, chart_values, ignore_kind_list)
         containers = {**containers, **k8s_version_containers}
 
     return containers
@@ -23,9 +21,7 @@ def init_test_probes():
 class TestProbes:
     chart_containers = init_test_probes()
 
-    @pytest.mark.parametrize(
-        "container", chart_containers.values(), ids=chart_containers.keys()
-    )
+    @pytest.mark.parametrize("container", chart_containers.values(), ids=chart_containers.keys())
     def test_container_readiness_probes(self, container):
         """Ensure all containers have liveness and readiness probes."""
 
@@ -34,9 +30,7 @@ class TestProbes:
         else:
             assert "readinessProbe" in container
 
-    @pytest.mark.parametrize(
-        "container", chart_containers.values(), ids=chart_containers.keys()
-    )
+    @pytest.mark.parametrize("container", chart_containers.values(), ids=chart_containers.keys())
     def test_container_liveness_probes(self, container):
         """Ensure all containers have liveness and readiness probes."""
 

--- a/tests/chart_tests/test_prometheus_alerts_configmap.py
+++ b/tests/chart_tests/test_prometheus_alerts_configmap.py
@@ -131,9 +131,7 @@ class TestPrometheusAlertConfigmap:
         assert len([x["rules"] for x in groups if x["name"] != section]) == 21
 
     @pytest.mark.parametrize("section", ["airflow", "platform"])
-    def test_default_alerts_section_disabled_with_additional_alerts(
-        self, kube_version, section
-    ):
+    def test_default_alerts_section_disabled_with_additional_alerts(self, kube_version, section):
         """Should only show the additional alert rules for the given section."""
         values = {
             "prometheus": {
@@ -163,8 +161,4 @@ class TestPrometheusAlertConfigmap:
         assert [x["rules"] for x in groups if x["name"] == section] == [
             [{"alert": "some-happy-alert", "expr": "sum(all-happiness)"}]
         ]
-        assert [
-            x["rules"] != [{"alert": "some-happy-alert", "expr": "sum(all-happiness)"}]
-            for x in groups
-            if x["name"] != section
-        ]
+        assert [x["rules"] != [{"alert": "some-happy-alert", "expr": "sum(all-happiness)"}] for x in groups if x["name"] != section]

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -40,13 +40,8 @@ class TestPrometheusBlackBoxExporterDeployment:
         doc = docs[0]
         assert doc["kind"] == "Deployment"
         assert doc["metadata"]["name"] == "release-name-prometheus-blackbox-exporter"
-        assert (
-            doc["spec"]["selector"]["matchLabels"]["component"] == "blackbox-exporter"
-        )
-        assert (
-            doc["spec"]["template"]["metadata"]["labels"]["app"]
-            == "prometheus-blackbox-exporter"
-        )
+        assert doc["spec"]["selector"]["matchLabels"]["component"] == "blackbox-exporter"
+        assert doc["spec"]["template"]["metadata"]["labels"]["app"] == "prometheus-blackbox-exporter"
 
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["blackbox-exporter"]["resources"] == {
@@ -60,9 +55,7 @@ class TestPrometheusBlackBoxExporterDeployment:
             "capabilities": {"drop": ["ALL"]},
         }
 
-    def test_prometheus_blackbox_exporter_deployment_custom_resources(
-        self, kube_version
-    ):
+    def test_prometheus_blackbox_exporter_deployment_custom_resources(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,
             values={
@@ -85,15 +78,11 @@ class TestPrometheusBlackBoxExporterDeployment:
             "requests": {"cpu": "666m", "memory": "888Mi"},
         }
 
-    def test_prometheus_blackbox_exporter_deployment_custom_security_context(
-        self, kube_version
-    ):
+    def test_prometheus_blackbox_exporter_deployment_custom_security_context(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,
             values={
-                "prometheus-blackbox-exporter": {
-                    "securityContext": {"runAsUser": 1000}
-                },
+                "prometheus-blackbox-exporter": {"securityContext": {"runAsUser": 1000}},
             },
             show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
         )[0]

--- a/tests/chart_tests/test_prometheus_ingress.py
+++ b/tests/chart_tests/test_prometheus_ingress.py
@@ -29,29 +29,17 @@ class TestIngress:
         if minor >= 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert "release-name-prometheus" in [
-                name[0]
-                for name in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.service.name", doc
-                )
+                name[0] for name in jmespath.search("spec.rules[*].http.paths[*].backend.service.name", doc)
             ]
             assert "prometheus-data" in [
-                port[0]
-                for port in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.service.port.name", doc
-                )
+                port[0] for port in jmespath.search("spec.rules[*].http.paths[*].backend.service.port.name", doc)
             ]
 
         if minor < 19:
             assert doc["apiVersion"] == "networking.k8s.io/v1beta1"
             assert "release-name-prometheus" in [
-                name[0]
-                for name in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.serviceName", doc
-                )
+                name[0] for name in jmespath.search("spec.rules[*].http.paths[*].backend.serviceName", doc)
             ]
             assert "prometheus-data" in [
-                port[0]
-                for port in jmespath.search(
-                    "spec.rules[*].http.paths[*].backend.servicePort", doc
-                )
+                port[0] for port in jmespath.search("spec.rules[*].http.paths[*].backend.servicePort", doc)
             ]

--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -47,13 +47,8 @@ class TestPrometheusNodeExporterDaemonset:
         assert len(docs) == 1
         doc = docs[0]
         self.node_exporter_common_tests(doc)
-        assert (
-            doc["spec"]["selector"]["matchLabels"]["app"] == "prometheus-node-exporter"
-        )
-        assert (
-            doc["spec"]["template"]["metadata"]["labels"]["app"]
-            == "prometheus-node-exporter"
-        )
+        assert doc["spec"]["selector"]["matchLabels"]["app"] == "prometheus-node-exporter"
+        assert doc["spec"]["template"]["metadata"]["labels"]["app"] == "prometheus-node-exporter"
 
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["node-exporter"]
@@ -86,9 +81,7 @@ class TestPrometheusNodeExporterDaemonset:
         }
         assert c_by_name["node-exporter"]["securityContext"] == {"runAsNonRoot": True}
 
-    def test_prometheus_node_exporter_daemonset_with_security_context_overrides(
-        self, kube_version
-    ):
+    def test_prometheus_node_exporter_daemonset_with_security_context_overrides(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,
             values={
@@ -128,18 +121,11 @@ class TestPrometheusNodeExporterDaemonset:
         """Test to validate node exporter with priority class configured."""
         docs = render_chart(
             kube_version=kube_version,
-            values={
-                "prometheus-node-exporter": {
-                    "priorityClassName": "node-exporter-priority-pod"
-                }
-            },
+            values={"prometheus-node-exporter": {"priorityClassName": "node-exporter-priority-pod"}},
             show_only=["charts/prometheus-node-exporter/templates/daemonset.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
         self.node_exporter_common_tests(doc)
         assert "priorityClassName" in doc["spec"]["template"]["spec"]
-        assert (
-            "node-exporter-priority-pod"
-            == doc["spec"]["template"]["spec"]["priorityClassName"]
-        )
+        assert "node-exporter-priority-pod" == doc["spec"]["template"]["spec"]["priorityClassName"]

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -47,6 +47,4 @@ class TestPrometheusPostgresExporter:
             "limits": {"cpu": "100m", "memory": "128Mi"},
             "requests": {"cpu": "10m", "memory": "128Mi"},
         }
-        assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {"runAsNonRoot": True}

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -28,19 +28,13 @@ class TestPrometheusStatefulset:
         assert sc["fsGroup"] == 65534
 
         c_by_name = get_containers_by_name(doc)
-        assert c_by_name["configmap-reloader"]["image"].startswith(
-            "quay.io/astronomer/ap-configmap-reloader:"
-        )
+        assert c_by_name["configmap-reloader"]["image"].startswith("quay.io/astronomer/ap-configmap-reloader:")
         assert c_by_name["configmap-reloader"]["volumeMounts"] == [
             {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
             {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
         ]
-        assert c_by_name["prometheus"]["image"].startswith(
-            "quay.io/astronomer/ap-prometheus:"
-        )
-        assert c_by_name["prometheus"]["ports"] == [
-            {"containerPort": 9090, "name": "prometheus-data"}
-        ]
+        assert c_by_name["prometheus"]["image"].startswith("quay.io/astronomer/ap-prometheus:")
+        assert c_by_name["prometheus"]["ports"] == [{"containerPort": 9090, "name": "prometheus-data"}]
         assert c_by_name["prometheus"]["volumeMounts"] == [
             {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
             {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
@@ -124,9 +118,7 @@ class TestPrometheusStatefulset:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
         print(c_by_name["prometheus"]["args"])
-        assert (
-            "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
-        )
+        assert "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
         assert "--enable-feature=agent" in c_by_name["prometheus"]["args"]
 
     def test_prometheus_persistentVolumeClaimRetentionPolicy(self, kube_version):
@@ -147,7 +139,4 @@ class TestPrometheusStatefulset:
         )[0]
 
         assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
-        assert (
-            test_persistentVolumeClaimRetentionPolicy
-            == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
-        )
+        assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]

--- a/tests/chart_tests/test_psp.py
+++ b/tests/chart_tests/test_psp.py
@@ -3,9 +3,7 @@ import pytest
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
-psp_compatible_versions = [
-    x for x in supported_k8s_versions if int(x.split(".")[1]) < 25
-]
+psp_compatible_versions = [x for x in supported_k8s_versions if int(x.split(".")[1]) < 25]
 
 
 @pytest.mark.parametrize(
@@ -96,9 +94,7 @@ class TestPspEnabled:
 
     clusterrole_doc_ids = [x["template"] for x in clusterrole_docs]
 
-    @pytest.mark.parametrize(
-        "clusterrole_docs", clusterrole_docs, ids=clusterrole_doc_ids
-    )
+    @pytest.mark.parametrize("clusterrole_docs", clusterrole_docs, ids=clusterrole_doc_ids)
     def test_clusterrole(self, kube_version, clusterrole_docs):
         """Test that helm errors when pspEnabled=False, and renders a good
         ClusterRole template when pspEnabled=True."""
@@ -122,10 +118,7 @@ class TestPspEnabled:
         assert doc["apiVersion"] == "rbac.authorization.k8s.io/v1"
         assert doc["metadata"]["name"] == clusterrole_docs["name"]
         assert "rules" in doc
-        assert all(
-            item in doc["rules"][0]
-            for item in ["apiGroups", "resources", "resourceNames", "verbs"]
-        )
+        assert all(item in doc["rules"][0] for item in ["apiGroups", "resources", "resourceNames", "verbs"])
 
     clusterrolebinding_docs = [
         {

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -32,9 +32,8 @@ class Test_Registry_Configmap:
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert (rc := yaml.safe_load(doc["data"]["config.yml"]))
         assert (
-            rc["storage"]["s3"]["regionendpoint"]
+            yaml.safe_load(doc["data"]["config.yml"])["storage"]["s3"]["regionendpoint"]
             == "s3.us-south.cloud-object-storage.appdomain.cloud"
         )
 
@@ -51,8 +50,7 @@ class Test_Registry_Configmap:
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert (rc := yaml.safe_load(doc["data"]["config.yml"]))
-        assert rc["log"]["level"] == "info"
+        assert yaml.safe_load(doc["data"]["config.yml"])["log"]["level"] == "info"
 
     def test_registry_configmap_with_logLevel_overrides(self, kube_version):
         """Test registry-configmap to validate log level defaults."""
@@ -67,5 +65,4 @@ class Test_Registry_Configmap:
         assert doc["kind"] == "ConfigMap"
         assert doc["apiVersion"] == "v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert (rc := yaml.safe_load(doc["data"]["config.yml"]))
-        assert rc["log"]["level"] == "debug"
+        assert yaml.safe_load(doc["data"]["config.yml"])["log"]["level"] == "debug"

--- a/tests/chart_tests/test_registry_statefulset.py
+++ b/tests/chart_tests/test_registry_statefulset.py
@@ -42,9 +42,7 @@ class TestRegistryStatefulset:
             show_only=self.show_only,
             values={
                 "global": {"baseDomain": "example.com"},
-                "astronomer": {
-                    "registry": {"gcs": {"useKeyfile": True, "enabled": True}}
-                },
+                "astronomer": {"registry": {"gcs": {"useKeyfile": True, "enabled": True}}},
             },
         )
 
@@ -55,10 +53,7 @@ class TestRegistryStatefulset:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
         assert doc["spec"]["template"]["spec"]["volumes"][2]["name"] == "gcs-keyfile"
-        assert (
-            doc["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][3]["name"]
-            == "gcs-keyfile"
-        )
+        assert doc["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][3]["name"] == "gcs-keyfile"
 
     def test_registry_sts_with_registry_persistence_enabled(self, kube_version):
         docs = render_chart(
@@ -68,9 +63,7 @@ class TestRegistryStatefulset:
         )
 
         assert docs[0]["kind"] == "Deployment"
-        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"]["volumes"]
 
     def test_registry_sts_with_registry_s3_enabled(self, kube_version):
         docs = render_chart(
@@ -80,9 +73,7 @@ class TestRegistryStatefulset:
         )
 
         assert docs[0]["kind"] == "Deployment"
-        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"]["volumes"]
 
     def test_registry_sts_with_registry_gcs_enabled(self, kube_version):
         docs = render_chart(
@@ -92,9 +83,7 @@ class TestRegistryStatefulset:
         )
 
         assert docs[0]["kind"] == "Deployment"
-        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"]["volumes"]
 
     def test_registry_sts_with_registry_azure_enabled(self, kube_version):
         docs = render_chart(
@@ -104,9 +93,7 @@ class TestRegistryStatefulset:
         )
 
         assert docs[0]["kind"] == "Deployment"
-        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"][
-            "volumes"
-        ]
+        assert {"name": "data", "emptyDir": {}} in docs[0]["spec"]["template"]["spec"]["volumes"]
 
     def test_registry_sts_with_podlabels(self, kube_version):
         labels = {"foo-key": "foo-value", "bar-key": "bar-value"}
@@ -123,9 +110,7 @@ class TestRegistryStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"privateCaCerts": ["private-root-ca"]}},
-            show_only=[
-                "charts/astronomer/templates/registry/registry-statefulset.yaml"
-            ],
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
         volume_mount_search_result = jmespath.search(
             "spec.template.spec.containers[*].volumeMounts[?name == 'private-root-ca']",
@@ -144,16 +129,12 @@ class TestRegistryStatefulset:
                 }
             ]
         ]
-        expected_volume_result = [
-            {"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}
-        ]
+        expected_volume_result = [{"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}]
 
         assert docs[0]["kind"] == "StatefulSet"
         assert volume_mount_search_result == expected_volume_mounts_result
         assert volume_search_result == expected_volume_result
-        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"][
-            "template"
-        ]["spec"]["containers"][0]["env"]
+        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
 
     def test_registry_privateca_enabled_with_external_backend(self, kube_version):
         docs = render_chart(
@@ -162,9 +143,7 @@ class TestRegistryStatefulset:
                 "global": {"privateCaCerts": ["private-root-ca"]},
                 "astronomer": {"registry": {"s3": {"enabled": True}}},
             },
-            show_only=[
-                "charts/astronomer/templates/registry/registry-statefulset.yaml"
-            ],
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
         volume_mount_search_result = jmespath.search(
             "spec.template.spec.containers[*].volumeMounts[?name == 'private-root-ca']",
@@ -183,12 +162,8 @@ class TestRegistryStatefulset:
                 }
             ]
         ]
-        expected_volume_result = [
-            {"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}
-        ]
+        expected_volume_result = [{"name": "private-root-ca", "secret": {"secretName": "private-root-ca"}}]
         assert docs[0]["kind"] == "Deployment"
         assert volume_mount_search_result == expected_volume_mounts_result
         assert volume_search_result == expected_volume_result
-        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"][
-            "template"
-        ]["spec"]["containers"][0]["env"]
+        assert {"name": "UPDATE_CA_CERTS", "value": "true"} in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -23,12 +23,8 @@ class TestStanStatefulSet:
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-stan"
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
-        assert c_by_name["metrics"]["image"].startswith(
-            "quay.io/astronomer/ap-nats-exporter:"
-        )
-        assert c_by_name["stan"]["image"].startswith(
-            "quay.io/astronomer/ap-nats-streaming:"
-        )
+        assert c_by_name["metrics"]["image"].startswith("quay.io/astronomer/ap-nats-exporter:")
+        assert c_by_name["stan"]["image"].startswith("quay.io/astronomer/ap-nats-streaming:")
         assert c_by_name["stan"]["livenessProbe"] == {
             "httpGet": {"path": "/streaming/serverz", "port": "monitor"},
             "initialDelaySeconds": 10,
@@ -40,9 +36,7 @@ class TestStanStatefulSet:
             "timeoutSeconds": 5,
         }
 
-        assert all(
-            c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values()
-        )
+        assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values())
         assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
         assert doc["spec"]["template"]["spec"]["affinity"] == {}
         assert doc["spec"]["template"]["spec"]["tolerations"] == []
@@ -70,9 +64,7 @@ class TestStanStatefulSet:
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
         assert len(c_by_name) == 3
-        assert all(
-            c["securityContext"] == securityContextResponse for c in c_by_name.values()
-        )
+        assert all(c["securityContext"] == securityContextResponse for c in c_by_name.values())
 
     def test_stan_statefulset_with_metrics_and_resources(self, kube_version):
         """Test that stan statefulset renders good metrics exporter."""
@@ -139,14 +131,7 @@ class TestStanStatefulSet:
         assert spec["nodeSelector"] != {}
         assert spec["nodeSelector"]["role"] == "astro"
         assert spec["affinity"] != {}
-        assert (
-            len(
-                spec["affinity"]["nodeAffinity"][
-                    "requiredDuringSchedulingIgnoredDuringExecution"
-                ]["nodeSelectorTerms"]
-            )
-            == 1
-        )
+        assert len(spec["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"]) == 1
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["stan"]["tolerations"]
 
@@ -195,18 +180,9 @@ class TestStanStatefulSet:
         assert spec["nodeSelector"] != {}
         assert spec["nodeSelector"]["role"] == "astro"
         assert spec["affinity"] != {}
-        assert (
-            len(
-                spec["affinity"]["nodeAffinity"][
-                    "requiredDuringSchedulingIgnoredDuringExecution"
-                ]["nodeSelectorTerms"]
-            )
-            == 1
-        )
+        assert len(spec["affinity"]["nodeAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]["nodeSelectorTerms"]) == 1
         assert len(spec["tolerations"]) > 0
-        assert (
-            spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
-        )
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
     def test_stan_statefulset_with_custom_images(self, kube_version):
         """Test we can customize the stan images."""
@@ -238,15 +214,9 @@ class TestStanStatefulSet:
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
 
-        assert (
-            c_by_name["stan"]["image"]
-            == "example.com/custom/image/the-stan-image:the-custom-stan-tag"
-        )
+        assert c_by_name["stan"]["image"] == "example.com/custom/image/the-stan-image:the-custom-stan-tag"
         assert c_by_name["stan"]["imagePullPolicy"] == "Always"
-        assert (
-            c_by_name["wait-for-nats-server"]["image"]
-            == "example.com/custom/image/the-init-image:the-custom-init-tag"
-        )
+        assert c_by_name["wait-for-nats-server"]["image"] == "example.com/custom/image/the-init-image:the-custom-init-tag"
         assert c_by_name["stan"]["imagePullPolicy"] == "Always"
 
     def test_stan_statefulset_with_private_registry(self, kube_version):
@@ -340,7 +310,4 @@ class TestStanStatefulSet:
         assert len(doc) == 1
 
         assert "persistentVolumeClaimRetentionPolicy" in doc[0]["spec"]
-        assert (
-            test_persistentVolumeClaimRetentionPolicy
-            == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]
-        )
+        assert test_persistentVolumeClaimRetentionPolicy == doc[0]["spec"]["persistentVolumeClaimRetentionPolicy"]

--- a/tests/chart_tests/test_sts_volume_claim_annotations.py
+++ b/tests/chart_tests/test_sts_volume_claim_annotations.py
@@ -43,9 +43,9 @@ class TestStatefulSetsAnnotations:
         )
         assert len(docs) == 2
         for doc in docs:
-            assert {"astro.io/elastic": "master-sts", "storage": "astro"} == doc[
-                "spec"
-            ]["volumeClaimTemplates"][0]["metadata"]["annotations"]
+            assert {"astro.io/elastic": "master-sts", "storage": "astro"} == doc["spec"]["volumeClaimTemplates"][0]["metadata"][
+                "annotations"
+            ]
 
     def test_prometheus_sts_with_overridden_annotations(self, kube_version):
         """Test prometheus sts for the volume claim templates annotations."""
@@ -70,7 +70,11 @@ class TestStatefulSetsAnnotations:
             assert {
                 "annotation": "astro-test",
                 "astro.io/monitoring": "prom-sts",
-            } == doc["spec"]["volumeClaimTemplates"][0]["metadata"]["annotations"]
+            } == doc["spec"][
+                "volumeClaimTemplates"
+            ][0][
+                "metadata"
+            ]["annotations"]
 
     def test_registry_sts_with_overridden_annotations(self, kube_version):
         """Test registry sts for the volume claim templates annotations."""
@@ -97,7 +101,11 @@ class TestStatefulSetsAnnotations:
             assert {
                 "annotation": "registry-test",
                 "astro.io/registry": "registry-sts",
-            } == doc["spec"]["volumeClaimTemplates"][0]["metadata"]["annotations"]
+            } == doc["spec"][
+                "volumeClaimTemplates"
+            ][0][
+                "metadata"
+            ]["annotations"]
 
     def test_stan_sts_with_overridden_annotations(self, kube_version):
         """Test stan sts for the volume claim templates annotations."""
@@ -119,6 +127,6 @@ class TestStatefulSetsAnnotations:
         )
         assert len(docs) == 1
         for doc in docs:
-            assert {"annotation": "stan-test", "astro.io/stan": "stan-sts"} == doc[
-                "spec"
-            ]["volumeClaimTemplates"][0]["metadata"]["annotations"]
+            assert {"annotation": "stan-test", "astro.io/stan": "stan-sts"} == doc["spec"]["volumeClaimTemplates"][0]["metadata"][
+                "annotations"
+            ]

--- a/tests/chart_tests/test_svc.py
+++ b/tests/chart_tests/test_svc.py
@@ -15,10 +15,7 @@ def init_test_svc_port_configs():
         docs,
     )
 
-    return {
-        f'{doc["chart"]}_{doc["component"]}_{doc["name"]}': doc["ports"]
-        for doc in svc_docs
-    }
+    return {f'{doc["chart"]}_{doc["component"]}_{doc["name"]}': doc["ports"] for doc in svc_docs}
 
 
 test_svc_port_configs_data = init_test_svc_port_configs()

--- a/tests/chart_tests/test_tags.py
+++ b/tests/chart_tests/test_tags.py
@@ -38,22 +38,14 @@ chart_values = chart_tests.get_all_features()
 # is deprecated we can set this to something higher, and will likely have to solve similar
 # problems for newer api differences.
 @pytest.mark.parametrize("template", show_only)
-def test_tags_monitoring_enabled(
-    template, chart_values=chart_values, kube_version="1.28.0"
-):
+def test_tags_monitoring_enabled(template, chart_values=chart_values, kube_version="1.28.0"):
     """Test that when monitoring is disabled, the monitoring components are not present."""
     chart_values["tags"] = {"monitoring": True}
-    docs = render_chart(
-        kube_version=kube_version, values=chart_values, show_only=template
-    )
+    docs = render_chart(kube_version=kube_version, values=chart_values, show_only=template)
 
     assert len(docs) >= 1
     assert (
-        template.split("/")[-1]
-        .split("-")[-1]
-        .removesuffix(".yaml")
-        .replace("psp", "podsecuritypolicy")
-        in docs[0]["kind"].lower()
+        template.split("/")[-1].split("-")[-1].removesuffix(".yaml").replace("psp", "podsecuritypolicy") in docs[0]["kind"].lower()
     )
 
 
@@ -61,9 +53,7 @@ def test_tags_monitoring_enabled(
 # is deprecated we can set this to something higher, and will likely have to solve similar
 # problems for newer api differences.
 @pytest.mark.parametrize("template", show_only)
-def test_tags_monitoring_disabled(
-    template, chart_values=chart_values, kube_version="1.28.0"
-):
+def test_tags_monitoring_disabled(template, chart_values=chart_values, kube_version="1.28.0"):
     """Test that when monitoring is disabled, the monitoring components are not present."""
     chart_values["tags"] = {"monitoring": False}
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -12,9 +12,7 @@ if not (namespace := getenv("NAMESPACE")):
     namespace = "astronomer"
 
 if not (release_name := getenv("RELEASE_NAME")):
-    print(
-        "RELEASE_NAME env var is not present, assuming 'astronomer' is the release name"
-    )
+    print("RELEASE_NAME env var is not present, assuming 'astronomer' is the release name")
     release_name = "astronomer"
 
 
@@ -63,17 +61,13 @@ def prometheus():
     """
 
     pod = f"{release_name}-prometheus-0"
-    yield testinfra.get_host(
-        f"kubectl://{pod}?container=prometheus&namespace={namespace}"
-    )
+    yield testinfra.get_host(f"kubectl://{pod}?container=prometheus&namespace={namespace}")
 
 
 @pytest.fixture(scope="function")
 def es_master():
     pod = f"{release_name}-elasticsearch-master-0"
-    yield testinfra.get_host(
-        f"kubectl://{pod}?container=es-master&namespace={namespace}"
-    )
+    yield testinfra.get_host(f"kubectl://{pod}?container=es-master&namespace={namespace}")
 
 
 @pytest.fixture(scope="function")
@@ -84,12 +78,8 @@ def es_data():
 
 @pytest.fixture(scope="function")
 def es_client(core_v1_client):
-    pod = get_pod_by_label_selector(
-        core_v1_client, "component=elasticsearch,role=client"
-    )
-    yield testinfra.get_host(
-        f"kubectl://{pod}?container=es-client&namespace={namespace}"
-    )
+    pod = get_pod_by_label_selector(core_v1_client, "component=elasticsearch,role=client")
+    yield testinfra.get_host(f"kubectl://{pod}?container=es-client&namespace={namespace}")
 
 
 @pytest.fixture(scope="session")
@@ -112,16 +102,10 @@ def core_v1_client(in_cluster=False):
     yield get_core_v1_client(in_cluster)
 
 
-def get_pod_by_label_selector(
-    core_v1_client, label_selector, pod_namespace=namespace
-) -> str:
+def get_pod_by_label_selector(core_v1_client, label_selector, pod_namespace=namespace) -> str:
     """Return the name of a pod found by label selector."""
-    pods = core_v1_client.list_namespaced_pod(
-        pod_namespace, label_selector=label_selector
-    ).items
-    assert (
-        len(pods) > 0
-    ), f"Expected to find at least one pod with labels '{label_selector}'"
+    pods = core_v1_client.list_namespaced_pod(pod_namespace, label_selector=label_selector).items
+    assert len(pods) > 0, f"Expected to find at least one pod with labels '{label_selector}'"
     return pods[0].metadata.name
 
 
@@ -146,9 +130,5 @@ def get_pod_running_containers(pod_namespace=namespace):
 
 @pytest.fixture(scope="function")
 def kibana_index_pod_client(core_v1_client):
-    pod = get_pod_by_label_selector(
-        core_v1_client, "component=kibana-default-index,tier=logging"
-    )
-    yield testinfra.get_host(
-        f"kubectl://{pod}?container=kibana-default-index&namespace={namespace}"
-    )
+    pod = get_pod_by_label_selector(core_v1_client, "component=kibana-default-index,tier=logging")
+    yield testinfra.get_host(f"kubectl://{pod}?container=kibana-default-index&namespace={namespace}")

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -28,16 +28,12 @@ def test_default_disabled(core_v1_client):
 def test_prometheus_user(prometheus):
     """Ensure user is 'nobody'."""
     user = prometheus.check_output("whoami")
-    assert (
-        user == "nobody"
-    ), f"Expected prometheus to be running as 'nobody', not '{user}'"
+    assert user == "nobody", f"Expected prometheus to be running as 'nobody', not '{user}'"
 
 
 def test_houston_config(houston_api):
     """Make assertions about Houston's configuration."""
-    data = houston_api.check_output(
-        "echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -"
-    )
+    data = houston_api.check_output("echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -")
     houston_config = json.loads(data)
     assert (
         "url" not in houston_config["nats"].keys()
@@ -72,30 +68,22 @@ def test_grafana_check_db_info(grafana):
 
 
 def test_houston_can_reach_prometheus(houston_api):
-    assert houston_api.check_output(
-        "wget --timeout=5 -qO- http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets"
-    )
+    assert houston_api.check_output("wget --timeout=5 -qO- http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
 
 
 def test_nginx_can_reach_default_backend(nginx):
-    assert nginx.check_output(
-        "curl -s --max-time 1 http://astronomer-nginx-default-backend:8080"
-    )
+    assert nginx.check_output("curl -s --max-time 1 http://astronomer-nginx-default-backend:8080")
 
 
 def test_nginx_ssl_cache(nginx):
     """Ensure nginx default ssl cache size is 10m."""
-    assert "ssl_session_cache shared:SSL:10m;" == nginx.check_output(
-        "cat nginx.conf | grep ssl_session_cache"
-    ).replace("\t", "")
+    assert "ssl_session_cache shared:SSL:10m;" == nginx.check_output("cat nginx.conf | grep ssl_session_cache").replace("\t", "")
 
 
 @pytest.mark.flaky(reruns=20, reruns_delay=10)
 def test_prometheus_targets(prometheus):
     """Ensure all Prometheus targets are healthy."""
-    data = prometheus.check_output(
-        "wget --timeout=5 -qO- http://localhost:9090/api/v1/targets"
-    )
+    data = prometheus.check_output("wget --timeout=5 -qO- http://localhost:9090/api/v1/targets")
     targets = json.loads(data)["data"]["activeTargets"]
     for target in targets:
         assert target["health"] == "up", (
@@ -108,9 +96,7 @@ def test_prometheus_targets(prometheus):
 def test_core_dns_metrics_are_collected(prometheus):
     """Ensure CoreDNS metrics are collected."""
 
-    data = prometheus.check_output(
-        "wget --timeout=5 -qO- http://localhost:9090/api/v1/query?query=coredns_dns_requests_total"
-    )
+    data = prometheus.check_output("wget --timeout=5 -qO- http://localhost:9090/api/v1/query?query=coredns_dns_requests_total")
     parsed = json.loads(data)
     assert (
         len(parsed["data"]["result"]) > 0
@@ -119,13 +105,9 @@ def test_core_dns_metrics_are_collected(prometheus):
 
 def test_houston_metrics_are_collected(prometheus):
     """Ensure Houston metrics are collected and prefixed with 'houston_'."""
-    data = prometheus.check_output(
-        "wget --timeout=5 -qO- http://localhost:9090/api/v1/query?query=houston_up"
-    )
+    data = prometheus.check_output("wget --timeout=5 -qO- http://localhost:9090/api/v1/query?query=houston_up")
     parsed = json.loads(data)
-    assert (
-        len(parsed["data"]["result"]) > 0
-    ), f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
+    assert len(parsed["data"]["result"]) > 0, f"Expected to find a metric houston_up, but we got this response:\n\n{parsed}"
 
 
 def test_prometheus_config_reloader_works(prometheus, core_v1_client):
@@ -135,9 +117,7 @@ def test_prometheus_config_reloader_works(prometheus, core_v1_client):
     new_scrape_interval = "31s"
 
     # get the current configmap
-    orig_cm = core_v1_client.read_namespaced_config_map(
-        "astronomer-prometheus-config", "astronomer"
-    )
+    orig_cm = core_v1_client.read_namespaced_config_map("astronomer-prometheus-config", "astronomer")
 
     prom_config = yaml.safe_load(orig_cm.data["config"])
     # modify the configmap
@@ -150,17 +130,13 @@ def test_prometheus_config_reloader_works(prometheus, core_v1_client):
 
     try:
         # update the configmap
-        core_v1_client.patch_namespaced_config_map(
-            name="astronomer-prometheus-config", namespace="astronomer", body=new_body
-        )
+        core_v1_client.patch_namespaced_config_map(name="astronomer-prometheus-config", namespace="astronomer", body=new_body)
     except ApiException as e:
         print(f"Exception when calling CoreV1Api->patch_namespaced_config_map: {e}\n")
 
     # This can take more than a minute.
     for _ in range(12):
-        data = prometheus.check_output(
-            "wget --timeout=5 -qO- http://localhost:9090/api/v1/status/config"
-        )
+        data = prometheus.check_output("wget --timeout=5 -qO- http://localhost:9090/api/v1/status/config")
         j_parsed = json.loads(data)
         y_parsed = yaml.safe_load(j_parsed["data"]["yaml"])
         if y_parsed["global"]["scrape_interval"] != "30s":
@@ -178,24 +154,18 @@ def test_prometheus_config_reloader_works(prometheus, core_v1_client):
 
     try:
         # update the configmap
-        core_v1_client.patch_namespaced_config_map(
-            name="astronomer-prometheus-config", namespace="astronomer", body=new_body
-        )
+        core_v1_client.patch_namespaced_config_map(name="astronomer-prometheus-config", namespace="astronomer", body=new_body)
     except ApiException as e:
         print(f"Exception when calling CoreV1Api->patch_namespaced_config_map: {e}\n")
 
-    assert (
-        y_parsed["global"]["scrape_interval"] != "30s"
-    ), "Expected the prometheus config file to change"
+    assert y_parsed["global"]["scrape_interval"] != "30s", "Expected the prometheus config file to change"
 
 
 @pytest.mark.skipif(
     not getenv("HELM_CHART_PATH"),
     reason="This test only works with HELM_CHART_PATH set to the path of the chart to be tested",
 )
-def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart(
-    houston_api, core_v1_client
-):
+def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart(houston_api, core_v1_client):
     """Test when helm upgrade occurs without Houston pods restarting that a
     Houston container restart will not miss the Houston connection backend
     secret.
@@ -222,9 +192,7 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
 
     result = houston_api.check_output("env | grep DATABASE_URL")
     # check that the connection is not reset
-    assert (
-        "postgres" in result
-    ), "Expected to find DB connection string before Houston restart"
+    assert "postgres" in result, "Expected to find DB connection string before Houston restart"
 
     # Kill houston in this pod so the container restarts
     houston_api.check_output("kill 1")
@@ -233,42 +201,30 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
     time.sleep(100)
 
     # we can use core_v1_client instead of fixture, because we restarted pod so houston_api still ref to old pod id.
-    pod = core_v1_client.list_namespaced_pod(
-        namespace, label_selector="component=houston"
-    ).items[0]
-    houston_api_new = testinfra.get_host(
-        f"kubectl://{pod.metadata.name}?container=houston&namespace={namespace}"
-    )
+    pod = core_v1_client.list_namespaced_pod(namespace, label_selector="component=houston").items[0]
+    houston_api_new = testinfra.get_host(f"kubectl://{pod.metadata.name}?container=houston&namespace={namespace}")
     result = houston_api_new.check_output("env | grep DATABASE_URL")
 
     # check that the connection is not reset
-    assert (
-        "postgres" in result
-    ), "Expected to find DB connection string after Houston restart"
+    assert "postgres" in result, "Expected to find DB connection string after Houston restart"
 
 
 def test_cve_2021_44228_es_client(es_client):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
     configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_client.check_output(
-        "/usr/share/elasticsearch/jdk/bin/jps -lv"
-    )
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_client.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
 
 
 def test_cve_2021_44228_es_data(es_data):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
     configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_data.check_output(
-        "/usr/share/elasticsearch/jdk/bin/jps -lv"
-    )
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_data.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
 
 
 def test_cve_2021_44228_es_master(es_master):
     """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
     configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_master.check_output(
-        "/usr/share/elasticsearch/jdk/bin/jps -lv"
-    )
+    assert "-Dlog4j2.formatMsgNoLookups=true" in es_master.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
 
 
 def test_kibana_index_pod(kibana_index_pod_client):

--- a/tests/functional_tests/test_network_security.py
+++ b/tests/functional_tests/test_network_security.py
@@ -46,9 +46,7 @@ class ScanTarget:
             ports = []
         self.name = name
         self.ip_address = ip_address
-        assert isinstance(
-            self.ip_address, str
-        ), f"Expected to find str, but found: {type(ip_address)}"
+        assert isinstance(self.ip_address, str), f"Expected to find str, but found: {type(ip_address)}"
         self._type = _type
         assert self._type in [
             "pod",
@@ -56,13 +54,9 @@ class ScanTarget:
         ], f"Expected to find 'pod' or 'service', but found {self._type}"
         self.ports = ports
         for port in self.ports:
-            assert isinstance(
-                port, int
-            ), f"Expected to find int, but found: {type(port)}"
+            assert isinstance(port, int), f"Expected to find int, but found: {type(port)}"
         self.namespace = namespace
-        assert isinstance(
-            self.namespace, str
-        ), f"Expected to find str, but found: {type(self.namespace)}"
+        assert isinstance(self.namespace, str), f"Expected to find str, but found: {type(self.namespace)}"
 
 
 class KubernetesNetworkChecker:
@@ -126,8 +120,7 @@ class KubernetesNetworkChecker:
                     logging.info("network-scanner is ready")
                     break
             test_fixture = testinfra.get_host(
-                f"kubectl://{pod.metadata.name}?"
-                + f"container={v1container.name}&namespace={namespace}"
+                f"kubectl://{pod.metadata.name}?" + f"container={v1container.name}&namespace={namespace}"
             )
             logging.info("Installing nmap into network-scanner")
             test_fixture.check_output("apk add nmap")
@@ -193,9 +186,7 @@ class KubernetesNetworkChecker:
                             if is_open:
                                 if ip_address not in open_ports:
                                     open_ports[ip_address] = []
-                                open_ports[ip_address].append(
-                                    int(port.attrib["portid"])
-                                )
+                                open_ports[ip_address].append(int(port.attrib["portid"]))
         result = ScanResult()
         for address, value in open_ports.items():
             if not open_ports[address]:
@@ -216,11 +207,7 @@ class KubernetesNetworkChecker:
 
 def test_network(core_v1_client):
     try:
-        core_v1_client.create_namespace(
-            client.V1Namespace(
-                metadata=client.V1ObjectMeta(name="astronomer-scan-test")
-            )
-        )
+        core_v1_client.create_namespace(client.V1Namespace(metadata=client.V1ObjectMeta(name="astronomer-scan-test")))
     except Exception as e:
         if "already exists" not in str(e):
             raise e

--- a/tests/functional_tests/test_versioning.py
+++ b/tests/functional_tests/test_versioning.py
@@ -9,9 +9,7 @@ from packaging.version import parse as semver
 from pytest import mark
 
 # The top-level path of this repository
-git_root_dir = Path(
-    check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").rstrip()
-)
+git_root_dir = Path(check_output(["git", "rev-parse", "--show-toplevel"]).decode("utf-8").rstrip())
 
 
 def test_astro_sub_chart_version_match():
@@ -23,8 +21,7 @@ def test_astro_sub_chart_version_match():
     with open(git_root_dir / "charts" / "astronomer" / "Chart.yaml") as f:
         astro_subchart_dot_yaml = yaml.safe_load(f.read())
     assert astro_chart_dot_yaml["version"] == astro_subchart_dot_yaml["version"], (
-        "Please ensure that 'version' in Chart.yaml and "
-        + "charts/astronomer/Chart.yaml exactly match."
+        "Please ensure that 'version' in Chart.yaml and " + "charts/astronomer/Chart.yaml exactly match."
     )
 
 
@@ -35,9 +32,7 @@ def test_downgrade_then_upgrade():
     version."""
     helm_chart_path = getenv("HELM_CHART_PATH")
     if not helm_chart_path:
-        raise Exception(
-            "This test only works with HELM_CHART_PATH set to the path of the chart to be tested"
-        )
+        raise Exception("This test only works with HELM_CHART_PATH set to the path of the chart to be tested")
     with open(git_root_dir / "Chart.yaml") as f:
         astro_chart_dot_yaml = yaml.safe_load(f.read())
     major, minor, patch = semver(astro_chart_dot_yaml["version"]).release
@@ -55,9 +50,7 @@ def test_downgrade_then_upgrade():
 
     config_path = git_root_dir / "upgrade_test_config.yaml"
     # Get the existing values
-    check_output(
-        f"helm get values -n {namespace} {release_name} > {config_path}", shell=True
-    )
+    check_output(f"helm get values -n {namespace} {release_name} > {config_path}", shell=True)
     # attempt downgrade with the documented procedure
     print("Performing patch version downgrade...")
     command = (


### PR DESCRIPTION
## Description

While working on the TestProbes issue I got into the weeds with debugging why it was failing, and decided to configure and improve the ruff linting in this chart. This is the result of that work.

## Itemized changes

- Add pyproject.toml to configure python tooling
- Configure ruff
- Fix ruff complaints
- Configure black to format lines at our standard length

## Related Issues

- https://github.com/astronomer/issues/issues/6606

## Testing

I have run unit tests, and they pass. Most of these changes are related to unit tests, and none of them are related directly to the product (IE: no helm changes)

## Merging

This should be merged everywhere if possible. There will likely be merge conflicts, which will take some effort to work through.