### PR TITLE
Commander and Prometheus changes needed for Airflow Operator Support.

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -35,6 +35,11 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
   {{- end }}
 rules:
+{{- if $.Values.global.operator.enabled }}
+- apiGroups: ["airflow.apache.org"]
+  resources: ["airflows"]
+  verbs: ["get", "list", "watch", "create", "update", “patch”, "delete"]
+{{- end }}
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["create", "delete", "deletecollection", "get", "list", "patch", "update", "watch"]

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -109,7 +109,7 @@ rules:
   verbs: ["list", "watch", "create", "delete", "get"]
 - apiGroups: ["batch"]
   resources: ["cronjobs"]
-  verbs: ["create", "delete", "get", "list", "patch", "watch"]
+  verbs: ["create", "delete", "get", "list", "patch", "watch", "deletecollection"]
 - apiGroups: ["extensions"]
   resources: ["daemonsets", "replicasets"]
   verbs: ["list", "watch"]

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -38,7 +38,7 @@ rules:
 {{- if $.Values.global.operator.enabled }}
 - apiGroups: ["airflow.apache.org"]
   resources: ["airflows"]
-  verbs: ["get", "list", "watch", "create", "update", “patch”, "delete"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}
 - apiGroups: [""]
   resources: ["configmaps"]

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -372,6 +372,11 @@ data:
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
+          {{- if $.Values.global.operator.enabled }}
+          - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
+            regex: ^astronomer$
+            action: keep
+          {{- end }}
           - source_labels: [__meta_kubernetes_service_annotation_astronomer_io_platform_release]
             action: keep
             regex: ^{{ .Release.Name }}$

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -374,7 +374,7 @@ data:
         relabel_configs:
           - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
-          {{- if $.Values.global.operator.enabled }}
+          {{- if .Values.global.operator.enabled }}
           - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
             regex: ^astronomer$
             action: keep

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -381,3 +381,39 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_MANAGE_NAMESPACE_RESOURCE"] == "false"
         assert env_vars["COMMANDER_MANUAL_NAMESPACE_NAMES"] == "true"
         assert env_vars["COMMANDER_AIRGAPPED"] == "true"
+
+    def test_astronomer_commander_operator_permissions(self, kube_version):
+        """Test template that helm renders when operator is enabled ."""
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "operator": {"enabled": True},
+                },
+                },
+            show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
+        )[0]
+        expected_rule = {
+                'apiGroups': ['airflow.apache.org'],
+                'resources': ['airflows'],
+                'verbs': ['get', 'list', 'watch', 'create', 'update', "patch", 'delete']
+            }
+        assert any(rule == expected_rule for rule in doc['rules'])
+    
+    def test_astronomer_commander_operator_permissions_disabled(self, kube_version):
+        """Test template that helm renders when operator is enabled ."""
+        doc = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "operator": {"enabled": False},
+                },
+                },
+            show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
+        )[0]
+        expected_rule = {
+                'apiGroups': ['airflow.apache.org'],
+                'resources': ['airflows'],
+                'verbs': ['get', 'list', 'watch', 'create', 'update', "patch", 'delete']
+            }
+        assert not any(rule == expected_rule for rule in doc['rules'])

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -390,16 +390,16 @@ class TestAstronomerCommander:
                 "global": {
                     "operator": {"enabled": True},
                 },
-                },
+            },
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
         )[0]
         expected_rule = {
-                'apiGroups': ['airflow.apache.org'],
-                'resources': ['airflows'],
-                'verbs': ['get', 'list', 'watch', 'create', 'update', "patch", 'delete']
-            }
-        assert any(rule == expected_rule for rule in doc['rules'])
-    
+            "apiGroups": ["airflow.apache.org"],
+            "resources": ["airflows"],
+            "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
+        }
+        assert any(rule == expected_rule for rule in doc["rules"])
+
     def test_astronomer_commander_operator_permissions_disabled(self, kube_version):
         """Test template that helm renders when operator is enabled ."""
         doc = render_chart(
@@ -408,12 +408,12 @@ class TestAstronomerCommander:
                 "global": {
                     "operator": {"enabled": False},
                 },
-                },
+            },
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
         )[0]
         expected_rule = {
-                'apiGroups': ['airflow.apache.org'],
-                'resources': ['airflows'],
-                'verbs': ['get', 'list', 'watch', 'create', 'update', "patch", 'delete']
-            }
-        assert not any(rule == expected_rule for rule in doc['rules'])
+            "apiGroups": ["airflow.apache.org"],
+            "resources": ["airflows"],
+            "verbs": ["get", "list", "watch", "create", "update", "patch", "delete"],
+        }
+        assert not any(rule == expected_rule for rule in doc["rules"])

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -331,7 +331,7 @@ class TestPrometheusConfigConfigmap:
         scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
 
         assert prometheus_job not in scrape_configs
