### PR TITLE
update kube state metrics version 2.14.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4
                 - quay.io/astronomer/ap-kibana:8.12.2
-                - quay.io/astronomer/ap-kube-state:2.10.1
+                - quay.io/astronomer/ap-kube-state:2.14.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
@@ -404,7 +404,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4
                 - quay.io/astronomer/ap-kibana:8.12.2
-                - quay.io/astronomer/ap-kube-state:2.10.1
+                - quay.io/astronomer/ap-kube-state:2.14.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-server:2.10.18-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.10.1
+    tag: 2.14.0
     pullPolicy: IfNotPresent
 
 securityContext:


### PR DESCRIPTION
## Description

update kube state metrics version 2.14.0

## Related Issues

- https://github.com/astronomer/issues/issues/6807

## Testing

Generic metrics testing

## Merging

cherry-pick to all valid branches
