### PR TITLE
update missing vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,7 +372,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.5
+                - quay.io/astronomer/ap-grafana:10.4.6
                 - quay.io/astronomer/ap-houston-api:0.35.15
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
@@ -382,11 +382,11 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
-                - quay.io/astronomer/ap-node-exporter:1.8.1-1
+                - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
-                - quay.io/astronomer/ap-postgresql:15.6.0-1
+                - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.9
                 - quay.io/astronomer/ap-vector:0.40.2-1
@@ -411,7 +411,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.5
+                - quay.io/astronomer/ap-grafana:10.4.6
                 - quay.io/astronomer/ap-houston-api:0.35.15
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
@@ -421,11 +421,11 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.1
                 - quay.io/astronomer/ap-nginx:1.11.2
-                - quay.io/astronomer/ap-node-exporter:1.8.1-1
+                - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
                 - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
-                - quay.io/astronomer/ap-postgresql:15.6.0-1
+                - quay.io/astronomer/ap-postgresql:15.8.0
                 - quay.io/astronomer/ap-prometheus:2.53.1
                 - quay.io/astronomer/ap-registry:3.18.9
                 - quay.io/astronomer/ap-vector:0.40.2-1

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.5
+    tag: 10.4.6
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicas }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
   selector:
     matchLabels:
       tier: {{ template "nginx.name" . }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -28,6 +28,8 @@ replicasDefaultBackend: 2
 maxUnavailable: 25%
 maxUnavailableDefaultBackend: 25%
 
+minReadySeconds: 0
+
 resources: {}
 #  limits:
 #   cpu: 100m

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.6.0-1
+  tag: 15.8.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.8.1-1
+  tag: 1.8.2
   pullPolicy: IfNotPresent
 
 service:

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -1,5 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
+from tests import get_containers_by_name
 
 
 class TestNginx:


### PR DESCRIPTION
## Description

update missing vendor packages
| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-grafana | 10.4.5 | 10.4.6 |
| ap-node-exporter | 1.8.1-1 | 1.8.2 |
| ap-postgresql | 15.6.0-1 | 15.8.0 | 

## Related Issues

https://github.com/astronomer/issues/issues/6557

## Testing

NA

## Merging

cherry-pick to release-0.35
