### PR TITLE
Use Enable_all_features for rendering chart

### DIFF
--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -92,6 +92,7 @@ def render_chart(
     """
     values = values or {}
     chart_dir = chart_dir or sys.path[0]
+    enable_all_features_path = os.path.join(chart_dir, "tests/enable_all_features.yaml")
     with NamedTemporaryFile(delete=not DEBUG) as tmp_file:  # export DEBUG=true to keep
         content = yaml.dump(values)
         tmp_file.write(content.encode())
@@ -105,6 +106,8 @@ def render_chart(
             chart_dir,
             "--set",
             f"global.baseDomain={baseDomain}",
+            "--values",
+            enable_all_features_path,
             "--values",
             tmp_file.name,
         ]


### PR DESCRIPTION
## Description

This PR intends to use Enable_all_features.yaml file present in our unittests as part of render_chart function. 

## Related Issues

NA

## Testing

NA

## Merging

If approved can be merged everywhere. 
