### PR TITLE
extend service account support

### DIFF
--- a/charts/astronomer/templates/commander/commander-serviceaccount.yaml
+++ b/charts/astronomer/templates/commander/commander-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ###############################
 ## Astronomer ServiceAccount ##
 ###############################
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.commander.serviceAccount.create .Values.global.rbacEnabled }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 #####################################
 ## Houson Bootstrap ServiceAccount ##
 #####################################
-{{- if and .Values.houston.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
+{{- if (and .Values.houston.serviceAccount.create .Values.global.rbacEnabled) (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 #####################################
 ## Houson Bootstrap ServiceAccount ##
 #####################################
-{{- if (and .Values.houston.serviceAccount.create .Values.global.rbacEnabled) (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
+{{- if and .Values.houston.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
+++ b/charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 #####################################
 ## Houson Bootstrap ServiceAccount ##
 #####################################
-{{- if and .Values.global.rbacEnabled (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
+{{- if and .Values.houston.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/elasticsearch/templates/es-serviceaccount.yaml
+++ b/charts/elasticsearch/templates/es-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## elasticsearch ServiceAccount ##
 ##################################
-{{- if and .Values.common.serviceAccount .Values.global.rbacEnabled }}
+{{- if and .Values.common.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/elasticsearch/templates/es-serviceaccount.yaml
+++ b/charts/elasticsearch/templates/es-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## elasticsearch ServiceAccount ##
 ##################################
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.common.serviceAccount .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-serviceaccount.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ########################################
 ## Elasticsearch Proxy ServiceAccount ##
 ########################################
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,6 +13,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
+  {{- if .Values.serviceAccount.annotations}}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
   {{- if .Values.global.customLogging.awsServiceAccountAnnotation }}
     eks.amazonaws.com/role-arn: {{ .Values.global.customLogging.awsServiceAccountAnnotation }}
   {{- end }}

--- a/charts/fluentd/templates/fluentd-serviceaccount.yaml
+++ b/charts/fluentd/templates/fluentd-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ############################
 ## Fluentd ServiceAccount ##
 ############################
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/fluentd/templates/fluentd-serviceaccount.yaml
+++ b/charts/fluentd/templates/fluentd-serviceaccount.yaml
@@ -13,8 +13,10 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   annotations:
-{{ toYaml (.Values.serviceAccountAnnotations) | indent 4 }}
-{{ if .Values.serviceAccount.annotations }}
-{{ toYaml (.Values.serviceAccount.annotations) | indent 4 }}
+{{- if .Values.serviceAccountAnnotations }}
+{{- toYaml (.Values.serviceAccountAnnotations) | indent 4 }}
+{{- end -}}
+{{- if .Values.serviceAccount.annotations }}
+{{- toYaml (.Values.serviceAccount.annotations) | nindent 4 }}
 {{- end -}}
 {{- end -}}

--- a/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
+++ b/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Grafana Bootstrap ServiceAccount ##
 ######################################
-{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
+{{- if (and .Values.serviceAccount.create .Values.global.rbacEnabled) (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
+++ b/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Grafana Bootstrap ServiceAccount ##
 ######################################
-{{- if (and .Values.serviceAccount.create .Values.global.rbacEnabled) (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
+++ b/charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Grafana Bootstrap ServiceAccount ##
 ######################################
-{{- if and .Values.global.rbacEnabled (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled (and (not .Values.backendSecretName) (not .Values.backendConnection)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/charts/kube-state/templates/kube-state-serviceaccount.yaml
+++ b/charts/kube-state/templates/kube-state-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Kube State Service Account ##
 ################################
-{{- if .Values.global.rbacEnabled }}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/nats/templates/nats-serviceaccount.yaml
+++ b/charts/nats/templates/nats-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Nats Server ServiceAccount ##
 ################################
-{{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
+{{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/nats/templates/nats-serviceaccount.yaml
+++ b/charts/nats/templates/nats-serviceaccount.yaml
@@ -1,3 +1,6 @@
+################################
+## Nats Server ServiceAccount ##
+################################
 {{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/pgbouncer/templates/pgbouncer-serviceaccount.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-serviceaccount.yaml
@@ -1,8 +1,7 @@
 #####################################
 ## Pgbouncer ServiceAccount      ####
 #####################################
-{{ if .Values.global.rbacEnabled }}
-{{- if .Values.serviceAccount.create }}
+{{ if and .Values.serviceAccount.create  .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -16,5 +15,4 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml
@@ -12,4 +12,8 @@ metadata:
     chart: {{ template "prometheus-blackbox-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+
 {{- end }}

--- a/charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml
@@ -15,5 +15,4 @@ metadata:
   {{- with .Values.serviceAccount.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
-
 {{- end }}

--- a/charts/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -9,4 +9,7 @@ metadata:
     chart: {{ template "prometheus-node-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus-node-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-node-exporter/templates/serviceaccount.yaml
@@ -1,3 +1,6 @@
+################################################
+## Promtheus Node Exporter ServiceAccount     ##
+################################################
 {{ if and .Values.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbacEnabled -}}
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,4 +8,7 @@ metadata:
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -1,4 +1,7 @@
-{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
+################################################
+## Promtheus Postgres Exporter ServiceAccount ##
+################################################
+{{- if and .Values.serviceAccount.create .Values.global.rbacEnabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/prometheus/templates/prometheus-serviceaccount.yaml
+++ b/charts/prometheus/templates/prometheus-serviceaccount.yaml
@@ -11,4 +11,7 @@ metadata:
     chart: {{ template "prometheus.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -36,13 +36,13 @@ resources: {}
 podAnnotations: {}
 
 serviceAccount:
-    # Specifies whether a service account should be created
-    create: true
-    # Annotations to add to the service account
-    annotations: {}
-    # The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template
-    name: ~
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ~
 
 livenessProbe: {}
   # httpGet:

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##########################
 ## Stan  ServiceAccount ##
 ##########################
-{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) -}}
+{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -1,3 +1,6 @@
+##########################
+## Stan  ServiceAccount ##
+##########################
 {{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -118,7 +118,7 @@ class TestServiceAccounts:
             "nginx": {"serviceAccount": {"create": False}, "defaultBackend": {"serviceAccount": {"create": False}}},
             "kube-state": {"serviceAccount": {"create": False}},
             "prometheus": {"serviceAccount": {"create": False}},
-            "elasticsearch": {"common":{"serviceAccount": {"create": False}}},
+            "elasticsearch": {"common": {"serviceAccount": {"create": False}}},
         }
         show_only = [
             str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "serviceaccount" in str(path)

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -132,7 +132,7 @@ class TestServiceAccounts:
         assert len(docs) == 0
 
     def test_serviceaccount_with_annotations(self, kube_version):
-        "Test that if SA create disabled"
+        "Test that if SA create enabled and supports user injected annotations"
 
         annotations = {"app.managedby": "astronomer"}
         values = {

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -90,39 +90,45 @@ class TestServiceAccounts:
     def test_serviceaccount_with_create_disabled(self, kube_version):
         "Test that if SA create disabled"
         values = {
-            "astronomer": {
-                "commander": {"serviceAccount": {"create": False, "name": "commander-test"}},
-                "registry": {"serviceAccount": {"create": False, "name": "registry-test"}},
-                "configSyncer": {"serviceAccount": {"create": False, "name": "configsyncer-test"}},
-                "houston": {"serviceAccount": {"create": False, "name": "houston-test"}},
-                "astroUI": {"serviceAccount": {"create": False, "name": "astroui-test"}},
+            "global": {
+                "postgresqlEnabled": True,
+                "customLogging": { "enabled": True},
+                "prometheusPostgresExporterEnabled": True,
+                "pgbouncer": {"enabled" : True},
             },
-            "nats": {"nats": {"serviceAccount": {"create": False, "name": "nats-test"}}},
-            "stan": {"stan": {"serviceAccount": {"create": False, "name": "stan-test"}}},
-            "grafana": {"serviceAccount": {"create": False, "name": "grafana-test"}},
-            "alertmanager": {"serviceAccount": {"create": False, "name": "alertmanager-test"}},
-            "kibana": {"serviceAccount": {"create": False, "name": "kibana-test"}},
-            "prometheus-blackbox-exporter": {"serviceAccount": {"create": False, "name": "blackbox-test"}},
+            "astronomer": {
+                "commander": {"serviceAccount": {"create": False}},
+                "registry": {"serviceAccount": {"create": False}},
+                "configSyncer": {"serviceAccount": {"create": False}},
+                "houston": {"serviceAccount": {"create": False}},
+                "astroUI": {"serviceAccount": {"create": False}},
+            },
+            "nats": {"nats": {"serviceAccount": {"create": False}}},
+            "stan": {"stan": {"serviceAccount": {"create": False}}},
+            "grafana": {"serviceAccount": {"create": False}},
+            "alertmanager": {"serviceAccount": {"create": False}},
+            "kibana": {"serviceAccount": {"create": False}},
+            "prometheus-blackbox-exporter": {"serviceAccount": {"create": False}},
+            "postgresql": {"serviceAccount": {"create": False}},
+            "external-es-proxy": {"serviceAccount": {"create": False}},
+            "prometheus-postgres-exporter": {"serviceAccount": {"create": False}},
+            "pgbouncer": {"serviceAccount": {"create": False}},
+            "fluentd": {"serviceAccount": {"create": False}},
+            "prometheus-node-exporter": {"serviceAccount": {"create": False}},
+            "nginx": {"serviceAccount": {"create": False}, "defaultBackend": {"serviceAccount": {"create": False}}},
+            "kube-state": {"serviceAccount": {"create": False}},
+            "prometheus": {"serviceAccount": {"create": False}}
         }
+        show_only = [
+            str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "serviceaccount" in str(path)
+        ]
         docs = render_chart(
             kube_version=kube_version,
             values=values,
-            show_only=[
-                "charts/astronomer/templates/commander/commander-serviceaccount.yaml",
-                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
-                "charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml",
-                "charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml",
-                "charts/astronomer/templates/astro-ui/astro-ui-serviceaccount.yaml",
-                "charts/nats/templates/nats-serviceaccount.yaml",
-                "charts/stan/templates/stan-serviceaccount.yaml",
-                "charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml",
-                "charts/alertmanager/templates/alertmanager-serviceaccount.yaml",
-                "charts/kibana/templates/kibana-serviceaccount.yaml",
-                "charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml",
-            ],
+            show_only=show_only,
         )
 
-        assert len(docs) == 0
+        assert len(docs) == 1
 
     def test_serviceaccount_with_overrides_rolebinding(self, kube_version):
         "Test that if custom SA are added it gets created"

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -118,6 +118,7 @@ class TestServiceAccounts:
             "nginx": {"serviceAccount": {"create": False}, "defaultBackend": {"serviceAccount": {"create": False}}},
             "kube-state": {"serviceAccount": {"create": False}},
             "prometheus": {"serviceAccount": {"create": False}},
+            "elasticsearch": {"common":{"serviceAccount": {"create": False}}},
         }
         show_only = [
             str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "serviceaccount" in str(path)
@@ -128,7 +129,7 @@ class TestServiceAccounts:
             show_only=show_only,
         )
 
-        assert len(docs) == 1
+        assert len(docs) == 0
 
     def test_serviceaccount_with_overrides_rolebinding(self, kube_version):
         "Test that if custom SA are added it gets created"

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -87,6 +87,43 @@ class TestServiceAccounts:
         extracted_names = {doc["metadata"]["name"] for doc in docs if "metadata" in doc and "name" in doc["metadata"]}
         assert expected_names.issubset(extracted_names)
 
+    def test_serviceaccount_with_create_disabled(self, kube_version):
+        "Test that if SA create disabled"
+        values = {
+            "astronomer": {
+                "commander": {"serviceAccount": {"create": False, "name": "commander-test"}},
+                "registry": {"serviceAccount": {"create": False, "name": "registry-test"}},
+                "configSyncer": {"serviceAccount": {"create": False, "name": "configsyncer-test"}},
+                "houston": {"serviceAccount": {"create": False, "name": "houston-test"}},
+                "astroUI": {"serviceAccount": {"create": False, "name": "astroui-test"}},
+            },
+            "nats": {"nats": {"serviceAccount": {"create": False, "name": "nats-test"}}},
+            "stan": {"stan": {"serviceAccount": {"create": False, "name": "stan-test"}}},
+            "grafana": {"serviceAccount": {"create": False, "name": "grafana-test"}},
+            "alertmanager": {"serviceAccount": {"create": False, "name": "alertmanager-test"}},
+            "kibana": {"serviceAccount": {"create": False, "name": "kibana-test"}},
+            "prometheus-blackbox-exporter": {"serviceAccount": {"create": False, "name": "blackbox-test"}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/astronomer/templates/commander/commander-serviceaccount.yaml",
+                "charts/astronomer/templates/registry/registry-serviceaccount.yaml",
+                "charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml",
+                "charts/astronomer/templates/houston/api/houston-bootstrap-serviceaccount.yaml",
+                "charts/astronomer/templates/astro-ui/astro-ui-serviceaccount.yaml",
+                "charts/nats/templates/nats-serviceaccount.yaml",
+                "charts/stan/templates/stan-serviceaccount.yaml",
+                "charts/grafana/templates/grafana-bootstrap-serviceaccount.yaml",
+                "charts/alertmanager/templates/alertmanager-serviceaccount.yaml",
+                "charts/kibana/templates/kibana-serviceaccount.yaml",
+                "charts/prometheus-blackbox-exporter/templates/blackbox-serviceaccount.yaml",
+            ],
+        )
+
+        assert len(docs) == 0
+
     def test_serviceaccount_with_overrides_rolebinding(self, kube_version):
         "Test that if custom SA are added it gets created"
         values = {

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -92,9 +92,9 @@ class TestServiceAccounts:
         values = {
             "global": {
                 "postgresqlEnabled": True,
-                "customLogging": { "enabled": True},
+                "customLogging": {"enabled": True},
                 "prometheusPostgresExporterEnabled": True,
-                "pgbouncer": {"enabled" : True},
+                "pgbouncer": {"enabled": True},
             },
             "astronomer": {
                 "commander": {"serviceAccount": {"create": False}},
@@ -117,7 +117,7 @@ class TestServiceAccounts:
             "prometheus-node-exporter": {"serviceAccount": {"create": False}},
             "nginx": {"serviceAccount": {"create": False}, "defaultBackend": {"serviceAccount": {"create": False}}},
             "kube-state": {"serviceAccount": {"create": False}},
-            "prometheus": {"serviceAccount": {"create": False}}
+            "prometheus": {"serviceAccount": {"create": False}},
         }
         show_only = [
             str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "serviceaccount" in str(path)

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -131,6 +131,55 @@ class TestServiceAccounts:
 
         assert len(docs) == 0
 
+    def test_serviceaccount_with_annotations(self, kube_version):
+        "Test that if SA create disabled"
+
+        annotations = {"app.managedby": "astronomer"}
+        values = {
+            "global": {
+                "postgresqlEnabled": True,
+                "customLogging": {"enabled": True},
+                "prometheusPostgresExporterEnabled": True,
+                "pgbouncer": {"enabled": True},
+            },
+            "astronomer": {
+                "commander": {"serviceAccount": {"create": True, "annotations": annotations}},
+                "registry": {"serviceAccount": {"create": True, "annotations": annotations}},
+                "configSyncer": {"serviceAccount": {"create": True, "annotations": annotations}},
+                "houston": {"serviceAccount": {"create": True, "annotations": annotations}},
+                "astroUI": {"serviceAccount": {"create": True, "annotations": annotations}},
+            },
+            "nats": {"nats": {"serviceAccount": {"create": True, "annotations": annotations}}},
+            "stan": {"stan": {"serviceAccount": {"create": True, "annotations": annotations}}},
+            "grafana": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "alertmanager": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "kibana": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "prometheus-blackbox-exporter": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "postgresql": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "external-es-proxy": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "prometheus-postgres-exporter": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "pgbouncer": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "fluentd": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "prometheus-node-exporter": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "nginx": {
+                "serviceAccount": {"create": True, "annotations": annotations},
+                "defaultBackend": {"serviceAccount": {"create": False, "annotations": annotations}},
+            },
+            "kube-state": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "prometheus": {"serviceAccount": {"create": True, "annotations": annotations}},
+            "elasticsearch": {"common": {"serviceAccount": {"create": True, "annotations": annotations}}},
+        }
+        show_only = [
+            str(path.relative_to(git_root_dir)) for path in git_root_dir.rglob("charts/**/*") if "serviceaccount" in str(path)
+        ]
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=show_only,
+        )
+        service_account_annotations = [doc["metadata"]["annotations"] for doc in docs if doc["kind"] == "ServiceAccount"]
+        assert annotations in service_account_annotations
+
     def test_serviceaccount_with_overrides_rolebinding(self, kube_version):
         "Test that if custom SA are added it gets created"
         values = {


### PR DESCRIPTION
## Description

This PR extends the scope of serviceAccount support and adds additional enhancements to existing changes

## Related Issues

- https://github.com/astronomer/issues/issues/6814

## Testing

QA should able to control individual creation of service account when global.rbacEnabled set to true

## Merging

Yet to update

