### PR TITLE
update vendor packages 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,20 +350,20 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.36.0
-                - quay.io/astronomer/ap-auth-sidecar:1.27.1
+                - quay.io/astronomer/ap-auth-sidecar:1.27.2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.26
                 - quay.io/astronomer/ap-commander:0.36.8
-                - quay.io/astronomer/ap-configmap-reloader:0.13.1
+                - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.0
                 - quay.io/astronomer/ap-default-backend:0.28.27
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.10
+                - quay.io/astronomer/ap-grafana:10.4.13
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
@@ -371,7 +371,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
-                - quay.io/astronomer/ap-nginx-es:1.27.1
+                - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.2-1
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-2
@@ -389,20 +389,20 @@ workflows:
               docker_image:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-3
                 - quay.io/astronomer/ap-astro-ui:0.36.0
-                - quay.io/astronomer/ap-auth-sidecar:1.27.1
+                - quay.io/astronomer/ap-auth-sidecar:1.27.2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
                 - quay.io/astronomer/ap-cli-install:0.26.26
                 - quay.io/astronomer/ap-commander:0.36.8
-                - quay.io/astronomer/ap-configmap-reloader:0.13.1
+                - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.0
                 - quay.io/astronomer/ap-default-backend:0.28.27
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
-                - quay.io/astronomer/ap-grafana:10.4.10
+                - quay.io/astronomer/ap-grafana:10.4.13
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.18.9
                 - quay.io/astronomer/ap-kibana:8.12.1
@@ -410,7 +410,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
-                - quay.io/astronomer/ap-nginx-es:1.27.1
+                - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.2-1
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.25.3-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,12 +354,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.26
+                - quay.io/astronomer/ap-cli-install:0.26.27
                 - quay.io/astronomer/ap-commander:0.36.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.0
-                - quay.io/astronomer/ap-default-backend:0.28.27
+                - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1
@@ -393,12 +393,12 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
-                - quay.io/astronomer/ap-cli-install:0.26.26
+                - quay.io/astronomer/ap-cli-install:0.26.27
                 - quay.io/astronomer/ap-commander:0.36.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.16-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.0
-                - quay.io/astronomer/ap-default-backend:0.28.27
+                - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.1
                 - quay.io/astronomer/ap-fluentd:1.17.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   cliInstall:
     repository: quay.io/astronomer/ap-cli-install
-    tag: 0.26.26
+    tag: 0.26.27
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.27.1
+    tag: 1.27.2
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.10
+    tag: 10.4.13
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.27
+    tag: 0.28.28
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.13.1
+    tag: 0.14.0
     pullPolicy: IfNotPresent
 
 resources: {}

--- a/values.yaml
+++ b/values.yaml
@@ -161,7 +161,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.27.1
+    tag: 1.27.2
     pullPolicy: IfNotPresent
     port: 8084
     securityContext: {}


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| quay.io/astronomer/ap-auth-sidecar  | 1.27.1 | 1.27.2 |
| quay.io/astronomer/ap-cli-install | 0.26.26 | 0.27.27 |
| quay.io/astronomer/ap-configmap-reloader | 0.13.1 | 0.14.0 |
| quay.io/astronomer/ap-default-backend | 0.28.27 | 0.28.28 |
| quay.io/astronomer/ap-grafana | 10.4.10 | 10.4.13 | 
| quay.io/astronomer/ap-nginx-es | 1.27.1 | 1.27.2 |

## Related Issues

NA

## Testing

NA

## Merging

cherry-pick to all branches
