### PR TITLE
Reworking few unittest cases 

### DIFF
--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -3,865 +3,865 @@ from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 import ast
 
+class TestHoustonConfigMap:
+    def common_test_cases(self, docs):
+        """Test some things that should apply to all cases."""
+        assert len(docs) == 1
 
-def common_test_cases(docs):
-    """Test some things that should apply to all cases."""
-    assert len(docs) == 1
+        doc = docs[0]
 
-    doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-houston-config"
 
-    assert doc["kind"] == "ConfigMap"
-    assert doc["apiVersion"] == "v1"
-    assert doc["metadata"]["name"] == "release-name-houston-config"
+        local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
 
-    local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
+        assert local_prod == {"nats": {"ackWait": 600000}}
 
-    assert local_prod == {"nats": {"ackWait": 600000}}
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
+        assert prod["deployments"]["disableManageClusterScopedResources"] is False
+        assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
+        airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
+        assert scheduler_update_strategy["type"] == "RollingUpdate"
+        assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
+        assert (
+            prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
+            == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
+        )
 
-    assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
-    assert prod["deployments"]["disableManageClusterScopedResources"] is False
-    assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
-    airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
-    assert scheduler_update_strategy["type"] == "RollingUpdate"
-    assert scheduler_update_strategy["rollingUpdate"]["maxUnavailable"] == 1
-    assert (
-        prod["deployments"]["helm"]["airflow"]["cleanup"]["schedule"]
-        == '{{- add 3 (regexFind ".$" (adler32sum .Release.Name)) -}}-59/15 * * * *'
-    )
-
-    # validate yaml-embedded python
-    ast.parse(airflow_local_settings.encode())
-
-
-def test_houston_configmap():
-    """Validate the houston configmap and its embedded data."""
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    # Ensure airflow elasticsearch param is at correct location
-    assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
-    # Ensure elasticsearch client param is at the correct location and contains http://
-    assert "node" in prod["elasticsearch"]["client"]
-    assert prod["elasticsearch"]["client"]["node"].startswith("http://")
-    with pytest.raises(KeyError):
-        # Ensure sccEnabled is not defined by default
-        assert prod["deployments"]["helm"]["sccEnabled"] is False
+        # validate yaml-embedded python
+        ast.parse(airflow_local_settings.encode())
 
 
-def test_houston_configmap_with_namespaceFreeFormEntry_true():
-    """Validate the houston configmap's embedded data with
-    namespaceFreeFormEntry=True."""
+    def test_houston_configmap(self):
+        """Validate the houston configmap and its embedded data."""
+        docs = render_chart(
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    docs = render_chart(
-        values={"global": {"namespaceFreeFormEntry": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    assert prod["deployments"]["namespaceFreeFormEntry"] is True
-
-
-def test_houston_configmap_with_namespaceFreeFormEntry_defaults():
-    """Validate the houston configmap's embedded data with
-    namespaceFreeFormEntry defaults."""
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    assert prod["deployments"]["namespaceFreeFormEntry"] is False
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        # Ensure airflow elasticsearch param is at correct location
+        assert prod["deployments"]["helm"]["airflow"]["elasticsearch"]["enabled"] is True
+        # Ensure elasticsearch client param is at the correct location and contains http://
+        assert "node" in prod["elasticsearch"]["client"]
+        assert prod["elasticsearch"]["client"]["node"].startswith("http://")
+        with pytest.raises(KeyError):
+            # Ensure sccEnabled is not defined by default
+            assert prod["deployments"]["helm"]["sccEnabled"] is False
 
 
-def test_houston_configmap_with_customlogging_enabled():
-    """Validate the houston configmap and its embedded data with
-    customLogging."""
-    docs = render_chart(
-        values={"global": {"customLogging": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmap_with_namespaceFreeFormEntry_true(self):
+        """Validate the houston configmap's embedded data with
+        namespaceFreeFormEntry=True."""
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-
-    assert "node" in prod["elasticsearch"]["client"]
-    assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
+        docs = render_chart(
+            values={"global": {"namespaceFreeFormEntry": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        assert prod["deployments"]["namespaceFreeFormEntry"] is True
 
 
-def test_houston_configmapwith_scc_enabled():
-    """Validate the houston configmap and its embedded data with sscEnabled."""
-    docs = render_chart(
-        values={"global": {"sccEnabled": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-
-    assert prod["deployments"]["helm"]["sccEnabled"] is True
+    def test_houston_configmap_with_namespaceFreeFormEntry_defaults(self):
+        """Validate the houston configmap's embedded data with
+        namespaceFreeFormEntry defaults."""
+        docs = render_chart(
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+        assert prod["deployments"]["namespaceFreeFormEntry"] is False
 
 
-def test_houston_configmap_with_azure_enabled():
-    """Validate the houston configmap and its embedded data with azure
-    enabled."""
-    docs = render_chart(
-        values={"global": {"azure": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmap_with_customlogging_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        customLogging."""
+        docs = render_chart(
+            values={"global": {"customLogging": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
-    with pytest.raises(KeyError):
-        assert prod["deployments"]["helm"]["sccEnabled"] is False
-
-    livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
-    assert livenessProbe["failureThreshold"] == 25
-    assert livenessProbe["periodSeconds"] == 10
+        assert "node" in prod["elasticsearch"]["client"]
+        assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
 
 
-def test_houston_configmap_with_config_syncer_enabled():
-    """Validate the houston configmap and its embedded data with configSyncer
-    enabled."""
-    docs = render_chart(
-        values={"astronomer": {"configSyncer": {"enabled": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmapwith_scc_enabled(self):
+        """Validate the houston configmap and its embedded data with sscEnabled."""
+        docs = render_chart(
+            values={"global": {"sccEnabled": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
-        {
-            "name": "signing-certificate",
-            "mountPath": "/etc/airflow/tls",
-            "readOnly": True,
-        }
-    ]
-    assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
-        {
-            "name": "signing-certificate",
-            "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
-        }
-    ]
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+        assert prod["deployments"]["helm"]["sccEnabled"] is True
 
 
-def test_houston_configmap_with_config_syncer_disabled():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={"astronomer": {"configSyncer": {"enabled": False}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmap_with_azure_enabled(self):
+        """Validate the houston configmap and its embedded data with azure
+        enabled."""
+        docs = render_chart(
+            values={"global": {"azure": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    assert not prod_yaml["deployments"].get("loggingSidecar")
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
 
+        with pytest.raises(KeyError):
+            assert prod["deployments"]["helm"]["sccEnabled"] is False
 
-def test_houston_configmap_with_fluentd_index_prefix_defaults():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+        livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
+        assert livenessProbe["failureThreshold"] == 25
+        assert livenessProbe["periodSeconds"] == 10
 
 
-def test_houston_configmap_with_fluentd_index_prefix_overrides():
-    """Validate the houston configmap and its embedded data with configSyncer
-    disabled."""
-    docs = render_chart(
-        values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+    def test_houston_configmap_with_config_syncer_enabled(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        enabled."""
+        docs = render_chart(
+            values={"astronomer": {"configSyncer": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumeMounts"] == [
+            {
+                "name": "signing-certificate",
+                "mountPath": "/etc/airflow/tls",
+                "readOnly": True,
+            }
+        ]
+        assert prod["deployments"]["helm"]["airflow"]["webserver"]["extraVolumes"] == [
+            {
+                "name": "signing-certificate",
+                "secret": {"secretName": "release-name-houston-jwt-signing-certificate"},
+            }
+        ]
 
 
-def test_houston_configmap_with_loggingsidecar_enabled():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "repository": "quay.io/astronomer/ap-vector",
-                    "tag": "0.22.3",
+    def test_houston_configmap_with_config_syncer_disabled(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={"astronomer": {"configSyncer": {"enabled": False}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+        assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
+        assert not prod_yaml["deployments"].get("loggingSidecar")
+
+
+    def test_houston_configmap_with_fluentd_index_prefix_defaults(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+
+
+    def test_houston_configmap_with_fluentd_index_prefix_overrides(self):
+        """Validate the houston configmap and its embedded data with configSyncer
+        disabled."""
+        docs = render_chart(
+            values={"global": {"logging": {"indexNamePrefix": "astronomer"}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
+
+
+    def test_houston_configmap_with_loggingsidecar_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "repository": "quay.io/astronomer/ap-vector",
+                        "tag": "0.22.3",
+                    },
                 },
             },
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": "sidecar-log-consumer",
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    image = "registry.example.com/foobar/test-image-name:99.88.77"
-    docs = render_chart(
-        values={
-            "global": {
-                "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
-                "loggingSidecar": {
-                    "enabled": True,
-                    "repository": image.split(":")[0],
-                    "tag": image.split(":")[1],
-                },
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": "sidecar-log-consumer",
-        "image": image,
-        "customConfig": False,
-        "indexNamePrefix": "test-index-name-prefix-999",
-    }
-    assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": "sidecar-log-consumer",
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": "quay.io/astronomer/ap-vector",
-                    "tag": "0.22.3",
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "example.com/some-repo/test-image-name:test-tag-foo"
-    indexPattern = "%Y.%m"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "indexPattern": indexPattern,
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": image_name,
-        "customConfig": False,
-        "indexPattern": indexPattern,
-    }
-
-
-def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
-    """Validate the houston configmap and its embedded data with loggingSidecar
-    customConfig Enabled."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:0.22.3"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "customConfig": True,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": True,
-    }
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:0.22.3"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "extraEnv": [
-                        {
-                            "name": "ES_USER",
-                            "valueFrom": {
-                                "secretKeyRef": {
-                                    "name": "elastic-creds",
-                                    "key": "ESUSER",
-                                }
-                            },
-                        },
-                        {
-                            "name": "ES_PASS",
-                            "valueFrom": {
-                                "secretKeyRef": {
-                                    "name": "elastic-creds",
-                                    "key": "ESPASS",
-                                }
-                            },
-                        },
-                    ],
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-        "extraEnv": [
-            {
-                "name": "ES_USER",
-                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
-            },
-            {
-                "name": "ES_PASS",
-                "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
-            },
-        ],
-    }
-
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    sidecar_container_name = "sidecar-log-test"
-    image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": f"{image_name['repository']}",
-                    "tag": f"{image_name['tag']}",
-                    "resources": {
-                        "requests": {"memory": "386Mi", "cpu": "100m"},
-                        "limits": {"memory": "386Mi", "cpu": "100m"},
+    def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        image = "registry.example.com/foobar/test-image-name:99.88.77"
+        docs = render_chart(
+            values={
+                "global": {
+                    "logging": {"indexNamePrefix": "test-index-name-prefix-999"},
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "repository": image.split(":")[0],
+                        "tag": image.split(":")[1],
                     },
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:0.22.3",
-        "customConfig": False,
-        "resources": {
-            "requests": {"memory": "386Mi", "cpu": "100m"},
-            "limits": {"memory": "386Mi", "cpu": "100m"},
-        },
-    }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": "sidecar-log-consumer",
+            "image": image,
+            "customConfig": False,
+            "indexNamePrefix": "test-index-name-prefix-999",
+        }
+        assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured():
-    """Validate the houston configmap and its embedded data with
-    loggingSidecar."""
-    securityContext = {
-        "runAsUser": 1000,
-    }
-    sidecar_container_name = "sidecar-log-test"
-    image_name = "quay.io/astronomer/ap-vector:unittest-tag"
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": sidecar_container_name,
-                    "repository": image_name.split(":")[0],
-                    "tag": image_name.split(":")[1],
-                    "securityContext": securityContext,
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
-    assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
-    assert prod_yaml["deployments"]["loggingSidecar"] == {
-        "enabled": True,
-        "name": sidecar_container_name,
-        "image": "quay.io/astronomer/ap-vector:unittest-tag",
-        "customConfig": False,
-        "securityContext": securityContext,
-    }
-
-    assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
-
-def test_houston_configmapwith_update_airflow_runtime_checks_enabled():
-    """Validate the houston configmap and its embedded data with
-    updateAirflowCheck and updateRuntimeCheck."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "updateAirflowCheck": {"enabled": True},
-                    "updateRuntimeCheck": {"enabled": True},
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-
-    assert prod["updateAirflowCheckEnabled"] is True
-    assert prod["updateRuntimeCheckEnabled"] is True
-
-
-def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
-    """Validate the houston configmap and its embedded data with
-    updateAirflowCheck and updateRuntimeCheck."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "updateAirflowCheck": {"enabled": False},
-                    "updateRuntimeCheck": {"enabled": False},
-                }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["updateAirflowCheckEnabled"] is False
-    assert prod["updateRuntimeCheckEnabled"] is False
-
-
-def test_houston_configmap_with_cleanup_airflow_db_enabled():
-    """Validate the houston configmap and its embedded data with
-    cleanupAirflowDb."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "cleanupAirflowDb": {
+    def test_houston_configmap_with_loggingsidecar_enabled_with_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
                         "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": "quay.io/astronomer/ap-vector",
+                        "tag": "0.22.3",
                     }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_cleanup_airflow_db_disabled():
-    """Validate the houston configmap and its embedded data with
-    cleanupAirflowDb."""
-    docs = render_chart(
-        values={
-            "astronomer": {
-                "houston": {
-                    "cleanupAirflowDb": {
-                        "enabled": False,
+    def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "example.com/some-repo/test-image-name:test-tag-foo"
+        indexPattern = "%Y.%m"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "indexPattern": indexPattern,
                     }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
 
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
-
-
-def test_houston_configmap_with_internal_authorization_flag_defaults():
-    """Validate the houston configmap to internal authorization."""
-    docs = render_chart(
-        values={},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": image_name,
+            "customConfig": False,
+            "indexPattern": indexPattern,
+        }
 
 
-def test_houston_configmap_with_internal_authorization_flag_enabled():
-    """Validate the houston configmap to internal authorization."""
-    docs = render_chart(
-        values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    common_test_cases(docs)
-    doc = docs[0]
-
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
-
-
-def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled():
-    """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
-    ."""
-    docs = render_chart(
-        values={"global": {"disableManageClusterScopedResources": True}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["deployments"]["disableManageClusterScopedResources"] is True
-
-
-def test_houston_configmap_with_tls_secretname_overrides():
-    """Validate the houston configmap and its embedded data with tls secretname overrides
-    ."""
-    docs = render_chart(
-        values={"global": {"tlsSecret": "astro-ssl-secret"}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    doc = docs[0]
-    prod = yaml.safe_load(doc["data"]["production.yaml"])
-    assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
-
-
-def test_houston_configmap_with_authsidecar_liveness_probe():
-    """Validate the authSidecar liveness probe in the Houston configmap."""
-    liveness_probe = {
-        "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
-        "initialDelaySeconds": 10,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "authSidecar": {
-                    "enabled": True,
-                    "repository": "someregistry.io/my-custom-image",
-                    "tag": "my-custom-tag",
-                    "resources": {},
-                    "livenessProbe": liveness_probe,
+    def test_houston_configmap_with_loggingsidecar_customConfig_enabled(self):
+        """Validate the houston configmap and its embedded data with loggingSidecar
+        customConfig Enabled."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:0.22.3"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "customConfig": True,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
-    assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": True,
+        }
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_authsidecar_readiness_probe():
-    """Validate the authSidecar readiness probe in the Houston configmap."""
-    readiness_probe = {
-        "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
-        "initialDelaySeconds": 10,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "authSidecar": {
-                    "enabled": True,
-                    "repository": "someregistry.io/my-custom-image",
-                    "tag": "my-custom-tag",
-                    "resources": {},
-                    "readinessProbe": readiness_probe,
+    def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:0.22.3"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "extraEnv": [
+                            {
+                                "name": "ES_USER",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "elastic-creds",
+                                        "key": "ESUSER",
+                                    }
+                                },
+                            },
+                            {
+                                "name": "ES_PASS",
+                                "valueFrom": {
+                                    "secretKeyRef": {
+                                        "name": "elastic-creds",
+                                        "key": "ESPASS",
+                                    }
+                                },
+                            },
+                        ],
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
-    assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+            "extraEnv": [
+                {
+                    "name": "ES_USER",
+                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESUSER"}},
+                },
+                {
+                    "name": "ES_PASS",
+                    "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
+                },
+            ],
+        }
+
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_dagonlydeployment_liveness_probe():
-    """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
-    liveness_probe = {
-        "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "dagOnlyDeployment": {
-                    "enabled": True,
-                    "livenessProbe": liveness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+    def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        sidecar_container_name = "sidecar-log-test"
+        image_name = {"repository": "quay.io/astronomer/ap-vector", "tag": "0.22.3"}
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": f"{image_name['repository']}",
+                        "tag": f"{image_name['tag']}",
+                        "resources": {
+                            "requests": {"memory": "386Mi", "cpu": "100m"},
+                            "limits": {"memory": "386Mi", "cpu": "100m"},
+                        },
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:0.22.3",
+            "customConfig": False,
+            "resources": {
+                "requests": {"memory": "386Mi", "cpu": "100m"},
+                "limits": {"memory": "386Mi", "cpu": "100m"},
+            },
+        }
 
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-    # Validate livenessProbe
-    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_dagonlydeployment_readiness_probe():
-    """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
-    readiness_probe = {
-        "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 5,
-        "periodSeconds": 10,
-        "successThreshold": 1,
-        "failureThreshold": 3,
-    }
-    docs = render_chart(
-        values={
-            "global": {
-                "dagOnlyDeployment": {
-                    "enabled": True,
-                    "readinessProbe": readiness_probe,
-                    "image": "quay.io/astronomer/ap-auth:0.22.3",
+    def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured(self):
+        """Validate the houston configmap and its embedded data with
+        loggingSidecar."""
+        securityContext = {
+            "runAsUser": 1000,
+        }
+        sidecar_container_name = "sidecar-log-test"
+        image_name = "quay.io/astronomer/ap-vector:unittest-tag"
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": sidecar_container_name,
+                        "repository": image_name.split(":")[0],
+                        "tag": image_name.split(":")[1],
+                        "securityContext": securityContext,
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'
+        assert log_cmd in prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+        assert prod_yaml["deployments"]["loggingSidecar"] == {
+            "enabled": True,
+            "name": sidecar_container_name,
+            "image": "quay.io/astronomer/ap-vector:unittest-tag",
+            "customConfig": False,
+            "securityContext": securityContext,
+        }
 
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-
-    # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
+        assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
 
-def test_houston_configmap_with_loggingsidecar_liveness_probe():
-    """Validate the houston configmap with liveness probe configured."""
-    liveness_probe = {
-        "httpGet": {
-            "path": "/healthz",
-            "port": 8080,
-            "scheme": "HTTP",
-        },
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 30,
-        "periodSeconds": 5,
-        "successThreshold": 1,
-        "failureThreshold": 20,
-    }
-
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": "sidecar-log-test",
-                    "livenessProbe": liveness_probe,
+    def test_houston_configmapwith_update_airflow_runtime_checks_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        updateAirflowCheck and updateRuntimeCheck."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateAirflowCheck": {"enabled": True},
+                        "updateRuntimeCheck": {"enabled": True},
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
 
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-    assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+        assert prod["updateAirflowCheckEnabled"] is True
+        assert prod["updateRuntimeCheckEnabled"] is True
 
 
-def test_houston_configmap_with_loggingsidecar_readiness_probe():
-    """Validate the houston configmap with readiness probe configured."""
-    readiness_probe = {
-        "httpGet": {
-            "path": "/healthz",
-            "port": 8080,
-            "scheme": "HTTP",
-        },
-        "initialDelaySeconds": 15,
-        "timeoutSeconds": 30,
-        "periodSeconds": 5,
-        "successThreshold": 1,
-        "failureThreshold": 20,
-    }
-
-    docs = render_chart(
-        values={
-            "global": {
-                "loggingSidecar": {
-                    "enabled": True,
-                    "name": "sidecar-log-test",
-                    "readinessProbe": readiness_probe,
+    def test_houston_configmapwith_update_airflow_runtime_checks_disabled(self):
+        """Validate the houston configmap and its embedded data with
+        updateAirflowCheck and updateRuntimeCheck."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "updateAirflowCheck": {"enabled": False},
+                        "updateRuntimeCheck": {"enabled": False},
+                    }
                 }
-            }
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
 
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
-    assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
-
-
-def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled():
-    """Validate the houston configmap with custom airflow ingress annotation."""
-    docs = render_chart(
-        values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    helm = prod_yaml["deployments"]["helm"]
-    assert "ingress" in helm
-    assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["updateAirflowCheckEnabled"] is False
+        assert prod["updateRuntimeCheckEnabled"] is False
 
 
-def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled():
-    """Validate the houston configmap does not include airflow ingress annotation."""
-    docs = render_chart(
-        values={
-            "global": {"authSidecar": {"enabled": True}, "extraAnnotations": {"route.openshift.io/termination": "passthrough"}}
-        },
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    assert len(docs) == 1
-    doc = docs[0]
-    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
-    assert not prod_yaml["deployments"]["helm"].get("ingress")
+    def test_houston_configmap_with_cleanup_airflow_db_enabled(self):
+        """Validate the houston configmap and its embedded data with
+        cleanupAirflowDb."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "cleanupAirflowDb": {
+                            "enabled": True,
+                        }
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
+
+
+    def test_houston_configmap_with_cleanup_airflow_db_disabled(self):
+        """Validate the houston configmap and its embedded data with
+        cleanupAirflowDb."""
+        docs = render_chart(
+            values={
+                "astronomer": {
+                    "houston": {
+                        "cleanupAirflowDb": {
+                            "enabled": False,
+                        }
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
+
+
+    def test_houston_configmap_with_internal_authorization_flag_defaults(self):
+        """Validate the houston configmap to internal authorization."""
+        docs = render_chart(
+            values={},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
+
+
+    def test_houston_configmap_with_internal_authorization_flag_enabled(self):
+        """Validate the houston configmap to internal authorization."""
+        docs = render_chart(
+            values={"astronomer": {"houston": {"enableHoustonInternalAuthorization": True}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        self.common_test_cases(docs)
+        doc = docs[0]
+
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
+
+
+    def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled(self):
+        """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
+        ."""
+        docs = render_chart(
+            values={"global": {"disableManageClusterScopedResources": True}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["deployments"]["disableManageClusterScopedResources"] is True
+
+
+    def test_houston_configmap_with_tls_secretname_overrides(self):
+        """Validate the houston configmap and its embedded data with tls secretname overrides
+        ."""
+        docs = render_chart(
+            values={"global": {"tlsSecret": "astro-ssl-secret"}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+        assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
+
+
+    def test_houston_configmap_with_authsidecar_liveness_probe(self):
+        """Validate the authSidecar liveness probe in the Houston configmap."""
+        liveness_probe = {
+            "httpGet": {"path": "/auth-liveness", "port": 8080, "scheme": "HTTP"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "authSidecar": {
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "resources": {},
+                        "livenessProbe": liveness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
+        assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
+
+
+    def test_houston_configmap_with_authsidecar_readiness_probe(self):
+        """Validate the authSidecar readiness probe in the Houston configmap."""
+        readiness_probe = {
+            "httpGet": {"path": "/auth-readiness", "port": 8080, "scheme": "HTTP"},
+            "initialDelaySeconds": 10,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "authSidecar": {
+                        "enabled": True,
+                        "repository": "someregistry.io/my-custom-image",
+                        "tag": "my-custom-tag",
+                        "resources": {},
+                        "readinessProbe": readiness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
+        assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
+
+
+    def test_houston_configmap_with_dagonlydeployment_liveness_probe(self):
+        """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
+        liveness_probe = {
+            "httpGet": {"path": "/dag-liveness", "port": 8081, "scheme": "HTTP"},
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "livenessProbe": liveness_probe,
+                        "image": "quay.io/astronomer/ap-auth:0.22.3",
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate livenessProbe
+        assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
+        assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
+
+
+    def test_houston_configmap_with_dagonlydeployment_readiness_probe(self):
+        """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
+        readiness_probe = {
+            "httpGet": {"path": "/dag-readiness", "port": 8081, "scheme": "HTTP"},
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 5,
+            "periodSeconds": 10,
+            "successThreshold": 1,
+            "failureThreshold": 3,
+        }
+        docs = render_chart(
+            values={
+                "global": {
+                    "dagOnlyDeployment": {
+                        "enabled": True,
+                        "readinessProbe": readiness_probe,
+                        "image": "quay.io/astronomer/ap-auth:0.22.3",
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+
+        # Validate readinessProbe
+        assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
+        assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
+
+
+    def test_houston_configmap_with_loggingsidecar_liveness_probe(self):
+        """Validate the houston configmap with liveness probe configured."""
+        liveness_probe = {
+            "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP",
+            },
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 30,
+            "periodSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 20,
+        }
+
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": "sidecar-log-test",
+                        "livenessProbe": liveness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+        assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
+
+
+    def test_houston_configmap_with_loggingsidecar_readiness_probe(self):
+        """Validate the houston configmap with readiness probe configured."""
+        readiness_probe = {
+            "httpGet": {
+                "path": "/healthz",
+                "port": 8080,
+                "scheme": "HTTP",
+            },
+            "initialDelaySeconds": 15,
+            "timeoutSeconds": 30,
+            "periodSeconds": 5,
+            "successThreshold": 1,
+            "failureThreshold": 20,
+        }
+
+        docs = render_chart(
+            values={
+                "global": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "name": "sidecar-log-test",
+                        "readinessProbe": readiness_probe,
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
+        assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
+
+
+    def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled(self):
+        """Validate the houston configmap with custom airflow ingress annotation."""
+        docs = render_chart(
+            values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        helm = prod_yaml["deployments"]["helm"]
+        assert "ingress" in helm
+        assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
+
+
+    def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled(self):
+        """Validate the houston configmap does not include airflow ingress annotation."""
+        docs = render_chart(
+            values={
+                "global": {"authSidecar": {"enabled": True}, "extraAnnotations": {"route.openshift.io/termination": "passthrough"}}
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+        assert not prod_yaml["deployments"]["helm"].get("ingress")

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -3,6 +3,7 @@ from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 import ast
 
+
 class TestHoustonConfigMap:
     def common_test_cases(self, docs):
         """Test some things that should apply to all cases."""
@@ -35,7 +36,6 @@ class TestHoustonConfigMap:
         # validate yaml-embedded python
         ast.parse(airflow_local_settings.encode())
 
-
     def test_houston_configmap(self):
         """Validate the houston configmap and its embedded data."""
         docs = render_chart(
@@ -54,7 +54,6 @@ class TestHoustonConfigMap:
             # Ensure sccEnabled is not defined by default
             assert prod["deployments"]["helm"]["sccEnabled"] is False
 
-
     def test_houston_configmap_with_namespaceFreeFormEntry_true(self):
         """Validate the houston configmap's embedded data with
         namespaceFreeFormEntry=True."""
@@ -66,7 +65,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["namespaceFreeFormEntry"] is True
 
-
     def test_houston_configmap_with_namespaceFreeFormEntry_defaults(self):
         """Validate the houston configmap's embedded data with
         namespaceFreeFormEntry defaults."""
@@ -75,7 +73,6 @@ class TestHoustonConfigMap:
         )
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["deployments"]["namespaceFreeFormEntry"] is False
-
 
     def test_houston_configmap_with_customlogging_enabled(self):
         """Validate the houston configmap and its embedded data with
@@ -92,7 +89,6 @@ class TestHoustonConfigMap:
         assert "node" in prod["elasticsearch"]["client"]
         assert prod["elasticsearch"]["client"]["node"].startswith("http://") is True
 
-
     def test_houston_configmapwith_scc_enabled(self):
         """Validate the houston configmap and its embedded data with sscEnabled."""
         docs = render_chart(
@@ -105,7 +101,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
 
         assert prod["deployments"]["helm"]["sccEnabled"] is True
-
 
     def test_houston_configmap_with_azure_enabled(self):
         """Validate the houston configmap and its embedded data with azure
@@ -125,7 +120,6 @@ class TestHoustonConfigMap:
         livenessProbe = prod["deployments"]["helm"]["airflow"]["webserver"]["livenessProbe"]
         assert livenessProbe["failureThreshold"] == 25
         assert livenessProbe["periodSeconds"] == 10
-
 
     def test_houston_configmap_with_config_syncer_enabled(self):
         """Validate the houston configmap and its embedded data with configSyncer
@@ -152,7 +146,6 @@ class TestHoustonConfigMap:
             }
         ]
 
-
     def test_houston_configmap_with_config_syncer_disabled(self):
         """Validate the houston configmap and its embedded data with configSyncer
         disabled."""
@@ -168,7 +161,6 @@ class TestHoustonConfigMap:
         assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
         assert not prod_yaml["deployments"].get("loggingSidecar")
 
-
     def test_houston_configmap_with_fluentd_index_prefix_defaults(self):
         """Validate the houston configmap and its embedded data with configSyncer
         disabled."""
@@ -182,7 +174,6 @@ class TestHoustonConfigMap:
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "fluentd" in prod_yaml["deployments"].get("fluentdIndexPrefix")
 
-
     def test_houston_configmap_with_fluentd_index_prefix_overrides(self):
         """Validate the houston configmap and its embedded data with configSyncer
         disabled."""
@@ -195,7 +186,6 @@ class TestHoustonConfigMap:
         doc = docs[0]
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "astronomer" in prod_yaml["deployments"].get("fluentdIndexPrefix")
-
 
     def test_houston_configmap_with_loggingsidecar_enabled(self):
         """Validate the houston configmap and its embedded data with
@@ -225,7 +215,6 @@ class TestHoustonConfigMap:
             "customConfig": False,
         }
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
 
     def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides(self):
         """Validate the houston configmap and its embedded data with
@@ -259,7 +248,6 @@ class TestHoustonConfigMap:
         }
         assert image in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
     def test_houston_configmap_with_loggingsidecar_enabled_with_overrides(self):
         """Validate the houston configmap and its embedded data with
         loggingSidecar."""
@@ -290,7 +278,6 @@ class TestHoustonConfigMap:
             "customConfig": False,
         }
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
 
     def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern(self):
         """Validate the houston configmap and its embedded data with
@@ -326,7 +313,6 @@ class TestHoustonConfigMap:
             "indexPattern": indexPattern,
         }
 
-
     def test_houston_configmap_with_loggingsidecar_customConfig_enabled(self):
         """Validate the houston configmap and its embedded data with loggingSidecar
         customConfig Enabled."""
@@ -359,7 +345,6 @@ class TestHoustonConfigMap:
             "customConfig": True,
         }
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
-
 
     def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides(self):
         """Validate the houston configmap and its embedded data with
@@ -423,7 +408,6 @@ class TestHoustonConfigMap:
 
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
     def test_houston_configmap_with_loggingsidecar_enabled_with_resource_overrides(self):
         """Validate the houston configmap and its embedded data with
         loggingSidecar."""
@@ -464,7 +448,6 @@ class TestHoustonConfigMap:
 
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
     def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_configured(self):
         """Validate the houston configmap and its embedded data with
         loggingSidecar."""
@@ -502,7 +485,6 @@ class TestHoustonConfigMap:
 
         assert "vector" in prod_yaml["deployments"]["loggingSidecar"]["image"]
 
-
     def test_houston_configmapwith_update_airflow_runtime_checks_enabled(self):
         """Validate the houston configmap and its embedded data with
         updateAirflowCheck and updateRuntimeCheck."""
@@ -525,7 +507,6 @@ class TestHoustonConfigMap:
         assert prod["updateAirflowCheckEnabled"] is True
         assert prod["updateRuntimeCheckEnabled"] is True
 
-
     def test_houston_configmapwith_update_airflow_runtime_checks_disabled(self):
         """Validate the houston configmap and its embedded data with
         updateAirflowCheck and updateRuntimeCheck."""
@@ -546,7 +527,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["updateAirflowCheckEnabled"] is False
         assert prod["updateRuntimeCheckEnabled"] is False
-
 
     def test_houston_configmap_with_cleanup_airflow_db_enabled(self):
         """Validate the houston configmap and its embedded data with
@@ -569,7 +549,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is True
 
-
     def test_houston_configmap_with_cleanup_airflow_db_disabled(self):
         """Validate the houston configmap and its embedded data with
         cleanupAirflowDb."""
@@ -591,7 +570,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["cleanupAirflowDb"]["enabled"] is False
 
-
     def test_houston_configmap_with_internal_authorization_flag_defaults(self):
         """Validate the houston configmap to internal authorization."""
         docs = render_chart(
@@ -603,7 +581,6 @@ class TestHoustonConfigMap:
 
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["enableHoustonInternalAuthorization"] is False
-
 
     def test_houston_configmap_with_internal_authorization_flag_enabled(self):
         """Validate the houston configmap to internal authorization."""
@@ -617,7 +594,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["enableHoustonInternalAuthorization"] is True
 
-
     def test_houston_configmap_with_disable_manage_clusterscopedresources_enabled(self):
         """Validate the houston configmap and its embedded data with disable manage clusterscoped resources enabled
         ."""
@@ -629,7 +605,6 @@ class TestHoustonConfigMap:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["disableManageClusterScopedResources"] is True
 
-
     def test_houston_configmap_with_tls_secretname_overrides(self):
         """Validate the houston configmap and its embedded data with tls secretname overrides
         ."""
@@ -640,7 +615,6 @@ class TestHoustonConfigMap:
         doc = docs[0]
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["helm"]["tlsSecretName"] == "astro-ssl-secret"
-
 
     def test_houston_configmap_with_authsidecar_liveness_probe(self):
         """Validate the authSidecar liveness probe in the Houston configmap."""
@@ -672,7 +646,6 @@ class TestHoustonConfigMap:
         assert "livenessProbe" in prod_yaml["deployments"]["authSideCar"]
         assert prod_yaml["deployments"]["authSideCar"]["livenessProbe"] == liveness_probe
 
-
     def test_houston_configmap_with_authsidecar_readiness_probe(self):
         """Validate the authSidecar readiness probe in the Houston configmap."""
         readiness_probe = {
@@ -702,7 +675,6 @@ class TestHoustonConfigMap:
         prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
         assert "readinessProbe" in prod_yaml["deployments"]["authSideCar"]
         assert prod_yaml["deployments"]["authSideCar"]["readinessProbe"] == readiness_probe
-
 
     def test_houston_configmap_with_dagonlydeployment_liveness_probe(self):
         """Validate the dagOnlyDeployment liveness probe in the Houston configmap."""
@@ -735,7 +707,6 @@ class TestHoustonConfigMap:
         assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
         assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
 
-
     def test_houston_configmap_with_dagonlydeployment_readiness_probe(self):
         """Validate the dagOnlyDeployment readiness probe in the Houston configmap."""
         readiness_probe = {
@@ -766,7 +737,6 @@ class TestHoustonConfigMap:
         # Validate readinessProbe
         assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
         assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
-
 
     def test_houston_configmap_with_loggingsidecar_liveness_probe(self):
         """Validate the houston configmap with liveness probe configured."""
@@ -802,7 +772,6 @@ class TestHoustonConfigMap:
         assert "livenessProbe" in prod_yaml["deployments"]["loggingSidecar"]
         assert prod_yaml["deployments"]["loggingSidecar"]["livenessProbe"] == liveness_probe
 
-
     def test_houston_configmap_with_loggingsidecar_readiness_probe(self):
         """Validate the houston configmap with readiness probe configured."""
         readiness_probe = {
@@ -837,7 +806,6 @@ class TestHoustonConfigMap:
         assert "readinessProbe" in prod_yaml["deployments"]["loggingSidecar"]
         assert prod_yaml["deployments"]["loggingSidecar"]["readinessProbe"] == readiness_probe
 
-
     def test_houston_configmap_with_custom_airflow_ingress_annotation_with_authsidecar_disabled(self):
         """Validate the houston configmap with custom airflow ingress annotation."""
         docs = render_chart(
@@ -851,7 +819,6 @@ class TestHoustonConfigMap:
         helm = prod_yaml["deployments"]["helm"]
         assert "ingress" in helm
         assert {"extraIngressAnnotations": {"route.openshift.io/termination": "passthrough"}} == helm["ingress"]
-
 
     def test_houston_configmap_with_custom_airflow_ingress_annotation_disabled_with_authsidecar_disabled(self):
         """Validate the houston configmap does not include airflow ingress annotation."""

--- a/tests/chart_tests/test_non_root_user.py
+++ b/tests/chart_tests/test_non_root_user.py
@@ -8,6 +8,8 @@ ignore_list = [
     "elasticsearch-exporter_metrics-exporter",
     "elasticsearch-nginx_nginx",
 ]
+
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,

--- a/tests/chart_tests/test_non_root_user.py
+++ b/tests/chart_tests/test_non_root_user.py
@@ -8,19 +8,18 @@ ignore_list = [
     "elasticsearch-exporter_metrics-exporter",
     "elasticsearch-nginx_nginx",
 ]
-
-
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
 )
-def test_container_runasnonroot(kube_version):
-    """Ensure all containers have runAsNonRoot."""
+class TestContainerRunasNonRoot:
+    def test_container_runasnonroot(self, kube_version):
+        """Ensure all containers have runAsNonRoot."""
 
-    containers = chart_tests.get_chart_containers(kube_version, chart_tests.get_all_features())
+        containers = chart_tests.get_chart_containers(kube_version, chart_tests.get_all_features())
 
-    for container in containers.values():
-        if container["key"].split("release-name-")[-1] in ignore_list:
-            pytest.skip("Info: Resource needs root access" + container["key"])
-        else:
-            assert container.get("securityContext").get("runAsNonRoot") is True
+        for container in containers.values():
+            if container["key"].split("release-name-")[-1] in ignore_list:
+                pytest.skip("Info: Resource needs root access" + container["key"])
+            else:
+                assert container.get("securityContext").get("runAsNonRoot") is True

--- a/tests/chart_tests/test_pods_annotation.py
+++ b/tests/chart_tests/test_pods_annotation.py
@@ -4,6 +4,7 @@ import pytest
 import tests.chart_tests as chart_tests
 from tests.chart_tests.helm_template_generator import render_chart
 
+
 class TestPodAnnotationConfig:
     @staticmethod
     def init_test_pod_annotation_configs():

--- a/tests/chart_tests/test_tags.py
+++ b/tests/chart_tests/test_tags.py
@@ -32,20 +32,19 @@ show_only = [
 
 chart_values = chart_tests.get_all_features()
 
-
 @pytest.mark.parametrize("template", show_only)
-def test_tags_monitoring_enabled(template, chart_values=chart_values, kube_version="1.30.0"):
-    """Test that when monitoring is disabled, the monitoring components are not present."""
-    chart_values["tags"] = {"monitoring": True}
-    docs = render_chart(kube_version=kube_version, values=chart_values, show_only=template)
+class Testtags:
+    def test_tags_monitoring_enabled(self,template, chart_values=chart_values, kube_version="1.30.0"):
+        """Test that when monitoring is disabled, the monitoring components are not present."""
+        chart_values["tags"] = {"monitoring": True}
+        docs = render_chart(kube_version=kube_version, values=chart_values, show_only=template)
 
-    assert len(docs) >= 1
+        assert len(docs) >= 1
 
 
-@pytest.mark.parametrize("template", show_only)
-def test_tags_monitoring_disabled(template, chart_values=chart_values, kube_version="1.30.0"):
-    """Test that when monitoring is disabled, the monitoring components are not present."""
-    chart_values["tags"] = {"monitoring": False}
+    def test_tags_monitoring_disabled(self,template, chart_values=chart_values, kube_version="1.30.0"):
+        """Test that when monitoring is disabled, the monitoring components are not present."""
+        chart_values["tags"] = {"monitoring": False}
 
-    with pytest.raises(subprocess.CalledProcessError):
-        render_chart(kube_version=kube_version, values=chart_values, show_only=template)
+        with pytest.raises(subprocess.CalledProcessError):
+            render_chart(kube_version=kube_version, values=chart_values, show_only=template)

--- a/tests/chart_tests/test_tags.py
+++ b/tests/chart_tests/test_tags.py
@@ -32,17 +32,17 @@ show_only = [
 
 chart_values = chart_tests.get_all_features()
 
+
 @pytest.mark.parametrize("template", show_only)
 class Testtags:
-    def test_tags_monitoring_enabled(self,template, chart_values=chart_values, kube_version="1.30.0"):
+    def test_tags_monitoring_enabled(self, template, chart_values=chart_values, kube_version="1.30.0"):
         """Test that when monitoring is disabled, the monitoring components are not present."""
         chart_values["tags"] = {"monitoring": True}
         docs = render_chart(kube_version=kube_version, values=chart_values, show_only=template)
 
         assert len(docs) >= 1
 
-
-    def test_tags_monitoring_disabled(self,template, chart_values=chart_values, kube_version="1.30.0"):
+    def test_tags_monitoring_disabled(self, template, chart_values=chart_values, kube_version="1.30.0"):
         """Test that when monitoring is disabled, the monitoring components are not present."""
         chart_values["tags"] = {"monitoring": False}
 


### PR DESCRIPTION
## Description

This PR intends to rework unittestcases

## Changes Made
- Refactored test classes to use proper Python class methods and static methods
- Moved initialization code from class level to setup methods
- Added proper class method decorators to fix "missing self" errors
- Improved code organization and readability

## Related Issues

https://github.com/astronomer/issues/issues/6923

## Key Updates
- Fixed the "missing self parameter" error in TestPodAnnotationConfig by converting to classmethod 
- Moved initialization of private_registry_docs_image_pull_secrets to setup_class
- Added proper class/static method decorators to fix function-calling issues
- Improved method organization in the HoustonConfigMap class

## Testing
- All existing tests pass
- No functional changes, only code organization improvements
- Verified proper initialization of test configurations

## Why is this change needed?
The original code had issues with Python class method calls and initialization ordering. These changes:
- Fix runtime errors from improper method calls
- Follow Python best practices for class organization
- Make the code more maintainable and easier to understand
- Improve test setup patterns


## Merging
Everywhere


## Code Review Notes
Please verify:
- Method decorator choices (@classmethod vs @staticmethod)
- Test initialization patterns in setup methods
- No functional changes to actual test logic

