### PR TITLE
disable default platform check job

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -249,7 +249,7 @@ houston:
   # This runs as a CronJob
   updateCheck:
     # Enable check updates CronJob
-    enabled: true
+    enabled: false
 
     # url for update service
     url: https://updates.astronomer.io/astronomer-platform

--- a/tests/chart_tests/test_poddisruptionbudget.py
+++ b/tests/chart_tests/test_poddisruptionbudget.py
@@ -11,11 +11,16 @@ class TestHoustonPDB:
             "charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml",
             "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml",
         ]
-
         for show_only in templates:
             labels = render_chart(
                 show_only=[show_only],
-                values={},
+                values={
+                    "astronomer": {
+                        "houston": {
+                            "updateCheck": {"enabled": True }
+                            }
+                            }
+                },
             )[0]["spec"]["jobTemplate"]["spec"]["template"]["metadata"]["labels"]
             assert labels["component"] != "houston", f"ERROR: tempplate '{show_only}' matched houston"
 

--- a/tests/chart_tests/test_poddisruptionbudget.py
+++ b/tests/chart_tests/test_poddisruptionbudget.py
@@ -14,13 +14,7 @@ class TestHoustonPDB:
         for show_only in templates:
             labels = render_chart(
                 show_only=[show_only],
-                values={
-                    "astronomer": {
-                        "houston": {
-                            "updateCheck": {"enabled": True }
-                            }
-                            }
-                },
+                values={"astronomer": {"houston": {"updateCheck": {"enabled": True}}}},
             )[0]["spec"]["jobTemplate"]["spec"]["template"]["metadata"]["labels"]
             assert labels["component"] != "houston", f"ERROR: tempplate '{show_only}' matched houston"
 

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -21,6 +21,8 @@ astronomer:
   houston:
     cleanupAirflowDb:
       enabled: true
+    updateCheck:
+      enabled: true
 nats:
   nats:
     createJetStreamJob: true


### PR DESCRIPTION
## Description

disable default platform check job

## Related Issues

- https://github.com/astronomer/issues/issues/6680

## Testing

QA should see update-platform-job check 

## Merging

cherry-pick to all valid branches
