### PR TITLE
extend support for service account annotation and service account inclusion

### DIFF
--- a/charts/alertmanager/templates/alertmanager-serviceaccount.yaml
+++ b/charts/alertmanager/templates/alertmanager-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     chart: {{ template "alertmanager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -20,6 +20,8 @@ securityContext:
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/charts/astronomer/templates/astro-ui/astro-ui-serviceaccount.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.astroUI.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/cli-install/cli-install-serviceaccount.yaml
+++ b/charts/astronomer/templates/cli-install/cli-install-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.install.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
@@ -11,8 +11,11 @@ metadata:
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
-  {{ if .Values.global.enableArgoCDAnnotation }}
   annotations:
+  {{- with .Values.houston.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
 {{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -534,6 +534,8 @@ install:
   serviceAccount:
     # Specifies whether a service account should be created
     create: false
+    # Annotations to add to the service account
+    annotations: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""

--- a/charts/elasticsearch/templates/es-serviceaccount.yaml
+++ b/charts/elasticsearch/templates/es-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     chart: {{ template "elasticsearch.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
+  annotations:
+  {{- with .Values.common.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -37,6 +37,8 @@ common:
   serviceAccount:
     # Specifies whether a ServiceAccount should be created
     create: true
+    # Annotations to add to the service account
+    annotations: {}
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ~

--- a/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
+++ b/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-  {{- with .Values.grafana.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
+++ b/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
@@ -11,4 +11,8 @@ metadata:
     chart: {{ template "grafana.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.grafana.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -22,6 +22,8 @@ securityContext:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ~

--- a/charts/kibana/templates/kibana-serviceaccount.yaml
+++ b/charts/kibana/templates/kibana-serviceaccount.yaml
@@ -12,4 +12,6 @@ metadata:
     chart: {{ template "kibana.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+{{ toYaml (.Values.serviceAccount.annotations) | indent 4 }}
 {{- end }}

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -62,6 +62,8 @@ createDefaultIndex: true
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""

--- a/charts/kube-state/templates/kube-state-serviceaccount.yaml
+++ b/charts/kube-state/templates/kube-state-serviceaccount.yaml
@@ -13,7 +13,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-  {{- with .Values.grafana.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/kube-state/templates/kube-state-serviceaccount.yaml
+++ b/charts/kube-state/templates/kube-state-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     chart: {{ template "kube-state.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.grafana.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -46,6 +46,8 @@ priorityClassName: ~
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ~

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -76,3 +76,11 @@ imagePullSecrets:
 {{- .Values.securityContext | toYaml | nindent 10 }}
 {{- end -}}
 {{- end }}
+
+{{ define "nats.ServiceAccount" -}}
+{{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
+{{ default (printf "%s" (include "nats.name" . )) .Values.nats.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.nats.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/nats/templates/nats-serviceaccount.yaml
+++ b/charts/nats/templates/nats-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "nats.ServiceAccount" . }}
+  labels:
+    app: {{ template "nats.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/charts/nats/templates/nats-serviceaccount.yaml
+++ b/charts/nats/templates/nats-serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     app: {{ template "nats.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+  {{- with .Values.nats.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
         component: nats
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
+      serviceAccountName: {{ template "nats.ServiceAccount" . }}
     {{- include "nats.imagePullSecrets" . | nindent 6 }}
 {{- if eq .Values.global.openshiftEnabled false }}
       securityContext: {{ toYaml .Values.podSecurityContext| nindent 8 }}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -24,7 +24,14 @@ nats:
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to
   # gather the public ip from a node.
-  serviceAccount: "nats-server"
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ~
 
   # The number of connect attempts against discovered routes.
   connectRetries: 30

--- a/charts/nginx/templates/nginx-default-backend-serviceaccount.yaml
+++ b/charts/nginx/templates/nginx-default-backend-serviceaccount.yaml
@@ -11,4 +11,8 @@ metadata:
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/nginx/templates/nginx-serviceaccount.yaml
+++ b/charts/nginx/templates/nginx-serviceaccount.yaml
@@ -11,4 +11,8 @@ metadata:
     chart: {{ template "nginx.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+  {{- with .Values.nginx.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/nginx/templates/nginx-serviceaccount.yaml
+++ b/charts/nginx/templates/nginx-serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-  {{- with .Values.nginx.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -27,6 +27,8 @@ securityContext:
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ~

--- a/charts/postgresql/templates/serviceaccount.yaml
+++ b/charts/postgresql/templates/serviceaccount.yaml
@@ -7,8 +7,11 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  {{ if .Values.global.enableArgoCDAnnotation }}
   annotations:
+  {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
   name: {{ template "postgresql.fullname" . }}

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -85,6 +85,8 @@ securityContext:
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 serviceAccount:
   enabled: false
+  # Annotations to add to the service account
+  annotations: {}
   ## Name of an already existing service account. Setting this value disables the automatic service account creation.
   # name:
 

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -51,6 +51,8 @@ resources:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ~

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -36,6 +36,8 @@ rbac:
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -36,6 +36,8 @@ resources: {}
 serviceAccount:
     # Specifies whether a service account should be created
     create: true
+    # Annotations to add to the service account
+    annotations: {}
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ~

--- a/charts/stan/templates/_helpers.tpl
+++ b/charts/stan/templates/_helpers.tpl
@@ -81,3 +81,11 @@ imagePullSecrets:
   - name: {{ .Values.global.privateRegistry.secretName }}
 {{- end -}}
 {{- end -}}
+
+{{ define "stan.ServiceAccount" -}}
+{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled -}}
+{{ default (printf "%s" (include "stan.name" . )) .Values.stan.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.stan.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/stan/templates/natsservicerole.yaml
+++ b/charts/stan/templates/natsservicerole.yaml
@@ -15,10 +15,5 @@ spec:
   permissions:
     publish: [">"]
     subscribe: [">"]
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: nats-streaming
 {{- end }}
 {{- end }}

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "stan.ServiceAccount" . }}
+  labels:
+    app: {{ template "stan.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     app: {{ template "stan.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+  {{- with .Values.stan.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -48,9 +48,7 @@ spec:
         component: stan
         chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     spec:
-      {{- if .Values.stan.nats.serviceRoleAuth.enabled }}
-      serviceAccountName: "nats-streaming"
-      {{- end }}
+      serviceAccountName: {{ template "stan.ServiceAccount" . }}
 {{- include "stan.imagePullSecrets" . | indent 6 }}
 {{- if eq .Values.global.openshiftEnabled false }}
       securityContext: {{ toYaml .Values.podSecurityContext| nindent 8 }}

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -32,6 +32,15 @@ stan:
   #   cpu: 100m
   #   memory: 128Mi
 
+  serviceAccount:
+    # Specifies whether a ServiceAccount should be created
+    create: false
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the ServiceAccount to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ~
+
   livenessProbe: {}
   readinessProbe: {}
 

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -35,6 +35,8 @@ class TestServiceAccounts:
                 "astroUI": {"serviceAccount": {"create": "true", "name": "astroui-test"}},
                 "install": {"serviceAccount": {"create": "true", "name": "cliinstall-test"}},
             },
+            "nats": {"nats": {"serviceAccount": {"create": "true", "name": "nats-test"}}},
+            "stan": {"stan": {"serviceAccount": {"create": "true", "name": "stan-test"}}},
             "grafana": {"serviceAccount": {"create": "true", "name": "grafana-test"}},
             "alertmanager": {"serviceAccount": {"create": "true", "name": "alertmanager-test"}},
             "kibana": {"serviceAccount": {"create": "true", "name": "kibana-test"}},
@@ -49,6 +51,9 @@ class TestServiceAccounts:
                 "charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml",
                 "charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml",
                 "charts/astronomer/templates/astro-ui/astro-ui-serviceaccount.yaml",
+                "charts/astronomer/templates/cli-install/cli-install-serviceaccount.yaml",
+                "charts/nats/templates/nats-serviceaccount.yaml",
+                "charts/stan/templates/stan-serviceaccount.yaml",
                 "charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml",
                 "charts/alertmanager/templates/alertmanager-serviceaccount.yaml",
                 "charts/kibana/templates/kibana-serviceaccount.yaml",
@@ -56,7 +61,7 @@ class TestServiceAccounts:
             ],
         )
 
-        assert len(docs) == 9
+        assert len(docs) == 12
         expected_names = {
             "commander-test",
             "registry-test",

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -20,7 +20,7 @@ class TestHoustonApiDeployment:
         assert len(docs) == 1
         doc = docs[0]
         assert doc["kind"] == "Deployment"
-        assert "annotations" in doc["metadata"]
+        assert "annotations" not in doc["metadata"]
         assert {
             "tier": "astronomer",
             "component": "houston",

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -20,7 +20,7 @@ class TestHoustonApiDeployment:
         assert len(docs) == 1
         doc = docs[0]
         assert doc["kind"] == "Deployment"
-        assert "annotations" not in doc["metadata"]
+        assert "annotations" in doc["metadata"]
         assert {
             "tier": "astronomer",
             "component": "houston",

--- a/tests/chart_tests/test_houston_bootstrap_serviceaccount.py
+++ b/tests/chart_tests/test_houston_bootstrap_serviceaccount.py
@@ -18,4 +18,4 @@ class TestHoustonBootstrapServiceAccount:
         doc = docs[0]
 
         assert doc["kind"] == "ServiceAccount"
-        assert "annotations" not in doc["metadata"]
+        assert "annotations" in doc["metadata"]


### PR DESCRIPTION
## Description

This PR adds support for service account annotation and missing service account template changes for nats and stan services 

Additionally extends supports to create service accounts for services listed below 
nats 
stan

## Related Issues

- https://github.com/astronomer/issues/issues/6772
- https://github.com/astronomer/issues/issues/6747


## Testing

Yet to update

## Merging

cherry-pick to release-0.36
