### PR TITLE
reduce kube state default unused collectors

### DIFF
--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -42,21 +42,21 @@ collectors:
   #- validatingwebhookconfigurations
   #- volumeattachments
   #- storageclasses
+  #- leases
+  #- nodes
+  #- endpoints
+  #- poddisruptionbudgets
   - daemonsets
-  - leases
   - namespaces
-  - nodes
   - configmaps
   - cronjobs
   - deployments
-  - endpoints
   - horizontalpodautoscalers
   - ingresses
   - jobs
   - limitranges
   - networkpolicies
   - persistentvolumeclaims
-  - poddisruptionbudgets
   - pods
   - replicasets
   - replicationcontrollers

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -163,7 +163,7 @@ class TestKubeStateDeployment:
             ],
         )
         c_by_name = get_containers_by_name(docs[1])
-        assert len(docs[0]["rules"]) == 22
+        assert len(docs[0]["rules"]) == 18
         assert c_by_name["kube-state"]["args"][0] == collector_resource_args
 
     def test_kube_state_specific_collector_enabled(self, kube_version):

--- a/tests/chart_tests/test_kube_state_deployment.py
+++ b/tests/chart_tests/test_kube_state_deployment.py
@@ -153,7 +153,7 @@ class TestKubeStateDeployment:
             assert role["metadata"]["namespace"] == roles_namespace_pools_list[i - 5]
 
     def test_kube_state_default_collectors(self, kube_version):
-        collector_resource_args = "--resources=daemonsets,leases,namespaces,nodes,configmaps,cronjobs,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,limitranges,networkpolicies,persistentvolumeclaims,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets"
+        collector_resource_args = "--resources=daemonsets,namespaces,configmaps,cronjobs,deployments,horizontalpodautoscalers,ingresses,jobs,limitranges,networkpolicies,persistentvolumeclaims,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets"
         docs = render_chart(
             kube_version=kube_version,
             values={},


### PR DESCRIPTION
## Description

reduce kube state default unused collectors

## Related Issues

https://github.com/astronomer/issues/issues/6571

## Testing

QA should able to validate platform metrics dashboard on astro-ui fully functional

## Merging

cherry-pick to release-0.36
