### PR TITLE
Add REGISTRY_WAIT_ENABLED to houston_environment

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -224,6 +224,8 @@ s3:
   # These are set here for Houston's entrypoint script
 - name: HOUSTON__HOST
   value: {{ .Release.Name }}-houston
+- name: REGISTRY_WAIT_ENABLED
+  value: 1
 - name: COMMANDER__HOST
   value: {{ .Release.Name }}-commander
 - name: COMMANDER__PORT

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -225,7 +225,7 @@ s3:
 - name: HOUSTON__HOST
   value: {{ .Release.Name }}-houston
 - name: REGISTRY_WAIT_ENABLED
-  value: 1
+  value: "true"
 - name: COMMANDER__HOST
   value: {{ .Release.Name }}-commander
 - name: COMMANDER__PORT


### PR DESCRIPTION
Description
This PR introduces an environment variable for houston to make sure REGISTRY_WAIT_ENABLED is enabled by default.

Related Issues
Related https://github.com/astronomer/issues/issues/6369

Testing
Do not merge this PR until this text is replaced with details about how these changes were tested.

Merging
Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.