### PR TITLE
add toleration support postgresql service

### DIFF
--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -41,18 +41,9 @@ spec:
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
 {{- include "postgresql.imagePullSecrets" . | indent 6 }}
-      {{- if .Values.slave.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.slave.nodeSelector | indent 8 }}
-      {{- end }}
-      {{- if .Values.slave.affinity }}
-      affinity:
-{{ toYaml .Values.slave.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.slave.tolerations }}
-      tolerations:
-{{ toYaml .Values.slave.tolerations | indent 8 }}
-      {{- end }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.slave.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.slave.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.slave.tolerations) | nindent 8 }}
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -51,18 +51,9 @@ spec:
       schedulerName: "{{ .Values.schedulerName }}"
       {{- end }}
 {{- include "postgresql.imagePullSecrets" . | indent 6 }}
-      {{- if .Values.master.nodeSelector }}
-      nodeSelector:
-{{ toYaml .Values.master.nodeSelector | indent 8 }}
-      {{- end }}
-      {{- if .Values.master.affinity }}
-      affinity:
-{{ toYaml .Values.master.affinity | indent 8 }}
-      {{- end }}
-      {{- if .Values.master.tolerations }}
-      tolerations:
-{{ toYaml .Values.master.tolerations | indent 8 }}
-      {{- end }}
+      nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.master.nodeSelector) | nindent 8 }}
+      affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.master.affinity) | nindent 8 }}
+      tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.master.tolerations) | nindent 8 }}
       {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       {{- end }}

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -8,6 +8,15 @@ from tests import supported_k8s_versions, get_containers_by_name
     supported_k8s_versions,
 )
 class TestPostgresql:
+
+    @staticmethod
+    def postgresql_common_tests(doc):
+        """Test common for postgresql statefulset."""
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-postgresql"
+
+
     def test_postgresql_statefulset_defaults(self, kube_version):
         """Test postgresql statefulset is good with defaults."""
         docs = render_chart(
@@ -18,9 +27,7 @@ class TestPostgresql:
 
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-postgresql"
+        self.postgresql_common_tests(doc)
         assert "initContainers" not in doc["spec"]["template"]["spec"]
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
 
@@ -41,9 +48,7 @@ class TestPostgresql:
 
         assert len(docs) == 1
         doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-postgresql"
+        self.postgresql_common_tests(doc)
         assert "initContainers" in doc["spec"]["template"]["spec"]
 
     def test_postgresql_statefulset_with_private_registry_enabled(self, kube_version):

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -12,7 +12,7 @@ class TestPrometheusStatefulset:
 
     @staticmethod
     def prometheus_common_tests(doc):
-        """Test common for fluentd daemonsets."""
+        """Test common for prometheus statefulset."""
         assert doc["kind"] == "StatefulSet"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-prometheus"


### PR DESCRIPTION
## Description

add toleration support postgresql service

## Related Issues

- https://github.com/astronomer/issues/issues/6792

## Testing

QA now should able to apply global platform tolerations to postgresql component

## Merging

cherry-pick to release-0.36