### PR TITLE
update nginx packages with 1.27.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.35.8
-                - quay.io/astronomer/ap-auth-sidecar:1.25.5
+                - quay.io/astronomer/ap-auth-sidecar:1.27.1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
@@ -380,7 +380,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
-                - quay.io/astronomer/ap-nginx-es:1.27.0
+                - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1
@@ -398,7 +398,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.35.8
-                - quay.io/astronomer/ap-auth-sidecar:1.25.5
+                - quay.io/astronomer/ap-auth-sidecar:1.27.1
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
-                - quay.io/astronomer/ap-nginx-es:1.27.0
+                - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-1

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.27.0
+    tag: 1.27.1
     pullPolicy: IfNotPresent
 
 common:

--- a/values.yaml
+++ b/values.yaml
@@ -158,7 +158,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.25.5
+    tag: 1.27.1
     pullPolicy: IfNotPresent
     port: 8084
     securityContext: {}


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-auth-sidecar | 1.25.5 | 1.27.1 |
| ap-nginx-es | 1.27.0 | 1.27.1 |

## Related Issues

https://github.com/astronomer/issues/issues/6557
https://github.com/astronomer/issues/issues/6634

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
