### PR TITLE
add nodeSelector, affinity, and toleration support

### DIFF
--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -36,6 +36,12 @@ spec:
             app: {{ template "elasticsearch.name" . }}-curator
             version: {{ .Chart.Version }}
         spec:
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
 {{- include "elasticsearch.imagePullSecrets" . | indent 10 }}
           containers:
           - name: curator

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -36,12 +36,9 @@ spec:
             app: {{ template "elasticsearch.name" . }}-curator
             version: {{ .Chart.Version }}
         spec:
-          nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
-          affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
-          tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 12 }}
+          affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 12 }}
+          tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 12 }}
 {{- include "elasticsearch.imagePullSecrets" . | indent 10 }}
           containers:
           - name: curator

--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -39,12 +39,9 @@ spec:
         iam.amazonaws.com/role: {{ .Values.global.customLogging.awsIAMRole }}
         {{- end }}
     spec:
-      nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
-      affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
-      tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 12 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 12 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 12 }}
       serviceAccountName: {{ include "external-es-proxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -39,6 +39,12 @@ spec:
         iam.amazonaws.com/role: {{ .Values.global.customLogging.awsIAMRole }}
         {{- end }}
     spec:
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+      affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
       serviceAccountName: {{ include "external-es-proxy.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/kibana/templates/kibana-default-index-cronjob.yaml
+++ b/charts/kibana/templates/kibana-default-index-cronjob.yaml
@@ -32,6 +32,12 @@ spec:
           sidecar.istio.io/inject: "false"
         {{- end }}
       spec:
+        nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 10 }}
+        affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 10 }}
+        tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 10 }}
 {{- include "kibana.imagePullSecrets" . | indent 8 }}
         containers:
         - name: kibana-default-index

--- a/charts/kibana/templates/kibana-default-index-cronjob.yaml
+++ b/charts/kibana/templates/kibana-default-index-cronjob.yaml
@@ -32,12 +32,9 @@ spec:
           sidecar.istio.io/inject: "false"
         {{- end }}
       spec:
-        nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 10 }}
-        affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 10 }}
-        tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 10 }}
+        nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 10 }}
+        affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 10 }}
+        tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 10 }}
 {{- include "kibana.imagePullSecrets" . | indent 8 }}
         containers:
         - name: kibana-default-index

--- a/charts/kibana/templates/kibana-default-index-cronjob.yaml
+++ b/charts/kibana/templates/kibana-default-index-cronjob.yaml
@@ -32,9 +32,9 @@ spec:
           sidecar.istio.io/inject: "false"
         {{- end }}
       spec:
-        nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 10 }}
-        affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 10 }}
-        tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 10 }}
+        nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 12 }}
+        affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 12 }}
+        tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 12 }}
 {{- include "kibana.imagePullSecrets" . | indent 8 }}
         containers:
         - name: kibana-default-index

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -82,12 +82,9 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-jetstream-sa
-      nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
-      affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
-      tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
 {{- include "nats.imagePullSecrets" . | indent 6 }}
       containers:
       - name: jetstream-template-fixer

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -82,6 +82,12 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-jetstream-sa
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
 {{- include "nats.imagePullSecrets" . | indent 6 }}
       containers:
       - name: jetstream-template-fixer

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -34,12 +34,9 @@ spec:
         {{ $key | replace "-" "_" }}: {{ $value | quote }}
         {{- end }}
     spec:
-      nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
-      affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
-      tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "pgbouncer.ServiceAccount" . }}
       containers:

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -35,11 +35,11 @@ spec:
         {{- end }}
     spec:
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "pgbouncer.ServiceAccount" . }}
       containers:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -29,18 +29,12 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-    {{- if .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
-    {{- if .Values.affinity }}
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-    {{- end }}
-    {{- if .Values.tolerations }}
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 6 }}
-    {{- end }}
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
 {{- include "prometheus-blackbox-exporter.imagePullSecrets" . | indent 6 }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- if .Values.priorityClassName }}

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -29,12 +29,9 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
         {{- end }}
     spec:
