### PR TITLE
update houston 0.35.17 and dag server 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.35.11
+                - quay.io/astronomer/ap-houston-api:0.35.17
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -401,7 +401,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.35.11
+                - quay.io/astronomer/ap-houston-api:0.35.17
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.35.11
+    tag: 0.35.17
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/values.yaml
+++ b/values.yaml
@@ -127,7 +127,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.5.4
+    tag: 0.6.0
     securityContext:
       fsGroup: 50000
     resources: {}


### PR DESCRIPTION
## Description

update houston 0.35.17 and dag server 0.6.0

## Related Issues

Related https://github.com/astronomer/issues/issues/6674
Related https://github.com/astronomer/issues/issues/6437
Related https://github.com/astronomer/issues/issues/6419

## Testing

QA should able to validate above tagged issues

## Merging

cherry-pick to release-0.35
