### PR TITLE
remove rbac conditional changes

### DIFF
--- a/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
@@ -35,9 +35,7 @@ spec:
         sidecar.istio.io/inject: "false"
       {{- end }}
     spec:
-      {{- if .Values.global.rbacEnabled }}
       serviceAccountName: {{ template "houston.bootstrapperServiceAccount" . }}
-      {{- end}}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -35,9 +35,7 @@ spec:
         sidecar.istio.io/inject: "false"
       {{- end }}
     spec:
-      {{- if .Values.global.rbacEnabled }}
       serviceAccountName: {{ template "houston.bootstrapperServiceAccount" . }}
-      {{- end}}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:


### PR DESCRIPTION
## Description

remove rbac conditional changes

This is a continutation from the PR https://github.com/astronomer/astronomer/pull/2301

our original intention was to mix it up with global.rbacEnabled so that we will be removing the serviceAccount section from all the templates, with the redefined approach we configured our helper templates to use default service account when serviceAccount create is set to false and no name is defined it will fallback the serviceAccountName to default 



## Related Issues

https://github.com/astronomer/issues/issues/6537
https://github.com/astronomer/issues/issues/6583

## Testing

refer notion doc

## Merging

cherry-pick to release-0.36
