### PR TITLE
Turn global_platform_node_pool_config into a fixture

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -10,33 +10,6 @@ metadata = yaml.safe_load((Path(git_root_dir) / "metadata.yaml").read_text())
 supported_k8s_versions = [".".join(x.split(".")[:-1] + ["0"]) for x in metadata["test_k8s_versions"]]
 k8s_version_too_old = f'1.{int(supported_k8s_versions[0].split(".")[1]) - 1!s}.0'
 k8s_version_too_new = f'1.{int(supported_k8s_versions[-1].split(".")[1]) + 1!s}.0'
-global_platform_node_pool_config = {
-    "nodeSelector": {"role": "astro"},
-    "affinity": {
-        "nodeAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [
-                    {
-                        "matchExpressions": [
-                            {
-                                "key": "astronomer.io/multi-tenant",
-                                "operator": "In",
-                                "values": ["false"],
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    },
-    "tolerations": [
-        {
-            "effect": "NoSchedule",
-            "key": "astronomer",
-            "operator": "Exists",
-        }
-    ],
-}
 
 
 def get_containers_by_name(doc, *, include_init_containers=False) -> dict:

--- a/tests/chart_tests/conftest.py
+++ b/tests/chart_tests/conftest.py
@@ -70,3 +70,34 @@ def docker_client():
         client = docker.from_env()
         yield client
         client.close()
+
+
+@pytest.fixture(scope="function")
+def global_platform_node_pool_config():
+    yield {
+        "nodeSelector": {"role": "astro"},
+        "affinity": {
+            "nodeAffinity": {
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                    "nodeSelectorTerms": [
+                        {
+                            "matchExpressions": [
+                                {
+                                    "key": "astronomer.io/multi-tenant",
+                                    "operator": "In",
+                                    "values": ["false"],
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "tolerations": [
+            {
+                "effect": "NoSchedule",
+                "key": "astronomer",
+                "operator": "Exists",
+            }
+        ],
+    }

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -4,7 +4,6 @@ from tests import (
     get_containers_by_name,
     get_cronjob_containerspec_by_name,
     supported_k8s_versions,
-    global_platform_node_pool_config,
 )
 from tests.chart_tests.helm_template_generator import render_chart
 
@@ -541,7 +540,7 @@ class TestElasticSearch:
         ]
         assert c_by_name["curator"]["securityContext"] == {}
 
-    def test_elasticsearch_curator_cronjob_overrides(self, kube_version):
+    def test_elasticsearch_curator_cronjob_overrides(self, kube_version, global_platform_node_pool_config):
         """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config overrides."""
         values = {
             "elasticsearch": {
@@ -575,7 +574,7 @@ class TestElasticSearch:
         ]
         assert c_by_name["curator"]["securityContext"] == {"runAsNonRoot": True}
 
-    def test_elasticsearch_curator_cronjob_subchart_overrides(self, kube_version):
+    def test_elasticsearch_curator_cronjob_subchart_overrides(self, kube_version, global_platform_node_pool_config):
         """Test ElasticSearch Curator cron job with nodeSelector, affinity, tolerations and config overrides."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astroelasticsearch"}
         values = {

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -5,7 +5,7 @@ import pytest
 import yaml
 import pathlib
 
-from tests import get_containers_by_name, supported_k8s_versions, global_platform_node_pool_config
+from tests import get_containers_by_name, supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
 secret = base64.b64encode(b"sample-secret").decode()
@@ -595,7 +595,9 @@ class TestExternalElasticSearch:
         assert spec["affinity"] == {}
         assert spec["tolerations"] == []
 
-    def test_external_elasticsearch_nginx_deployment_global_platformnodepool_overrides(self, kube_version):
+    def test_external_elasticsearch_nginx_deployment_global_platformnodepool_overrides(
+        self, kube_version, global_platform_node_pool_config
+    ):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,
         and tolerations with global config and nginx overrides."""
         values = {
@@ -622,7 +624,7 @@ class TestExternalElasticSearch:
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
-    def test_external_elasticsearch_nginx_deployment_with_subchart_overrides(self, kube_version):
+    def test_external_elasticsearch_nginx_deployment_with_subchart_overrides(self, kube_version, global_platform_node_pool_config):
         """Test that External ElasticSearch renders proper nodeSelector, affinity,
         and tolerations with global config and nginx overrides."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astroesproxy"}

--- a/tests/chart_tests/test_kibana.py
+++ b/tests/chart_tests/test_kibana.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import supported_k8s_versions, get_containers_by_name, global_platform_node_pool_config
+from tests import supported_k8s_versions, get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 
 
@@ -60,7 +60,7 @@ class TestKibana:
         assert spec["tolerations"] == []
         assert "fluentd.*" in spec["containers"][0]["command"][2]
 
-    def test_kibana_index_defaults_with_global_overrides(self, kube_version):
+    def test_kibana_index_defaults_with_global_overrides(self, kube_version, global_platform_node_pool_config):
         """Test that kibana index cronjobs renders proper nodeSelector, affinity,
         and tolerations with global config and index defaults."""
         values = {
@@ -83,7 +83,7 @@ class TestKibana:
 
         assert "fluentd.*" in spec["containers"][0]["command"][2]
 
-    def test_kibana_index_defaults_with_subchart_overrides(self, kube_version):
+    def test_kibana_index_defaults_with_subchart_overrides(self, kube_version, global_platform_node_pool_config):
         """Test that kibana index cronjobs renders proper nodeSelector, affinity,
         and tolerations with global config and index defaults."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astrokibana"}

--- a/tests/chart_tests/test_prometheus_blackbox_exporter.py
+++ b/tests/chart_tests/test_prometheus_blackbox_exporter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import supported_k8s_versions, get_containers_by_name, global_platform_node_pool_config
+from tests import supported_k8s_versions, get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 
 
@@ -105,7 +105,7 @@ class TestPrometheusBlackBoxExporterDeployment:
             "runAsUser": 1000,
         }
 
-    def test_prometheus_blackbox_exporter_deployment_global_platform_nodepool(self, kube_version):
+    def test_prometheus_blackbox_exporter_deployment_global_platform_nodepool(self, kube_version, global_platform_node_pool_config):
         """Test that blackbox exporter renders proper nodeSelector, affinity,
         and tolerations with global overrides"""
         values = {
@@ -124,7 +124,7 @@ class TestPrometheusBlackBoxExporterDeployment:
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
-    def test_prometheus_blackbox_exporter_defaults_with_subchart_overrides(self, kube_version):
+    def test_prometheus_blackbox_exporter_defaults_with_subchart_overrides(self, kube_version, global_platform_node_pool_config):
         """Test that blackbox exporter renders proper nodeSelector, affinity,
         and tolerations with sunchart overrides"""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astro-prometheus-blackbox-exporter"}

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests import supported_k8s_versions, get_containers_by_name, global_platform_node_pool_config
+from tests import supported_k8s_versions, get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 
 
@@ -53,7 +53,7 @@ class TestPrometheusPostgresExporter:
         assert spec["affinity"] == {}
         assert spec["tolerations"] == []
 
-    def test_prometheus_postgres_exporter_with_global_platform_nodepool(self, kube_version):
+    def test_prometheus_postgres_exporter_with_global_platform_nodepool(self, kube_version, global_platform_node_pool_config):
         """Test that postgres exporter renders proper nodeSelector, affinity,
         and tolerations with global values."""
         values = {
@@ -73,7 +73,7 @@ class TestPrometheusPostgresExporter:
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
-    def test_prometheus_postgres_exporter_defaults_with_subchart_overrides(self, kube_version):
+    def test_prometheus_postgres_exporter_defaults_with_subchart_overrides(self, kube_version, global_platform_node_pool_config):
         """Test that postgres exporter renders proper nodeSelector, affinity,
         and tolerations with subchart overrides."""
 

--- a/tests/chart_tests/test_stan_sts.py
+++ b/tests/chart_tests/test_stan_sts.py
@@ -1,6 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import supported_k8s_versions, get_containers_by_name, global_platform_node_pool_config
+from tests import supported_k8s_versions, get_containers_by_name
 import re
 
 
@@ -89,7 +89,7 @@ class TestStanStatefulSet:
         assert c_by_name["stan"]["resources"]["requests"]["cpu"] == "123m"
         assert c_by_name["metrics"]["resources"]["requests"]["cpu"] == "234m"
 
-    def test_stan_statefulset_with_global_affinity_and_tolerations(self, kube_version):
+    def test_stan_statefulset_with_global_affinity_and_tolerations(self, kube_version, global_platform_node_pool_config):
         """Test that stan statefulset renders proper nodeSelector, affinity,
         and tolerations with global config."""
         values = {
@@ -112,7 +112,7 @@ class TestStanStatefulSet:
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
 
-    def test_stan_statefulset_with_affinity_and_tolerations(self, kube_version):
+    def test_stan_statefulset_with_affinity_and_tolerations(self, kube_version, global_platform_node_pool_config):
         """Test that stan statefulset renders proper nodeSelector, affinity,
         and tolerations."""
         global_platform_node_pool_config["nodeSelector"] = {"role": "astrostan"}


### PR DESCRIPTION
## Description

Turn global_platform_node_pool_config into a fixture to avoid race conditions where global state is modified.

## Related Issues

https://github.com/astronomer/issues/issues/6720

## Testing

I have manually tested this and it has worked 100%. I was skeptical that the original code would work because of the global state change, and by chance I did not trigger the race condition when I tested the original code. The problem is well understood and fixtures are really the right way to do this.

This is only test code changes, no product changes are affected by this, so no further testing is needed. Only `pytest` runs are affected by the bug.

QA does not need to do anything here.

## Merging

The original bug was only merged into 0.36, so this should only go to master and 0.36.