### PR TITLE
update dag server security context default format

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -455,11 +455,11 @@ tlsEnabled: false
 {{ default (printf "%s-jetstream-tls-certificate" .Release.Name)}}
 {{- end }}
 
-{{- define "dagOnlyDeployment.securityContext" -}}
-{{- if or (eq ( toString ( .Values.global.dagOnlyDeployment.securityContext.fsGroup )) "auto") ( .Values.global.openshiftEnabled )  }}
-{{- omit  .Values.global.dagOnlyDeployment.securityContext "fsGroup" | toYaml | nindent 10 }}
+{{- define "dagOnlyDeployment.securityContexts" -}}
+{{- if or (eq ( toString ( .Values.global.dagOnlyDeployment.securityContexts.pod.fsGroup )) "auto") ( .Values.global.openshiftEnabled )  }}
+{{- omit  .Values.global.dagOnlyDeployment.securityContexts.pod "fsGroup" | toYaml | nindent 10 }}
 {{- else }}
-{{- .Values.global.dagOnlyDeployment.securityContext | toYaml | nindent 10 }}
+{{- .Values.global.dagOnlyDeployment.securityContexts | toYaml | nindent 10 }}
 {{- end -}}
 {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -163,8 +163,8 @@ data:
           dagServer:
             repository: {{ (splitList ":"  $dagOnlyDeployment ) | first  }}
             tag: {{ (splitList ":"  $dagOnlyDeployment ) | last  }}
-        {{- if .Values.global.dagOnlyDeployment.securityContext }}
-        securityContext: {{ template "dagOnlyDeployment.securityContext" . }}
+        {{- if .Values.global.dagOnlyDeployment.securityContexts }}
+        securityContexts: {{ template "dagOnlyDeployment.securityContexts" . }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.resources }}
         server:

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -50,7 +50,7 @@ class TestDagOnlyDeploy:
                         "enabled": True,
                         "repository": images.split(":")[0],
                         "tag": images.split(":")[1],
-                        "securityContext": {"fsGroup": 55555},
+                        "securityContexts": { "pod": { "fsGroup": 55555}},
                         "resources": resources,
                     }
                 }
@@ -69,7 +69,7 @@ class TestDagOnlyDeploy:
                     "tag": "my-custom-tag",
                 }
             },
-            "securityContext": {"fsGroup": 55555},
+            "securityContexts": { "pod": { "fsGroup": 55555}},
             "server": {"resources": resources},
             "client": {"resources": resources},
         }
@@ -128,7 +128,7 @@ class TestDagOnlyDeploy:
                 "global": {
                     "dagOnlyDeployment": {
                         "enabled": True,
-                        "securityContext": {"fsGroup": "auto"},
+                        "securityContexts": { "pod": { "fsGroup": "auto"}},
                     },
                 }
             },
@@ -139,7 +139,7 @@ class TestDagOnlyDeploy:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
 
-        assert {} == prod["deployments"]["dagDeploy"]["securityContext"]
+        assert {} == prod["deployments"]["dagDeploy"]["securityContexts"]
 
     def test_dagonlydeploy_config_enabled_with_persistence_retain(self, kube_version):
         """Test dagonlydeploy to validate persistence policy retain."""

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -50,7 +50,9 @@ class TestDagOnlyDeploy:
                         "enabled": True,
                         "repository": images.split(":")[0],
                         "tag": images.split(":")[1],
-                        "securityContexts": { "pod": { "fsGroup": 55555}},
+                        "securityContexts": {
+                            "pod":        { "fsGroup": 55555},
+                            "container" : {"runAsUser": 12345}},
                         "resources": resources,
                     }
                 }
@@ -69,7 +71,9 @@ class TestDagOnlyDeploy:
                     "tag": "my-custom-tag",
                 }
             },
-            "securityContexts": { "pod": { "fsGroup": 55555}},
+            "securityContexts": {
+                "pod":        { "fsGroup": 55555},
+                "container" : {"runAsUser": 12345}},
             "server": {"resources": resources},
             "client": {"resources": resources},
         }

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -118,7 +118,7 @@ class TestDagOnlyDeploy:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["dagOnlyDeployment"] is True
 
-        assert {} == prod["deployments"]["dagDeploy"]["securityContext"]
+        assert {} == prod["deployments"]["dagDeploy"]["securityContexts"]
 
     def test_dagonlydeploy_config_enabled_with_fsGroup_auto(self, kube_version):
         """Test dagonlydeploy with auto to validate fsGroup removal."""

--- a/values.yaml
+++ b/values.yaml
@@ -130,8 +130,9 @@ global:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
     tag: 0.6.3
-    securityContext:
-      fsGroup: 50000
+    securityContexts:
+      pod:
+        fsGroup: 50000
     resources: {}
     persistence: {}
 


### PR DESCRIPTION
## Description

This PR intends to update dag server security contexts default format to allow usage of security contexts with separate pod and container capabilities. 

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6729

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

0.36
