### PR TITLE
disable kibana telemetry by default

### DIFF
--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -34,6 +34,9 @@ env:
   # XPACK_ML_ENABLED: "false"
   # XPACK_REPORTING_ENABLED: "false"
   # XPACK_SECURITY_ENABLED: "false"
+  TELEMETRY_ALLOW_CHANING_OPT_IN_STATUS: "false"
+  TELEMETRY_OPT_IN: "false"
+  TELEMETRY_ENABLED: "false"
 
 serviceType: ClusterIP
 

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -37,12 +37,11 @@ class TestKibana:
             "requests": {"cpu": "250m", "memory": "512Mi"},
         }
 
-        assert {
-            "name": "SERVER_PUBLICBASEURL",
-            "value": "https://kibana.example.com",
-        } in c_by_name[
-            "kibana"
-        ]["env"]
+        env_vars = {x["name"]: x["value"] for x in c_by_name["kibana"]["env"]}
+        assert env_vars["SERVER_PUBLICBASEURL"] == "https://kibana.example.com"
+        assert env_vars["TELEMETRY_ALLOW_CHANING_OPT_IN_STATUS"] == "false"
+        assert env_vars["TELEMETRY_OPT_IN"] == "false"
+        assert env_vars["TELEMETRY_ENABLED"] == "false"
 
     def test_kibana_index_defaults(self, kube_version):
         """Test kibana Service with index defaults."""


### PR DESCRIPTION
## Description

This PR disables kibana telemetry data collection setting by default

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related https://github.com/astronomer/issues/issues/6706

## Testing

before this option

<img width="1747" alt="image" src="https://github.com/user-attachments/assets/d295d2c9-4d51-4e4b-9ce4-b9ee96dce99f">


after this option
<img width="1632" alt="image" src="https://github.com/user-attachments/assets/15e13929-9e47-441c-88df-4e26e3984bf6">



## Merging

cherry-pick to all valid releases
