### PR TITLE
Fix 6582 ns resources

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -4,10 +4,18 @@
 # Here, we either:
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
-# 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
-{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
+# 3. Create roles for each namespace in the namespacePool (+ astronomer namespace) if enabled.
+# 4. If keepExistingRolesAndBindings is set to true, we skip creating roles and bindings if they already exist.
+# 5. manageNamespaceResources, if false, disables management of namespace resources (roles, rolebindings, etc.)
+{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled) }}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
+
+# Logic for keepExistingRolesAndBindings and manageNamespaceResources
+{{- if not .Values.global.keepExistingRolesAndBindings }}
+  {{- $shouldCreateResources = and $shouldCreateResources .Values.global.manageNamespaceResources }}
+{{- end }}
+
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
 {{- else  }}

--- a/values.yaml
+++ b/values.yaml
@@ -50,8 +50,11 @@ global:
   acme: false
 
   # Flag for keeping existing roles and bindings i.e. upon helm upgrade existing roles would not be updated
-  keepExistingRolesAndBindings: false 
-  
+  keepExistingRolesAndBindings: false
+
+  # Flag to manage namespace labels and annotations
+  manageNamespaceResources: true
+
   # If RBAC on cluster is enabled
   rbacEnabled: true
 

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,9 @@ global:
   # Use kube-lego
   acme: false
 
+  # Flag for keeping existing roles and bindings i.e. upon helm upgrade existing roles would not be updated
+  keepExistingRolesAndBindings: false 
+  
   # If RBAC on cluster is enabled
   rbacEnabled: true
 


### PR DESCRIPTION
## Description

This PR introduces a keep flag so the already create role and rolebindings are not deleted and synchronize on a helm update/upgrade. Disable management of namespace resources - patching labels/annotations etc.

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6582

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
