### PR TITLE
update dag server version 0.6.3

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -129,7 +129,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.6.2
+    tag: 0.6.3
     securityContext:
       fsGroup: 50000
     resources: {}


### PR DESCRIPTION
## Description

update dag server version 0.6.3

## Related Issues

- Parent ticket https://github.com/astronomer/issues/issues/6524
- Related houston issue https://github.com/astronomer/houston-api/pull/1844

## Testing

refer above ticket 

## Merging

chery-pick to release-0.36