-    
+
     def test_prometheus_operator_integration_config(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,
@@ -339,7 +339,7 @@ class TestPrometheusConfigConfigmap:
             name="astronomer",
             values={"global": {"operator": {"enabled": True}}},
         )[0]
-        assert '__meta_kubernetes_service_label_astronomer_io_platform_release' in doc['data']['config']
+        assert "__meta_kubernetes_service_label_astronomer_io_platform_release" in doc["data"]["config"]
 
     def test_prometheus_operator_integration_config_disabled(self, kube_version):
         doc = render_chart(
@@ -348,6 +348,4 @@ class TestPrometheusConfigConfigmap:
             name="astronomer",
             values={"global": {"operator": {"enabled": False}}},
         )[0]
-        assert '__meta_kubernetes_service_label_astronomer_io_platform_release' not in doc['data']['config']
-
-        
+        assert "__meta_kubernetes_service_label_astronomer_io_platform_release" not in doc["data"]["config"]

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -331,3 +331,22 @@ class TestPrometheusConfigConfigmap:
         scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
 
         assert prometheus_job not in scrape_configs
+    
+    def test_prometheus_operator_integration_config(self, kube_version):
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            name="astronomer",
+            values={"global": {"operator": {"enabled": True}}},
+        )[0]
+        assert '__meta_kubernetes_service_label_astronomer_io_platform_release' in doc['data']['config']
+
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            name="astronomer",
+            values={"global": {"operator": {"enabled": False}}},
+        )[0]
+        assert '__meta_kubernetes_service_label_astronomer_io_platform_release' not in doc['data']['config']
+
+        

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -341,6 +341,7 @@ class TestPrometheusConfigConfigmap:
         )[0]
         assert '__meta_kubernetes_service_label_astronomer_io_platform_release' in doc['data']['config']
 
+    def test_prometheus_operator_integration_config_disabled(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,


### PR DESCRIPTION
## Description
This PR adds support for managing Airflow Operator deployments and collecting their metrics by:

### Key Changes

1. **Commander RBAC Enhancements**
   - Added new RBAC rules to enable Commander to manage Airflow CRDs:
     ```yaml
     - apiGroups: ["airflow.apache.org"]
       resources: ["airflows"]
       verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
     ```
   - These permissions enable Commander to:
     - Create and manage Operator-based deployments
     - Monitor deployment status
     - Update configurations
     - Handle lifecycle operations

2. **Prometheus Service Discovery Updates**
   - Added new relabel configuration in Prometheus ConfigMap:
     ```yaml
     - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
       regex: ^astronomer$
       action: keep
     ```
   - This change addresses a key difference between Helm and Operator deployments:
     - Helm: Uses service annotations for metrics discovery
     - Operator: Uses service labels (native limitation)
   - Benefits:
     - Unified metrics collection across both deployment types
     - Seamless integration with Astronomer UI
     - Consistent monitoring experience


## Migration Considerations
- No migration needed for existing deployments
- New configuration automatically applies to Operator deployments
- Helm deployments continue to use annotation-based discovery

## Related Issues

Related astronomer/issues#6896

### Key Changes
1. **Commander RBAC Updates**
   - Added permissions for the `airflow.apache.org` API group
   - Granted full CRUD access to `airflows` resources
   - This enables the Commander to manage Operator-based deployments alongside Helm deployments

2. **Prometheus Configuration Enhancement**
   - Added service discovery based on labels since the Operator doesn't natively support service annotations
   - Added relabel config to match the `astronomer_io_platform_release` label
   - Ensures metrics collection from Operator-managed deployments appears in Astronomer UI

## Technical Implementation
- Changes are implemented in a backward-compatible manner
- No impact on existing Helm-based deployments
- Feature toggling using `global.operator.enabled` flag
- Prometheus configuration changes maintain existing scrape patterns

## Testing Performed
1. **RBAC Verification**
   - Tested Commander's ability to:
     - Create new Operator deployments
     - Update existing deployments
     - Delete deployments
     - List and watch deployment status

2. **Metrics Collection**
   - Verified metrics appear in Prometheus
   - Confirmed dashboard visualization
   - Tested with both Helm and Operator deployments
   - Validated metric labels and tags

3. **Environment Testing**
   - Deployed to stage cluster
   - Tested with various deployment configurations
   - Verified backward compatibility

## Post-Deployment Verification
After deployment, verify:
1. Commander can manage Operator deployments
2. Metrics are being collected correctly
3. Dashboards show data from both deployment types
4. No impact on existing deployments

## Version
Target Release: 0.37
