### PR TITLE
add authSidecar resources to houston configmap

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -103,7 +103,7 @@ data:
       {{- end }}
       {{ end }}
 
-      {{- if .Values.global.authSidecar.enabled }}
+            {{- if .Values.global.authSidecar.enabled }}
       # enables nginx auth sidecar for airflow deployments
       {{- $authSidecar := include "authSidecar.image" . }}
       authSideCar:
@@ -114,6 +114,23 @@ data:
         pullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
         {{- if .Values.global.authSidecar.securityContext}}
         securityContext: {{- .Values.global.authSidecar.securityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.authSidecar.resources }}
+        resources:
+          limits:
+            {{- if .Values.global.authSidecar.resources.limits.cpu }}
+            cpu: {{ .Values.global.authSidecar.resources.limits.cpu }}
+            {{- end }}
+            {{- if .Values.global.authSidecar.resources.limits.memory }}
+            memory: {{ .Values.global.authSidecar.resources.limits.memory }}
+            {{- end }}
+          requests:
+            {{- if .Values.global.authSidecar.resources.requests.cpu }}
+            cpu: {{ .Values.global.authSidecar.resources.requests.cpu }}
+            {{- end }}
+            {{- if .Values.global.authSidecar.resources.requests.memory }}
+            memory: {{ .Values.global.authSidecar.resources.requests.memory }}
+            {{- end }}
         {{- end }}
         annotations: {
           {{- range $key, $value := .Values.global.extraAnnotations}}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -115,23 +115,7 @@ data:
         {{- if .Values.global.authSidecar.securityContext}}
         securityContext: {{- .Values.global.authSidecar.securityContext | toYaml | nindent 10 }}
         {{- end }}
-        {{- if .Values.global.authSidecar.resources }}
-        resources:
-          limits:
-            {{- if .Values.global.authSidecar.resources.limits.cpu }}
-            cpu: {{ .Values.global.authSidecar.resources.limits.cpu }}
-            {{- end }}
-            {{- if .Values.global.authSidecar.resources.limits.memory }}
-            memory: {{ .Values.global.authSidecar.resources.limits.memory }}
-            {{- end }}
-          requests:
-            {{- if .Values.global.authSidecar.resources.requests.cpu }}
-            cpu: {{ .Values.global.authSidecar.resources.requests.cpu }}
-            {{- end }}
-            {{- if .Values.global.authSidecar.resources.requests.memory }}
-            memory: {{ .Values.global.authSidecar.resources.requests.memory }}
-            {{- end }}
-        {{- end }}
+        resources: {{- .Values.global.authSidecar.resources | toYaml | nindent 10 }}
         annotations: {
           {{- range $key, $value := .Values.global.extraAnnotations}}
           {{ $key }}: {{ $value | quote }},

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -103,7 +103,7 @@ data:
       {{- end }}
       {{ end }}
 
-            {{- if .Values.global.authSidecar.enabled }}
+      {{- if .Values.global.authSidecar.enabled }}
       # enables nginx auth sidecar for airflow deployments
       {{- $authSidecar := include "authSidecar.image" . }}
       authSideCar:

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -53,30 +53,21 @@ class TestAuthSidecar:
 
         assert "NetworkPolicy" == docs[3]["kind"]
         assert [{"port": 8084, "protocol": "TCP"}] == jmespath.search("spec.ingress[*].ports[1]", docs[3])
-    
+
     def test_authSidecar_houston_with_custom_resources(self, kube_version):
         """Test custom resources are applied on Houston"""
         docs = render_chart(
             kube_version=kube_version,
-            values = {
+            values={
                 "global": {
                     "authSidecar": {
-                    "enabled": True,
-                    "repository": "someregistry.io/my-custom-image",
-                    "tag": "my-custom-tag",
-                    "resources": {
-                        "limits": {
-                            "cpu": "500m",
-                            "memory": "256Mi"
-                                },
-                        "requests": {
-                        "cpu": "200m",
-                        "memory": "128Mi"
-                        }
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}, "requests": {"cpu": "200m", "memory": "128Mi"}},
                     }
                 }
-            }
-        },
+            },
             show_only=[
                 "charts/astronomer/templates/houston/houston-configmap.yaml",
             ],

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -56,6 +56,10 @@ class TestAuthSidecar:
 
     def test_authSidecar_houston_with_custom_resources(self, kube_version):
         """Test custom resources are applied on Houston"""
+        custom_resources = {
+        "limits": {"cpu": "999m", "memory": "888Mi"},
+        "requests": {"cpu": "777m", "memory": "666Mi"},
+    }
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -64,7 +68,7 @@ class TestAuthSidecar:
                         "enabled": True,
                         "repository": "someregistry.io/my-custom-image",
                         "tag": "my-custom-tag",
-                        "resources": {"limits": {"cpu": "999m", "memory": "888Mi"}, "requests": {"cpu": "777m", "memory": "666Mi"}},
+                        "resources": custom_resources,
                     }
                 }
             },
@@ -83,7 +87,7 @@ class TestAuthSidecar:
             "port": 8084,
             "pullPolicy": "IfNotPresent",
             "annotations": {},
-            "resources": {"limits": {"cpu": "999m", "memory": "888Mi"}, "requests": {"cpu": "777m", "memory": "666Mi"}},
+            "resources": custom_resources,
         }
 
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -224,8 +224,7 @@ class TestAuthSidecar:
             "securityContext": {
                 "runAsUser": 1000,
             },
-            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"},
-               "requests": {"cpu": "500m", "memory": "512Mi"}},
+            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -64,7 +64,7 @@ class TestAuthSidecar:
                         "enabled": True,
                         "repository": "someregistry.io/my-custom-image",
                         "tag": "my-custom-tag",
