### PR TITLE
fix missing csp policies

### DIFF
--- a/charts/nginx/templates/nginx-headers-configmap.yaml
+++ b/charts/nginx/templates/nginx-headers-configmap.yaml
@@ -14,13 +14,13 @@ data:
   # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
   Content-Security-Policy: >-
     default-src 'self' *.{{ .Values.global.baseDomain }} ;
-    connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} ;
+    connect-src *.{{ .Values.global.baseDomain }} wss://*.{{ .Values.global.baseDomain }} cdn.jsdelivr.net ;
     font-src *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.gstatic.com data: ;
     frame-src 'self' ;
     img-src 'self' data: * ;
-    script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.astronomer.io ;
-    style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} ;
-    worker-src blob: ;
+    script-src 'unsafe-inline' 'unsafe-eval' *.{{ .Values.global.baseDomain }} cdn.astronomer.io fonts.googleapis.com cdn.jsdelivr.net ;
+    style-src 'unsafe-inline' *.{{ .Values.global.baseDomain }} cdn.jsdelivr.net fonts.googleapis.com ;
+    worker-src blob: *.{{ .Values.global.baseDomain }} ;
   Referrer-Policy: "same-origin"
   X-Frame-Options: "deny"
   X-XSS-Protection: "1; mode=block"


### PR DESCRIPTION
## Description

currently some of our pages still uses jsdeliver and google fonts within our apps. this change re-adds well known sources required for app to operate normally

## Related Issues

- https://github.com/astronomer/issues/issues/6749
- https://github.com/astronomer/issues/issues/6709

## Screenshots

### Altair IDE
![image (2)](https://github.com/user-attachments/assets/516078e1-a3a5-4bb2-905d-c728ec811b2c)

### GraphQL Playground
![image (1)](https://github.com/user-attachments/assets/1298f0c6-28db-4e10-94ad-645ce519c233)

## Testing
QA should able to view our v1 - playground and v2 playground under console logs with no CSP errors

## Merging

cherry-pick to release-0.36
