### PR TITLE
Fix 6380

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -376,20 +376,21 @@ Return  the proper Storage Class
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+This version prioritizes component-specific registry.persistence.storageClassName over global.storageClass.
 */}}
-{{- if .Values.global.storageClass -}}
-    {{- if (eq "-" .Values.global.storageClass) -}}
+{{- if .Values.registry.persistence.storageClassName -}}
+    {{- if (eq "~" .Values.registry.persistence.storageClassName) -}}
         {{- printf "storageClassName: \"\"" -}}
     {{- else }}
-        {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- printf "storageClassName: %s" .Values.registry.persistence.storageClassName -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.registry.persistence.storageClassName -}}
-          {{- if (eq "~" .Values.registry.persistence.storageClassName) -}}
-              {{- printf "storageClassName: \"\"" -}}
-          {{- else }}
-              {{- printf "storageClassName: %s" .Values.registry.persistence.storageClassName -}}
-          {{- end -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -117,20 +117,21 @@ Return  the proper Storage Class
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+This version prioritizes component-specific common.persistence.storageClassName over global.storageClass.
 */}}
-{{- if .Values.global.storageClass -}}
-    {{- if (eq "-" .Values.global.storageClass) -}}
+{{- if .Values.common.persistence.storageClassName -}}
+    {{- if (eq "-" .Values.common.persistence.storageClassName) -}}
         {{- printf "storageClassName: \"\"" -}}
     {{- else }}
-        {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- printf "storageClassName: %s" .Values.common.persistence.storageClassName -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.common.persistence.storageClassName -}}
-          {{- if (eq "-" .Values.common.persistence.storageClassName) -}}
-              {{- printf "storageClassName: \"\"" -}}
-          {{- else }}
-              {{- printf "storageClassName: %s" .Values.common.persistence.storageClassName -}}
-          {{- end -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/postgresql/templates/_helpers.tpl
+++ b/charts/postgresql/templates/_helpers.tpl
@@ -303,30 +303,21 @@ Return  the proper Storage Class
 {{- define "postgresql.storageClass" -}}
 {{/*
 Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+but Helm 2.9 and 2.10 do not support it, so we need to implement this if-else logic.
+This version prioritizes component-specific persistence.storageClass over global.storageClass.
 */}}
-{{- if .Values.global -}}
+{{- if .Values.persistence.storageClass -}}
+    {{- if (eq "-" .Values.persistence.storageClass) -}}
+        {{- printf "storageClassName: \"\"" -}}
+    {{- else }}
+        {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
+    {{- end -}}
+{{- else -}}
     {{- if .Values.global.storageClass -}}
         {{- if (eq "-" .Values.global.storageClass) -}}
             {{- printf "storageClassName: \"\"" -}}
         {{- else }}
             {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
-    {{- else -}}
-        {{- if .Values.persistence.storageClass -}}
-              {{- if (eq "-" .Values.persistence.storageClass) -}}
-                  {{- printf "storageClassName: \"\"" -}}
-              {{- else }}
-                  {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
-              {{- end -}}
-        {{- end -}}
-    {{- end -}}
-{{- else -}}
-    {{- if .Values.persistence.storageClass -}}
-        {{- if (eq "-" .Values.persistence.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.persistence.storageClass -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -67,18 +67,18 @@ Return  the proper Storage Class
 Refactored logic to prioritize component-specific persistence.storageClassName over global.storageClass
 */}}
 {{- if .Values.persistence.storageClassName -}}
-    {{- if (eq "~" .Values.persistence.storageClassName) -}}
+    {{- if (eq "-" .Values.persistence.storageClassName) -}}
         {{- printf "storageClassName: \"\"" -}}
     {{- else }}
         {{- printf "storageClassName: %s" .Values.persistence.storageClassName -}}
     {{- end -}}
 {{- else -}}
     {{- if .Values.global.storageClass -}}
-        {{- if (eq "-" .Values.global.storageClass) -}}
-            {{- printf "storageClassName: \"\"" -}}
-        {{- else }}
-            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
-        {{- end -}}
+          {{- if (eq "~" .Values.global.storageClass) -}}
+              {{- printf "storageClassName: \"\"" -}}
+          {{- else }}
+              {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+          {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -64,22 +64,21 @@ Return  the proper Storage Class
 */}}
 {{- define "prometheus.storageClass" -}}
 {{/*
-Helm 2.11 supports the assignment of a value to a variable defined in a different scope,
-but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
+Refactored logic to prioritize component-specific persistence.storageClassName over global.storageClass
 */}}
-{{- if .Values.global.storageClass -}}
-    {{- if (eq "-" .Values.global.storageClass) -}}
+{{- if .Values.persistence.storageClassName -}}
+    {{- if (eq "~" .Values.persistence.storageClassName) -}}
         {{- printf "storageClassName: \"\"" -}}
     {{- else }}
-        {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- printf "storageClassName: %s" .Values.persistence.storageClassName -}}
     {{- end -}}
 {{- else -}}
-    {{- if .Values.persistence.storageClassName -}}
-          {{- if (eq "~" .Values.persistence.storageClassName) -}}
-              {{- printf "storageClassName: \"\"" -}}
-          {{- else }}
-              {{- printf "storageClassName: %s" .Values.persistence.storageClassName -}}
-          {{- end -}}
+    {{- if .Values.global.storageClass -}}
+        {{- if (eq "-" .Values.global.storageClass) -}}
+            {{- printf "storageClassName: \"\"" -}}
+        {{- else }}
+            {{- printf "storageClassName: %s" .Values.global.storageClass -}}
+        {{- end -}}
     {{- end -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Description

This PR intends to prioritize component.storageclass over global.storageclass

## Related Issues
https://github.com/astronomer/issues/issues/6380

## Testing

When both global.storageclass and component.storageclass are added, the priority should be component.storageclass, for example:
```
(venv) shubhamsingh@Shubhams-MacBook-Pro astro % helm template astronomer --show-only charts/elasticsearch/templates/master/es-master-statefulset.yaml . --set elasticsearch.common.persistence.storageClassName=gp2 --set global.storageClass=gp1 --debug | grep -i storageclass
install.go:222: [debug] Original chart version: ""
install.go:239: [debug] CHART PATH: /Users/shubhamsingh/Desktop/git/astro

      storageClassName: gp2                    <<<< expected value
(venv) shubhamsingh@Shubhams-MacBook-Pro astro % 

```

## Merging

0.36.1
