### PR TITLE
add deletecollection privilge to commander roles

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -36,7 +36,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
-  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]


### PR DESCRIPTION
## Description

we recently introduced configmap based metrics collection in order to reduce the usage of cluster scoped resource privilges that introuded some edge cases where the configmap is maintained outside of helm and hard deleting the deployment was consuming deletecollection rbac on configmap to delete the resources created which was missing and causing the hard delete feature to  fail. 

This PR fixes that edge case and allows hard delete to function normally without any issues

## Related Issues

https://github.com/astronomer/issues/issues/6620

## Testing

QA should see resources and namespaces getting deleted without any issues

## Merging

cherry-pick to master and release-0.36
