### PR TITLE
Refactor nginx CSP

### DIFF
--- a/charts/nginx/templates/nginx-headers-configmap.yaml
+++ b/charts/nginx/templates/nginx-headers-configmap.yaml
@@ -11,8 +11,16 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  # Policy was generated using https://report-uri.com/home/generate
-  Content-Security-Policy: "default-src 'self' *.{{ .Values.global.baseDomain }}; script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net cdn.astronomer.io cdn.metarouter.io cdn.segment.com www.google-analytics.com js.stripe.com widget.intercom.io js.intercomcdn.com cdn.lr-ingest.io; img-src 'self' data: *; connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} e.metarouter.io api.segment.com api.segment.io api-iam.intercom.io wss://nexus-websocket-a.intercom.io https://grafana.com/blog/news.xml; style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net fonts.googleapis.com; frame-src js.stripe.com; font-src *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.gstatic.com js.intercomcdn.com data:; worker-src blob:"
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
+  Content-Security-Policy: >-
+    default-src 'self' *.{{ .Values.global.baseDomain }} ;
+    connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} ;
+    font-src *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.gstatic.com data: ;
+    frame-src 'self' ;
+    img-src 'self' data: * ;
+    script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.astronomer.io ;
+    style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} fonts.googleapis.com ;
+    worker-src blob: ;
   Referrer-Policy: "same-origin"
   X-Frame-Options: "deny"
   X-XSS-Protection: "1; mode=block"

--- a/charts/nginx/templates/nginx-headers-configmap.yaml
+++ b/charts/nginx/templates/nginx-headers-configmap.yaml
@@ -19,7 +19,7 @@ data:
     frame-src 'self' ;
     img-src 'self' data: * ;
     script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.astronomer.io ;
-    style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} fonts.googleapis.com ;
+    style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} ;
     worker-src blob: ;
   Referrer-Policy: "same-origin"
   X-Frame-Options: "deny"


### PR DESCRIPTION
## Description

Refactor Nginx CSP:
- remove third party entries: jsdeliver, stripe, segment, metarouter, intercom, lr-ingest, grafana.com
- Reformat yaml as folded strip block style https://yaml-multiline.info>

## Related Issues

https://github.com/astronomer/issues/issues/6749

## Testing

I have not tested this. I also don't know a good way to write a valuable unit test for this. We will need to manually make sure this does not break anything.

## Merging

Merge everywhere.