### PR TITLE
Fold features of get_cronjob_containerspec_by_name into get_containers_by_name

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -12,24 +12,22 @@ k8s_version_too_old = f'1.{int(supported_k8s_versions[0].split(".")[1]) - 1!s}.0
 k8s_version_too_new = f'1.{int(supported_k8s_versions[-1].split(".")[1]) + 1!s}.0'
 
 
-def get_containers_by_name(doc, *, include_init_containers=False) -> dict:
+def get_containers_by_name(doc: dict, *, include_init_containers=False) -> dict:
     """Given a single doc, return all the containers by name.
 
-    doc must be a valid spec for a pod manager. (EG: ds, sts)
+    doc must be a valid spec for a pod manager. (EG: ds, sts, cronjob, etc.)
     """
 
-    c_by_name = {c["name"]: c for c in doc["spec"]["template"]["spec"]["containers"]}
+    if doc["kind"] in ["Deployment", "StatefulSet", "ReplicaSet", "DaemonSet", "Job"]:
+        containers = doc["spec"]["template"]["spec"].get("containers", [])
+        initContainers = doc["spec"]["template"]["spec"].get("initContainers", [])
+    elif doc["kind"] == "CronJob":
+        containers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("containers", [])
+        initContainers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("initContainers", [])
 
-    if include_init_containers and doc["spec"]["template"]["spec"].get("initContainers"):
-        c_by_name.update({c["name"]: c for c in doc["spec"]["template"]["spec"].get("initContainers")})
+    c_by_name = {c["name"]: c for c in containers}
+
+    if include_init_containers and initContainers:
+        c_by_name.update({c["name"]: c for c in initContainers})
 
     return c_by_name
-
-
-def get_cronjob_containerspec_by_name(doc) -> dict:
-    """Given a single doc, return all the containers by name.
-
-    doc must be a valid spec for a CronJob.
-    """
-
-    return {c["name"]: c for c in doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"]}

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -1,6 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 cron_test_data = [
     ("development-angular-system-6091", 0, 5),
@@ -182,7 +182,7 @@ class TestAstronomerConfigSyncer:
                 "charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml",
             ],
         )[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(doc)
+        job_container_by_name = get_containers_by_name(doc)
         assert "--target-namespaces" in job_container_by_name["config-syncer"]["args"]
         assert ",".join(namespaces) in job_container_by_name["config-syncer"]["args"]
         assert {"runAsNonRoot": True} == job_container_by_name["config-syncer"]["securityContext"]
@@ -207,7 +207,7 @@ class TestAstronomerConfigSyncer:
             ],
         )[0]
 
-        job_container_by_name = get_cronjob_containerspec_by_name(doc)
+        job_container_by_name = get_containers_by_name(doc)
 
         assert {
             "runAsNonRoot": True,
@@ -235,7 +235,7 @@ class TestAstronomerConfigSyncer:
             ],
         )[0]
 
-        job_container_by_name = get_cronjob_containerspec_by_name(doc)
+        job_container_by_name = get_containers_by_name(doc)
 
         assert "--target-namespaces" not in job_container_by_name["config-syncer"]["args"]
         assert ",".join(namespaces) not in job_container_by_name["config-syncer"]["args"]

--- a/tests/chart_tests/test_astronomer_houston_airflow_db_cleanup.py
+++ b/tests/chart_tests/test_astronomer_houston_airflow_db_cleanup.py
@@ -1,7 +1,7 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 import yaml
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 
 @pytest.mark.parametrize(
@@ -35,7 +35,7 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
         )
 
         assert len(docs) == 1
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-airflow-db-data"
         assert docs[0]["spec"]["schedule"] == "23 5 * * *"
@@ -56,7 +56,7 @@ class TestAstronomerHoustonAirflowDbCleanupCronjob:
         )
 
         assert len(docs) == 1
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-airflow-db-data"
         assert docs[0]["spec"]["schedule"] == "22 5 * * *"

--- a/tests/chart_tests/test_astronomer_houston_cronjob.py
+++ b/tests/chart_tests/test_astronomer_houston_cronjob.py
@@ -1,5 +1,5 @@
 import pytest
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
 
@@ -16,7 +16,7 @@ class TestHoustonCronjobJob:
             show_only=["charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"],
         )
         assert len(docs) == 1
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-deployments"
         assert docs[0]["spec"]["schedule"] == "0 0 * * *"
@@ -51,7 +51,7 @@ class TestHoustonCronjobJob:
             show_only=["charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml"],
         )
         assert len(docs) == 1
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-deployments"
         assert docs[0]["spec"]["schedule"] == "22 5 * * *"

