### PR TITLE
Remove `helm lint` from build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: pre-commit run --all-files --show-diff-on-failure
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.3
+      - image: quay.io/astronomer/ap-build:0.3.0-4
     steps:
       - checkout
       - run:
@@ -180,7 +180,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.3
+      - image: quay.io/astronomer/ap-build:0.3.0-4
     parameters:
       qa_release:
         type: boolean

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,17 +131,6 @@ jobs:
       - run:
           name: Run pre-commit
           command: pre-commit run --all-files --show-diff-on-failure
-  lint:
-    docker:
-      - image: quay.io/astronomer/ap-build:0.3.0-4
-    steps:
-      - checkout
-      - run:
-          name: Install ci tools
-          command: ./bin/install-ci-tools 1
-      - run:
-          name: Lint the Astronomer chart
-          command: export PATH=/tmp/bin:$PATH make lint
 
   unittest-charts:
     docker:
@@ -438,14 +427,12 @@ workflows:
         - not: << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
-      - lint
       - run_pre_commit
       - unittest-charts
       - check-commander-airflow-version
       - build-artifact:
           requires:
             - check-commander-airflow-version
-            - lint
             - run_pre_commit
             - unittest-charts
       - approve-test-all-platforms:
@@ -532,7 +519,6 @@ workflows:
         - << pipeline.parameters.qa-release >>
         - not: << pipeline.parameters.scan-docker-images >>
     jobs:
-      - lint
       - run_pre_commit
       - unittest-charts
       - check-commander-airflow-version
@@ -540,7 +526,6 @@ workflows:
           qa_release: true
           requires:
             - check-commander-airflow-version
-            - lint
             - run_pre_commit
             - unittest-charts
       - release-to-internal:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -131,7 +131,7 @@ jobs:
           command: pre-commit run --all-files --show-diff-on-failure
   lint:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.3
+      - image: quay.io/astronomer/ap-build:{{ ap_build_tag }}
     steps:
       - checkout
       - run:
@@ -178,7 +178,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ap-build:0.2.3
+      - image: quay.io/astronomer/ap-build:{{ ap_build_tag }}
     parameters:
       qa_release:
         type: boolean

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -129,17 +129,6 @@ jobs:
       - run:
           name: Run pre-commit
           command: pre-commit run --all-files --show-diff-on-failure
-  lint:
-    docker:
-      - image: quay.io/astronomer/ap-build:{{ ap_build_tag }}
-    steps:
-      - checkout
-      - run:
-          name: Install ci tools
-          command: ./bin/install-ci-tools 1
-      - run:
-          name: Lint the Astronomer chart
-          command: export PATH=/tmp/bin:$PATH make lint
 
   unittest-charts:
     docker:
@@ -313,14 +302,12 @@ workflows:
         - not: << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
-      - lint
       - run_pre_commit
       - unittest-charts
       - check-commander-airflow-version
       - build-artifact:
           requires:
             - check-commander-airflow-version
-            - lint
             - run_pre_commit
             - unittest-charts
       - approve-test-all-platforms:
@@ -396,7 +383,6 @@ workflows:
         - << pipeline.parameters.qa-release >>
         - not: << pipeline.parameters.scan-docker-images >>
     jobs:
-      - lint
       - run_pre_commit
       - unittest-charts
       - check-commander-airflow-version
@@ -404,7 +390,6 @@ workflows:
           qa_release: true
           requires:
             - check-commander-airflow-version
-            - lint
             - run_pre_commit
             - unittest-charts
       - release-to-internal:

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,6 @@ CHARTS := astronomer nginx grafana prometheus alertmanager elasticsearch kibana 
 
 TEMPDIR := /tmp/astro-temp
 
-.PHONY: lint
-lint: lint-prep lint-astro lint-charts ## Run all lint steps on the Astronomer helm chart and subcharts
-
-.PHONY: lint-prep
-lint-prep: ## Prepare a clean env for linting
-	rm -rf ${TEMPDIR}/astronomer || true
-	mkdir -p ${TEMPDIR}
-	cp -R . ${TEMPDIR}/astronomer
-
-.PHONY: lint-astro
-lint-astro: lint-prep ## Lint the Astronomer helm chart
-	helm lint ${TEMPDIR}/astronomer
-
 unittest-requirements: .unittest-requirements ## Setup venv required for unit testing the Astronomer helm chart
 .unittest-requirements:
 	[ -d venv ] || virtualenv venv -p python3
