### PR TITLE
Introduce rbac flag to optionate role and rolebindings for namespace pools

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -5,7 +5,7 @@
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
-{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.rbacCreate .Values.global.features.namespacePools.enabled}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -5,6 +5,7 @@
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
+{{- $commanderns:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
@@ -40,9 +41,11 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+{{- if not $.Values.global.disableManageClusterScopedResources }}
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+{{- end}}
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -5,7 +5,7 @@
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
-{{- $commanderns:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
+{{- $commanderrole:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
@@ -15,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if $shouldCreateResources }}
+{{- if and $shouldCreateResources (not $commanderrole)}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -5,9 +5,9 @@
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
-{{- $commanderrole:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.rbacCreate .Values.global.features.namespacePools.enabled}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
@@ -15,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if and $shouldCreateResources (not $commanderrole)}}
+{{- if $shouldCreateResources}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}
@@ -41,11 +41,9 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
-{{- if not $.Values.global.disableManageClusterScopedResources }}
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
-{{- end}}
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -5,6 +5,7 @@
 # 1. Do not create anything is rbacEnabled is disabled
 # 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
+{{- $commanderrole:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
@@ -14,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if $shouldCreateResources }}
+{{- if and $shouldCreateResources (not $commanderrole)}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -5,7 +5,7 @@
 # 1. Do not create anything is rbacEnabled is disabled
 # 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
-{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.rbacCreate .Values.global.features.namespacePools.enabled}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -5,9 +5,9 @@
 # 1. Do not create anything is rbacEnabled is disabled
 # 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
-{{- $commanderrole:= and .Values.global.features.namespacePools.keeproleandrolebindings (not $.Values.global.features.namespacePools.namespaces.create)}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.rbacCreate .Values.global.features.namespacePools.enabled}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
@@ -15,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if and $shouldCreateResources (not $commanderrole)}}
+{{- if $shouldCreateResources}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
-      # if rbacCreate is set to false then platform does not create roles and rolebinding. 
+      # if rbacCreate is set to false then platform does not create roles and rolebinding.
       rbacCreate: true
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces

--- a/values.yaml
+++ b/values.yaml
@@ -41,8 +41,8 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
-      # if rbacCreate is set to false then platform does not create roles and rolebinding.
-      rbacCreate: true
+      # if createRbac is set to false then platform does not create roles and rolebinding.
+      createRbac: true
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
-      keeproleandrolebindings: false
+      keeproles: true
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,8 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
-      keeproles: true
+      # if rbacCreate is set to false then platform does not create roles and rolebinding. 
+      rbacCreate: true
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false

--- a/values.yaml
+++ b/values.yaml
@@ -41,6 +41,7 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
+      keeproleandrolebindings: true
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false

--- a/values.yaml
+++ b/values.yaml
@@ -41,7 +41,7 @@ global:
     # namespace pools: define k8s namespaces in which Astronomer will manage Airflow deployments
     namespacePools:
       enabled: false
-      keeproleandrolebindings: true
+      keeproleandrolebindings: false
       namespaces:
         # if create is enabled, this helm chart will create the provided k8s namespaces
         create: false


### PR DESCRIPTION
## Description

This PR introduces a keep flag so the already create role and rolebindings are not deleted and synchronize on a helm update/upgrade. Disable management of commander namespace resources.

## Related Issues
Related https://github.com/astronomer/issues/issues/6582

## Testing
Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging
Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.