### PR TITLE
db-bootstrapper 0.35.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.36.3
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-2
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.7
                 - quay.io/astronomer/ap-default-backend:0.28.27
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
@@ -406,7 +406,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.36.3
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-2
-                - quay.io/astronomer/ap-db-bootstrapper:0.35.6
+                - quay.io/astronomer/ap-db-bootstrapper:0.35.7
                 - quay.io/astronomer/ap-default-backend:0.28.27
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.6
+    tag: 0.35.7
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.6
+    tag: 0.35.7
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.35.6
+    tag: 0.35.7
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

update db-bootstrapper with 0.35.7

## Related Issues

https://github.com/astronomer/issues/issues/6557

## Testing

NA

## Merging

cherry-pick to all release-0.35,release-0.36
