### PR TITLE
Added rbac condition for porometheus-postgres

### DIFF
--- a/charts/postgresql/templates/serviceaccount.yaml
+++ b/charts/postgresql/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.rbacEnabled }}
 {{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/postgresql/templates/serviceaccount.yaml
+++ b/charts/postgresql/templates/serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.global.rbacEnabled }}
-{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
+{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/postgresql/templates/serviceaccount.yaml
+++ b/charts/postgresql/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) .Values.global.rbacEnabled }}
+{{- if and (.Values.serviceAccount.enabled) (not .Values.serviceAccount.name) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/prometheus-postgres-exporter/templates/role.yaml
+++ b/charts/prometheus-postgres-exporter/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create }}
+{{- if and .Values.rbac.create .Values.global.rbacEnabled }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: Role
 metadata:

--- a/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.global.rbacEnabled -}}
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: RoleBinding
 metadata:

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.global.rbacEnabled }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.global.rbacEnabled }}
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
+{{- if .Values.global.rbacEnabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Description

This PR intends to add BYO SA condition to prometheus-postgres-exporter.

## Related Issues

Related astronomer/issues#6704

## Testing

Upon setting global. rbacEnabled to False., kubectl get as should show only default SA created by k8s namespace. 

## Merging

Needs to be cherry picked to 0.36.0
