### PR TITLE
add airflow downgrade component logs for fluentd

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -97,7 +97,7 @@ data:
       @type kubernetes_metadata
     </filter>
 
-    # Filter down by namespace and component (scheduler/webserver/worker/triggerer/git-sync-relay/dag-server)
+    # Filter down by namespace and component (scheduler/webserver/worker/triggerer/git-sync-relay/dag-server/airflow-downgrade)
     <filter kubernetes.**>
       @type grep
       <regexp>
@@ -117,7 +117,7 @@ data:
       </regexp>
       <regexp>
         key $.kubernetes.labels.component
-        pattern ^(scheduler|webserver|worker|triggerer|git-sync-relay|dag-server)$
+        pattern ^(scheduler|webserver|worker|triggerer|git-sync-relay|dag-server|airflow-downgrade)$
       </regexp>
     </filter>
 


### PR DESCRIPTION
## Description

Add airflow downgrade component logs support in fluentd

## Related Issues

https://github.com/astronomer/issues/issues/6401

## Testing

QA should able to see logs in the astro ui when a downgrade is triggered 

## Merging

cherry-pick to release-0.35