-                        "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}, "requests": {"cpu": "200m", "memory": "128Mi"}},
+                        "resources": {"limits": {"cpu": "999m", "memory": "888Mi"}, "requests": {"cpu": "777m", "memory": "666Mi"}},
                     }
                 }
             },
@@ -83,7 +83,7 @@ class TestAuthSidecar:
             "port": 8084,
             "pullPolicy": "IfNotPresent",
             "annotations": {},
-            "resources": {"limits": {"cpu": "500m", "memory": "256Mi"}, "requests": {"cpu": "200m", "memory": "128Mi"}},
+            "resources": {"limits": {"cpu": "999m", "memory": "888Mi"}, "requests": {"cpu": "777m", "memory": "666Mi"}},
         }
 
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -14,7 +14,9 @@ def common_houston_config_test_cases(docs):
     assert doc["apiVersion"] == "v1"
     assert doc["metadata"]["name"] == "release-name-houston-config"
 
+
 default_resource = {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}}
+
 
 @pytest.mark.parametrize(
     "kube_version",

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -224,6 +224,8 @@ class TestAuthSidecar:
             "securityContext": {
                 "runAsUser": 1000,
             },
+            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"},
+               "requests": {"cpu": "500m", "memory": "512Mi"}},
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -14,13 +14,13 @@ def common_houston_config_test_cases(docs):
     assert doc["apiVersion"] == "v1"
     assert doc["metadata"]["name"] == "release-name-houston-config"
 
+default_resource = {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}}
 
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
 )
 class TestAuthSidecar:
-    default_resource = {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}}
 
     def test_authSidecar_alertmanager(self, kube_version):
         """Test Alertmanager Service with authSidecar."""
@@ -192,7 +192,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
-            "resources": self.default_resource,
+            "resources": default_resource,
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]
@@ -228,7 +228,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
-            "resources": self.default_resource,
+            "resources": default_resource,
             "annotations": {
                 "kubernetes.io/ingress.class": "astronomer-nginx",
                 "nginx.ingress.kubernetes.io/proxy-body-size": "1024m",
@@ -266,7 +266,7 @@ class TestAuthSidecar:
             "securityContext": {
                 "runAsUser": 1000,
             },
-            "resources": self.default_resource,
+            "resources": default_resource,
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -152,6 +152,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
+            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]
@@ -187,6 +188,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
+            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
             "annotations": {
                 "kubernetes.io/ingress.class": "astronomer-nginx",
                 "nginx.ingress.kubernetes.io/proxy-body-size": "1024m",

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -20,6 +20,8 @@ def common_houston_config_test_cases(docs):
     supported_k8s_versions,
 )
 class TestAuthSidecar:
+    default_resource = {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}}
+
     def test_authSidecar_alertmanager(self, kube_version):
         """Test Alertmanager Service with authSidecar."""
         docs = render_chart(
@@ -190,7 +192,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
-            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
+            "resources": self.default_resource,
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]
@@ -226,7 +228,7 @@ class TestAuthSidecar:
             "tag": "my-custom-tag",
             "port": 8084,
             "pullPolicy": "IfNotPresent",
-            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
+            "resources": self.default_resource,
             "annotations": {
                 "kubernetes.io/ingress.class": "astronomer-nginx",
                 "nginx.ingress.kubernetes.io/proxy-body-size": "1024m",
@@ -264,7 +266,7 @@ class TestAuthSidecar:
             "securityContext": {
                 "runAsUser": 1000,
             },
-            "resources": {"limits": {"cpu": "1000m", "memory": "1024Mi"}, "requests": {"cpu": "500m", "memory": "512Mi"}},
+            "resources": self.default_resource,
             "annotations": {},
         }
         assert expected_output == prod["deployments"]["authSideCar"]

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -57,9 +57,9 @@ class TestAuthSidecar:
     def test_authSidecar_houston_with_custom_resources(self, kube_version):
         """Test custom resources are applied on Houston"""
         custom_resources = {
-        "limits": {"cpu": "999m", "memory": "888Mi"},
-        "requests": {"cpu": "777m", "memory": "666Mi"},
-    }
+            "limits": {"cpu": "999m", "memory": "888Mi"},
+            "requests": {"cpu": "777m", "memory": "666Mi"},
+        }
         docs = render_chart(
             kube_version=kube_version,
             values={


### PR DESCRIPTION
## Description

This PR intends to add auth sidecar resource requests and limits to the Houston config map so that customers can add resource requests and limits from global.authsidecar values. 

## What was observed:

1. Currently when authsidecar is enabled:

```
shubhamsingh@Shubhams-MacBook-Pro astro % helm -n astronomer get values astronomer | grep authSidecar: -A2
  authSidecar:
    enabled: true
```
2. The auth-proxy does get applied with authproxy sidecar container:

```
shubhamsingh@Shubhams-MacBook-Pro astro % kubectl get pods -n "$NS" -o json |
  jq -r '.items[] | .metadata.name as $podname | .spec.containers[] | "\($podname) \(.name)"' |
  column -t | grep auth
nuclear-cosmology-7338-flower-69bfb888-rwgsg       auth-proxy
nuclear-cosmology-7338-webserver-7b47fb994d-kvrh2  auth-proxy
```

3. But the limit and requests are not same:
a. in astronomer namespace it is:
```
Limits:
      cpu:     900m
      memory:  1Gi
    Requests:
      cpu:        550m
      memory:     520Mi
```
b. while in the deployment it seems to be:
```
Limits:
      cpu:     100m
      memory:  384Mi
    Requests:
      cpu:        100m
      memory:     384Mi
```

## Related Issues

Related astronomer/issues#6665

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Needs to be merged to 0.34.5, 0.35.5, 0.36.0
