### PR TITLE
add airflow extra ingress annotation support

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -210,8 +210,7 @@ data:
 
       {{- if and .Values.global.extraAnnotations ( not .Values.global.authSidecar.enabled ) }}
         ingress:
-          extraIngressAnnotations:
-{{- toYaml .Values.global.extraAnnotations | nindent 12 }}
+          extraIngressAnnotations: {{- toYaml .Values.global.extraAnnotations | nindent 12 }}
       {{- end }}
 
       {{- if .Values.global.networkNSLabels }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -208,6 +208,12 @@ data:
         sccEnabled: true
       {{- end }}
 
+      {{- if and .Values.global.extraAnnotations ( not .Values.global.authSidecar.enabled ) }}
+        ingress:
+          extraIngressAnnotations:
+{{- toYaml .Values.global.extraAnnotations | nindent 12 }}
+      {{- end }}
+
       {{- if .Values.global.networkNSLabels }}
         networkNSLabels: true
       {{- end }}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -705,10 +705,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
-        assert len(docs) > 0
-
-        # Parse the rendered configmap
+        assert len(docs) == 1
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -739,10 +736,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
-        assert len(docs) > 0
-
-        # Parse the rendered configmap
+        assert len(docs) == 1
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -778,10 +772,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
-        assert len(docs) > 0
-
-        # Parse the rendered configmap
+        assert len(docs) == 1
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -817,10 +808,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
-        assert len(docs) > 0
-
-        # Parse the rendered configmap
+        assert len(docs) == 1
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -835,10 +823,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
         assert len(docs) == 1
-
-        # Parse the rendered configmap
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -856,10 +841,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        # Ensure the chart was rendered
         assert len(docs) == 1
-
-        # Parse the rendered configmap
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -36,827 +36,821 @@ def common_test_cases(docs):
     ast.parse(airflow_local_settings.encode())
 
 
-def test_houston_configmap():
-    """Validate the houston configmap and its embedded data."""
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+class TestHoustonConfigmap:
+    def test_houston_configmap(self):
+        """Validate the houston configmap and its embedded data."""
+        docs = render_chart(
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        # Ensure airflow elasticsearch param is at correct location
+        assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
+        # Ensure elasticsearch client param is at the correct location and contains http://
+        assert "node" in prod["elasticsearch"]["client"]
+        assert prod["elasticsearch"]["client"]["node"].startswith("http://")
+        with pytest.raises(KeyError):
+            # Ensure sccEnabled is not defined by default
+            assert prod["deployments"]["helm"]["sccEnabled"] is False
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    # Ensure airflow elasticsearch param is at correct location
-    assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
-    # Ensure elasticsearch client param is at the correct location and contains http://
-    assert "node" in prod["elasticsearch"]["client"]
-    assert prod["elasticsearch"]["client"]["node"].startswith("http://")
-    with pytest.raises(KeyError):
-        # Ensure sccEnabled is not defined by default
-        assert prod["deployments"]["helm"]["sccEnabled"] is False
+    def test_houston_configmap_with_namespaceFreeFormEntry_true(self):
+        """Validate the houston configmap's embedded data with
+        namespaceFreeFormEntry=True."""
 
+        docs = render_chart(
+            values={"global": {"namespaceFreeFormEntry": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        assert prod["deployments"]["namespaceFreeFormEntry"] is True
 
-def test_houston_configmap_with_namespaceFreeFormEntry_true():
-    """Validate the houston configmap's embedded data with
-    namespaceFreeFormEntry=True."""
+    def test_houston_configmap_with_namespaceFreeFormEntry_defaults(self):
+        """Validate the houston configmap's embedded data with
+        namespaceFreeFormEntry defaults."""
+        docs = render_chart(
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
-    docs = render_chart(
-        values={"global": {"namespaceFreeFormEntry": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    assert prod["deployments"]["namespaceFreeFormEntry"] is True
+    def test_houston_configmap_with_customlogging_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        customLogging."""
+        docs = render_chart(
+            values={"global": {"customLogging": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
+        common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
-    """Validate the houston configmap's embedded data with
-    namespaceFreeFormEntry defaults."""
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    assert prod["deployments"]["namespaceFreeFormEntry"] is False
+        assert "node" in prod["elasticsearch"]["client"]
+        assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
 
+    def test_houston_configmapwith_scc_enabled(self):
+        """Validate the houston configmap and its embedded data with sscEnabled."""
+        docs = render_chart(
+            values={"global": {"sccEnabled": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-def test_houston_configmap_with_customlogging_enabled():
-    """Validate the houston configmap and its embedded data with
-    customLogging."""
-    docs = render_chart(
-        values={"global": {"customLogging": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["helm"]["sccEnabled"] is True
 
-    assert "node" in prod["elasticsearch"]["client"]
-    assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
+    def test_houston_configmap_with_azure_enabled(self):
+        """Validate the houston configmap and its embedded data with azure
+        enabled."""
+        docs = render_chart(
+            values={"global": {"azure": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
+        common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-def test_houston_configmapwith_scc_enabled():
-    """Validate the houston configmap and its embedded data with sscEnabled."""
-    docs = render_chart(
-        values={"global": {"sccEnabled": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+        with pytest.raises(KeyError):
+            assert prod["deployments"]["helm"]["sccEnabled"] is False
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+        livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
+        assert livenessProbe["failureThreshold"] == 25
+        assert livenessProbe["periodSeconds"] == 10
 
-    assert prod["deployments"]["helm"]["sccEnabled"] is True
+    def test_houston_configmap_with_config_syncer_enabled(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        enabled."""
+        docs = render_chart(
+            values={"astronomer": {"configSyncer": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
+        common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
+            {
+                "name": "signing-certificate",
+                "mountPath": "/etc/airflow/tls",
+                "readOnly": True,
+            }
+        ]
+        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
+            {
+                "name": "signing-certificate",
+                "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
+            }
+        ]
 
-def test_houston_configmap_with_azure_enabled():
-    """Validate the houston configmap and its embedded data with azure
-    enabled."""
-    docs = render_chart(
-        values={"global": {"azure": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmap_with_config_syncer_disabled(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={"astronomer": {"configSyncer": {"enabled": False}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+        assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+        assert not prod_yaml["deployments"].get("loggingSidecar")
 
-    with pytest.raises(KeyError):
-        assert prod["deployments"]["helm"]["sccEnabled"] is False
+    def test_houston_configmap_with_fluentd_index_prefix_defaults(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
-    assert livenessProbe["failureThreshold"] == 25
-    assert livenessProbe["periodSeconds"] == 10
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
 
+    def test_houston_configmap_with_fluentd_index_prefix_overrides(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-def test_houston_configmap_with_config_syncer_enabled():
-    """Validate the houston configmap and its embedded data with configSyncer
-    enabled."""
-    docs = render_chart(
-        values={"astronomer": {"configSyncer": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
-        {
-            "name": "signing-certificate",
-            "mountPath": "/etc/airflow/tls",
-            "readOnly": True,
-        }
-    ]
-    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
-        {
-            "name": "signing-certificate",
-            "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
-        }
-    ]
-
-
-def test_houston_configmap_with_config_syncer_disabled():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={"astronomer": {"configSyncer": {"enabled": False}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    assert not prod_yaml["deployments"].get("loggingSidecar")
-
-
-def test_houston_configmap_with_fluentd_index_prefix_defaults():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
-
-
-def test_houston_configmap_with_fluentd_index_prefix_overrides():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
-
-
-def test_houston_configmap_with_loggingsidecar_enabled():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "repository": "quay.io/astronomer/ap-vector",
-                    "tag": "0.22.3",
+    def test_houston_configmap_with_loggingsidecar_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "repository": "quay.io/astronomer/ap-vector",
+                        "tag": "0.22.3",
+                    },
                 },
             },
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": "sidecar-log-consumer",
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": "sidecar-log-consumer",
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    image = "registry.example.com/foobar/test-image-name:99.88.77"
-    docs = render_chart(
-        values={
-            "global": {
-                "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
-                "loggingSidecar": {
-                    "enabled": True,
-                    "repository": image.split(":")[0],
-                    "tag": image.split(":")[1],
-                },
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": "sidecar-log-consumer",
-        "image": image,
-        "customConfig": False,
-        "indexNamePrefix": "test-index-name-prefix-999",
-    }
-    assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": "quay.io/astronomer/ap-vector",
-                    "tag": "0.22.3",
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "example.com/some-repo/test-image-name:test-tag-foo"
-    indexPattern = "%Y.%m"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "indexPattern": indexPattern,
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": image_name,
-        "customConfig": False,
-        "indexPattern": indexPattern,
-    }
-
-
-def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
-    """Validate the houston configmap and its embedded data with loggingSidecar
-    customConfig Enabled."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:0.22.3"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "customConfig": True,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": True,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:0.22.3"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "extraEnv": [
-                        {
-                            "name": "ES_USER",
-                            "valueFrom": {
-                                "secretKeyRef": {
-                                    "name": "elastic-creds",
-                                    "key": "ESUSER",
-                                }
-                            },
-                        },
-                        {
-                            "name": "ES_PASS",
-                            "valueFrom": {
-                                "secretKeyRef": {
-                                    "name": "elastic-creds",
-                                    "key": "ESPASS",
-                                }
-                            },
-                        },
-                    ],
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-        "extraEnv": [
-            {
-                "name": "ES_USER",
-                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
-            },
-            {
-                "name": "ES_PASS",
-                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
-            },
-        ],
-    }
-
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": f"{image_name['repository']}",
-                    "tag": f"{image_name['tag']}",
-                    "resources": {
-                        "requests": {"memory": "386Mi", "cpu": "100m"},
-                        "limits": {"memory": "386Mi", "cpu": "100m"},
+    def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        image = "registry.example.com/foobar/test-image-name:99.88.77"
+        docs = render_chart(
+            values={
+                "global": {
+                    "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "repository": image.split(":")[0],
+                        "tag": image.split(":")[1],
                     },
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-        "resources": {
-            "requests": {"memory": "386Mi", "cpu": "100m"},
-            "limits": {"memory": "386Mi", "cpu": "100m"},
-        },
-    }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": "sidecar-log-consumer",
+            "image": image,
+            "customConfig": False,
+            "indexNamePrefix": "test-index-name-prefix-999",
+        }
+        assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    securityContext = {
-        "runAsUser": 1000,
-    }
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:unittest-tag"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "securityContext": securityContext,
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:unittest-tag",
-        "customConfig": False,
-        "securityContext": securityContext,
-    }
-
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
-    """Validate the houston configmap and its embedded data with
-    updateAirflowCheck and updateRuntimeCheck."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "updateAirflowCheck": {"enabled": True},
-                    "updateRuntimeCheck": {"enabled": True},
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-
-    assert prod["updateAirflowCheckEnabled"] is True
-    assert prod["updateRuntimeCheckEnabled"] is True
-
-
-def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
-    """Validate the houston configmap and its embedded data with
-    updateAirflowCheck and updateRuntimeCheck."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "updateAirflowCheck": {"enabled": False},
-                    "updateRuntimeCheck": {"enabled": False},
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["updateAirflowCheckEnabled"] is False
-    assert prod["updateRuntimeCheckEnabled"] is False
-
-
-def test_houston_configmap_with_cleanup_airflow_db_enabled():
-    """Validate the houston configmap and its embedded data with
-    cleanupAirflowDb."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "cleanupAirflowDb": {
+    def test_houston_configmap_with_loggingsidecar_enabled_with_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
                         "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": "quay.io/astronomer/ap-vector",
+                        "tag": "0.22.3",
                     }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
-def test_houston_configmap_with_cleanup_airflow_db_disabled():
-    """Validate the houston configmap and its embedded data with
-    cleanupAirflowDb."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "cleanupAirflowDb": {
-                        "enabled": False,
+    def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "example.com/some-repo/test-image-name:test-tag-foo"
+        indexPattern = "%Y.%m"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "indexPattern": indexPattern,
                     }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": image_name,
+            "customConfig": False,
+            "indexPattern": indexPattern,
+        }
 
-
-def test_houston_configmap_with_internal_authorization_flag_defaults():
-    """Validate the houston configmap to internal authorization."""
-    docs = render_chart(
-        values={},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
-
-
-def test_houston_configmap_with_internal_authorization_flag_enabled():
-    """Validate the houston configmap to internal authorization."""
-    docs = render_chart(
-        values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
-
-
-def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled():
-    """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
-    ."""
-    docs = render_chart(
-        values={"global": {"disableManageClusterScopedResources": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["disableManageClusterScopedResources"] is True
-
-
-def test_houston_configmap_with_tls_secretname_overrides():
-    """Validate the houston configmap and its embedded data with tls secretname overrides
-    ."""
-    docs = render_chart(
-        values={"global": {"tlsSecret": "astro-ssl-secret"}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
-
-
-def test_houston_configmap_with_authsidecar_liveness_probe():
-    """Validate the authSidecar liveness probe in the Houston configmap."""
-    liveness_probe = {
-        "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
-        "initialDelaySeconds": 10,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "authSidecar": {
-                    "enabled": True,
-                    "repository": "someregistry.io/my-custom-image",
-                    "tag": "my-custom-tag",
-                    "resources": {},
-                    "livenessProbe": liveness_probe,
+    def test_houston_configmap_with_loggingsidecar_customConfig_enabled(self):
+        """Validate the houston configmap and its embedded data with loggingSidecar
+        customConfig Enabled."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:0.22.3"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "customConfig": True,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    assert len(docs) > 0
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": True,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    # Validate livenessProbe
-    assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
-    assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
-
-
-def test_houston_configmap_with_authsidecar_readiness_probe():
-    """Validate the authSidecar readiness probe in the Houston configmap."""
-    readiness_probe = {
-        "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
-        "initialDelaySeconds": 10,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "authSidecar": {
-                    "enabled": True,
-                    "repository": "someregistry.io/my-custom-image",
-                    "tag": "my-custom-tag",
-                    "resources": {},
-                    "readinessProbe": readiness_probe,
+    def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:0.22.3"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "extraEnv": [
+                            {
+                                "name": "ES_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "elastic-creds",
+                                        "key": "ESUSER",
+                                    }
+                                },
+                            },
+                            {
+                                "name": "ES_PASS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "elastic-creds",
+                                        "key": "ESPASS",
+                                    }
+                                },
+                            },
+                        ],
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    assert len(docs) > 0
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+            "extraEnv": [
+                {
+                    "name": "ES_USER",
+                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
+                },
+                {
+                    "name": "ES_PASS",
+                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
+                },
+            ],
+        }
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
-    assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
-
-
-def test_houston_configmap_with_dagonlydeployment_liveness_probe():
-    """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
-    liveness_probe = {
-        "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "dagOnlyDeployment": {
-                    "enabled": True,
-                    "livenessProbe": liveness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+    def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": f"{image_name['repository']}",
+                        "tag": f"{image_name['tag']}",
+                        "resources": {
+                            "requests": {"memory": "386Mi", "cpu": "100m"},
+                            "limits": {"memory": "386Mi", "cpu": "100m"},
+                        },
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+            "resources": {
+                "requests": {"memory": "386Mi", "cpu": "100m"},
+                "limits": {"memory": "386Mi", "cpu": "100m"},
+            },
+        }
 
-    # Ensure the chart was rendered
-    assert len(docs) > 0
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-    # Validate livenessProbe
-    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
-
-
-def test_houston_configmap_with_dagonlydeployment_readiness_probe():
-    """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
-    readiness_probe = {
-        "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "dagOnlyDeployment": {
-                    "enabled": True,
-                    "readinessProbe": readiness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+    def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        securityContext = {
+            "runAsUser": 1000,
+        }
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:unittest-tag"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "securityContext": securityContext,
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:unittest-tag",
+            "customConfig": False,
+            "securityContext": securityContext,
+        }
 
-    # Ensure the chart was rendered
-    assert len(docs) > 0
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-    # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
-
-
-def test_houston_configmap_with_loggingsidecar_liveness_probe():
-    """Validate the houston configmap with liveness probe configured."""
-    liveness_probe = {
-        "httpGet": {
-            "path": "/healthz",
-            "port": 8080,
-            "scheme": "HTTP",
-        },
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 30,
-        "periodSeconds": 5,
-        "successThreshold": 1,
-        "failureThreshold": 20,
-    }
-
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": "sidecar-log-test",
-                    "livenessProbe": liveness_probe,
+    def test_houston_configmapwith_update_airflow_runtime_checks_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        updateAirflowCheck and updateRuntimeCheck."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateAirflowCheck": {"enabled": True},
+                        "updateRuntimeCheck": {"enabled": True},
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
 
-    # Ensure the chart was rendered
-    assert len(docs) > 0
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["updateAirflowCheckEnabled"] is True
+        assert prod["updateRuntimeCheckEnabled"] is True
 
-    # Validate livenessProbe
-    assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-    assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
-
-
-def test_houston_configmap_with_loggingsidecar_readiness_probe():
-    """Validate the houston configmap with readiness probe configured."""
-    readiness_probe = {
-        "httpGet": {
-            "path": "/healthz",
-            "port": 8080,
-            "scheme": "HTTP",
-        },
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 30,
-        "periodSeconds": 5,
-        "successThreshold": 1,
-        "failureThreshold": 20,
-    }
-
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": "sidecar-log-test",
-                    "readinessProbe": readiness_probe,
+    def test_houston_configmapwith_update_airflow_runtime_checks_disabled(self):
+        """Validate the houston configmap and its embedded data with
+        updateAirflowCheck and updateRuntimeCheck."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateAirflowCheck": {"enabled": False},
+                        "updateRuntimeCheck": {"enabled": False},
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
 
-    # Ensure the chart was rendered
-    assert len(docs) > 0
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["updateAirflowCheckEnabled"] is False
+        assert prod["updateRuntimeCheckEnabled"] is False
 
-    # Parse the rendered configmap
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    def test_houston_configmap_with_cleanup_airflow_db_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        cleanupAirflowDb."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "cleanupAirflowDb": {
+                            "enabled": True,
+                        }
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
 
-    # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-    assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
+
+    def test_houston_configmap_with_cleanup_airflow_db_disabled(self):
+        """Validate the houston configmap and its embedded data with
+        cleanupAirflowDb."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "cleanupAirflowDb": {
+                            "enabled": False,
+                        }
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
+
+    def test_houston_configmap_with_internal_authorization_flag_defaults(self):
+        """Validate the houston configmap to internal authorization."""
+        docs = render_chart(
+            values={},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
+
+    def test_houston_configmap_with_internal_authorization_flag_enabled(self):
+        """Validate the houston configmap to internal authorization."""
+        docs = render_chart(
+            values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
+
+    def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled(self):
+        """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
+        ."""
+        docs = render_chart(
+            values={"global": {"disableManageClusterScopedResources": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["disableManageClusterScopedResources"] is True
+
+    def test_houston_configmap_with_tls_secretname_overrides(self):
+        """Validate the houston configmap and its embedded data with tls secretname overrides
+        ."""
+        docs = render_chart(
+            values={"global": {"tlsSecret": "astro-ssl-secret"}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
+
+    def test_houston_configmap_with_authsidecar_liveness_probe(self):
+        """Validate the authSidecar liveness probe in the Houston configmap."""
+        liveness_probe = {
+            "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "authSidecar": {
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "resources": {},
+                        "livenessProbe": liveness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate livenessProbe
+        assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
+        assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
+
+    def test_houston_configmap_with_authsidecar_readiness_probe(self):
+        """Validate the authSidecar readiness probe in the Houston configmap."""
+        readiness_probe = {
+            "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "authSidecar": {
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "resources": {},
+                        "readinessProbe": readiness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate readinessProbe
+        assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
+        assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
+
+    def test_houston_configmap_with_dagonlydeployment_liveness_probe(self):
+        """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
+        liveness_probe = {
+            "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "livenessProbe": liveness_probe,
+                        "image": "quay.io/astronomer/ap-auth:0.22.3",
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate livenessProbe
+        assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
+        assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
+
+    def test_houston_configmap_with_dagonlydeployment_readiness_probe(self):
+        """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
+        readiness_probe = {
+            "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "readinessProbe": readiness_probe,
+                        "image": "quay.io/astronomer/ap-auth:0.22.3",
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate readinessProbe
+        assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
+        assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
+
+    def test_houston_configmap_with_loggingsidecar_liveness_probe(self):
+        """Validate the houston configmap with liveness probe configured."""
+        liveness_probe = {
+            "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP",
+            },
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 30,
+            "periodSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 20,
+        }
+
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": "sidecar-log-test",
+                        "livenessProbe": liveness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate livenessProbe
+        assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+        assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
+
+    def test_houston_configmap_with_loggingsidecar_readiness_probe(self):
+        """Validate the houston configmap with readiness probe configured."""
+        readiness_probe = {
+            "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP",
+            },
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 30,
+            "periodSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 20,
+        }
+
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": "sidecar-log-test",
+                        "readinessProbe": readiness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate readinessProbe
+        assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+        assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
+
+    def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled(self):
+        """Validate the houston configmap with custom airflow ingress annotation."""
+        docs = render_chart(
+            values={
+                "global": {
+                    "extraAnnotations": {
+                        "route.openshift.io/termination": "passthrough"
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate extra ingress annotation
+        helm = prod_yaml["deployments"]["helm"]
+        assert "ingress" in helm
+        assert {"extraIngressAnnotations":{"route.openshift.io/termination": "passthrough"}} == helm["ingress"]

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -854,3 +854,28 @@ class TestHoustonConfigmap:
         helm = prod_yaml["deployments"]["helm"]
         assert "ingress" in helm
         assert {"extraIngressAnnotations":{"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
+
+    def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled(self):
+        """Validate the houston configmap does not include airflow ingress annotation."""
+        docs = render_chart(
+            values={
+                "global": {
+                    "authSidecar":{"enabled": True},
+                    "extraAnnotations": {
+                        "route.openshift.io/termination": "passthrough"
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        # Ensure the chart was rendered
+        assert len(docs) > 0
+
+        # Parse the rendered configmap
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate extra ingress annotation
+        helm = prod_yaml["deployments"]["helm"]
+        assert "ingress" not in helm

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -864,5 +864,4 @@ class TestHoustonConfigmap:
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
         # Validate extra ingress annotation
-        helm = prod_yaml["deployments"]["helm"]
-        assert "ingress" not in helm
+        assert not prod_yaml["deployments"]["helm"].get("ingress")

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -4,45 +4,43 @@ import pytest
 import ast
 
 
-def common_test_cases(docs):
-    """Test some things that should apply to all cases."""
-    assert len(docs) == 1
-
-    doc = docs[0]
-
-    assert doc["kind"] == "ConfigMap"
-    assert doc["apiVersion"] == "v1"
-    assert doc["metadata"]["name"] == "release-name-houston-config"
-
-    local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
-
-    assert local_prod == {"nats": {"ackWait": 600000}}
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-
-    assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-    assert prod["deployments"]["disableManageClusterScopedResources"] is False
-    assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
-    airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
-    assert scheduler_update_strategy["type"] == "RollingUpdate"
-    assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
-    assert (
-        prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
-        == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
-    )
-
-    # validate yaml-embedded python
-    ast.parse(airflow_local_settings.encode())
-
-
 class TestHoustonConfigmap:
+    @staticmethod
+    def common_test_cases(docs):
+        """Test some things that should apply to all cases."""
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-houston-config"
+
+        local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
+
+        assert local_prod == {"nats": {"ackWait": 600000}}
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+        assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
+        assert prod["deployments"]["disableManageClusterScopedResources"] is False
+        assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
+        airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
+        assert scheduler_update_strategy["type"] == "RollingUpdate"
+        assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
+        assert (
+            prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
+            == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
+        )
+
+        # validate yaml-embedded python
+        ast.parse(airflow_local_settings.encode())
+
     def test_houston_configmap(self):
         """Validate the houston configmap and its embedded data."""
         docs = render_chart(
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         # Ensure airflow elasticsearch param is at correct location
@@ -82,7 +80,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -96,7 +94,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -110,7 +108,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
 
@@ -129,7 +127,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
@@ -154,7 +152,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
@@ -169,7 +167,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
@@ -182,7 +180,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
@@ -203,7 +201,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -234,7 +232,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -266,7 +264,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -300,7 +298,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -333,7 +331,7 @@ class TestHoustonConfigmap:
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -384,7 +382,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -430,7 +428,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -470,7 +468,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
@@ -499,7 +497,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -521,7 +519,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -543,7 +541,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -564,7 +562,7 @@ class TestHoustonConfigmap:
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -576,7 +574,7 @@ class TestHoustonConfigmap:
             values={},
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -588,7 +586,7 @@ class TestHoustonConfigmap:
             values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
-        common_test_cases(docs)
+        self.common_test_cases(docs)
         doc = docs[0]
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
@@ -833,18 +831,12 @@ class TestHoustonConfigmap:
     def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled(self):
         """Validate the houston configmap with custom airflow ingress annotation."""
         docs = render_chart(
-            values={
-                "global": {
-                    "extraAnnotations": {
-                        "route.openshift.io/termination": "passthrough"
-                    }
-                }
-            },
+            values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
         # Ensure the chart was rendered
-        assert len(docs) > 0
+        assert len(docs) == 1
 
         # Parse the rendered configmap
         doc = docs[0]
@@ -853,24 +845,19 @@ class TestHoustonConfigmap:
         # Validate extra ingress annotation
         helm = prod_yaml["deployments"]["helm"]
         assert "ingress" in helm
-        assert {"extraIngressAnnotations":{"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
+        assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
 
     def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled(self):
         """Validate the houston configmap does not include airflow ingress annotation."""
         docs = render_chart(
             values={
-                "global": {
-                    "authSidecar":{"enabled": True},
-                    "extraAnnotations": {
-                        "route.openshift.io/termination": "passthrough"
-                    }
-                }
+                "global": {"authSidecar": {"enabled": True}, "extraAnnotations": {"route.openshift.io/termination": "passthrough"}}
             },
             show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
         )
 
         # Ensure the chart was rendered
-        assert len(docs) > 0
+        assert len(docs) == 1
 
         # Parse the rendered configmap
         doc = docs[0]

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -4,846 +4,864 @@ import pytest
 import ast
 
 
-class TestHoustonConfigmap:
-    @staticmethod
-    def common_test_cases(docs):
-        """Test some things that should apply to all cases."""
-        assert len(docs) == 1
-        doc = docs[0]
-        assert doc["kind"] == "ConfigMap"
-        assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "release-name-houston-config"
+def common_test_cases(docs):
+    """Test some things that should apply to all cases."""
+    assert len(docs) == 1
 
-        local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
+    doc = docs[0]
 
-        assert local_prod == {"nats": {"ackWait": 600000}}
+    assert doc["kind"] == "ConfigMap"
+    assert doc["apiVersion"] == "v1"
+    assert doc["metadata"]["name"] == "release-name-houston-config"
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
+    local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
 
-        assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-        assert prod["deployments"]["disableManageClusterScopedResources"] is False
-        assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
-        airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
-        assert scheduler_update_strategy["type"] == "RollingUpdate"
-        assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
-        assert (
-            prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
-            == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
-        )
+    assert local_prod == {"nats": {"ackWait": 600000}}
 
-        # validate yaml-embedded python
-        ast.parse(airflow_local_settings.encode())
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    def test_houston_configmap(self):
-        """Validate the houston configmap and its embedded data."""
-        docs = render_chart(
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        # Ensure airflow elasticsearch param is at correct location
-        assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
-        # Ensure elasticsearch client param is at the correct location and contains http://
-        assert "node" in prod["elasticsearch"]["client"]
-        assert prod["elasticsearch"]["client"]["node"].startswith("http://")
-        with pytest.raises(KeyError):
-            # Ensure sccEnabled is not defined by default
-            assert prod["deployments"]["helm"]["sccEnabled"] is False
+    assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
+    assert prod["deployments"]["disableManageClusterScopedResources"] is False
+    assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
+    airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
+    assert scheduler_update_strategy["type"] == "RollingUpdate"
+    assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
+    assert (
+        prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
+        == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
+    )
 
-    def test_houston_configmap_with_namespaceFreeFormEntry_true(self):
-        """Validate the houston configmap's embedded data with
-        namespaceFreeFormEntry=True."""
+    # validate yaml-embedded python
+    ast.parse(airflow_local_settings.encode())
 
-        docs = render_chart(
-            values={"global": {"namespaceFreeFormEntry": True}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-        assert prod["deployments"]["namespaceFreeFormEntry"] is True
 
-    def test_houston_configmap_with_namespaceFreeFormEntry_defaults(self):
-        """Validate the houston configmap's embedded data with
-        namespaceFreeFormEntry defaults."""
-        docs = render_chart(
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-        assert prod["deployments"]["namespaceFreeFormEntry"] is False
+def test_houston_configmap():
+    """Validate the houston configmap and its embedded data."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-    def test_houston_configmap_with_customlogging_enabled(self):
-        """Validate the houston configmap and its embedded data with
-        customLogging."""
-        docs = render_chart(
-            values={"global": {"customLogging": {"enabled": True}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    # Ensure airflow elasticsearch param is at correct location
+    assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
+    # Ensure elasticsearch client param is at the correct location and contains http://
+    assert "node" in prod["elasticsearch"]["client"]
+    assert prod["elasticsearch"]["client"]["node"].startswith("http://")
+    with pytest.raises(KeyError):
+        # Ensure sccEnabled is not defined by default
+        assert prod["deployments"]["helm"]["sccEnabled"] is False
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-        assert "node" in prod["elasticsearch"]["client"]
-        assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
+def test_houston_configmap_with_namespaceFreeFormEntry_true():
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry=True."""
 
-    def test_houston_configmapwith_scc_enabled(self):
-        """Validate the houston configmap and its embedded data with sscEnabled."""
-        docs = render_chart(
-            values={"global": {"sccEnabled": True}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+    docs = render_chart(
+        values={"global": {"namespaceFreeFormEntry": True}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is True
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-        assert prod["deployments"]["helm"]["sccEnabled"] is True
+def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
+    """Validate the houston configmap's embedded data with
+    namespaceFreeFormEntry defaults."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
-    def test_houston_configmap_with_azure_enabled(self):
-        """Validate the houston configmap and its embedded data with azure
-        enabled."""
-        docs = render_chart(
-            values={"global": {"azure": {"enabled": True}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
+def test_houston_configmap_with_customlogging_enabled():
+    """Validate the houston configmap and its embedded data with
+    customLogging."""
+    docs = render_chart(
+        values={"global": {"customLogging": {"enabled": True}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        with pytest.raises(KeyError):
-            assert prod["deployments"]["helm"]["sccEnabled"] is False
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-        livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
-        assert livenessProbe["failureThreshold"] == 25
-        assert livenessProbe["periodSeconds"] == 10
+    assert "node" in prod["elasticsearch"]["client"]
+    assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
 
-    def test_houston_configmap_with_config_syncer_enabled(self):
-        """Validate the houston configmap and its embedded data with configSyncer
-        enabled."""
-        docs = render_chart(
-            values={"astronomer": {"configSyncer": {"enabled": True}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
-            {
-                "name": "signing-certificate",
-                "mountPath": "/etc/airflow/tls",
-                "readOnly": True,
+def test_houston_configmapwith_scc_enabled():
+    """Validate the houston configmap and its embedded data with sscEnabled."""
+    docs = render_chart(
+        values={"global": {"sccEnabled": True}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+    assert prod["deployments"]["helm"]["sccEnabled"] is True
+
+
+def test_houston_configmap_with_azure_enabled():
+    """Validate the houston configmap and its embedded data with azure
+    enabled."""
+    docs = render_chart(
+        values={"global": {"azure": {"enabled": True}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+    with pytest.raises(KeyError):
+        assert prod["deployments"]["helm"]["sccEnabled"] is False
+
+    livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
+    assert livenessProbe["failureThreshold"] == 25
+    assert livenessProbe["periodSeconds"] == 10
+
+
+def test_houston_configmap_with_config_syncer_enabled():
+    """Validate the houston configmap and its embedded data with configSyncer
+    enabled."""
+    docs = render_chart(
+        values={"astronomer": {"configSyncer": {"enabled": True}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
+        {
+            "name": "signing-certificate",
+            "mountPath": "/etc/airflow/tls",
+            "readOnly": True,
+        }
+    ]
+    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
+        {
+            "name": "signing-certificate",
+            "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
+        }
+    ]
+
+
+def test_houston_configmap_with_config_syncer_disabled():
+    """Validate the houston configmap and its embedded data with configSyncer
+    disabled."""
+    docs = render_chart(
+        values={"astronomer": {"configSyncer": {"enabled": False}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+    assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+    assert not prod_yaml["deployments"].get("loggingSidecar")
+
+
+def test_houston_configmap_with_fluentd_index_prefix_defaults():
+    """Validate the houston configmap and its embedded data with configSyncer
+    disabled."""
+    docs = render_chart(
+        values={},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+
+
+def test_houston_configmap_with_fluentd_index_prefix_overrides():
+    """Validate the houston configmap and its embedded data with configSyncer
+    disabled."""
+    docs = render_chart(
+        values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+
+
+def test_houston_configmap_with_loggingsidecar_enabled():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "repository": "quay.io/astronomer/ap-vector",
+                    "tag": "0.22.3",
+                },
+            },
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": "sidecar-log-consumer",
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "customConfig": False,
+    }
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+
+
+def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    image = "registry.example.com/foobar/test-image-name:99.88.77"
+    docs = render_chart(
+        values={
+            "global": {
+                "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
+                "loggingSidecar": {
+                    "enabled": True,
+                    "repository": image.split(":")[0],
+                    "tag": image.split(":")[1],
+                },
             }
-        ]
-        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
-            {
-                "name": "signing-certificate",
-                "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": "sidecar-log-consumer",
+        "image": image,
+        "customConfig": False,
+        "indexNamePrefix": "test-index-name-prefix-999",
+    }
+    assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
+
+
+def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    sidecar_container_name = "sidecar-log-test"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "repository": "quay.io/astronomer/ap-vector",
+                    "tag": "0.22.3",
+                }
             }
-        ]
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-    def test_houston_configmap_with_config_syncer_disabled(self):
-        """Validate the houston configmap and its embedded data with configSyncer
-        disabled."""
-        docs = render_chart(
-            values={"astronomer": {"configSyncer": {"enabled": False}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "customConfig": False,
+    }
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-        assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-        assert not prod_yaml["deployments"].get("loggingSidecar")
 
-    def test_houston_configmap_with_fluentd_index_prefix_defaults(self):
-        """Validate the houston configmap and its embedded data with configSyncer
-        disabled."""
-        docs = render_chart(
-            values={},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
-
-    def test_houston_configmap_with_fluentd_index_prefix_overrides(self):
-        """Validate the houston configmap and its embedded data with configSyncer
-        disabled."""
-        docs = render_chart(
-            values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
-
-    def test_houston_configmap_with_loggingsidecar_enabled(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "repository": "quay.io/astronomer/ap-vector",
-                        "tag": "0.22.3",
-                    },
-                },
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": "sidecar-log-consumer",
-            "image": "quay.io/astronomer/ap-vector:0.22.3",
-            "customConfig": False,
-        }
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-    def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        image = "registry.example.com/foobar/test-image-name:99.88.77"
-        docs = render_chart(
-            values={
-                "global": {
-                    "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "repository": image.split(":")[0],
-                        "tag": image.split(":")[1],
-                    },
+def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    sidecar_container_name = "sidecar-log-test"
+    image_name = "example.com/some-repo/test-image-name:test-tag-foo"
+    indexPattern = "%Y.%m"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "repository": image_name.split(":")[0],
+                    "tag": image_name.split(":")[1],
+                    "indexPattern": indexPattern,
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": "sidecar-log-consumer",
-            "image": image,
-            "customConfig": False,
-            "indexNamePrefix": "test-index-name-prefix-999",
-        }
-        assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": image_name,
+        "customConfig": False,
+        "indexPattern": indexPattern,
+    }
 
-    def test_houston_configmap_with_loggingsidecar_enabled_with_overrides(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        sidecar_container_name = "sidecar-log-test"
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": sidecar_container_name,
-                        "repository": "quay.io/astronomer/ap-vector",
-                        "tag": "0.22.3",
-                    }
+
+def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
+    """Validate the houston configmap and its embedded data with loggingSidecar
+    customConfig Enabled."""
+    sidecar_container_name = "sidecar-log-test"
+    image_name = "quay.io/astronomer/ap-vector:0.22.3"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "customConfig": True,
+                    "repository": image_name.split(":")[0],
+                    "tag": image_name.split(":")[1],
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": "quay.io/astronomer/ap-vector:0.22.3",
-            "customConfig": False,
-        }
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "customConfig": True,
+    }
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        sidecar_container_name = "sidecar-log-test"
-        image_name = "example.com/some-repo/test-image-name:test-tag-foo"
-        indexPattern = "%Y.%m"
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": sidecar_container_name,
-                        "repository": image_name.split(":")[0],
-                        "tag": image_name.split(":")[1],
-                        "indexPattern": indexPattern,
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
 
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": image_name,
-            "customConfig": False,
-            "indexPattern": indexPattern,
-        }
-
-    def test_houston_configmap_with_loggingsidecar_customConfig_enabled(self):
-        """Validate the houston configmap and its embedded data with loggingSidecar
-        customConfig Enabled."""
-        sidecar_container_name = "sidecar-log-test"
-        image_name = "quay.io/astronomer/ap-vector:0.22.3"
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": sidecar_container_name,
-                        "customConfig": True,
-                        "repository": image_name.split(":")[0],
-                        "tag": image_name.split(":")[1],
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": "quay.io/astronomer/ap-vector:0.22.3",
-            "customConfig": True,
-        }
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-    def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        sidecar_container_name = "sidecar-log-test"
-        image_name = "quay.io/astronomer/ap-vector:0.22.3"
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": sidecar_container_name,
-                        "repository": image_name.split(":")[0],
-                        "tag": image_name.split(":")[1],
-                        "extraEnv": [
-                            {
-                                "name": "ES_USER",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "name": "elastic-creds",
-                                        "key": "ESUSER",
-                                    }
-                                },
+def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    sidecar_container_name = "sidecar-log-test"
+    image_name = "quay.io/astronomer/ap-vector:0.22.3"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "repository": image_name.split(":")[0],
+                    "tag": image_name.split(":")[1],
+                    "extraEnv": [
+                        {
+                            "name": "ES_USER",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "elastic-creds",
+                                    "key": "ESUSER",
+                                }
                             },
-                            {
-                                "name": "ES_PASS",
-                                "valueFrom": {
-                                    "secretKeyRef": {
-                                        "name": "elastic-creds",
-                                        "key": "ESPASS",
-                                    }
-                                },
-                            },
-                        ],
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": "quay.io/astronomer/ap-vector:0.22.3",
-            "customConfig": False,
-            "extraEnv": [
-                {
-                    "name": "ES_USER",
-                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
-                },
-                {
-                    "name": "ES_PASS",
-                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
-                },
-            ],
-        }
-
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-    def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        sidecar_container_name = "sidecar-log-test"
-        image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": sidecar_container_name,
-                        "repository": f"{image_name['repository']}",
-                        "tag": f"{image_name['tag']}",
-                        "resources": {
-                            "requests": {"memory": "386Mi", "cpu": "100m"},
-                            "limits": {"memory": "386Mi", "cpu": "100m"},
                         },
-                    }
+                        {
+                            "name": "ES_PASS",
+                            "valueFrom": {
+                                "secretKeyRef": {
+                                    "name": "elastic-creds",
+                                    "key": "ESPASS",
+                                }
+                            },
+                        },
+                    ],
                 }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "customConfig": False,
+        "extraEnv": [
+            {
+                "name": "ES_USER",
+                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
             },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": "quay.io/astronomer/ap-vector:0.22.3",
-            "customConfig": False,
-            "resources": {
-                "requests": {"memory": "386Mi", "cpu": "100m"},
-                "limits": {"memory": "386Mi", "cpu": "100m"},
+            {
+                "name": "ES_PASS",
+                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
             },
-        }
+        ],
+    }
 
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-    def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured(self):
-        """Validate the houston configmap and its embedded data with
-        loggingSidecar."""
-        securityContext = {
-            "runAsUser": 1000,
-        }
-        sidecar_container_name = "sidecar-log-test"
-        image_name = "quay.io/astronomer/ap-vector:unittest-tag"
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
+
+def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    sidecar_container_name = "sidecar-log-test"
+    image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "repository": f"{image_name['repository']}",
+                    "tag": f"{image_name['tag']}",
+                    "resources": {
+                        "requests": {"memory": "386Mi", "cpu": "100m"},
+                        "limits": {"memory": "386Mi", "cpu": "100m"},
+                    },
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:0.22.3",
+        "customConfig": False,
+        "resources": {
+            "requests": {"memory": "386Mi", "cpu": "100m"},
+            "limits": {"memory": "386Mi", "cpu": "100m"},
+        },
+    }
+
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+
+
+def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured():
+    """Validate the houston configmap and its embedded data with
+    loggingSidecar."""
+    securityContext = {
+        "runAsUser": 1000,
+    }
+    sidecar_container_name = "sidecar-log-test"
+    image_name = "quay.io/astronomer/ap-vector:unittest-tag"
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": sidecar_container_name,
+                    "repository": image_name.split(":")[0],
+                    "tag": image_name.split(":")[1],
+                    "securityContext": securityContext,
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    assert prod_yaml["deployments"]["loggingSidecar"] == {
+        "enabled": True,
+        "name": sidecar_container_name,
+        "image": "quay.io/astronomer/ap-vector:unittest-tag",
+        "customConfig": False,
+        "securityContext": securityContext,
+    }
+
+    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+
+
+def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
+    """Validate the houston configmap and its embedded data with
+    updateAirflowCheck and updateRuntimeCheck."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "updateAirflowCheck": {"enabled": True},
+                    "updateRuntimeCheck": {"enabled": True},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+    assert prod["updateAirflowCheckEnabled"] is True
+    assert prod["updateRuntimeCheckEnabled"] is True
+
+
+def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
+    """Validate the houston configmap and its embedded data with
+    updateAirflowCheck and updateRuntimeCheck."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "updateAirflowCheck": {"enabled": False},
+                    "updateRuntimeCheck": {"enabled": False},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["updateAirflowCheckEnabled"] is False
+    assert prod["updateRuntimeCheckEnabled"] is False
+
+
+def test_houston_configmap_with_cleanup_airflow_db_enabled():
+    """Validate the houston configmap and its embedded data with
+    cleanupAirflowDb."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "cleanupAirflowDb": {
                         "enabled": True,
-                        "name": sidecar_container_name,
-                        "repository": image_name.split(":")[0],
-                        "tag": image_name.split(":")[1],
-                        "securityContext": securityContext,
                     }
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-        assert prod_yaml["deployments"]["loggingSidecar"] == {
-            "enabled": True,
-            "name": sidecar_container_name,
-            "image": "quay.io/astronomer/ap-vector:unittest-tag",
-            "customConfig": False,
-            "securityContext": securityContext,
-        }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
 
-        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
 
-    def test_houston_configmapwith_update_airflow_runtime_checks_enabled(self):
-        """Validate the houston configmap and its embedded data with
-        updateAirflowCheck and updateRuntimeCheck."""
-        docs = render_chart(
-            values={
-                "astronomer": {
-                    "houston": {
-                        "updateAirflowCheck": {"enabled": True},
-                        "updateRuntimeCheck": {"enabled": True},
+
+def test_houston_configmap_with_cleanup_airflow_db_disabled():
+    """Validate the houston configmap and its embedded data with
+    cleanupAirflowDb."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "cleanupAirflowDb": {
+                        "enabled": False,
                     }
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
 
-        assert prod["updateAirflowCheckEnabled"] is True
-        assert prod["updateRuntimeCheckEnabled"] is True
 
-    def test_houston_configmapwith_update_airflow_runtime_checks_disabled(self):
-        """Validate the houston configmap and its embedded data with
-        updateAirflowCheck and updateRuntimeCheck."""
-        docs = render_chart(
-            values={
-                "astronomer": {
-                    "houston": {
-                        "updateAirflowCheck": {"enabled": False},
-                        "updateRuntimeCheck": {"enabled": False},
-                    }
+def test_houston_configmap_with_internal_authorization_flag_defaults():
+    """Validate the houston configmap to internal authorization."""
+    docs = render_chart(
+        values={},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
+
+
+def test_houston_configmap_with_internal_authorization_flag_enabled():
+    """Validate the houston configmap to internal authorization."""
+    docs = render_chart(
+        values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
+
+
+def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled():
+    """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
+    ."""
+    docs = render_chart(
+        values={"global": {"disableManageClusterScopedResources": True}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["deployments"]["disableManageClusterScopedResources"] is True
+
+
+def test_houston_configmap_with_tls_secretname_overrides():
+    """Validate the houston configmap and its embedded data with tls secretname overrides
+    ."""
+    docs = render_chart(
+        values={"global": {"tlsSecret": "astro-ssl-secret"}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    doc = docs[0]
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
+
+
+def test_houston_configmap_with_authsidecar_liveness_probe():
+    """Validate the authSidecar liveness probe in the Houston configmap."""
+    liveness_probe = {
+        "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={
+            "global": {
+                "authSidecar": {
+                    "enabled": True,
+                    "repository": "someregistry.io/my-custom-image",
+                    "tag": "my-custom-tag",
+                    "resources": {},
+                    "livenessProbe": liveness_probe,
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
+    assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["updateAirflowCheckEnabled"] is False
-        assert prod["updateRuntimeCheckEnabled"] is False
 
-    def test_houston_configmap_with_cleanup_airflow_db_enabled(self):
-        """Validate the houston configmap and its embedded data with
-        cleanupAirflowDb."""
-        docs = render_chart(
-            values={
-                "astronomer": {
-                    "houston": {
-                        "cleanupAirflowDb": {
-                            "enabled": True,
-                        }
-                    }
+def test_houston_configmap_with_authsidecar_readiness_probe():
+    """Validate the authSidecar readiness probe in the Houston configmap."""
+    readiness_probe = {
+        "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
+        "initialDelaySeconds": 10,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={
+            "global": {
+                "authSidecar": {
+                    "enabled": True,
+                    "repository": "someregistry.io/my-custom-image",
+                    "tag": "my-custom-tag",
+                    "resources": {},
+                    "readinessProbe": readiness_probe,
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
+    assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
 
-    def test_houston_configmap_with_cleanup_airflow_db_disabled(self):
-        """Validate the houston configmap and its embedded data with
-        cleanupAirflowDb."""
-        docs = render_chart(
-            values={
-                "astronomer": {
-                    "houston": {
-                        "cleanupAirflowDb": {
-                            "enabled": False,
-                        }
-                    }
+def test_houston_configmap_with_dagonlydeployment_liveness_probe():
+    """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
+    liveness_probe = {
+        "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={
+            "global": {
+                "dagOnlyDeployment": {
+                    "enabled": True,
+                    "livenessProbe": liveness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
-    def test_houston_configmap_with_internal_authorization_flag_defaults(self):
-        """Validate the houston configmap to internal authorization."""
-        docs = render_chart(
-            values={},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
+    # Validate livenessProbe
+    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
+    assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
 
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
 
-    def test_houston_configmap_with_internal_authorization_flag_enabled(self):
-        """Validate the houston configmap to internal authorization."""
-        docs = render_chart(
-            values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        self.common_test_cases(docs)
-        doc = docs[0]
-
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
-
-    def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled(self):
-        """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
-        ."""
-        docs = render_chart(
-            values={"global": {"disableManageClusterScopedResources": True}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["deployments"]["disableManageClusterScopedResources"] is True
-
-    def test_houston_configmap_with_tls_secretname_overrides(self):
-        """Validate the houston configmap and its embedded data with tls secretname overrides
-        ."""
-        docs = render_chart(
-            values={"global": {"tlsSecret": "astro-ssl-secret"}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        doc = docs[0]
-        prod = yaml.safe_load(doc["data"]["production.yaml"])
-        assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
-
-    def test_houston_configmap_with_authsidecar_liveness_probe(self):
-        """Validate the authSidecar liveness probe in the Houston configmap."""
-        liveness_probe = {
-            "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
-            "initialDelaySeconds": 10,
-            "timeoutSeconds": 5,
-            "periodSeconds": 10,
-            "successThreshold": 1,
-            "failureThreshold": 3,
-        }
-        docs = render_chart(
-            values={
-                "global": {
-                    "authSidecar": {
-                        "enabled": True,
-                        "repository": "someregistry.io/my-custom-image",
-                        "tag": "my-custom-tag",
-                        "resources": {},
-                        "livenessProbe": liveness_probe,
-                    }
+def test_houston_configmap_with_dagonlydeployment_readiness_probe():
+    """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
+    readiness_probe = {
+        "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 5,
+        "periodSeconds": 10,
+        "successThreshold": 1,
+        "failureThreshold": 3,
+    }
+    docs = render_chart(
+        values={
+            "global": {
+                "dagOnlyDeployment": {
+                    "enabled": True,
+                    "readinessProbe": readiness_probe,
+                    "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        assert len(docs) > 0
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        # Parse the rendered configmap
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
-        # Validate livenessProbe
-        assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
-        assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
+    # Validate readinessProbe
+    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
+    assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
 
-    def test_houston_configmap_with_authsidecar_readiness_probe(self):
-        """Validate the authSidecar readiness probe in the Houston configmap."""
-        readiness_probe = {
-            "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
-            "initialDelaySeconds": 10,
-            "timeoutSeconds": 5,
-            "periodSeconds": 10,
-            "successThreshold": 1,
-            "failureThreshold": 3,
-        }
-        docs = render_chart(
-            values={
-                "global": {
-                    "authSidecar": {
-                        "enabled": True,
-                        "repository": "someregistry.io/my-custom-image",
-                        "tag": "my-custom-tag",
-                        "resources": {},
-                        "readinessProbe": readiness_probe,
-                    }
+
+def test_houston_configmap_with_loggingsidecar_liveness_probe():
+    """Validate the houston configmap with liveness probe configured."""
+    liveness_probe = {
+        "httpGet": {
+            "path": "/healthz",
+            "port": 8080,
+            "scheme": "HTTP",
+        },
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 30,
+        "periodSeconds": 5,
+        "successThreshold": 1,
+        "failureThreshold": 20,
+    }
+
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": "sidecar-log-test",
+                    "livenessProbe": liveness_probe,
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-        assert len(docs) > 0
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        # Parse the rendered configmap
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+    assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
 
-        # Validate readinessProbe
-        assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
-        assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
 
-    def test_houston_configmap_with_dagonlydeployment_liveness_probe(self):
-        """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
-        liveness_probe = {
-            "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
-            "initialDelaySeconds": 15,
-            "timeoutSeconds": 5,
-            "periodSeconds": 10,
-            "successThreshold": 1,
-            "failureThreshold": 3,
-        }
-        docs = render_chart(
-            values={
-                "global": {
-                    "dagOnlyDeployment": {
-                        "enabled": True,
-                        "livenessProbe": liveness_probe,
-                        "image": "quay.io/astronomer/ap-auth:0.22.3",
-                    }
+def test_houston_configmap_with_loggingsidecar_readiness_probe():
+    """Validate the houston configmap with readiness probe configured."""
+    readiness_probe = {
+        "httpGet": {
+            "path": "/healthz",
+            "port": 8080,
+            "scheme": "HTTP",
+        },
+        "initialDelaySeconds": 15,
+        "timeoutSeconds": 30,
+        "periodSeconds": 5,
+        "successThreshold": 1,
+        "failureThreshold": 20,
+    }
+
+    docs = render_chart(
+        values={
+            "global": {
+                "loggingSidecar": {
+                    "enabled": True,
+                    "name": "sidecar-log-test",
+                    "readinessProbe": readiness_probe,
                 }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+    assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
 
-        # Validate livenessProbe
-        assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
-        assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
 
-    def test_houston_configmap_with_dagonlydeployment_readiness_probe(self):
-        """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
-        readiness_probe = {
-            "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
-            "initialDelaySeconds": 15,
-            "timeoutSeconds": 5,
-            "periodSeconds": 10,
-            "successThreshold": 1,
-            "failureThreshold": 3,
-        }
-        docs = render_chart(
-            values={
-                "global": {
-                    "dagOnlyDeployment": {
-                        "enabled": True,
-                        "readinessProbe": readiness_probe,
-                        "image": "quay.io/astronomer/ap-auth:0.22.3",
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
+def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled():
+    """Validate the houston configmap with custom airflow ingress annotation."""
+    docs = render_chart(
+        values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
 
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    helm = prod_yaml["deployments"]["helm"]
+    assert "ingress" in helm
+    assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
 
-        # Validate readinessProbe
-        assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
-        assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
 
-    def test_houston_configmap_with_loggingsidecar_liveness_probe(self):
-        """Validate the houston configmap with liveness probe configured."""
-        liveness_probe = {
-            "httpGet": {
-                "path": "/healthz",
-                "port": 8080,
-                "scheme": "HTTP",
-            },
-            "initialDelaySeconds": 15,
-            "timeoutSeconds": 30,
-            "periodSeconds": 5,
-            "successThreshold": 1,
-            "failureThreshold": 20,
-        }
-
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": "sidecar-log-test",
-                        "livenessProbe": liveness_probe,
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-        # Validate livenessProbe
-        assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-        assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
-
-    def test_houston_configmap_with_loggingsidecar_readiness_probe(self):
-        """Validate the houston configmap with readiness probe configured."""
-        readiness_probe = {
-            "httpGet": {
-                "path": "/healthz",
-                "port": 8080,
-                "scheme": "HTTP",
-            },
-            "initialDelaySeconds": 15,
-            "timeoutSeconds": 30,
-            "periodSeconds": 5,
-            "successThreshold": 1,
-            "failureThreshold": 20,
-        }
-
-        docs = render_chart(
-            values={
-                "global": {
-                    "loggingSidecar": {
-                        "enabled": True,
-                        "name": "sidecar-log-test",
-                        "readinessProbe": readiness_probe,
-                    }
-                }
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-        # Validate readinessProbe
-        assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-        assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
-
-    def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled(self):
-        """Validate the houston configmap with custom airflow ingress annotation."""
-        docs = render_chart(
-            values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-        # Validate extra ingress annotation
-        helm = prod_yaml["deployments"]["helm"]
-        assert "ingress" in helm
-        assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
-
-    def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled(self):
-        """Validate the houston configmap does not include airflow ingress annotation."""
-        docs = render_chart(
-            values={
-                "global": {"authSidecar": {"enabled": True}, "extraAnnotations": {"route.openshift.io/termination": "passthrough"}}
-            },
-            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-        # Validate extra ingress annotation
-        assert not prod_yaml["deployments"]["helm"].get("ingress")
+def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled():
+    """Validate the houston configmap does not include airflow ingress annotation."""
+    docs = render_chart(
+        values={
+            "global": {"authSidecar": {"enabled": True}, "extraAnnotations": {"route.openshift.io/termination": "passthrough"}}
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert not prod_yaml["deployments"]["helm"].get("ingress")


### PR DESCRIPTION
## Description

Add airflow extra ingress annotation support

## Related Issues

- https://github.com/astronomer/issues/issues/6744

## Testing
QA should able to see custom ingress annotation passed from global.extraAnnotations to airflow ingress objects as well

## Merging

cherry-pick to release-0.37
