### PR TITLE
extend rbac create for namespace pools

### DIFF
--- a/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
@@ -6,7 +6,9 @@
 # 2. Create a Cluster Role if namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
 {{- if .Values.configSyncer.enabled }}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled (not .Values.global.features.namespacePools.enabled)}}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
@@ -14,7 +16,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}''
 
-{{- if .Values.global.rbacEnabled }}
+{{- if $shouldCreateResources -}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
@@ -6,15 +6,17 @@
 # 2. Create ClusterRoleBinding if namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
 {{- if .Values.configSyncer.enabled }}
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled (not .Values.global.features.namespacePools.enabled)}}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- if $useClusterRoles }}
   {{- $namespaces = list .Release.Namespace}}
 {{- else }}
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- if .Values.global.rbacEnabled -}}
+{{- if $shouldCreateResources -}}
 {{- range $i, $namespaceName := $namespaces -}}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/kube-state/templates/kube-state-role.yaml
+++ b/charts/kube-state/templates/kube-state-role.yaml
@@ -1,9 +1,10 @@
 #################################
 ## Kube State Role/ClusterRole ##
 #################################
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useRoles := or .Values.global.features.namespacePools.enabled .Values.global.singleNamespace }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not $useRoles )}}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- if $shouldCreateResources }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}

--- a/charts/kube-state/templates/kube-state-rolebinding.yaml
+++ b/charts/kube-state/templates/kube-state-rolebinding.yaml
@@ -1,9 +1,10 @@
 ###############################################
 ## Kube State ClusterRoleBinding/RoleBinding ##
 ###############################################
+{{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useRoles := or .Values.global.features.namespacePools.enabled .Values.global.singleNamespace }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled .Values.global.clusterRoles (not $useRoles )}}
-{{- $shouldCreateResources := and .Values.global.rbacEnabled (or .Values.global.clusterRoles .Values.global.features.namespacePools.enabled) }}
+{{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}
 {{- if $shouldCreateResources }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- if $useClusterRoles }}

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -274,6 +274,10 @@ class TestAstronomerNamespacePools:
             show_only=[
                 "charts/astronomer/templates/commander/commander-role.yaml",
                 "charts/astronomer/templates/commander/commander-rolebinding.yaml",
+                "charts/kube-state/templates/kube-state-rolebinding.yaml",
+                "charts/kube-state/templates/kube-state-role.yaml",
+                "charts/astronomer/templates/config-syncer/config-syncer-role.yaml",
+                "charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml"
             ],
         )
 

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -277,7 +277,7 @@ class TestAstronomerNamespacePools:
                 "charts/kube-state/templates/kube-state-rolebinding.yaml",
                 "charts/kube-state/templates/kube-state-role.yaml",
                 "charts/astronomer/templates/config-syncer/config-syncer-role.yaml",
-                "charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml"
+                "charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml",
             ],
         )
 


### PR DESCRIPTION
## Description

This feature provisions service account with no roles for kube state, config syncer when rbacCreate is set to false with  namespace pools 

## Related Issues

https://github.com/astronomer/issues/issues/6731

## Testing

QA should not see any roles for these platform services when namespace pools is enabled with createRbac flag set to false

## Merging

cherry-pick to release-0.36
