### PR TITLE
Fix typo in  configsyncer service account template

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -147,7 +147,7 @@
 {{- if and .Values.configSyncer.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s-config-syncer" .Release.Name ) .Values.configSyncer.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.commander.serviceAccount.name }}
+    {{ default "default" .Values.configSyncer.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -24,7 +24,7 @@ class TestServiceAccounts:
         docs = [doc for doc in render_chart(kube_version=kube_version, values=values) if doc["kind"] in ["RoleBinding", "Role"]]
         assert not docs
 
-    def test_customSA(self, kube_version):
+    def test_serviceaccount_with_overrides(self, kube_version):
         "Test that if custom SA are added it gets created"
         values = {
             "astronomer": {

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -23,3 +23,29 @@ class TestServiceAccounts:
 
         docs = [doc for doc in render_chart(kube_version=kube_version, values=values) if doc["kind"] in ["RoleBinding", "Role"]]
         assert not docs
+
+    def test_customSA(self, kube_version):
+        "Test that if custom SA are added it gets created"
+        values = {
+            "astronomer": {
+                "commander": {"serviceAccount": {"create": "true", "name": "commander-test"}},
+                "registry": {"serviceAccount": {"create": "true", "name": "registry-test"}},
+                "configSyncer": {"serviceAccount": {"create": "true", "name": "configsyncer-test"}},
+                "houston": {"serviceAccount": {"create": "true", "name": "houston-test"}},
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/astronomer/templates/commander/commander-serviceaccount.yaml",
+                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
+                "charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml",
+                "charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml",
+            ],
+        )
+
+        assert len(docs) == 4
+        expected_names = {"commander-test", "registry-test", "configsyncer-test", "houston-test"}
+        extracted_names = {doc["metadata"]["name"] for doc in docs if "metadata" in doc and "name" in doc["metadata"]}
+        assert expected_names.issubset(extracted_names)


### PR DESCRIPTION
## Description

This PR intends to update the configsyncer SA helper template

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6537

## Testing

Upon creation of custom SA configsyncer pod should be able to pick the correct configsyncer SA. 

## Merging

cherry pick to 0.36
