### PR TITLE
update db-boostrapper version 0.36.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.36.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17
-                - quay.io/astronomer/ap-db-bootstrapper:0.36.0
+                - quay.io/astronomer/ap-db-bootstrapper:0.36.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
@@ -395,7 +395,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.36.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17
-                - quay.io/astronomer/ap-db-bootstrapper:0.36.0
+                - quay.io/astronomer/ap-db-bootstrapper:0.36.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.0
+    tag: 0.36.2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.0
+    tag: 0.36.2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.0
+    tag: 0.36.2
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

update db-boostrapper version 0.36.2

## Related Issues

- https://github.com/astronomer/issues/issues/6808

## Testing

generic QA testing

## Merging

cherry-pick to release-0.36
