### PR TITLE
fixing storageclass indentation for registry

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -403,7 +403,7 @@ Helm 2.11 supports the assignment of a value to a variable defined in a differen
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
 This version prioritizes component-specific registry.persistence.storageClassName over global.storageClass.
 */}}
-        storageClassName: {{ or .Values.registry.persistence.storageClassName .Values.global.storageClass | default "" }}
+{{- printf "storageClassName: %s" (or .Values.registry.persistence.storageClassName .Values.global.storageClass | default "") | nindent 8 }}
 {{- end -}}
 
 {{- define "configSyncer.schedule" -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -403,7 +403,7 @@ Helm 2.11 supports the assignment of a value to a variable defined in a differen
 but Helm 2.9 and 2.10 does not support it, so we need to implement this if-else logic.
 This version prioritizes component-specific registry.persistence.storageClassName over global.storageClass.
 */}}
-storageClassName: {{ or .Values.registry.persistence.storageClassName .Values.global.storageClass | default "" }}
+        storageClassName: {{ or .Values.registry.persistence.storageClassName .Values.global.storageClass | default "" }}
 {{- end -}}
 
 {{- define "configSyncer.schedule" -}}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -161,6 +161,6 @@ spec:
         resources:
           requests:
             storage: {{ .Values.registry.persistence.size }}
-        {{ include "registry.storageClass" . }}
+        {{- include "registry.storageClass" . }}
   {{- end }}
 {{- end }}

--- a/tests/chart_tests/test_global_storageclass.py
+++ b/tests/chart_tests/test_global_storageclass.py
@@ -19,21 +19,10 @@ def test_global_storageclass(chart_file, expected_sc_name):
         show_only=[chart_file],
     )
 
-    # Assert that one document is rendered
-    assert len(docs) == 1  # Expecting one document per chart file
-
-    # Since docs[0] is already a dictionary, we can directly access the fields
+    assert len(docs) == 1 
     statefulset_doc = docs[0]
+    storage_class_name = statefulset_doc["spec"]["volumeClaimTemplates"][0]["spec"]["storageClassName"]
 
-    # Determine if we're dealing with the registry chart or another chart
-    if chart_file == "charts/astronomer/templates/registry/registry-statefulset.yaml":
-        # Registry chart has the storageClassName directly in the statefulset
-        storage_class_name = statefulset_doc["storageClassName"]
-    else:
-        # Other charts have the storageClassName inside volumeClaimTemplates
-        storage_class_name = statefulset_doc["spec"]["volumeClaimTemplates"][0]["spec"]["storageClassName"]
-
-    # Assert that the storageClassName matches the expected one
     assert storage_class_name == expected_sc_name
 
 

--- a/tests/chart_tests/test_global_storageclass.py
+++ b/tests/chart_tests/test_global_storageclass.py
@@ -49,24 +49,10 @@ def test_component_storageclass_precendence():
 
     docs = render_chart(
         values=values,
-        show_only=[chart_file for chart_file, _ in parametrization_data],  # Use the list of chart files
+        show_only=[chart_file for chart_file, _ in parametrization_data],
     )
-
-    # Assert that five documents are rendered (one for each chart file)
     assert len(docs) == 5
 
-    # Loop through the rendered documents and verify storageClassName
     for chart_file, doc in zip([x[0] for x in parametrization_data], docs):
-        # Since each doc is already a dictionary, we can work with it directly
-        statefulset_doc = doc
-
-        # Determine if we're dealing with the registry chart or another chart
-        if chart_file == "charts/astronomer/templates/registry/registry-statefulset.yaml":
-            # Registry chart has the storageClassName directly in the statefulset
-            storage_class_name = statefulset_doc["storageClassName"]
-        else:
-            # Other charts have the storageClassName inside volumeClaimTemplates
-            storage_class_name = statefulset_doc["spec"]["volumeClaimTemplates"][0]["spec"]["storageClassName"]
-
-        # Assert that "gp2" is in the storageClassName, indicating the component-specific storageClass overrides the global one
-        assert "gp2" in storage_class_name
+        doc = doc["spec"]["volumeClaimTemplates"][0]["spec"]["storageClassName"]
+        assert "gp2" in doc

