### PR TITLE
allow service account modification for dag server config

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -167,6 +167,9 @@ data:
         {{- if .Values.global.dagOnlyDeployment.persistence }}
         persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 10 }}
         {{- end }}
+        {{ if .Values.global.dagOnlyDeployment.serviceAccount }}
+        serviceAccount: {{- .Values.global.dagOnlyDeployment.serviceAccount | toYaml | nindent 10 }}
+        {{- end }}
       {{- end }}
 
       # These values get passed directly into the airflow helm deployments

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -30,10 +30,9 @@ class TestDagOnlyDeploy:
 
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
-        assert prod["deployments"]["dagDeploy"]["enabled"] == True
+        assert prod["deployments"]["dagDeploy"]["enabled"] is True
         assert "serviceAccount" in prod["deployments"]["dagDeploy"]
-        print(prod["deployments"]["dagDeploy"]["serviceAccount"])
-        # assert {"create": True} in prod["deployments"]["dagDeploy"]["serviceAccount"]
+        assert {"create": True} == prod["deployments"]["dagDeploy"]["serviceAccount"]
 
     def test_dagonlydeploy_config_enabled(self, kube_version):
         """Test dagonlydeploy Service defaults."""

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -28,6 +28,7 @@ class TestDagOnlyDeploy:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
+        assert len(docs) == 1
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
         assert prod["deployments"]["dagDeploy"]["enabled"] is True

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -20,6 +20,21 @@ class TestDagOnlyDeploy:
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is False
 
+    def test_dagonlydeploy_with_serviceaccount_overrides(self, kube_version):
+        """Test dagonlydeploy Service Account overrides."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"dagOnlyDeployment": {"enabled": True, "serviceAccount": {"create": True}}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        assert prod["deployments"]["dagOnlyDeployment"] is True
+        assert prod["deployments"]["dagDeploy"]["enabled"] == True
+        assert "serviceAccount" in prod["deployments"]["dagDeploy"]
+        print(prod["deployments"]["dagDeploy"]["serviceAccount"])
+        # assert {"create": True} in prod["deployments"]["dagDeploy"]["serviceAccount"]
+
     def test_dagonlydeploy_config_enabled(self, kube_version):
         """Test dagonlydeploy Service defaults."""
         resources = {


### PR DESCRIPTION
## Description

Adds astro.dagDeploy.serviceAccount.create and astro.dagDeploy.serviceAccount.name to let users specify a service account name and specify that they don't want the chart to create the service-account and associated rolebindings for the dag-deploy server.

## Related Issues

https://github.com/astronomer/issues/issues/6583
https://github.com/astronomer/issues/issues/6662

## Testing

QA should able to override service account in dag server service 

## Merging

cherry-pick to release-0.36
