### PR TITLE
update houston-api version 0.35.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.35.15
+                - quay.io/astronomer/ap-houston-api:0.35.16
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.35.15
+                - quay.io/astronomer/ap-houston-api:0.35.16
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.15
+    tag: 0.35.16
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston-api version 0.35.16

## Related Issues

Related https://github.com/astronomer/issues/issues/6437
Related https://github.com/astronomer/issues/issues/6666
Related https://github.com/astronomer/issues/issues/6667
Related https://github.com/astronomer/issues/issues/6369

## Testing

refer above linked issues

## Merging

cherry-pick to release-0.35
