### PR TITLE
update commander version 0.36.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,7 +354,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
-                - quay.io/astronomer/ap-commander:0.36.8
+                - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.2
@@ -392,7 +392,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
-                - quay.io/astronomer/ap-commander:0.36.8
+                - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.36.8
+    tag: 0.36.9
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander version 0.36.9

## Related Issues

- https://github.com/astronomer/issues/issues/6816

## Testing

NA

## Merging

cherry-pick to release-0.36