--- a/tests/chart_tests/test_global_storageclass.py
+++ b/tests/chart_tests/test_global_storageclass.py
@@ -19,7 +19,7 @@ def test_global_storageclass(chart_file, expected_sc_name):
         show_only=[chart_file],
     )
 
-    assert len(docs) == 1 
+    assert len(docs) == 1
     statefulset_doc = docs[0]
     storage_class_name = statefulset_doc["spec"]["volumeClaimTemplates"][0]["spec"]["storageClassName"]
 


### PR DESCRIPTION
## Description

This PR intends to fix the indentation of storageclass component for registry stateful sets. 

## Related Issues

Related astronomer/issues#6380

## Testing

Tested manually for the indentation:
```
shubhamsingh@Shubhams-MacBook-Pro astronomer % helm template --kube-version 1.31.0 release-name . --set global.baseDomain=example.com --set global.storageClass=gp1 --set astronomer.registry.persistence.storageClassName=gp2  --show-only charts/astronomer/templates/registry/registry-statefulset.yaml

---
# Source: astronomer/charts/astronomer/templates/registry/registry-statefulset.yaml
#####################################
## Astronomer Registry StatefulSet ##
#####################################
kind: StatefulSet
apiVersion: apps/v1
metadata:
  name: release-name-registry
  labels:
    component: registry
    tier: astronomer
    release: release-name
    chart: "astronomer-0.36.0"
    heritage: Helm
  
spec:
  replicas: 1
  selector:
    matchLabels:
      component: registry
      tier: astronomer
      release: release-name
  serviceName: release-name-registry
  template:
    metadata:
      labels:
        component: registry
        tier: astronomer
        release: release-name
        app: registry
        version: 0.36.0
      annotations:
        checksum/configmap: 0b8c0635f8257471b0f8e028b95ede09afdfe822dca61781e98ab86d5fb9172e
    spec:
      serviceAccountName: default
      nodeSelector:
        {}
      affinity:
        {}
      tolerations:
        []
      restartPolicy: Always
      securityContext: 
        fsGroup: 1000
        runAsGroup: 1000
        runAsUser: 1000      
      containers:
        - name: registry
          image: quay.io/astronomer/ap-registry:3.18.9
          securityContext: 
            runAsNonRoot: true
          imagePullPolicy: IfNotPresent
          env:
          - name: REGISTRY_NOTIFICATIONS_ENDPOINTS_0_HEADERS
            valueFrom:
              secretKeyRef:
                name: release-name-registry-auth-key
                key: authHeaders
          - name: REGISTRY_HTTP_SECRET
            value: oMwWbuvZuXUnzgeiZIXZqcwEVMw2T8kX
          resources:
            limits:
              cpu: 500m
              memory: 1024Mi
            requests:
              cpu: 250m
              memory: 512Mi
          volumeMounts:
            - name: config
              mountPath: /etc/docker/registry
            - name: certificate
              mountPath: /etc/docker/ssl
            - name: data
              mountPath: /var/lib/registry            
            
          ports:
            - name: registry-http
              containerPort: 5000
            # - name: registry-scrape
            #   containerPort: 5001
          livenessProbe:
            httpGet:
              path: /
              port: 5000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 5
          readinessProbe:
            httpGet:
              path: /
              port: 5000
            initialDelaySeconds: 10
            periodSeconds: 10
            timeoutSeconds: 5
      volumes:
        - name: config
          configMap:
            name: release-name-registry
            items:
              - key: config.yml
                path: config.yml
        - name: certificate
          secret:
            secretName: astronomer-tls
                
        
  volumeClaimTemplates:
    - metadata:
        name: data
      spec:
        accessModes: ["ReadWriteOnce"]
        resources:
          requests:
            storage: 100Gi
        
        storageClassName: gp2

```

## Merging

0.37
