### PR TITLE
Adding CAPABILITY_DROP to nginx component

### DIFF
--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -19,6 +19,10 @@ images:
 securityContext:
   runAsUser: 101
   runAsNonRoot: true
+  capabilities:
+    drop:
+      - ALL
+  allowPrivilegeEscalation: false
 
 serviceAccount:
   # Specifies whether a service account should be created

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -285,7 +285,6 @@ class TestNginx:
                     "runAsNonRoot": True,
                     "capabilities": {
                         "drop": ["ALL"],
-                        # Add the capability NET_BIND_SERVICE if needed
                         "add": ["NET_BIND_SERVICE"],
                     },
                     "allowPrivilegeEscalation": False,

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -211,8 +211,6 @@ class TestNginx:
             values={},
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
         )[0]
-
-        security_context = doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]
         expected_security_context = {
             "runAsUser": 101,
             "runAsNonRoot": True,
@@ -227,14 +225,13 @@ class TestNginx:
         disableLeaderElection = "--disable-leader-election"
 
         c_by_name = get_containers_by_name(doc)
-
-        assert security_context == expected_security_context
         assert doc["spec"]["minReadySeconds"] == 0
         assert electionId in c_by_name["nginx"]["args"]
         assert electionTTL not in c_by_name["nginx"]["args"]
         assert topologyAwareRouting not in c_by_name["nginx"]["args"]
         assert annotationValidation not in c_by_name["nginx"]["args"]
         assert disableLeaderElection not in c_by_name["nginx"]["args"]
+        assert expected_security_context == c_by_name["nginx"]["securityContext"]
 
     def test_nginx_min_ready_seconds_overrides(self):
         minReadySeconds = 300
@@ -293,7 +290,6 @@ class TestNginx:
             values=values,
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
         )[0]
-        security_context = doc["spec"]["template"]["spec"]["containers"][0]["securityContext"]
         expected_security_context = {
             "runAsUser": 101,
             "runAsNonRoot": True,
@@ -301,4 +297,5 @@ class TestNginx:
             "allowPrivilegeEscalation": False,
         }
 
-        assert security_context == expected_security_context
+        c_by_name = get_containers_by_name(doc)
+        assert expected_security_context == c_by_name["nginx"]["securityContext"]

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -199,6 +199,7 @@ class TestNginx:
         assert annotationValidation in doc["spec"]["template"]["spec"]["containers"][0]["args"]
 
     def test_nginx_backend_serviceaccount_defaults(self):
+        """Test nginx ingress deployment service account defaults."""
         doc = render_chart(
             values={},
             show_only=["charts/nginx/templates/nginx-default-backend-serviceaccount.yaml"],
@@ -207,6 +208,7 @@ class TestNginx:
         assert "release-name-nginx-default-backend" == doc["metadata"]["name"]
 
     def test_nginx_defaults(self):
+        """Test nginx ingress deployment template defaults."""
         doc = render_chart(
             values={},
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
@@ -234,6 +236,7 @@ class TestNginx:
         assert expected_security_context == c_by_name["nginx"]["securityContext"]
 
     def test_nginx_min_ready_seconds_overrides(self):
+        """Test nginx ingress deployment template with min ready seconds overrides."""
         minReadySeconds = 300
         doc = render_chart(
             values={"nginx": {"minReadySeconds": minReadySeconds}},
@@ -243,6 +246,7 @@ class TestNginx:
         assert doc["spec"]["minReadySeconds"] == minReadySeconds
 
     def test_nginx_election_ttl_overrides(self):
+        """Test nginx ingress deployment template with election ttl overrides."""
         doc = render_chart(
             values={"nginx": {"electionTTL": "30s"}},
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
@@ -252,6 +256,7 @@ class TestNginx:
         assert electionTTL in c_by_name["nginx"]["args"]
 
     def test_nginx_topology_aware_routing_overrides(self):
+        """Test nginx ingress deployment template with topology aware routing overrides."""
         doc = render_chart(
             values={"nginx": {"enableTopologyAwareRouting": True}},
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
@@ -261,6 +266,7 @@ class TestNginx:
         assert topologyAwareRouting in c_by_name["nginx"]["args"]
 
     def test_nginx_disable_leader_election_overrides(self):
+        """Test nginx ingress deployment template with leader election overrides."""
         doc = render_chart(
             values={"nginx": {"disableLeaderElection": True}},
             show_only=["charts/nginx/templates/nginx-deployment.yaml"],
@@ -270,6 +276,7 @@ class TestNginx:
         assert disableLeaderElection in c_by_name["nginx"]["args"]
 
     def test_nginx_security_context_overrides(self):
+        """Test nginx ingress deployment template with security context overrides."""
 
         values = {
             "nginx": {


### PR DESCRIPTION
## Description

This PR intends to add the ability for ingress-nginx to run with the CAPABILITY_DROP ALL option

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6672

## Testing

QA needs to verify that correct security context is added to nginx and with CAPABILITY_DROP option nginx is stable.
Original security context:
```
pod: astronomer-nginx-75ffb7c956-4lp4b
    PodSecurity Context is not set
    
    container name: nginx
    image: quay.io/astronomer/ap-nginx:1.11.2                                      
        allowPrivilegeEscalation: <no value>   
        privileged: <no value>                               
        readOnlyRootFilesystem: <no value>       
        runAsGroup: <no value>                               
        runAsNonRoot: true                           
        runAsUser: 101
```

## Merging

Cherry pick to 0.36.0
