### PR TITLE
dag-deploy 0.6.1

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -127,7 +127,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.6.0
+    tag: 0.6.1
     securityContext:
       fsGroup: 50000
     resources: {}


### PR DESCRIPTION
## Description

Bump dag-deploy from 0.6.0 to 0.6.1

## Related Issues

https://github.com/astronomer/issues/issues/6674

## Testing

Need to test the canDeployDags behaviors

## Merging

Merge only into 0.35, 0.36