### PR TITLE
Fix 6651 disable default jetstream

### DIFF
--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -19,7 +19,7 @@ images:
 
 
 nats:
-  createJetStreamJob: true
+  createJetStreamJob: false
 
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -13,6 +13,7 @@ class TestNatsJetstream:
         """Test that nats statefulset is good with defaults."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": True}}},
+            "nats": {"nats": {"createJetStreamJob": True}},
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -36,6 +37,7 @@ class TestNatsJetstream:
         """Test Nats with jetstream config."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": True, "tls": True}}},
+            "nats": {"nats": {"createJetStreamJob": True}},
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -123,6 +125,7 @@ class TestNatsJetstream:
         """Test that stan statefulset is disabled when jetstream is enabled."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": True}}},
+            "nats": {"nats": {"createJetStreamJob": True}},
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -141,6 +144,7 @@ class TestNatsJetstream:
         """Test that stan statefulset is disabled when jetstream is enabled."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": False}}},
+            "nats": {"nats": {"createJetStreamJob": True}},
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -13,7 +13,6 @@ class TestNatsJetstream:
         """Test that nats statefulset is good with defaults."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": True}}},
-            "nats": {"nats": {"createJetStreamJob": True}},
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -26,12 +25,12 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 7
+        assert len(docs) == 3
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["nats"] == {"jetStreamEnabled": True, "tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
-        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[6]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
+        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test Nats with jetstream config."""


### PR DESCRIPTION
## Description

This PR removes the default usage of the jetstream component. 

## Related Issues

Related astronomer/issues#6651

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

Tested locally with the modified testcases

![Screenshot 2024-09-24 at 6 26 46 PM](https://github.com/user-attachments/assets/1e15c82b-40b9-400b-bd4f-cd7b0e9325b0)


## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
