### PR TITLE
add conditional approach for namespace create

### DIFF
--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -101,7 +101,7 @@ spec:
             - name: COMMANDER_AIRGAPPED
               value: "true"
             {{- end }}
-            {{ if .Values.global.features.namespacePools.enabled -}}
+            {{ if and .Values.global.features.namespacePools.enabled ( not .Values.global.features.namespacePools.namespaces.create ) -}}
             - name: COMMANDER_MANUAL_NAMESPACE_NAMES
               value: "true"
             {{- end }}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -5,8 +5,8 @@
 # 1. Do not create any resource if rbacEnabled is disabled
 # 2. Create a Cluster Role if clusterRoles and rbacEnabled are enabled and namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
-{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled}}
-{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
+{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled) }}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -7,7 +7,7 @@
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
 {{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled}}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -5,8 +5,8 @@
 # 1. Do not create anything is rbacEnabled is disabled
 # 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
-{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled}}
-{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled)}}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
+{{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled) }}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
@@ -15,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if $shouldCreateResources}}
+{{- if or (and $shouldCreateResources (not .Values.global.features.namespacePools.enabled) ) (and $namespacepoolsRBACresources .Values.global.rbacEnabled) }}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -7,7 +7,7 @@
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
 {{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled) }}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles $namespacepoolsRBACresources) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
@@ -15,7 +15,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if or (and $shouldCreateResources (not .Values.global.features.namespacePools.enabled) ) (and $namespacepoolsRBACresources .Values.global.rbacEnabled) }}
+{{- if $shouldCreateResources }}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -5,7 +5,7 @@
 # 1. Do not create anything is rbacEnabled is disabled
 # 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
-{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
+{{- $namespacepoolsRBACresources := and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled) }}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -71,7 +71,7 @@ data:
       {{- end }}
     # Airflow deployment configuration
     deployments:
-      {{ if or .Values.global.disableManageClusterScopedResources (and .Values.global.features.namespacePools.enabled ( not .Values.global.features.namespacePools.namespaces.create ))}}
+      {{ if or .Values.global.disableManageClusterScopedResources  .Values.global.features.namespacePools.enabled }}
       disableManageClusterScopedResources: true
       {{ end }}
       fluentdIndexPrefix: {{ include "fluentd.IndexPattern" .}}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -71,7 +71,7 @@ data:
       {{- end }}
     # Airflow deployment configuration
     deployments:
-      {{ if or .Values.global.disableManageClusterScopedResources  .Values.global.features.namespacePools.enabled }}
+      {{ if or .Values.global.disableManageClusterScopedResources .Values.global.features.namespacePools.enabled }}
       disableManageClusterScopedResources: true
       {{ end }}
       fluentdIndexPrefix: {{ include "fluentd.IndexPattern" .}}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -71,9 +71,7 @@ data:
       {{- end }}
     # Airflow deployment configuration
     deployments:
-      {{ if or .Values.global.disableManageClusterScopedResources .Values.global.features.namespacePools.enabled }}
-      disableManageClusterScopedResources: true
-      {{ end }}
+      disableManageClusterScopedResources: {{ default false ( or .Values.global.disableManageClusterScopedResources  .Values.global.features.namespacePools.enabled ) }}
       fluentdIndexPrefix: {{ include "fluentd.IndexPattern" .}}
       enableHoustonInternalAuthorization: {{ include "houston.InternalAuthorization" . }}
       dagOnlyDeployment: {{ .Values.global.dagOnlyDeployment.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -71,7 +71,9 @@ data:
       {{- end }}
     # Airflow deployment configuration
     deployments:
-      disableManageClusterScopedResources: {{ .Values.global.disableManageClusterScopedResources }}
+      {{ if or .Values.global.disableManageClusterScopedResources (and .Values.global.features.namespacePools.enabled ( not .Values.global.features.namespacePools.namespaces.create ))}}
+      disableManageClusterScopedResources: true
+      {{ end }}
       fluentdIndexPrefix: {{ include "fluentd.IndexPattern" .}}
       enableHoustonInternalAuthorization: {{ include "houston.InternalAuthorization" . }}
       dagOnlyDeployment: {{ .Values.global.dagOnlyDeployment.enabled }}

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -139,7 +139,7 @@ class TestAstronomerNamespacePools:
                     "features": {
                         "namespacePools": {
                             "enabled": True,
-                            "namespaces": {"create": True, "names": namespaces},
+                            "namespaces": {"create": False, "names": namespaces},
                         }
                     }
                 }

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -277,4 +277,4 @@ class TestAstronomerNamespacePools:
             ],
         )
 
-        assert len(docs) == 1
+        assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -209,6 +209,7 @@ class TestAstronomerNamespacePools:
         assert deployments_config["deployments"]["hardDeleteDeployment"]
         assert deployments_config["deployments"]["manualNamespaceNames"]
         assert deployments_config["deployments"]["preCreatedNamespaces"] == [{"name": namespace} for namespace in namespaces]
+        assert deployments_config["deployments"]["disableManageClusterScopedResources"] == True
 
         # test configuration when namespacePools is disabled -> should not add configuration parameters
         doc = render_chart(

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -209,7 +209,7 @@ class TestAstronomerNamespacePools:
         assert deployments_config["deployments"]["hardDeleteDeployment"]
         assert deployments_config["deployments"]["manualNamespaceNames"]
         assert deployments_config["deployments"]["preCreatedNamespaces"] == [{"name": namespace} for namespace in namespaces]
-        assert deployments_config["deployments"]["disableManageClusterScopedResources"] == True
+        assert deployments_config["deployments"]["disableManageClusterScopedResources"] is True
 
         # test configuration when namespacePools is disabled -> should not add configuration parameters
         doc = render_chart(
@@ -255,3 +255,26 @@ class TestAstronomerNamespacePools:
 
         expected_rule = f"key $.kubernetes.namespace_name\n    pattern ^({namespaces[0]}|{namespaces[1]})$"
         assert expected_rule in doc["data"]["output.conf"]
+
+    def test_astronomer_namespace_pools_create_rbac_mode_is_disabled(self, kube_version):
+        """Test that commander deployment rbac is generating roles and role binding on namespace pools mode."""
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "features": {
+                        "namespacePools": {
+                            "enabled": True,
+                            "createRbac": False,
+                        }
+                    }
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/commander/commander-role.yaml",
+                "charts/astronomer/templates/commander/commander-rolebinding.yaml",
+            ],
+        )
+
+        assert len(docs) == 1

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -21,7 +21,7 @@ def common_test_cases(docs):
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-    assert prod["deployments"]["disableManageClusterScopedResources"] is False
+    assert "disableManageClusterScopedResources" not in prod["deployments"]
     assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
     airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -21,7 +21,7 @@ def common_test_cases(docs):
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-    assert "disableManageClusterScopedResources" not in prod["deployments"]
+    assert prod["deployments"]["disableManageClusterScopedResources"] is False
     assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
     airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]


### PR DESCRIPTION
## Description

This change introduces more granular config for namespace pools to optionate namespace creation and management , additionally when namespace management is disabled it will switch to configmap based labelling query in houston.

## Related Issues

with existing approach  when namespace pools  create set to true namespace will be auto created with roles with subsequent deloyment approach the status indicator will be broken showing status indicating deploying....

this change will fix these behaviours
Related https://github.com/astronomer/issues/issues/6582

## Testing
QA should able to verify global.features.namespacePools.enabled: true and global.features.namespacePools.createRbac: true/false changes

## Merging

cherry-pick to release-0.36