-      nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
-      affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
-      tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
 {{- include "prometheus-blackbox-exporter.imagePullSecrets" . | indent 6 }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- if .Values.priorityClassName }}

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -37,12 +37,9 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
-      nodeSelector:
-{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
-      affinity:
-{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
-      tolerations:
-{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
 {{- include "prometheus-postgres-exporter.imagePullSecrets" . | indent 6 }}
       containers:

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:
+      nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
+      tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
 {{- include "prometheus-postgres-exporter.imagePullSecrets" . | indent 6 }}
       containers:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,6 +10,33 @@ metadata = yaml.safe_load((Path(git_root_dir) / "metadata.yaml").read_text())
 supported_k8s_versions = [".".join(x.split(".")[:-1] + ["0"]) for x in metadata["test_k8s_versions"]]
 k8s_version_too_old = f'1.{int(supported_k8s_versions[0].split(".")[1]) - 1!s}.0'
 k8s_version_too_new = f'1.{int(supported_k8s_versions[-1].split(".")[1]) + 1!s}.0'
+global_platform_node_pool_config = {
+    "nodeSelector": {"role": "astro"},
+    "affinity": {
+        "nodeAffinity": {
+            "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [
+                    {
+                        "matchExpressions": [
+                            {
+                                "key": "astronomer.io/multi-tenant",
+                                "operator": "In",
+                                "values": ["false"],
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "tolerations": [
+        {
+            "effect": "NoSchedule",
+            "key": "astronomer",
+            "operator": "Exists",
+        }
+    ],
+}
 
 
 def get_containers_by_name(doc, *, include_init_containers=False) -> dict:

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -531,9 +531,10 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 1 * * *"
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["affinity"] == {}
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"] == []
+        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
@@ -598,10 +599,11 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 45 * * *"
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["nodeSelector"]["role"] == "astroelasticsearch"
-        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["affinity"]) == 1
-        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"] == values["elasticsearch"]["tolerations"]
+        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"]["role"] == "astroelasticsearch"
+        assert len(spec["affinity"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["elasticsearch"]["tolerations"]
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -542,7 +542,7 @@ class TestElasticSearch:
         assert c_by_name["curator"]["securityContext"] == {}
 
     def test_elasticsearch_curator_cronjob_overrides(self, kube_version):
-        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
+        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config overrides."""
         values = {
             "elasticsearch": {
                 "curator": {

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -559,7 +559,6 @@ class TestElasticSearch:
             show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
         )
         assert len(docs) == 1
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 45 * * *"
@@ -570,6 +569,7 @@ class TestElasticSearch:
             docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]
             == values["global"]["platformNodePool"]["tolerations"]
         )
+        c_by_name = get_cronjob_containerspec_by_name(docs[0])
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -519,7 +519,7 @@ class TestElasticSearch:
         assert "https://release-name-elasticsearch:9200" in LS["elasticsearch"]["client"]["hosts"]
 
     def test_elasticsearch_curator_cronjob_defaults(self, kube_version):
-        """Test ElasticSearch Curator cron job with defaults"""
+        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
         docs = render_chart(
             kube_version=kube_version,
             values={},
@@ -540,7 +540,7 @@ class TestElasticSearch:
         assert c_by_name["curator"]["securityContext"] == {}
 
     def test_elasticsearch_curator_cronjob_overrides(self, kube_version):
-        """Test ElasticSearch Curator cron job with defaults"""
+        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
         values = {
             "elasticsearch": {
                 "curator": {
@@ -595,6 +595,61 @@ class TestElasticSearch:
             docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]
             == values["global"]["platformNodePool"]["tolerations"]
         )
+        assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
+        assert c_by_name["curator"]["args"] == [
+            "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
+        ]
+        assert c_by_name["curator"]["securityContext"] == {"runAsNonRoot": True}
+
+    def test_elasticsearch_curator_cronjob_subchart_overrides(self, kube_version):
+        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
+        values = {
+            "elasticsearch": {
+                "curator": {
+                    "schedule": "0 45 * * *",
+                    "securityContext": {"runAsNonRoot": True},
+                },
+                "nodeSelector": {"role": "astroelasticsearch"},
+                "affinity": {
+                    "nodeAffinity": {
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "nodeSelectorTerms": [
+                                {
+                                    "matchExpressions": [
+                                        {
+                                            "key": "astronomer.io/multi-tenant",
+                                            "operator": "In",
+                                            "values": ["false"],
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                "tolerations": [
+                    {
+                        "effect": "NoSchedule",
+                        "key": "astronomer",
+                        "operator": "Exists",
+                    }
+                ],
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        assert docs[0]["kind"] == "CronJob"
+        assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
+        assert docs[0]["spec"]["schedule"] == "0 45 * * *"
+        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["nodeSelector"]["role"] == "astroelasticsearch"
+        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["affinity"]) == 1
+        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]) > 0
+        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"] == values["elasticsearch"]["tolerations"]
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -562,13 +562,11 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 45 * * *"
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["nodeSelector"]["role"] == "astro"
-        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["affinity"]) == 1
-        assert len(docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert (
-            docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["tolerations"]
-            == values["global"]["platformNodePool"]["tolerations"]
-        )
+        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"]["role"] == "astro"
+        assert len(spec["affinity"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
         c_by_name = get_cronjob_containerspec_by_name(docs[0])
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -578,37 +578,16 @@ class TestElasticSearch:
 
     def test_elasticsearch_curator_cronjob_subchart_overrides(self, kube_version):
         """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
+        global_platform_node_pool_config["nodeSelector"] = {"role": "astroelasticsearch"}
         values = {
             "elasticsearch": {
                 "curator": {
                     "schedule": "0 45 * * *",
                     "securityContext": {"runAsNonRoot": True},
                 },
-                "nodeSelector": {"role": "astroelasticsearch"},
-                "affinity": {
-                    "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
-                                    "matchExpressions": [
-                                        {
-                                            "key": "astronomer.io/multi-tenant",
-                                            "operator": "In",
-                                            "values": ["false"],
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                },
-                "tolerations": [
-                    {
-                        "effect": "NoSchedule",
-                        "key": "astronomer",
-                        "operator": "Exists",
-                    }
-                ],
+                "nodeSelector": global_platform_node_pool_config["nodeSelector"],
+                "affinity": global_platform_node_pool_config["affinity"],
+                "tolerations": global_platform_node_pool_config["tolerations"],
             },
         }
         docs = render_chart(

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -576,7 +576,7 @@ class TestElasticSearch:
         assert c_by_name["curator"]["securityContext"] == {"runAsNonRoot": True}
 
     def test_elasticsearch_curator_cronjob_subchart_overrides(self, kube_version):
-        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config defaults"""
+        """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config overrides."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astroelasticsearch"}
         values = {
             "elasticsearch": {

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -4,6 +4,7 @@ from tests import (
     get_containers_by_name,
     get_cronjob_containerspec_by_name,
     supported_k8s_versions,
+    global_platform_node_pool_config,
 )
 from tests.chart_tests.helm_template_generator import render_chart
 
@@ -549,33 +550,7 @@ class TestElasticSearch:
                 }
             },
             "global": {
-                "platformNodePool": {
-                    "nodeSelector": {"role": "astro"},
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": [
-                                            {
-                                                "key": "astronomer.io/multi-tenant",
-                                                "operator": "In",
-                                                "values": ["false"],
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "astronomer",
-                            "operator": "Exists",
-                        }
-                    ],
-                },
+                "platformNodePool": global_platform_node_pool_config,
             },
         }
         docs = render_chart(

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -625,6 +625,7 @@ class TestExternalElasticSearch:
     def test_external_elasticsearch_nginx_deployment_with_subchart_overrides(self, kube_version):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,
         and tolerations with global config and nginx defaults"""
+        global_platform_node_pool_config["nodeSelector"] = {"role": "astroesproxy"}
         values = {
             "global": {
                 "customLogging": {
@@ -633,33 +634,7 @@ class TestExternalElasticSearch:
                     "host": "esdemo.example.com",
                 },
             },
-            "external-es-proxy": {
-                "nodeSelector": {"role": "astroesproxy"},
-                "affinity": {
-                    "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
-                                    "matchExpressions": [
-                                        {
-                                            "key": "astronomer.io/multi-tenant",
-                                            "operator": "In",
-                                            "values": ["false"],
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                },
-                "tolerations": [
-                    {
-                        "effect": "NoSchedule",
-                        "key": "astronomer",
-                        "operator": "Exists",
-                    }
-                ],
-            },
+            "external-es-proxy": global_platform_node_pool_config,
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -624,7 +624,7 @@ class TestExternalElasticSearch:
 
     def test_external_elasticsearch_nginx_deployment_with_subchart_overrides(self, kube_version):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,
-        and tolerations with global config and nginx defaults"""
+        and tolerations with global config and nginx overrides."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astroesproxy"}
         values = {
             "global": {

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -617,10 +617,10 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 1
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
     def test_external_elasticsearch_nginx_deployment_with_subchart_overrides(self, kube_version):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -597,7 +597,7 @@ class TestExternalElasticSearch:
 
     def test_external_elasticsearch_nginx_deployment_global_platformnodepool_overrides(self, kube_version):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,
-        and tolerations with global config and nginx defaults"""
+        and tolerations with global config and nginx overrides."""
         values = {
             "global": {
                 "platformNodePool": global_platform_node_pool_config,

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -645,7 +645,7 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 1
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["external-es-proxy"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["external-es-proxy"]["tolerations"]

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -590,10 +590,10 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 1
-        doc = docs[0]
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_external_elasticsearch_nginx_deployment_global_platformnodepool_overrides(self, kube_version):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_fluentd.py
+++ b/tests/chart_tests/test_fluentd.py
@@ -311,8 +311,9 @@ class TestFluentd:
         assert len(docs) == 1
         doc = docs[0]
         self.fluentd_common_tests(doc)
-        assert "priorityClassName" in doc["spec"]["template"]["spec"]
-        assert "fluentd-priority-pod" == doc["spec"]["template"]["spec"]["priorityClassName"]
+        spec = doc["spec"]["template"]["spec"]
+        assert "priorityClassName" in spec
+        assert "fluentd-priority-pod" == spec["priorityClassName"]
 
     def test_fluentd_with_custom_env(self, kube_version):
         """Test to validate fluentd extraEnv configured."""

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -54,11 +54,11 @@ class TestKibana:
             ],
         )
         common_kibana_cronjob_test(docs)
-        doc = docs[0]
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
-        assert "fluentd.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["spec"]["affinity"] == {}
+        assert spec["spec"]["tolerations"] == []
+        assert "fluentd.*" in spec["containers"][0]["command"][2]
 
     def test_kibana_index_defaults_with_global_overrides(self, kube_version):
         """Test that kibana index cronjobs renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import supported_k8s_versions, get_containers_by_name
+from tests import supported_k8s_versions, get_containers_by_name, global_platform_node_pool_config
 from tests.chart_tests.helm_template_generator import render_chart
 
 
@@ -65,33 +65,7 @@ class TestKibana:
         and tolerations with global config and index defaults."""
         values = {
             "global": {
-                "platformNodePool": {
-                    "nodeSelector": {"role": "astro"},
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": [
-                                            {
-                                                "key": "astronomer.io/multi-tenant",
-                                                "operator": "In",
-                                                "values": ["false"],
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "astronomer",
-                            "operator": "Exists",
-                        }
-                    ],
-                },
+                "platformNodePool": global_platform_node_pool_config,
             },
         }
         docs = render_chart(

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -96,13 +96,13 @@ class TestKibana:
             ],
         )
         common_kibana_cronjob_test(docs)
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["affinity"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        doc["spec"]["template"]["spec"]["nodeSelector"] == "astrokibana"
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["kibana"]["tolerations"]
-        assert "fluentd.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["affinity"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["nodeSelector"] == "astrokibana"
+        assert spec["tolerations"] == values["kibana"]["tolerations"]
+        assert "fluentd.*" in docs[0]["spec"]["template"]["spec"]["containers"][0]["command"][2]
 
     def test_kibana_index_with_logging_sidecar(self, kube_version):
         """Test kibana Service with logging sidecar index."""

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -76,12 +76,12 @@ class TestKibana:
             ],
         )
         common_kibana_cronjob_test(docs)
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
-        assert "fluentd.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
+        assert "fluentd.*" in spec["containers"][0]["command"][2]
 
     def test_kibana_index_defaults_with_subchart_overrides(self, kube_version):
         """Test that kibana index cronjobs renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -166,8 +166,7 @@ class TestKibana:
             ],
         )
         common_kibana_cronjob_test(docs)
-        doc = docs[0]
-        assert {"runAsNonRoot": True, "runAsUser": 1000} == doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]
+        assert {"runAsNonRoot": True, "runAsUser": 1000} == docs[0]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
 
     def test_kibana_index_securitycontext_with_openshiftEnabled(self, kube_version):
         """Test kibana Service with index defaults."""
@@ -179,5 +178,4 @@ class TestKibana:
             ],
         )
         common_kibana_cronjob_test(docs)
-        doc = docs[0]
-        assert {"runAsNonRoot": True} == doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]
+        assert {"runAsNonRoot": True} == docs[0]["spec"]["template"]["spec"]["containers"][0]["securityContext"]

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -86,35 +86,8 @@ class TestKibana:
     def test_kibana_index_defaults_with_subchart_overrides(self, kube_version):
         """Test that kibana index cronjobs renders proper nodeSelector, affinity,
         and tolerations with global config and index defaults."""
-        values = {
-            "kibana": {
-                "nodeSelector": {"role": "astrokibana"},
-                "affinity": {
-                    "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
-                                    "matchExpressions": [
-                                        {
-                                            "key": "astronomer.io/multi-tenant",
-                                            "operator": "In",
-                                            "values": ["false"],
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                },
-                "tolerations": [
-                    {
-                        "effect": "NoSchedule",
-                        "key": "astronomer",
-                        "operator": "Exists",
-                    }
-                ],
-            }
-        }
+        global_platform_node_pool_config["nodeSelector"] = {"role": "astrokibana"}
+        values = {"kibana": global_platform_node_pool_config}
         docs = render_chart(
             kube_version=kube_version,
             values=values,

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -55,6 +55,9 @@ class TestKibana:
         )
         common_kibana_cronjob_test(docs)
         doc = docs[0]
+        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
+        assert doc["spec"]["template"]["spec"]["affinity"] == {}
+        assert doc["spec"]["template"]["spec"]["tolerations"] == []
         assert "fluentd.*" in doc["spec"]["template"]["spec"]["containers"][0]["command"][2]
 
     def test_kibana_index_with_logging_sidecar(self, kube_version):

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -56,8 +56,8 @@ class TestKibana:
         common_kibana_cronjob_test(docs)
         spec = docs[0]["spec"]["template"]["spec"]
         assert spec["nodeSelector"] == {}
-        assert spec["spec"]["affinity"] == {}
-        assert spec["spec"]["tolerations"] == []
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
         assert "fluentd.*" in spec["containers"][0]["command"][2]
 
     def test_kibana_index_defaults_with_global_overrides(self, kube_version):

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -100,7 +100,7 @@ class TestKibana:
         assert len(spec["nodeSelector"]) == 1
         assert len(spec["affinity"]) == 1
         assert len(spec["tolerations"]) > 0
-        assert spec["nodeSelector"] == "astrokibana"
+        assert spec["nodeSelector"] == values["kibana"]["nodeSelector"]
         assert spec["tolerations"] == values["kibana"]["tolerations"]
         assert "fluentd.*" in docs[0]["spec"]["template"]["spec"]["containers"][0]["command"][2]
 

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -68,6 +68,9 @@ class TestNatsJetstream:
                 "keyFile": f"{jetStreamCertPrefix}-client/tls.key",
             },
         }
+        assert docs[7]["spec"]["template"]["spec"]["nodeSelector"] == {}
+        assert docs[7]["spec"]["template"]["spec"]["affinity"] == {}
+        assert docs[7]["spec"]["template"]["spec"]["tolerations"] == []
 
         assert {
             "name": "release-name-jetstream-tls-certificate-client-volume",

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -33,7 +33,7 @@ class TestNatsJetstream:
         assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
-        """Test Nats with jetstream config."""
+        """Test jetstream config with nodeSelector, affinity, and tolerations defaults."""
         values = {
             "global": {"nats": {"jetStream": {"enabled": True, "tls": True}}},
             "nats": {"nats": {"createJetStreamJob": True}},

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -37,9 +37,10 @@ class TestNatsStatefulSet:
             "timeoutSeconds": 5,
         }
 
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
+        spec = doc["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_nats_statefulset_with_metrics_and_resources(self, kube_version):
         """Test that nats statefulset renders good metrics exporter."""

--- a/tests/chart_tests/test_privateca.py
+++ b/tests/chart_tests/test_privateca.py
@@ -98,5 +98,7 @@ class TestPrivateCaDaemonset:
         assert len(docs) == 1
         doc = docs[0]
         self.common_tests_daemonset(doc)
-        assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == 1
-        assert doc["spec"]["template"]["spec"]["containers"][0]["image"] == "snarks:boojums"
+        spec = doc["spec"]["template"]["spec"]
+        
+        assert len(spec["containers"]) == 1
+        assert spec["containers"][0]["image"] == "snarks:boojums"

--- a/tests/chart_tests/test_privateca.py
+++ b/tests/chart_tests/test_privateca.py
@@ -99,6 +99,6 @@ class TestPrivateCaDaemonset:
         doc = docs[0]
         self.common_tests_daemonset(doc)
         spec = doc["spec"]["template"]["spec"]
-        
+
         assert len(spec["containers"]) == 1
         assert spec["containers"][0]["image"] == "snarks:boojums"

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -80,8 +80,7 @@ class TestPrometheusBlackBoxExporterDeployment:
         )
 
         common_blackbox_exporter_tests(docs)
-        doc = docs[0]
-        c_by_name = get_containers_by_name(doc)
+        c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["blackbox-exporter"].get("resources") == {
             "limits": {"cpu": "777m", "memory": "999Mi"},
             "requests": {"cpu": "666m", "memory": "888Mi"},
@@ -96,8 +95,7 @@ class TestPrometheusBlackBoxExporterDeployment:
             show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
         )
         common_blackbox_exporter_tests(docs)
-        doc = docs[0]
-        c_by_name = get_containers_by_name(doc)
+        c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["blackbox-exporter"]["securityContext"] == {
             "allowPrivilegeEscalation": False,
             "capabilities": {"drop": ["ALL"]},
@@ -139,5 +137,5 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert len(spec["nodeSelector"]) == 1
         assert len(spec["affinity"]) == 1
         assert len(spec["tolerations"]) > 0
-        spec["nodeSelector"] == values["prometheus-blackbox-exporter"]["nodeSelector"]
+        assert spec["nodeSelector"] == values["prometheus-blackbox-exporter"]["nodeSelector"]
         assert spec["tolerations"] == values["prometheus-blackbox-exporter"]["tolerations"]

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -129,9 +129,7 @@ class TestPrometheusBlackBoxExporterDeployment:
         """Test that blackbox exporter renders proper nodeSelector, affinity,
         and tolerations with sunchart overrides"""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astro-prometheus-blackbox-exporter"}
-        values = {
-            "prometheus-blackbox-exporter": global_platform_node_pool_config
-        }
+        values = {"prometheus-blackbox-exporter": global_platform_node_pool_config}
         docs = render_chart(
             kube_version=kube_version,
             values=values,

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -49,9 +49,6 @@ class TestPrometheusBlackBoxExporterDeployment:
 
         common_blackbox_exporter_tests(docs)
         doc = docs[0]
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
 
         c_by_name = get_containers_by_name(doc)
         assert c_by_name["blackbox-exporter"]["resources"] == {
@@ -64,6 +61,10 @@ class TestPrometheusBlackBoxExporterDeployment:
             "runAsNonRoot": True,
             "capabilities": {"drop": ["ALL"]},
         }
+        spec = doc["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_prometheus_blackbox_exporter_deployment_custom_resources(self, kube_version):
         docs = render_chart(

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -139,5 +139,5 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert len(spec["nodeSelector"]) == 1
         assert len(spec["affinity"]) == 1
         assert len(spec["tolerations"]) > 0
-        spec["nodeSelector"] == "astro-prometheus-blackbox-exporter"
+        spec["nodeSelector"] == values["prometheus-blackbox-exporter"]["nodeSelector"]
         assert spec["tolerations"] == values["prometheus-blackbox-exporter"]["tolerations"]

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -128,34 +128,9 @@ class TestPrometheusBlackBoxExporterDeployment:
     def test_prometheus_blackbox_exporter_defaults_with_subchart_overrides(self, kube_version):
         """Test that blackbox exporter renders proper nodeSelector, affinity,
         and tolerations with sunchart overrides"""
+        global_platform_node_pool_config["nodeSelector"] = {"role": "astro-prometheus-blackbox-exporter"}
         values = {
-            "prometheus-blackbox-exporter": {
-                "nodeSelector": {"role": "astro-prometheus-blackbox-exporter"},
-                "affinity": {
-                    "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
-                                    "matchExpressions": [
-                                        {
-                                            "key": "astronomer.io/multi-tenant",
-                                            "operator": "In",
-                                            "values": ["false"],
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                },
-                "tolerations": [
-                    {
-                        "effect": "NoSchedule",
-                        "key": "astronomer",
-                        "operator": "Exists",
-                    }
-                ],
-            }
+            "prometheus-blackbox-exporter": global_platform_node_pool_config
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -135,9 +135,9 @@ class TestPrometheusBlackBoxExporterDeployment:
             values=values,
             show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
         )
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["affinity"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        doc["spec"]["template"]["spec"]["nodeSelector"] == "astro-prometheus-blackbox-exporter"
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["prometheus-blackbox-exporter"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["affinity"]) == 1
+        assert len(spec["tolerations"]) > 0
+        spec["nodeSelector"] == "astro-prometheus-blackbox-exporter"
+        assert spec["tolerations"] == values["prometheus-blackbox-exporter"]["tolerations"]

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -120,10 +120,10 @@ class TestPrometheusBlackBoxExporterDeployment:
             show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
         )
         common_blackbox_exporter_tests(docs)
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
     def test_prometheus_blackbox_exporter_defaults_with_subchart_overrides(self, kube_version):
         """Test that blackbox exporter renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -92,5 +92,5 @@ class TestPrometheusPostgresExporter:
         assert len(spec["nodeSelector"]) == 1
         assert len(spec["affinity"]) == 1
         assert len(spec["tolerations"]) > 0
-        spec["nodeSelector"] == values["prometheus-postgres-exporter"]["nodeSelector"]
+        assert spec["nodeSelector"] == values["prometheus-postgres-exporter"]["nodeSelector"]
         assert spec["tolerations"] == values["prometheus-postgres-exporter"]["tolerations"]

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -67,10 +67,10 @@ class TestPrometheusPostgresExporter:
             show_only=["charts/prometheus-blackbox-exporter/templates/deployment.yaml"],
         )
         assert len(docs) == 1
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["tolerations"]) > 0
+        assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
     def test_prometheus_postgres_exporter_defaults_with_subchart_overrides(self, kube_version):
         """Test that postgres exporter renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -75,35 +75,11 @@ class TestPrometheusPostgresExporter:
     def test_prometheus_postgres_exporter_defaults_with_subchart_overrides(self, kube_version):
         """Test that postgres exporter renders proper nodeSelector, affinity,
         and tolerations with subchart overrides."""
+
+        global_platform_node_pool_config["nodeSelector"] = {"role": "astro-prometheus-postgres-exporter"}
         values = {
             "global": {"prometheusPostgresExporterEnabled": True},
-            "prometheus-postgres-exporter": {
-                "nodeSelector": {"role": "astro-prometheus-postgres-exporter"},
-                "affinity": {
-                    "nodeAffinity": {
-                        "requiredDuringSchedulingIgnoredDuringExecution": {
-                            "nodeSelectorTerms": [
-                                {
-                                    "matchExpressions": [
-                                        {
-                                            "key": "astronomer.io/multi-tenant",
-                                            "operator": "In",
-                                            "values": ["false"],
-                                        }
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                },
-                "tolerations": [
-                    {
-                        "effect": "NoSchedule",
-                        "key": "astronomer",
-                        "operator": "Exists",
-                    }
-                ],
-            },
+            "prometheus-postgres-exporter": global_platform_node_pool_config,
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -48,9 +48,10 @@ class TestPrometheusPostgresExporter:
             "requests": {"cpu": "10m", "memory": "128Mi"},
         }
         assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {"runAsNonRoot": True}
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
+        spec = docs[1]["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_prometheus_postgres_exporter_with_global_platform_nodepool(self, kube_version):
         """Test that postgres exporter renders proper nodeSelector, affinity,

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -87,9 +87,9 @@ class TestPrometheusPostgresExporter:
             show_only=["charts/prometheus-postgres-exporter/templates/deployment.yaml"],
         )
         assert len(docs) == 1
-        doc = docs[0]
-        assert len(doc["spec"]["template"]["spec"]["nodeSelector"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["affinity"]) == 1
-        assert len(doc["spec"]["template"]["spec"]["tolerations"]) > 0
-        doc["spec"]["template"]["spec"]["nodeSelector"] == "astro-prometheus-postgres-exporter"
-        assert doc["spec"]["template"]["spec"]["tolerations"] == values["prometheus-postgres-exporter"]["tolerations"]
+        spec = docs[0]["spec"]["template"]["spec"]
+        assert len(spec["nodeSelector"]) == 1
+        assert len(spec["affinity"]) == 1
+        assert len(spec["tolerations"]) > 0
+        spec["nodeSelector"] == values["prometheus-postgres-exporter"]["nodeSelector"]
+        assert spec["tolerations"] == values["prometheus-postgres-exporter"]["tolerations"]

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -120,33 +120,7 @@ class TestStanStatefulSet:
         and tolerations with global config."""
         values = {
             "global": {
-                "platformNodePool": {
-                    "nodeSelector": {"role": "astro"},
-                    "affinity": {
-                        "nodeAffinity": {
-                            "requiredDuringSchedulingIgnoredDuringExecution": {
-                                "nodeSelectorTerms": [
-                                    {
-                                        "matchExpressions": [
-                                            {
-                                                "key": "astronomer.io/multi-tenant",
-                                                "operator": "In",
-                                                "values": ["false"],
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        }
-                    },
-                    "tolerations": [
-                        {
-                            "effect": "NoSchedule",
-                            "key": "astronomer",
-                            "operator": "Exists",
-                        }
-                    ],
-                },
+                "platformNodePool": global_platform_node_pool_config,
             }
         }
         docs = render_chart(

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -37,9 +37,10 @@ class TestStanStatefulSet:
         }
 
         assert all(c["securityContext"] == {"runAsNonRoot": True} for c in c_by_name.values())
-        assert doc["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert doc["spec"]["template"]["spec"]["affinity"] == {}
-        assert doc["spec"]["template"]["spec"]["tolerations"] == []
+        spec = doc["spec"]["template"]["spec"]
+        assert spec["nodeSelector"] == {}
+        assert spec["affinity"] == {}
+        assert spec["tolerations"] == []
 
     def test_stan_statefulset_with_security_context_overrides(self, kube_version):
         """Test that stan statefulset renders good metrics exporter."""


### PR DESCRIPTION
## Description

Add scheduling support for kibana index job and jetstream job

## Related Issues

- https://github.com/astronomer/issues/issues/6676
- https://github.com/astronomer/issues/issues/6684
- https://github.com/astronomer/astronomer/issues/2319

## Testing

QA should able to define nodeselector, tolleration, affinity for these pods 

## Merging

cherry-pick to all valid releases
