### PR TITLE
update houston-api with version 0.35.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.11
+                - quay.io/astronomer/ap-houston-api:0.35.14
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.5
-                - quay.io/astronomer/ap-houston-api:0.35.11
+                - quay.io/astronomer/ap-houston-api:0.35.14
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.11
+    tag: 0.35.14
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston-api with version 0.35.14

## Related Issues

NA

## Testing

QA should able to see all existing features works as expected

## Merging

cherry-pick to release-0.35
