### PR TITLE
update es exporter version 1.8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ workflows:
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.7
                 - quay.io/astronomer/ap-default-backend:0.28.27
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.7
                 - quay.io/astronomer/ap-default-backend:0.28.27
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.7.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.7.0
+    tag: 1.8.0
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es


### PR DESCRIPTION
## Description

update es exporter version 1.8.0

## Related Issues

https://github.com/astronomer/issues/issues/6557

## Testing

QA generic validation

## Merging

cherry-pick to all valid releases
