### PR TITLE
update the ap-openresty from 1.25.3-1 to 1.25.3-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,7 +383,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
-                - quay.io/astronomer/ap-openresty:1.25.3-1
+                - quay.io/astronomer/ap-openresty:1.25.3-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
                 - quay.io/astronomer/ap-postgresql:15.8.0
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
                 - quay.io/astronomer/ap-node-exporter:1.8.2
-                - quay.io/astronomer/ap-openresty:1.25.3-1
+                - quay.io/astronomer/ap-openresty:1.25.3-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
                 - quay.io/astronomer/ap-postgresql:15.8.0

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.25.3-1
+    tag: 1.25.3-2
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy


### PR DESCRIPTION
## Description

update the ap-openresty from 1.25.3-1 to 1.25.3-2

## Related Issues

https://github.com/astronomer/issues/issues/6557

Related astronomer/issues#XXXX

## Testing


## Merging
 this PR should be merged / cherry-picked into 0.35,0.36.0.34
