### PR TITLE
adding commander ns conditions

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -41,9 +41,11 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+{{- if $namespacepoolsRBACresources}}
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]
+{{- end }}
 - apiGroups: [""]
   resources: ["serviceaccounts"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -96,6 +96,8 @@ class TestAstronomerCommander:
                 "namespace": "default",
             }
         ]
+
+        assert (cluster_role["rules"][2]["resources"][0]) != "namespaces"
         assert cluster_role_binding["kind"] == "ClusterRoleBinding"
         assert cluster_role_binding["roleRef"] == expected_role_ref
         assert cluster_role_binding["subjects"] == expected_subjects
@@ -367,11 +369,16 @@ class TestAstronomerCommander:
                     }
                 },
             },
-            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
+            show_only=[
+                "charts/astronomer/templates/commander/commander-deployment.yaml",
+                "charts/astronomer/templates/commander/commander-role.yaml",
+            ],
         )
 
-        assert len(docs) == 1
+        assert len(docs) == 2
         doc = docs[0]
+        cluster_role = docs[1]
+        assert (cluster_role["rules"][2]["resources"][0]) == "namespaces"
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-commander"


### PR DESCRIPTION
## Description

This PR intends to put condition around commander's namespace permissions. 

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6582

## Testing

Commander should not be able to do any namespace related operations when .Values.global.features.namespacePools.createRbac is set to false 

## Merging

cherry pick to 0.35, 0.36
