### PR TITLE
allow prometheus to disable rbac independently

### DIFF
--- a/charts/prometheus/templates/prometheus-role.yaml
+++ b/charts/prometheus/templates/prometheus-role.yaml
@@ -2,7 +2,7 @@
 ## Prometheus ClusterRole ##
 ############################
 {{- $singleNamespace := .Values.global.singleNamespace }}
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.global.rbacEnabled .Values.serviceAccount.create }}
 kind: {{ if $singleNamespace }}Role{{ else }}ClusterRole{{ end }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:

--- a/charts/prometheus/templates/prometheus-rolebinding.yaml
+++ b/charts/prometheus/templates/prometheus-rolebinding.yaml
@@ -2,7 +2,7 @@
 ## Prometheus Cluster Role Binding ##
 #####################################
 {{- $singleNamespace := .Values.global.singleNamespace }}
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.global.rbacEnabled .Values.serviceAccount.create }}
 kind: {{ if $singleNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:

--- a/charts/prometheus/templates/prometheus-serviceaccount.yaml
+++ b/charts/prometheus/templates/prometheus-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Prometheus Service Account ##
 ################################
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.global.rbacEnabled .Values.serviceAccount.create }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -34,8 +34,11 @@ resources: {}
 #   memory: 128Mi
 
 serviceAccount:
-  create: true
-  name: ~
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ~
 
 livenessProbe: {}
   # httpGet:

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -101,3 +101,23 @@ class TestPrometheusStatefulset:
 
         assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
         assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+
+
+    def test_prometheus_service_account_overrides(self, kube_version):
+        """Test the prometheus do not render service account and rbac when global rbac is true and prometheus service account create is false."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "prometheus": {
+                    "serviceAccount": {
+                        "create": False,
+                    },
+                },
+            },
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml",
+                       "charts/prometheus/templates/prometheus-role.yaml",
+                       "charts/prometheus/templates/prometheus-rolebinding.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "default" in docs[0]["spec"]["template"]["spec"]["serviceAccountName"]


### PR DESCRIPTION
## Description

Allow prometheus to indepently disable rbac and service account when global.rbacEnabled is set to true 

## Related Issues

- https://github.com/astronomer/issues/issues/6537
- https://github.com/astronomer/issues/issues/6742

## Testing

QA should able to disable prometheus service account and rbac below config
```
prometheus:
  serviceAccount:
      create: false 
      name: platform-prometheus
```
## Merging

NA
