### PR TITLE
update postgres exporter 0.16.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0
                 - quay.io/astronomer/ap-postgresql:15.9.0
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-registry:3.18.9
@@ -413,7 +413,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-14
-                - quay.io/astronomer/ap-postgres-exporter:0.15.0-8
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0
                 - quay.io/astronomer/ap-postgresql:15.9.0
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-registry:3.18.9

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.15.0-8
+  tag: 0.16.0
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

update postgres exporter 0.16.0

## Related Issues

- https://github.com/astronomer/issues/issues/6802

## Testing

QA should able to see postgres metrics 

## Merging

cherry-pick to all valid releases
