### PR TITLE
update commander version 0.35.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.26
-                - quay.io/astronomer/ap-commander:0.35.7
+                - quay.io/astronomer/ap-commander:0.35.8
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.7
@@ -403,7 +403,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.26
-                - quay.io/astronomer/ap-commander:0.35.7
+                - quay.io/astronomer/ap-commander:0.35.8
                 - quay.io/astronomer/ap-configmap-reloader:0.13.1
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.35.7

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.35.7
+    tag: 0.35.8
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander version 0.35.8

## Related Issues

https://github.com/astronomer/issues/issues/6696
https://github.com/astronomer/issues/issues/6693

## Testing

QA need to verify above issues 

## Merging

cherry-pick to release-0.35
