### PR TITLE
Update houston-configmap.yaml with strategy

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -274,7 +274,7 @@ data:
               requests:
                 ephemeral-storage: "1Gi"
 
-            updateStrategy:
+            strategy:
               type: RollingUpdate
               rollingUpdate:
                 maxUnavailable: 1

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -23,7 +23,7 @@ def common_test_cases(docs):
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
     assert prod["deployments"]["disableManageClusterScopedResources"] is False
     airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["updateStrategy"]
+    scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
     assert scheduler_update_strategy["type"] == "RollingUpdate"
     assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
     assert (


### PR DESCRIPTION
## Description

This PR replaces updateStrategy with strategy as  updateStrategy is only supported when worker has persistence enabled, hence we are replacing with strategy: https://github.com/astronomer/airflow/blob/helm-chart/v1-11-0/chart/values.schema.json#L2039C1-L2053C19

## Related Issues

Related astronomer/issues#6628

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
