### PR TITLE
update fluentd version 1.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,7 +361,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
-                - quay.io/astronomer/ap-fluentd:1.17.0-1
+                - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.13
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4
@@ -399,7 +399,7 @@ workflows:
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
-                - quay.io/astronomer/ap-fluentd:1.17.0-1
+                - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.13
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4

--- a/charts/fluentd/values.yaml
+++ b/charts/fluentd/values.yaml
@@ -9,7 +9,7 @@ container:
 images:
   fluentd:
     repository: quay.io/astronomer/ap-fluentd
-    tag: 1.17.0-1
+    tag: 1.17.1
     pullPolicy: IfNotPresent
 
 elasticsearch:


### PR DESCRIPTION
## Description

update fluend version 1.17.1

## Related Issues

- https://github.com/astronomer/issues/issues/6806

## Testing

QA generic testing

## Merging

cherry-pick to all branches
