### PR TITLE
add configmap names support for airflow  runtime version

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -275,7 +275,7 @@ s3:
 - name: houston-config-volume
   mountPath: /houston/config/local-production.yaml
   subPath: local-production.yaml
-{{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesconfigMapName ) }}
+{{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesConfigMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -280,7 +280,7 @@ s3:
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json
 {{- end }}
-{{ if and .Values.houston.RuntimeReleasesConfig ( not .Values.houston.runtimeReleasesconfigMapName ) }}
+{{ if and .Values.houston.runtimeReleasesConfig ( not .Values.houston.runtimeReleasesConfigMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/astro_runtime_releases.json
   subPath: astro_runtime_releases.json
@@ -306,12 +306,12 @@ s3:
   mountPath: /usr/local/share/ca-certificates/{{ $secretName }}.crt
   subPath: ca.crt
 {{- end }}
-{{- if .Values.houston.runtimeReleasesconfigMapName -}}
+{{- if .Values.houston.runtimeReleasesConfigMapName -}}
 - mountPath: /houston/astro_runtime_releases.json
   name: runtimeversions
   subPath: astro_runtime_releases.json
 {{- end }}
-{{- if .Values.houston.airflowReleasesconfigMapName -}}
+{{- if .Values.houston.airflowReleasesConfigMapName -}}
 - mountPath: /houston/airflow_releases.json
   name: certifiedversions
   subPath: airflow_releases.json
@@ -353,15 +353,15 @@ s3:
   secret:
     secretName: {{ $secretName }}
 {{- end }}
-{{- if .Values.houston.runtimeReleasesconfigMapName -}}
+{{- if .Values.houston.runtimeReleasesConfigMapName }}
 - name: runtimeversions
   configMap:
-    name: {{ .Values.houston.runtimeReleasesconfigMapName }}
+    name: {{ .Values.houston.runtimeReleasesConfigMapName }}
 {{- end }}
-{{- if .Values.houston.airflowReleasesconfigMapName  -}}
+{{- if .Values.houston.airflowReleasesConfigMapName  }}
 - name: certifiedversions
   configMap:
-    name: {{ .Values.houston.airflowReleasesconfigMapName  }}
+    name: {{ .Values.houston.airflowReleasesConfigMapName  }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -361,7 +361,7 @@ s3:
 {{- if .Values.houston.airflowReleasesConfigMapName }}
 - name: certifiedversions
   configMap:
-    name: {{ .Values.houston.airflowReleasesConfigMapName  }}
+    name: {{ .Values.houston.airflowReleasesConfigMapName }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -311,7 +311,7 @@ s3:
   name: runtimeversions
   subPath: astro_runtime_releases.json
 {{- end }}
-{{- if .Values.houston.airflowReleasesConfigMapName -}}
+{{ if .Values.houston.airflowReleasesConfigMapName -}}
 - mountPath: /houston/airflow_releases.json
   name: certifiedversions
   subPath: airflow_releases.json

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -275,12 +275,12 @@ s3:
 - name: houston-config-volume
   mountPath: /houston/config/local-production.yaml
   subPath: local-production.yaml
-{{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesConfig.configMapName ) }}
+{{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesconfigMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json
 {{- end }}
-{{ if and .Values.houston.RuntimeReleasesConfig ( not .Values.houston.RuntimeReleasesConfig.configMapName ) }}
+{{ if and .Values.houston.RuntimeReleasesConfig ( not .Values.houston.runtimeReleasesconfigMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/astro_runtime_releases.json
   subPath: astro_runtime_releases.json
@@ -327,10 +327,15 @@ s3:
         path: production.yaml
       - key: local-production.yaml
         path: local-production.yaml
-      {{ if .Values.houston.airflowReleasesConfig }}
+      {{ if and .Values.houston.airflowReleasesConfig (not .Values.houston.airflowReleasesconfigMapName )}}
       - key: airflow_releases.json
         path: airflow_releases.json
       {{- end }}
+      {{ if and .Values.houston.RuntimeReleasesConfig (not .Values.houston.runtimeReleasesconfigMapName )}}
+      - key: astro_runtime_releases.json
+        path: astro_runtime_releases.json
+      {{- end }}
+
 - name: houston-jwt-key-volume
   secret:
     secretName: {{ template "houston.jwtKeySecret" . }}
@@ -348,15 +353,15 @@ s3:
   secret:
     secretName: {{ $secretName }}
 {{- end }}
-{{- if .Values.houston.RuntimeReleasesConfig.configMapName -}}
+{{- if .Values.houston.runtimeReleasesconfigMapName -}}
 - name: runtimeversions
   configMap:
-    name: {{ .Values.houston.RuntimeReleasesConfig.configMapName }}
+    name: {{ .Values.houston.runtimeReleasesconfigMapName }}
 {{- end }}
-{{- if .Values.houston.airflowReleasesConfig.configMapName -}}
+{{- if .Values.houston.airflowReleasesconfigMapName  -}}
 - name: certifiedversions
   configMap:
-    name: {{ .Values.houston.airflowReleasesConfig.configMapName }}
+    name: {{ .Values.houston.airflowReleasesconfigMapName  }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -275,12 +275,12 @@ s3:
 - name: houston-config-volume
   mountPath: /houston/config/local-production.yaml
   subPath: local-production.yaml
-{{ if .Values.houston.airflowReleasesConfig }}
+{{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesConfig.configMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json
 {{- end }}
-{{ if .Values.houston.RuntimeReleasesConfig ( not .Values.houston.RuntimeReleasesConfig.configMapName ) }}
+{{ if and .Values.houston.RuntimeReleasesConfig ( not .Values.houston.RuntimeReleasesConfig.configMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/astro_runtime_releases.json
   subPath: astro_runtime_releases.json
@@ -306,10 +306,15 @@ s3:
   mountPath: /usr/local/share/ca-certificates/{{ $secretName }}.crt
   subPath: ca.crt
 {{- end }}
-{{- if .Values.RuntimeReleasesConfig.configMapName -}}
+{{- if .Values.houston.RuntimeReleasesConfig.configMapName -}}
 - mountPath: /houston/astro_runtime_releases.json
   name: runtimeversions
   subPath: astro_runtime_releases.json
+{{- end }}
+{{- if .Values.houston.airflowReleasesConfig.configMapName -}}
+- mountPath: /houston/airflow_releases.json
+  name: certifiedversions
+  subPath: airflow_releases.json
 {{- end }}
 {{- end }}
 
@@ -343,10 +348,15 @@ s3:
   secret:
     secretName: {{ $secretName }}
 {{- end }}
-{{- if .Values.RuntimeReleasesConfig.configMapName -}}
+{{- if .Values.houston.RuntimeReleasesConfig.configMapName -}}
 - name: runtimeversions
   configMap:
-    name: {{ .Values.RuntimeReleasesConfig.configMapName }}
+    name: {{ .Values.houston.RuntimeReleasesConfig.configMapName }}
+{{- end }}
+{{- if .Values.houston.airflowReleasesConfig.configMapName -}}
+- name: certifiedversions
+  configMap:
+    name: {{ .Values.houston.airflowReleasesConfig.configMapName }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -280,7 +280,7 @@ s3:
   mountPath: /houston/airflow_releases.json
   subPath: airflow_releases.json
 {{- end }}
-{{ if .Values.houston.RuntimeReleasesConfig }}
+{{ if .Values.houston.RuntimeReleasesConfig ( not .Values.houston.RuntimeReleasesConfig.configMapName ) }}
 - name: houston-config-volume
   mountPath: /houston/astro_runtime_releases.json
   subPath: astro_runtime_releases.json
@@ -305,6 +305,11 @@ s3:
 - name: nats-jetstream-client-tls-volume
   mountPath: /usr/local/share/ca-certificates/{{ $secretName }}.crt
   subPath: ca.crt
+{{- end }}
+{{- if .Values.RuntimeReleasesConfig.configMapName -}}
+- mountPath: /houston/astro_runtime_releases.json
+  name: runtimeversions
+  subPath: astro_runtime_releases.json
 {{- end }}
 {{- end }}
 
@@ -337,6 +342,11 @@ s3:
 - name: nats-jetstream-client-tls-volume
   secret:
     secretName: {{ $secretName }}
+{{- end }}
+{{- if .Values.RuntimeReleasesConfig.configMapName -}}
+- name: runtimeversions
+  configMap:
+    name: {{ .Values.RuntimeReleasesConfig.configMapName }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -306,12 +306,12 @@ s3:
   mountPath: /usr/local/share/ca-certificates/{{ $secretName }}.crt
   subPath: ca.crt
 {{- end }}
-{{- if .Values.houston.RuntimeReleasesConfig.configMapName -}}
+{{- if .Values.houston.runtimeReleasesconfigMapName -}}
 - mountPath: /houston/astro_runtime_releases.json
   name: runtimeversions
   subPath: astro_runtime_releases.json
 {{- end }}
-{{- if .Values.houston.airflowReleasesConfig.configMapName -}}
+{{- if .Values.houston.airflowReleasesconfigMapName -}}
 - mountPath: /houston/airflow_releases.json
   name: certifiedversions
   subPath: airflow_releases.json

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -358,7 +358,7 @@ s3:
   configMap:
     name: {{ .Values.houston.runtimeReleasesConfigMapName }}
 {{- end }}
-{{- if .Values.houston.airflowReleasesConfigMapName  }}
+{{- if .Values.houston.airflowReleasesConfigMapName }}
 - name: certifiedversions
   configMap:
     name: {{ .Values.houston.airflowReleasesConfigMapName  }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -12,14 +12,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
 data:
-  {{ if .Values.houston.airflowReleasesConfig }}
+  {{ if and .Values.houston.airflowReleasesConfig ( not .Values.houston.airflowReleasesConfigMapName ) }}
   airflow_releases.json: |
     {{ .Values.houston.airflowReleasesConfig | toJson }}
   # These are system-specified config overrides.
   {{- end }}
-  {{ if .Values.houston.RuntimeReleasesConfig }}
+  {{ if and .Values.houston.runtimeReleasesConfig ( not .Values.houston.runtimeReleasesConfigMapName ) }}
   astro_runtime_releases.json: |
-    {{ .Values.houston.RuntimeReleasesConfig | toJson }}
+    {{ .Values.houston.runtimeReleasesConfig | toJson }}
   # These are system-specified config overrides.
   {{- end }}
   production.yaml: |

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -299,7 +299,6 @@ houston:
   #
   airflowReleasesConfigMapName: ~
   airflowReleasesConfig:
-    configMapName: ~
     # example of usage:
     # available_releases:
     # - version: 1.10.7-15
@@ -331,8 +330,7 @@ houston:
     #   channel: stable
 
   runtimeReleasesConfigMapName: ~
-  RuntimeReleasesConfig:
-    configMapName: ~
+  runtimeReleasesConfig:
     # example of usage:
     # below are default mandatory fields
     # runtimeVersions:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -330,7 +330,7 @@ houston:
     #   - 2.0.0-alpine3.10-onbuild
     #   channel: stable
 
-  runtimeReleasesconfigMapName: ~
+  runtimeReleasesConfigMapName: ~
   RuntimeReleasesConfig:
     configMapName: ~
     # example of usage:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -297,6 +297,7 @@ houston:
 
   # this option allows to override airflow releases config
   #
+  airflowReleasesconfigMapName: ~
   airflowReleasesConfig:
     configMapName: ~
     # example of usage:
@@ -329,6 +330,7 @@ houston:
     #   - 2.0.0-alpine3.10-onbuild
     #   channel: stable
 
+  runtimeReleasesconfigMapName: ~
   RuntimeReleasesConfig:
     configMapName: ~
     # example of usage:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -298,6 +298,7 @@ houston:
   # this option allows to override airflow releases config
   #
   airflowReleasesConfig:
+    configMapName: ~
     # example of usage:
     # available_releases:
     # - version: 1.10.7-15
@@ -329,6 +330,7 @@ houston:
     #   channel: stable
 
   RuntimeReleasesConfig:
+    configMapName: ~
     # example of usage:
     # below are default mandatory fields
     # runtimeVersions:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -297,7 +297,7 @@ houston:
 
   # this option allows to override airflow releases config
   #
-  airflowReleasesconfigMapName: ~
+  airflowReleasesConfigMapName: ~
   airflowReleasesConfig:
     configMapName: ~
     # example of usage:

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -249,13 +249,13 @@ class TestHoustonApiDeployment:
         assert {
             "name": "runtimeversions",
             "mountPath": "/houston/astro_runtime_releases.json",
-            "subPath": runtimeConfigmapName,
+            "subPath": "astro_runtime_releases.json",
         } in c_by_name["houston"]["volumeMounts"]
 
         assert {
             "name": "certifiedversions",
             "mountPath": "/houston/airflow_releases.json",
-            "subPath": certifiedConfigmapName,
+            "subPath": "airflow_releases.json",
         } in c_by_name["houston"]["volumeMounts"]
 
         assert {"configMap": {"name": runtimeConfigmapName}, "name": "runtimeversions"} in doc["spec"]["template"]["spec"][

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -196,13 +196,13 @@ class TestHoustonApiDeployment:
             if "__HOST" in env.get("name") and env.get("value")
         )
 
-    def test_houston_configmap_with_RuntimeReleasesConfig_enabled(self, kube_version):
+    def test_houston_configmap_with_runtimeReleasesConfig_enabled(self, kube_version):
         """Validate the houston configmap and its embedded data with RuntimeReleasesConfig defined
         ."""
         runtime_releases_json = {"runtimeVersions": {"12.1.1": {"metadata": {"airflowVersion": "2.2.5", "channel": "stable"}}}}
         docs = render_chart(
             kube_version=kube_version,
-            values={"astronomer": {"houston": {"RuntimeReleasesConfig": runtime_releases_json}}},
+            values={"astronomer": {"houston": {"runtimeReleasesConfig": runtime_releases_json}}},
             show_only=[
                 "charts/astronomer/templates/houston/houston-configmap.yaml",
                 "charts/astronomer/templates/houston/api/houston-deployment.yaml",
@@ -222,13 +222,16 @@ class TestHoustonApiDeployment:
     def test_houston_configmap_with_airflow_and_runtime_configmap_name_enabled(self, kube_version):
         """Validate that houston configmap and its embedded data with runtime and airflow configmap name defined
         ."""
+        runtimeConfigmapName = "runtime-certfied-json"
+        certifiedConfigmapName = "certified-json"
+
         docs = render_chart(
             kube_version=kube_version,
             values={
                 "astronomer": {
                     "houston": {
-                        "runtimeReleasesConfigMapName": "runtime-certfied-json",
-                        "airflowReleasesConfigMapName": "certified-json",
+                        "runtimeReleasesConfigMapName": runtimeConfigmapName,
+                        "airflowReleasesConfigMapName": certifiedConfigmapName,
                     }
                 }
             },
@@ -246,17 +249,17 @@ class TestHoustonApiDeployment:
         assert {
             "name": "runtimeversions",
             "mountPath": "/houston/astro_runtime_releases.json",
-            "subPath": "astro_runtime_releases.json",
+            "subPath": runtimeConfigmapName,
         } in c_by_name["houston"]["volumeMounts"]
 
         assert {
             "name": "certifiedversions",
             "mountPath": "/houston/airflow_releases.json",
-            "subPath": "airflow_releases.json",
+            "subPath": certifiedConfigmapName,
         } in c_by_name["houston"]["volumeMounts"]
 
-        assert {"configMap": {"name": "runtime-certfied-json"}, "name": "runtimeversions"} in doc["spec"]["template"]["spec"][
+        assert {"configMap": {"name": runtimeConfigmapName}, "name": "runtimeversions"} in doc["spec"]["template"]["spec"][
             "volumes"
         ]
 
-        assert {"configMap": {"name": "certified-json"}, "name": "certifiedversions"} in doc["spec"]["template"]["spec"]["volumes"]
+        assert {"configMap": {"name": certifiedConfigmapName}, "name": "certifiedversions"} in doc["spec"]["template"]["spec"]["volumes"]

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -262,4 +262,6 @@ class TestHoustonApiDeployment:
             "volumes"
         ]
 
-        assert {"configMap": {"name": certifiedConfigmapName}, "name": "certifiedversions"} in doc["spec"]["template"]["spec"]["volumes"]
+        assert {"configMap": {"name": certifiedConfigmapName}, "name": "certifiedversions"} in doc["spec"]["template"]["spec"][
+            "volumes"
+        ]

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -220,8 +220,7 @@ class TestHoustonApiDeployment:
         } in c_by_name["houston"]["volumeMounts"]
 
     def test_houston_configmap_with_airflow_and_runtime_configmap_name_enabled(self, kube_version):
-        """Validate that houston configmap and its embedded data with runtime and airflow configmap name defined
-        ."""
+        """Validate that houston configmap and its embedded data with runtime and airflow configmap name defined."""
         runtimeConfigmapName = "runtime-certfied-json"
         certifiedConfigmapName = "certified-json"
 


### PR DESCRIPTION
## Description

This PR implements a change to include config name support to mount volume and volume mounts automatically by providing a file name 

## Related Issues

- https://github.com/astronomer/issues/issues/6680

## Testing

QA should able to provide pre-created configmap with runtime and airflow versions list

## Merging

cherry-pick to release-0.36 , release-0.37