### PR TITLE
Update Grafana package from 10.4.6 to 10.4.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.6
+                - quay.io/astronomer/ap-grafana:10.4.10
                 - quay.io/astronomer/ap-houston-api:0.36.5
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
@@ -402,7 +402,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.6
+                - quay.io/astronomer/ap-grafana:10.4.10
                 - quay.io/astronomer/ap-houston-api:0.36.5
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.6
+    tag: 10.4.10
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update missing vendor packages
| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-grafana | 10.4.6 | 10.4.10 |

## Related Issues


## Testing

QA should be able to access the Grafana UI, without any issues. 

## Merging

cherry-pick to release-0.36
