### PR TITLE
add kibana extra annotation support

### DIFF
--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -24,6 +24,9 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "Content-Security-Policy: script-src 'self'";
     {{- end }}
+    {{- if .Values.ingressAnnotations }}
+{{- toYaml .Values.ingressAnnotations| nindent 4 }}
+    {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
   tls:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -69,3 +69,4 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
+ingressAnnotations: {}


### PR DESCRIPTION
## Description

This PR adds kibana extra annotation to be passed from kibana  values independent from global annotatio 

## Related Issues

- https://github.com/astronomer/issues/issues/6812

## Testing

QA should be able pass custom kibana annotation by following below config
```
kibana:
   ingressAnnotations: 
      your annotations here
```

## Merging

cherry-pick to all valid releases
