### PR TITLE
update houston api 0.36.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.36.2
+                - quay.io/astronomer/ap-houston-api:0.36.3
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1
@@ -401,7 +401,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
                 - quay.io/astronomer/ap-grafana:10.4.6
-                - quay.io/astronomer/ap-houston-api:0.36.2
+                - quay.io/astronomer/ap-houston-api:0.36.3
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
                 - quay.io/astronomer/ap-kube-state:2.10.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.36.2
+    tag: 0.36.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.36.3

## Related Issues

- Related https://github.com/astronomer/issues/issues/6524
- Related https://github.com/astronomer/dag-deploy/pull/44
- Related https://github.com/astronomer/issues/issues/6712
- Related https://github.com/astronomer/issues/issues/6717
- Relatedhttps://github.com/astronomer/issues/issues/6344

## Testing

QA should validate above issues

## Merging

cherry-pick to release-0.36
