### PR TITLE
add support for runtime release config overrides from config

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -280,6 +280,11 @@ s3:
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json
 {{- end }}
+{{ if .Values.houston.RuntimeReleasesConfig }}
+- name: houston-config-volume
+  mountPath: /houston/astro_runtime_releases.json
+  subPath: astro_runtime_releases.json
+{{- end }}
 - name: houston-jwt-key-volume
   mountPath: {{ template "houston.jwtKeyPath" . }}
   subPath: tls.key

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -17,6 +17,11 @@ data:
     {{ .Values.houston.airflowReleasesConfig | toJson }}
   # These are system-specified config overrides.
   {{- end }}
+  {{ if .Values.houston.RuntimeReleasesConfig }}
+  astro_runtime_releases.json: |
+    {{ .Values.houston.RuntimeReleasesConfig | toJson }}
+  # These are system-specified config overrides.
+  {{- end }}
   production.yaml: |
     webserver:
       port: {{ .Values.ports.houstonHTTP }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -311,6 +311,19 @@ houston:
     #   - 2.0.0-alpine3.10-onbuild
     #   channel: stable
 
+  RuntimeReleasesConfig:
+    # example of usage:
+    # available_releases:
+    #runtimeVersions:
+    #  4.2.6:
+    #    metadata:
+    #      airflowVersion: 2.2.5
+    #      channel: stable
+    #      releaseDate: '2022-04-19'
+    #    migrations:
+    #      airflowDatabase: false
+
+
   # Add extra containers here
   extraContainers: []
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -313,16 +313,12 @@ houston:
 
   RuntimeReleasesConfig:
     # example of usage:
-    # available_releases:
-    #runtimeVersions:
-    #  4.2.6:
+    # below are default mandatory fields
+    # runtimeVersions:
+    #  12.1.1:
     #    metadata:
-    #      airflowVersion: 2.2.5
+    #      airflowVersion: 2.10.2
     #      channel: stable
-    #      releaseDate: '2022-04-19'
-    #    migrations:
-    #      airflowDatabase: false
-
 
   # Add extra containers here
   extraContainers: []
@@ -340,7 +336,6 @@ configSyncer:
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.
   schedule: ~
   securityContext: {}
-  resources: {}
   serviceAccount:
     # Specifies whether a service account should be created
     create: true

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -336,6 +336,7 @@ configSyncer:
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.
   schedule: ~
   securityContext: {}
+  resources: {}
   serviceAccount:
     # Specifies whether a service account should be created
     create: true

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -1,5 +1,6 @@
 import pytest
 import jmespath
+import yaml
 from tests import get_containers_by_name
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
@@ -196,3 +197,34 @@ class TestHoustonApiDeployment:
             for env in docs[0]["spec"]["template"]["spec"]["containers"][0]["env"]
             if "__HOST" in env.get("name") and env.get("value")
         )
+
+    def test_houston_configmap_with_RuntimeReleasesConfig_enabled(self, kube_version):
+        """Validate the houston configmap and its embedded data with RuntimeReleasesConfig defined
+        ."""
+
+        runtime_releases_json = {
+            "runtimeVersions": {
+                "4.2.6": {
+                    "metadata": {"airflowVersion": "2.2.5", "channel": "stable", "releaseDate": "2022-04-19"},
+                    "migrations": {"airflowDatabase": False},
+                }
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"RuntimeReleasesConfig": runtime_releases_json}}},
+            show_only=[
+                "charts/astronomer/templates/houston/houston-configmap.yaml",
+                "charts/astronomer/templates/houston/api/houston-deployment.yaml",
+            ],
+        )
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["astro_runtime_releases.json"])
+        assert prod == runtime_releases_json
+        doc = docs[1]
+        c_by_name = get_containers_by_name(doc, include_init_containers=False)
+        assert {
+            "name": "houston-config-volume",
+            "mountPath": "/houston/astro_runtime_releases.json",
+            "subPath": "astro_runtime_releases.json",
+        } in c_by_name["houston"]["volumeMounts"]

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -201,15 +201,7 @@ class TestHoustonApiDeployment:
     def test_houston_configmap_with_RuntimeReleasesConfig_enabled(self, kube_version):
         """Validate the houston configmap and its embedded data with RuntimeReleasesConfig defined
         ."""
-
-        runtime_releases_json = {
-            "runtimeVersions": {
-                "4.2.6": {
-                    "metadata": {"airflowVersion": "2.2.5", "channel": "stable", "releaseDate": "2022-04-19"},
-                    "migrations": {"airflowDatabase": False},
-                }
-            }
-        }
+        runtime_releases_json = {"runtimeVersions": {"12.1.1": {"metadata": {"airflowVersion": "2.2.5", "channel": "stable"}}}}
         docs = render_chart(
             kube_version=kube_version,
             values={"astronomer": {"houston": {"RuntimeReleasesConfig": runtime_releases_json}}},

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -627,3 +627,24 @@ def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled():
     doc = docs[0]
     prod = yaml.safe_load(doc["data"]["production.yaml"])
     assert prod["deployments"]["disableManageClusterScopedResources"] is True
+
+
+def test_houston_configmap_with_RuntimeReleasesConfig_enabled():
+    """Validate the houston configmap and its embedded data with RuntimeReleasesConfig defined
+    ."""
+
+    runtime_releases_json = {
+        "runtimeVersions": {
+            "4.2.6": {
+                "metadata": {"airflowVersion": "2.2.5", "channel": "stable", "releaseDate": "2022-04-19"},
+                "migrations": {"airflowDatabase": False},
+            }
+        }
+    }
+    docs = render_chart(
+        values={"astronomer": {"houston": {"RuntimeReleasesConfig": runtime_releases_json}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["astro_runtime_releases.json"])
+    assert prod == runtime_releases_json

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -627,24 +627,3 @@ def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled():
     doc = docs[0]
     prod = yaml.safe_load(doc["data"]["production.yaml"])
     assert prod["deployments"]["disableManageClusterScopedResources"] is True
-
-
-def test_houston_configmap_with_RuntimeReleasesConfig_enabled():
-    """Validate the houston configmap and its embedded data with RuntimeReleasesConfig defined
-    ."""
-
-    runtime_releases_json = {
-        "runtimeVersions": {
-            "4.2.6": {
-                "metadata": {"airflowVersion": "2.2.5", "channel": "stable", "releaseDate": "2022-04-19"},
-                "migrations": {"airflowDatabase": False},
-            }
-        }
-    }
-    docs = render_chart(
-        values={"astronomer": {"houston": {"RuntimeReleasesConfig": runtime_releases_json}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["astro_runtime_releases.json"])
-    assert prod == runtime_releases_json


### PR DESCRIPTION
## Description

Allow users to pass runtime versions list  overrides from astronomer helm chart 

## Related Issues

https://github.com/astronomer/issues/issues/6680

## Testing

QA should able to pass custom runtime versions config from helm values

## Merging

cherry-pick to all valid releases
