### PR TITLE
updating vector and postgresql packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,10 +370,10 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
-                - quay.io/astronomer/ap-postgresql:15.7.0-1
+                - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.8
-                - quay.io/astronomer/ap-vector:0.40.0-1
+                - quay.io/astronomer/ap-vector:0.40.1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -409,10 +409,10 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.25.3-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
-                - quay.io/astronomer/ap-postgresql:15.7.0-1
+                - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.8
-                - quay.io/astronomer/ap-vector:0.40.0-1
+                - quay.io/astronomer/ap-vector:0.40.1
           context:
             - twistcli
 

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.7.0-1
+  tag: 15.8.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/values.yaml
+++ b/values.yaml
@@ -141,7 +141,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.40.0-1
+    image: quay.io/astronomer/ap-vector:0.40.1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Image Name |  Old-tag|  New-tag 
-- | -- | -- 
ap-vector | 0.40.0-1 |0.40.1
ap-postgresql | 15.7.0-1 | 15.8.0

## Related Issues
https://github.com/astronomer/issues/issues/6557

## Testing
QA should see the components up and running and able see the all the logs when logging side car enabled 

## Merging

this PR should be cherry-picked into release-0.34, 0.35, 0.36