--- a/tests/chart_tests/test_astronomer_houston_task_metrics.py
+++ b/tests/chart_tests/test_astronomer_houston_task_metrics.py
@@ -1,7 +1,7 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 import yaml
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 
 @pytest.mark.parametrize(
@@ -30,7 +30,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
         assert docs[0]["spec"]["schedule"] == "40 23 * * *"
         assert job_container_by_name["cleanup"]["securityContext"] == {"runAsNonRoot": True}
@@ -52,7 +52,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-task-usage-data"
         assert docs[0]["spec"]["schedule"] == "0 23 * * *"
         assert job_container_by_name["cleanup"]["securityContext"] == {
@@ -81,7 +81,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["metadata"]["name"] == "release-name-houston-populate-hourly-ta-metrics"
         assert docs[0]["spec"]["schedule"] == "57 * * * *"
         assert job_container_by_name["populate-daily-task-metrics"]["securityContext"] == {"runAsNonRoot": True}
@@ -124,7 +124,7 @@ class TestAstronomerHoustonTaskMetricsCronjobs:
 
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
         assert docs[0]["metadata"]["name"] == "release-name-houston-populate-daily-task-metrics"
         assert docs[0]["spec"]["schedule"] == "8 0 * * *"
         assert job_container_by_name["populate-daily-task-metrics"]["securityContext"] == {"runAsNonRoot": True}

--- a/tests/chart_tests/test_check_platform_updates.py
+++ b/tests/chart_tests/test_check_platform_updates.py
@@ -1,6 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 default_houston_resource_spec = {"limits": {"cpu": "1000m", "memory": "2048Mi"}, "requests": {"cpu": "500m", "memory": "1024Mi"}}
 
@@ -19,7 +19,7 @@ class TestHoustonCronJobPlatformUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "0 0 * * *"
@@ -46,7 +46,7 @@ class TestHoustonCronJobPlatformUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "57 * * * *"

--- a/tests/chart_tests/test_cronjob_check_airflow_updates.py
+++ b/tests/chart_tests/test_cronjob_check_airflow_updates.py
@@ -1,6 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 
 default_houston_resource_spec = {"limits": {"cpu": "1000m", "memory": "2048Mi"}, "requests": {"cpu": "500m", "memory": "1024Mi"}}
@@ -20,7 +20,7 @@ class TestHoustonCronJobAirflowUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "57 * * * *"
@@ -46,7 +46,7 @@ class TestHoustonCronJobAirflowUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "57 * * * *"

--- a/tests/chart_tests/test_cronjob_check_runtime_updates.py
+++ b/tests/chart_tests/test_cronjob_check_runtime_updates.py
@@ -1,6 +1,6 @@
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
-from tests import get_cronjob_containerspec_by_name, supported_k8s_versions
+from tests import get_containers_by_name, supported_k8s_versions
 
 default_houston_resource_spec = {"limits": {"cpu": "1000m", "memory": "2048Mi"}, "requests": {"cpu": "500m", "memory": "1024Mi"}}
 
@@ -19,7 +19,7 @@ class TestHoustonCronJobAstroRuntimeUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "43 0 * * *"
@@ -45,7 +45,7 @@ class TestHoustonCronJobAstroRuntimeUpdates:
 
         assert len(docs) == 1
         doc = docs[0]
-        job_container_by_name = get_cronjob_containerspec_by_name(docs[0])
+        job_container_by_name = get_containers_by_name(docs[0])
 
         assert doc["kind"] == "CronJob"
         assert doc["spec"]["schedule"] == "43 0 * * *"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -2,7 +2,6 @@ import pytest
 import yaml
 from tests import (
     get_containers_by_name,
-    get_cronjob_containerspec_by_name,
     supported_k8s_versions,
 )
 from tests.chart_tests.helm_template_generator import render_chart
@@ -524,7 +523,7 @@ class TestElasticSearch:
             show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
         )
         assert len(docs) == 1
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 1 * * *"
@@ -565,7 +564,7 @@ class TestElasticSearch:
         assert len(spec["affinity"]) == 1
         assert len(spec["tolerations"]) > 0
         assert spec["tolerations"] == values["global"]["platformNodePool"]["tolerations"]
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
         assert c_by_name["curator"]["command"] == ["/bin/sh", "-c"]
         assert c_by_name["curator"]["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
@@ -592,7 +591,7 @@ class TestElasticSearch:
             show_only=["charts/elasticsearch/templates/curator/es-curator-cronjob.yaml"],
         )
         assert len(docs) == 1
-        c_by_name = get_cronjob_containerspec_by_name(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-curator"
         assert docs[0]["spec"]["schedule"] == "0 45 * * *"


### PR DESCRIPTION
## Description

Fold `get_cronjob_containerspec_by_name()` features into `get_containers_by_name()`. Having one function that does the same thing to all pod manager docs is easier than having to handle Jobs separately from other pod managers.

## Related Issues

This was created as part of https://github.com/astronomer/issues/issues/6747 but is not directly related to that work. I'm just breaking this out into its own PR so it's easy to backport.

## Testing

These are only test changes, so no human QA is needed. CI passing is enough.

## Merging

This should be merged to all branches to make our test functions consistent.