### PR TITLE
Update ap-base packages from 3.18.8 to 3.18.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,16 +357,16 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0-2
+                - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.35.8
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-10
-                - quay.io/astronomer/ap-base:3.18.8
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-11
+                - quay.io/astronomer/ap-base:3.18.9
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.3
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
-                - quay.io/astronomer/ap-curator:8.0.16-1
+                - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -374,38 +374,38 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
                 - quay.io/astronomer/ap-houston-api:0.35.11
-                - quay.io/astronomer/ap-init:3.18.8
+                - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-2
-                - quay.io/astronomer/ap-nats-server:2.10.14-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-5
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-3
+                - quay.io/astronomer/ap-nats-server:2.10.18-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.0
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
                 - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
-                - quay.io/astronomer/ap-registry:3.18.8
-                - quay.io/astronomer/ap-vector:0.40.1
+                - quay.io/astronomer/ap-registry:3.18.9
+                - quay.io/astronomer/ap-vector:0.40.2-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/ap-alertmanager:0.27.0-2
+                - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.35.8
                 - quay.io/astronomer/ap-auth-sidecar:1.25.5
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-10
-                - quay.io/astronomer/ap-base:3.18.8
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-2
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-11
+                - quay.io/astronomer/ap-base:3.18.9
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.25
                 - quay.io/astronomer/ap-commander:0.36.3
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
-                - quay.io/astronomer/ap-curator:8.0.16-1
+                - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.6
                 - quay.io/astronomer/ap-default-backend:0.28.26
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
@@ -413,22 +413,22 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
                 - quay.io/astronomer/ap-houston-api:0.35.11
-                - quay.io/astronomer/ap-init:3.18.8
+                - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-2
-                - quay.io/astronomer/ap-nats-server:2.10.14-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-5
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-3
+                - quay.io/astronomer/ap-nats-server:2.10.18-1
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.0
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-13
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-7
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
+                - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
                 - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
-                - quay.io/astronomer/ap-registry:3.18.8
-                - quay.io/astronomer/ap-vector:0.40.1
+                - quay.io/astronomer/ap-registry:3.18.9
+                - quay.io/astronomer/ap-vector:0.40.2-1
           context:
             - twistcli
 

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.27.0-2
+    tag: 0.27.0-3
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.8
+    tag: 3.18.9
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.8
+    tag: 3.18.9
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.16-1
+    tag: 8.0.16-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-10
+    tag: 1.5.0-11
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.8
+    tag: 3.18.9
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.14-2
+    tag: 2.10.18-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-2
+    tag: 0.15.0-3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-13
+  tag: 1.17.0-14
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -14,7 +14,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-2
+  tag: 0.25.0-3
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-7
+  tag: 0.15.0-8
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -6,15 +6,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.18.8
+    tag: 3.18.9
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-5
+    tag: 0.25.6-6
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-2
+    tag: 0.15.0-3
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ global:
     containerdTolerations: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.18.8
+      tag: 3.18.9
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
@@ -139,7 +139,7 @@ global:
   loggingSidecar:
     enabled: false
     name: sidecar-log-consumer
-    image: quay.io/astronomer/ap-vector:0.40.1
+    image: quay.io/astronomer/ap-vector:0.40.2-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Update ap-base packages from 3.18.8 to 3.18.9

Image Name |  old  Tag| New tag |
-- | -- | -- |
ap-alertmanager | 0.27.0-2 | 0.27.0-3
ap-blackbox-exporter | 0.25.0-2 | 0.25.0-3
ap-registry| 3.18.8 | 3.18.9
ap-postgres-exporter|0.15.0-7 |  0.15.0-8
ap-nats-streaming| 0.25.6-5 | 0.25.6-6
ap-nats-server| 2.10.18 | 2.10.18-1
ap-nats-exporter| 0.15.0-2 | 0.15.0-3
ap-init | 3.18.8 | 3.18.9
ap-curator | 8.0.16-1 | 8.0.16-2
ap-awsesproxy| 1.5.0-10 | 1.5.0-11
ap-pgbouncer-exporter | 0.15.0-10 | 0.15.0-11
ap-vector | 0.40.1| 0.40.1-1
ap-pgbouncer-krb |1.17.0-13 | 1.17.0-14
ap-base | 3.18.8 | 3.18.9

## Related Issues

https://github.com/astronomer/issues/issues/6557
https://github.com/astronomer/issues/issues/6634

## Testing

All components should be up and running without any errors, QA should test vector logs 

## Merging

cherry-pick to 0.35,0.36 and 0.34 branches