@@ -39,21 +26,6 @@ validate-commander-airflow-version: ## Validate that airflowChartVersion is the 
 
 .PHONY: test
 test: validate-commander-airflow-version unittest-charts
-
-.PHONY: lint-charts
-lint-charts: lint-prep ## Lint Astronomer sub-charts
-	# Check that nothing accidentally is using release name instead of namespace for metadata.namespace
-	! helm template --namespace samplenamespace samplerelease . | grep 'namespace: samplerelease'
-	# get a copy of the global values for helm lint'n the dependent charts
-	python3 -c "import yaml; from pathlib import Path; globals = {'global': yaml.safe_load(Path('${TEMPDIR}/astronomer/values.yaml').read_text())['global']}; Path('${TEMPDIR}/globals.yaml').write_text(yaml.dump(globals))"
-	find "${TEMPDIR}/astronomer/charts" -mindepth 1 -maxdepth 1 -print0 | xargs -0 -n1 helm lint -f ${TEMPDIR}/globals.yaml
-
-.PHONY: lint-prom
-lint-prom: ## Lint the Prometheus alerts configuration
-	helm template -s ${TEMPDIR}/astronomer/charts/prometheus/templates/prometheus-alerts-configmap.yaml ${TEMPDIR}/astronomer > ${TEMPDIR}/prometheus_alerts.yaml
-	# Parse the alerts.yaml data from the config map resource
-	python3 -c "import yaml; from pathlib import Path; alerts = yaml.safe_load(Path('${TEMPDIR}/prometheus_alerts.yaml').read_text())['data']['alerts']; Path('${TEMPDIR}/prometheus_alerts.yaml').write_text(alerts)"
-	promtool check rules ${TEMPDIR}/prometheus_alerts.yaml
 
 .PHONY: clean
 clean: ## Clean build and test artifacts

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -11,9 +11,9 @@ git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".
 metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
-# https://circleci.com/developer/machine/image/ubuntu-2204
-machine_image_version = "ubuntu-2204:2024.05.1"
-ci_runner_version = "2024-09"
+ap_build_tag = "0.3.0-4"  # https://quay.io/repository/astronomer/ap-build?tab=tags&tag=latest
+ci_runner_version = "2024-09"  # This should be the current YYYY-MM
+machine_image_version = "ubuntu-2204:2024.05.1"  # https://circleci.com/developer/machine/image/ubuntu-2204
 
 
 def list_docker_images():
@@ -38,10 +38,11 @@ def main():
     templated_file_content = config_file_template_path.read_text()
     template = Template(templated_file_content)
     config = template.render(
-        kube_versions=kube_versions,
-        docker_images=docker_images,
-        machine_image_version=machine_image_version,
+        ap_build_tag=ap_build_tag,
         ci_runner_version=ci_runner_version,
+        docker_images=docker_images,
+        kube_versions=kube_versions,
+        machine_image_version=machine_image_version,
     )
     with open(config_file_path, "w") as circle_ci_config_file:
         warning_header = (


### PR DESCRIPTION
## Description

`helm lint` is broken for us because of how tightly our sub-charts are intertwined with the umbrella chart. Fixing this would require a large refactor that would not justify merely fixing `helm lint`, and should be considered only under a refactor with higher goals. You can read more about why I think this here: <https://github.com/astronomer/issues/issues/6604#issuecomment-2380685110>

This PR removes all of the `helm lint` bits from the Makefile and circleci configs, and improves `bin/generate_circleci_config.py`.

## Related Issues

https://github.com/astronomer/issues/issues/6604

## Testing

The `helm lint` removals do not have anything that needs to be tested, but part of this PR is to build our chart with helm 3.16 vs helm 2.7.10. This should theoretically not cause any changes, but I want to note it here just in case.

## Merging

This should be merged everywhere. It only affects the build, not the software that runs in customer environments.