### PR TITLE
fix fluentd logging on reducing cluster role privileges

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -104,7 +104,7 @@ data:
         {{- if and .Values.global.features.namespacePools.enabled (gt (len .Values.global.features.namespacePools.namespaces.names) 0) }}
         key $.kubernetes.namespace_name
         pattern ^({{ join "|" .Values.global.features.namespacePools.namespaces.names }})$
-        {{- else if .Values.global.manualNamespaceNamesEnabled }}
+        {{- else if or .Values.global.manualNamespaceNamesEnabled .Values.global.disableManageClusterScopedResources }}
         key $.kubernetes.namespace_name
         # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled
         pattern "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -355,11 +355,7 @@ class TestFluentd:
         """Test that with disable_manage_cluster_scoped_resources, helm renders fluentd configmap targeting all namespaces."""
         doc = render_chart(
             kube_version=kube_version,
-            values={
-                "global": {
-                    "disableManageClusterScopedResources": True
-                }
-            },
+            values={"global": {"disableManageClusterScopedResources": True}},
             show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
         )[0]
 

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -350,3 +350,18 @@ class TestFluentd:
         assert liveness_probe["periodSeconds"] == 15
         assert liveness_probe["successThreshold"] == 1
         assert liveness_probe["timeoutSeconds"] == 5
+
+    def test_fluentd_configmap_disable_manage_cluster_scoped_resources(self, kube_version):
+        """Test that with disable_manage_cluster_scoped_resources, helm renders fluentd configmap targeting all namespaces."""
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "disableManageClusterScopedResources": True
+                }
+            },
+            show_only=["charts/fluentd/templates/fluentd-configmap.yaml"],
+        )[0]
+
+        expected_rule = "key $.kubernetes.namespace_name\n    # fluentd should gather logs from all namespaces if manualNamespaceNamesEnabled is enabled"
+        assert expected_rule in doc["data"]["output.conf"]


### PR DESCRIPTION
## Description

fix fluentd logging on reducing cluster role privileges


## Related Issues

https://github.com/astronomer/issues/issues/6639

## Testing

QA should able to see logs on astro-ui and airflow webserver ui task logs section

## Merging

cherry-pick to release-0.36 and master
