### PR TITLE
Add configurable liveness/readiness probes for authsidecar and dagdeployment

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -158,6 +158,12 @@ data:
         {{- if .Values.global.logging.indexNamePrefix }}
         indexNamePrefix: {{ .Values.global.logging.indexNamePrefix }}
         {{- end }}
+        {{- if .Values.global.loggingSidecar.livenessProbe}}
+        livenessProbe: {{- .Values.global.loggingSidecar.livenessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.loggingSidecar.readinessProbe}}
+        readinessProbe: {{- .Values.global.loggingSidecar.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
       {{- end }}
 
       {{- if .Values.global.dagOnlyDeployment.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -122,6 +122,12 @@ data:
         {{- if .Values.global.authSidecar.securityContext}}
         securityContext: {{- .Values.global.authSidecar.securityContext | toYaml | nindent 10 }}
         {{- end }}
+        {{- if .Values.global.authSidecar.livenessProbe}}
+        livenessProbe: {{- .Values.global.authSidecar.livenessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.authSidecar.readinessProbe}}
+        readinessProbe: {{- .Values.global.authSidecar.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
         resources: {{- .Values.global.authSidecar.resources | toYaml | nindent 10 }}
         annotations: {
           {{- range $key, $value := .Values.global.extraAnnotations}}
@@ -177,6 +183,12 @@ data:
         {{- end }}
         {{ if .Values.global.dagOnlyDeployment.serviceAccount }}
         serviceAccount: {{- .Values.global.dagOnlyDeployment.serviceAccount | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.livenessProbe}}
+        livenessProbe: {{- .Values.global.dagOnlyDeployment.livenessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.readinessProbe}}
+        readinessProbe: {{- .Values.global.dagOnlyDeployment.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -692,8 +692,10 @@ def test_houston_configmap_with_authsidecar_readiness_probe():
             "global": {
                 "authSidecar": {
                     "enabled": True,
+                    "repository": "someregistry.io/my-custom-image",
+                    "tag": "my-custom-tag",
+                    "resources": {},
                     "readinessProbe": readiness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
             }
         },

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -669,14 +669,14 @@ def test_houston_configmap_with_loggingsidecar_with_liveness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
-    
+
     # Ensure the chart was rendered
     assert len(docs) > 0
-    
+
     # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    
+
     # Validate livenessProbe
     assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
     assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
@@ -709,14 +709,14 @@ def test_houston_configmap_with_loggingsidecar_with_readiness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
-    
+
     # Ensure the chart was rendered
     assert len(docs) > 0
-    
+
     # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    
+
     # Validate readinessProbe
     assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
     assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -657,16 +657,24 @@ def test_houston_configmap_with_authsidecar_liveness_probe():
             "global": {
                 "authSidecar": {
                     "enabled": True,
+                    "repository": "someregistry.io/my-custom-image",
+                    "tag": "my-custom-tag",
+                    "resources": {},
                     "livenessProbe": liveness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
             }
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
+    assert len(docs) > 0
+
+    # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod_yaml["authSideCar"]["livenessProbe"] == liveness_probe
+
+    # Validate livenessProbe
+    assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
+    assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
 
 
 def test_houston_configmap_with_authsidecar_readiness_probe():
@@ -691,9 +699,17 @@ def test_houston_configmap_with_authsidecar_readiness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
+
+    # Ensure the chart was rendered
+    assert len(docs) > 0
+
+    # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod_yaml["authSideCar"]["readinessProbe"] == readiness_probe
+
+    # Validate readinessProbe
+    assert "readinessProbe" in prod_yaml["deployments"]["authSidecar"]
+    assert prod_yaml["deployments"]["authSidecar"]["readinessProbe"] == readiness_probe
 
 
 def test_houston_configmap_with_dagonlydeployment_liveness_probe():
@@ -718,9 +734,17 @@ def test_houston_configmap_with_dagonlydeployment_liveness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
+
+    # Ensure the chart was rendered
+    assert len(docs) > 0
+
+    # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod_yaml["dagDeploy"]["livenessProbe"] == liveness_probe
+
+    # Validate livenessProbe
+    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
+    assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
 
 
 def test_houston_configmap_with_dagonlydeployment_readiness_probe():
@@ -745,9 +769,17 @@ def test_houston_configmap_with_dagonlydeployment_readiness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
+
+    # Ensure the chart was rendered
+    assert len(docs) > 0
+
+    # Parse the rendered configmap
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod_yaml["dagDeploy"]["readinessProbe"] == readiness_probe
+
+    # Validate readinessProbe
+    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
+    assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
 
 
 def test_houston_configmap_with_loggingsidecar_liveness_probe():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -642,7 +642,83 @@ def test_houston_configmap_with_tls_secretname_overrides():
     assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
 
 
-def test_houston_configmap_with_loggingsidecar_with_liveness_probe():
+def test_houston_configmap_with_authsidecar_liveness_probe():
+    """Validate the authSidecar liveness probe in the Houston configmap."""
+    liveness_probe = {
+        "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={"global": {"authSidecar": {"enabled": True, "livenessProbe": liveness_probe}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["authSideCar"]["livenessProbe"] == liveness_probe
+
+
+def test_houston_configmap_with_authsidecar_readiness_probe():
+    """Validate the authSidecar readiness probe in the Houston configmap."""
+    readiness_probe = {
+        "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={"global": {"authSidecar": {"enabled": True, "readinessProbe": readiness_probe}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["authSideCar"]["readinessProbe"] == readiness_probe
+
+
+def test_houston_configmap_with_dagonlydeployment_liveness_probe():
+    """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
+    liveness_probe = {
+        "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={"global": {"dagOnlyDeployment": {"enabled": True, "livenessProbe": liveness_probe}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["dagDeploy"]["livenessProbe"] == liveness_probe
+
+
+def test_houston_configmap_with_dagonlydeployment_readiness_probe():
+    """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
+    readiness_probe = {
+        "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={"global": {"dagOnlyDeployment": {"enabled": True, "readinessProbe": readiness_probe}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["dagDeploy"]["readinessProbe"] == readiness_probe
+
+
+def test_houston_configmap_with_loggingsidecar_liveness_probe():
     """Validate the houston configmap with liveness probe configured."""
     liveness_probe = {
         "httpGet": {
@@ -682,7 +758,7 @@ def test_houston_configmap_with_loggingsidecar_with_liveness_probe():
     assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
 
 
-def test_houston_configmap_with_loggingsidecar_with_readiness_probe():
+def test_houston_configmap_with_loggingsidecar_readiness_probe():
     """Validate the houston configmap with readiness probe configured."""
     readiness_probe = {
         "httpGet": {

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -653,7 +653,15 @@ def test_houston_configmap_with_authsidecar_liveness_probe():
         "failureThreshold": 3,
     }
     docs = render_chart(
-        values={"global": {"authSidecar": {"enabled": True, "livenessProbe": liveness_probe}}},
+        values={
+            "global": {
+                "authSidecar": {
+                    "enabled": True,
+                    "livenessProbe": liveness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+                }
+            }
+        },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     doc = docs[0]
@@ -672,7 +680,15 @@ def test_houston_configmap_with_authsidecar_readiness_probe():
         "failureThreshold": 3,
     }
     docs = render_chart(
-        values={"global": {"authSidecar": {"enabled": True, "readinessProbe": readiness_probe}}},
+        values={
+            "global": {
+                "authSidecar": {
+                    "enabled": True,
+                    "readinessProbe": readiness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+                }
+            }
+        },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     doc = docs[0]
@@ -691,7 +707,15 @@ def test_houston_configmap_with_dagonlydeployment_liveness_probe():
         "failureThreshold": 3,
     }
     docs = render_chart(
-        values={"global": {"dagOnlyDeployment": {"enabled": True, "livenessProbe": liveness_probe}}},
+        values={
+            "global": {
+                "dagOnlyDeployment": {
+                    "enabled": True,
+                    "livenessProbe": liveness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+                }
+            }
+        },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     doc = docs[0]
@@ -710,7 +734,15 @@ def test_houston_configmap_with_dagonlydeployment_readiness_probe():
         "failureThreshold": 3,
     }
     docs = render_chart(
-        values={"global": {"dagOnlyDeployment": {"enabled": True, "readinessProbe": readiness_probe}}},
+        values={
+            "global": {
+                "dagOnlyDeployment": {
+                    "enabled": True,
+                    "readinessProbe": readiness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+                }
+            }
+        },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     doc = docs[0]

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -701,8 +701,6 @@ def test_houston_configmap_with_authsidecar_readiness_probe():
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
-
-    # Ensure the chart was rendered
     assert len(docs) > 0
 
     # Parse the rendered configmap
@@ -710,8 +708,8 @@ def test_houston_configmap_with_authsidecar_readiness_probe():
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
     # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["authSidecar"]
-    assert prod_yaml["deployments"]["authSidecar"]["readinessProbe"] == readiness_probe
+    assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
+    assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
 
 
 def test_houston_configmap_with_dagonlydeployment_liveness_probe():

--- a/values.yaml
+++ b/values.yaml
@@ -151,6 +151,8 @@ global:
     indexPattern: ~
     extraEnv: []
     securityContext: {}
+    readinessProbe: {}
+    livenessProbe: {}
     resources: {}
     #  requests:
     #    cpu: "100m"

--- a/values.yaml
+++ b/values.yaml
@@ -135,6 +135,8 @@ global:
         fsGroup: 50000
     resources: {}
     persistence: {}
+    readinessProbe: {}
+    livenessProbe: {}
 
   logging:
     indexNamePrefix: ~
@@ -165,6 +167,8 @@ global:
     pullPolicy: IfNotPresent
     port: 8084
     securityContext: {}
+    readinessProbe: {}
+    livenessProbe: {}
     default_nginx_settings: |
       internal;
       proxy_pass_request_body     off;


### PR DESCRIPTION
## Description

This PR adds configurable liveness/readiness probes for authsidecar and dagdeployment for houston config

## Related Issues

Related astronomer/issues#6745

## Testing

N/A

## Merging

0.37.0
