### PR TITLE
Operator unittest

### DIFF
--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -18,7 +18,7 @@ class TestAirflowOperator:
                     "certManager": {"enabled": True},
                 },
                 "global": {
-                    "airflow_operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=[
@@ -38,7 +38,7 @@ class TestAirflowOperator:
                     "crd": {"create": True},
                 },
                 "global": {
-                    "airflow_operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=[
@@ -75,7 +75,7 @@ class TestAirflowOperator:
                     },
                 },
                 "global": {
-                    "airflow_operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=["charts/airflow-operator/templates/secrets/webhooks-tls.yaml"],
@@ -92,7 +92,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "airflow_operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=[

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -69,8 +69,8 @@ class TestAirflowOperator:
         )
         assert len(docs) == 14
     
-    def test_airflow_operator_webhook_tls(self, kube_version):
-        """""Test Webhook tls"""""
+    def test_airflow_operator_secret(self, kube_version):
+        """""Test Airflow Operator Webhook tls"""""
         docs = render_chart(
         kube_version=kube_version,
         values={"airflow-operator": {
@@ -90,3 +90,21 @@ class TestAirflowOperator:
         show_only=[ "charts/airflow-operator/templates/secrets/webhooks-tls.yaml"]
         )
         assert len(docs) == 1
+        ## add more validations to add cabundle,tlscert,tlskey
+    
+    def test_airflow_operator_webhooks(self,kube_version):
+        """""Test Airflow Operator Webhook tls"""""
+        docs = render_chart(
+        kube_version=kube_version,
+        values={
+                "global":{
+                                "airflow_operator":{
+                                    "enabled": True
+                                },
+                        },
+                },      
+        show_only=[ "charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml",
+                    "charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml",
+                    ],
+        )
+        assert len(docs) == 2

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -27,12 +27,12 @@ class TestAirflowOperator:
             ],
         )
         assert len(docs) == 2
-        assert 'Issuer' == docs[0]['kind']
-        assert 'Certificate' == docs[1]['kind']
-        assert 'cert-manager.io/v1' == docs[0]['apiVersion']
-        assert 'cert-manager.io/v1' == docs[1]['apiVersion']
-        assert 'release-name-airflow-operator-serving-cert' == docs[1]['metadata']['name']
-        assert 'release-name-airflow-operator-selfsigned-issuer' == docs[0]['metadata']['name']      
+        assert "Issuer" == docs[0]["kind"]
+        assert "Certificate" == docs[1]["kind"]
+        assert "cert-manager.io/v1" == docs[0]["apiVersion"]
+        assert "cert-manager.io/v1" == docs[1]["apiVersion"]
+        assert "release-name-airflow-operator-serving-cert" == docs[1]["metadata"]["name"]
+        assert "release-name-airflow-operator-selfsigned-issuer" == docs[0]["metadata"]["name"]
 
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""
@@ -66,11 +66,10 @@ class TestAirflowOperator:
         )
         assert len(docs) == 14
         for i in range(len(docs)):
-            assert 'apiextensions.k8s.io/v1' == docs[i]['apiVersion']
-            assert 'CustomResourceDefinition' == docs[i]['kind']
-            assert 'cert-manager.io/inject-ca-from' in docs[i]['metadata']['annotations']
-            assert 'airflow.apache.org' in docs[i]['metadata']['name']
-
+            assert "apiextensions.k8s.io/v1" == docs[i]["apiVersion"]
+            assert "CustomResourceDefinition" == docs[i]["kind"]
+            assert "cert-manager.io/inject-ca-from" in docs[i]["metadata"]["annotations"]
+            assert "airflow.apache.org" in docs[i]["metadata"]["name"]
 
     def test_airflow_operator_secret(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""
@@ -94,10 +93,10 @@ class TestAirflowOperator:
         )
 
         assert len(docs) == 1
-        assert 'v1' in docs[0]['apiVersion']
-        assert 'Secret'in docs[0]['kind']
-        assert 'release-name-webhooks-tls-certs' in docs[0]['metadata']['name']
-        assert 'kubernetes.io/tls' in docs[0]['type']
+        assert "v1" in docs[0]["apiVersion"]
+        assert "Secret" in docs[0]["kind"]
+        assert "release-name-webhooks-tls-certs" in docs[0]["metadata"]["name"]
+        assert "kubernetes.io/tls" in docs[0]["type"]
         expected_data = {"tls.crt": "dGxzY2VydDEyMw==", "tls.key": "dGxza2V5MTIz"}
         assert docs[0]["data"] == expected_data
 
@@ -117,8 +116,8 @@ class TestAirflowOperator:
             ],
         )
         assert len(docs) == 2
-        assert 'admissionregistration.k8s.io/v1' == docs[0]['apiVersion']
-        assert 'MutatingWebhookConfiguration' == docs[0]['kind']
-        assert 'ValidatingWebhookConfiguration' == docs[1]['kind']
-        assert 'release-name-airflow-operator-mutating-webhook-configuration' == docs[0]['metadata']['name']
-        assert 'release-name-airflow-operator-validating-webhook-configuration' == docs[1]['metadata']['name']
+        assert "admissionregistration.k8s.io/v1" == docs[0]["apiVersion"]
+        assert "MutatingWebhookConfiguration" == docs[0]["kind"]
+        assert "ValidatingWebhookConfiguration" == docs[1]["kind"]
+        assert "release-name-airflow-operator-mutating-webhook-configuration" == docs[0]["metadata"]["name"]
+        assert "release-name-airflow-operator-validating-webhook-configuration" == docs[1]["metadata"]["name"]

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -94,6 +94,10 @@ class TestAirflowOperator:
         )
 
         assert len(docs) == 1
+        assert 'v1' in docs[0]['apiVersion']
+        assert 'Secret'in docs[0]['kind']
+        assert 'release-name-webhooks-tls-certs' in docs[0]['metadata']['name']
+        assert 'kubernetes.io/tls' in docs[0]['type']
         expected_data = {"tls.crt": "dGxzY2VydDEyMw==", "tls.key": "dGxza2V5MTIz"}
         assert docs[0]["data"] == expected_data
 

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -33,7 +33,7 @@ class TestAirflowOperator:
         assert len(docs) == 2
     
     def test_airflow_operator_crd(self, kube_version):
-        """Test Airflow Operator crd"""
+        """Test Airflow Operator crd template"""
         docs = render_chart(
         kube_version=kube_version,
         values={"airflow-operator": {
@@ -51,7 +51,42 @@ class TestAirflowOperator:
                         },
                 },      
                     
-        show_only=["charts/airflow-operator/templates/crds/airflow.yaml",
+        show_only=[ "charts/airflow-operator/templates/crds/airflow.yaml",
+                    "charts/airflow-operator/templates/crds/allocator.yaml",
+                    "charts/airflow-operator/templates/crds/apiserver.yaml",
+                    "charts/airflow-operator/templates/crds/dagprocessor.yaml",
+                    "charts/airflow-operator/templates/crds/pgbouncer.yaml",
+                    "charts/airflow-operator/templates/crds/postgres.yaml",
+                    "charts/airflow-operator/templates/crds/rbac.yaml",
+                    "charts/airflow-operator/templates/crds/redis.yaml",
+                    "charts/airflow-operator/templates/crds/runner.yaml",
+                    "charts/airflow-operator/templates/crds/scheduler.yaml",
+                    "charts/airflow-operator/templates/crds/statsd.yaml",
+                    "charts/airflow-operator/templates/crds/triggerer.yaml",
+                    "charts/airflow-operator/templates/crds/webserver.yaml",
+                    "charts/airflow-operator/templates/crds/worker.yaml",
                 ],
-    )
+        )
+        assert len(docs) == 14
+    
+    def test_airflow_operator_webhook_tls(self, kube_version):
+        """""Test Webhook tls"""""
+        docs = render_chart(
+        kube_version=kube_version,
+        values={"airflow-operator": {
+                        "webhooks":{ 
+                            "useCustomTlsCerts": True,
+                            "caBundle": "abc123",
+                            "tlsCert": "tlscert123",
+                            "tlsKey": "tlskey123",
+                        },
+                        },
+                    "global":{
+                                "airflow_operator":{
+                                    "enabled": True
+                                },
+                        },
+                },      
+        show_only=[ "charts/airflow-operator/templates/secrets/webhooks-tls.yaml"]
+        )
         assert len(docs) == 1

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -80,8 +80,11 @@ class TestAirflowOperator:
             },
             show_only=["charts/airflow-operator/templates/secrets/webhooks-tls.yaml"],
         )
+
         assert len(docs) == 1
-        ## add more validations to add cabundle,tlscert,tlskey
+        expected_data = {'tls.crt': 'dGxzY2VydDEyMw==', 'tls.key': 'dGxza2V5MTIz'}
+        assert docs[0]['data'] == expected_data
+        
 
     def test_airflow_operator_webhooks(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -26,7 +26,11 @@ class TestAirflowOperator:
                 "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
             ],
         )
-        assert len(docs) == 2
+        assert len(docs) == 3
+        assert 'Issuer' == docs[0]['kind']
+        assert 'Certificate' == docs[1]['kind']
+        assert 'cert-manager.io/v1' == docs[0]['apiVersion']
+        assert 'cert-manager.io/v1' == docs[1]['apiVersion']
 
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -11,6 +11,7 @@ class TestAirflowOperator:
     def test_airflow_operator_cert_manager(self, kube_version):
         """Test Airflow operator cert manager with flags."""
         docs = render_chart(
+            validate_objects=False,
             kube_version=kube_version,
             values={
                 "airflow-operator": {
@@ -30,6 +31,7 @@ class TestAirflowOperator:
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""
         docs = render_chart(
+            validate_objects=False,
             kube_version=kube_version,
             values={
                 "airflow-operator": {
@@ -61,6 +63,7 @@ class TestAirflowOperator:
     def test_airflow_operator_secret(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""
         docs = render_chart(
+            validate_objects=False,
             kube_version=kube_version,
             values={
                 "airflow-operator": {
@@ -83,6 +86,7 @@ class TestAirflowOperator:
     def test_airflow_operator_webhooks(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""
         docs = render_chart(
+            validate_objects=False,
             kube_version=kube_version,
             values={
                 "global": {

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -23,10 +23,12 @@ class TestAirflowOperator:
                     "airflowOperator": {"enabled": True},
                 },
             },
-            show_only=[
-                "charts/airflow-operator/templates/certmanager/selfsigned-issuer.yaml",
-                "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
-            ],
+            show_only=sorted(
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/airflow-operator/templates/certmanager").glob("*")
+                ]
+            ),
         )
         assert len(docs) == 2
         assert "Issuer" == docs[0]["kind"]
@@ -99,10 +101,12 @@ class TestAirflowOperator:
                     "airflowOperator": {"enabled": True},
                 },
             },
-            show_only=[
-                "charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml",
-                "charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml",
-            ],
+            show_only=sorted(
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/airflow-operator/templates/webhooks").glob("*")
+                ]
+            ),
         )
         assert len(docs) == 2
         assert "admissionregistration.k8s.io/v1" == docs[0]["apiVersion"]

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -2,6 +2,7 @@ from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
 
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,
@@ -11,100 +12,86 @@ class TestAirflowOperator:
         """Test Airflow operator cert manager with flags."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"airflow-operator": {
-                            "certManager":
-                            { 
-                                "enabled": True
-                            },
-                            },
-                        "global":
-                            {
-                                    "airflow_operator":
-                                    {
-                                        "enabled": True
-                                    },
-                            },
-                    },      
-                        
-            show_only=["charts/airflow-operator/templates/certmanager/selfsigned-issuer.yaml",
-                    "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
-                    ],
+            values={
+                "airflow-operator": {
+                    "certManager": {"enabled": True},
+                },
+                "global": {
+                    "airflow_operator": {"enabled": True},
+                },
+            },
+            show_only=[
+                "charts/airflow-operator/templates/certmanager/selfsigned-issuer.yaml",
+                "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
+            ],
         )
         assert len(docs) == 2
-    
+
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""
         docs = render_chart(
-        kube_version=kube_version,
-        values={"airflow-operator": {
-                        "crd":
-                        { 
-                            "create": True
-                        },
-                        },
-                    "global":
-                        {
-                                "airflow_operator":
-                                {
-                                    "enabled": True
-                                },
-                        },
-                },      
-                    
-        show_only=[ "charts/airflow-operator/templates/crds/airflow.yaml",
-                    "charts/airflow-operator/templates/crds/allocator.yaml",
-                    "charts/airflow-operator/templates/crds/apiserver.yaml",
-                    "charts/airflow-operator/templates/crds/dagprocessor.yaml",
-                    "charts/airflow-operator/templates/crds/pgbouncer.yaml",
-                    "charts/airflow-operator/templates/crds/postgres.yaml",
-                    "charts/airflow-operator/templates/crds/rbac.yaml",
-                    "charts/airflow-operator/templates/crds/redis.yaml",
-                    "charts/airflow-operator/templates/crds/runner.yaml",
-                    "charts/airflow-operator/templates/crds/scheduler.yaml",
-                    "charts/airflow-operator/templates/crds/statsd.yaml",
-                    "charts/airflow-operator/templates/crds/triggerer.yaml",
-                    "charts/airflow-operator/templates/crds/webserver.yaml",
-                    "charts/airflow-operator/templates/crds/worker.yaml",
-                ],
+            kube_version=kube_version,
+            values={
+                "airflow-operator": {
+                    "crd": {"create": True},
+                },
+                "global": {
+                    "airflow_operator": {"enabled": True},
+                },
+            },
+            show_only=[
+                "charts/airflow-operator/templates/crds/airflow.yaml",
+                "charts/airflow-operator/templates/crds/allocator.yaml",
+                "charts/airflow-operator/templates/crds/apiserver.yaml",
+                "charts/airflow-operator/templates/crds/dagprocessor.yaml",
+                "charts/airflow-operator/templates/crds/pgbouncer.yaml",
+                "charts/airflow-operator/templates/crds/postgres.yaml",
+                "charts/airflow-operator/templates/crds/rbac.yaml",
+                "charts/airflow-operator/templates/crds/redis.yaml",
+                "charts/airflow-operator/templates/crds/runner.yaml",
+                "charts/airflow-operator/templates/crds/scheduler.yaml",
+                "charts/airflow-operator/templates/crds/statsd.yaml",
+                "charts/airflow-operator/templates/crds/triggerer.yaml",
+                "charts/airflow-operator/templates/crds/webserver.yaml",
+                "charts/airflow-operator/templates/crds/worker.yaml",
+            ],
         )
         assert len(docs) == 14
-    
+
     def test_airflow_operator_secret(self, kube_version):
-        """""Test Airflow Operator Webhook tls"""""
+        """""Test Airflow Operator Webhook tls""" ""
         docs = render_chart(
-        kube_version=kube_version,
-        values={"airflow-operator": {
-                        "webhooks":{ 
-                            "useCustomTlsCerts": True,
-                            "caBundle": "abc123",
-                            "tlsCert": "tlscert123",
-                            "tlsKey": "tlskey123",
-                        },
-                        },
-                    "global":{
-                                "airflow_operator":{
-                                    "enabled": True
-                                },
-                        },
-                },      
-        show_only=[ "charts/airflow-operator/templates/secrets/webhooks-tls.yaml"]
+            kube_version=kube_version,
+            values={
+                "airflow-operator": {
+                    "webhooks": {
+                        "useCustomTlsCerts": True,
+                        "caBundle": "abc123",
+                        "tlsCert": "tlscert123",
+                        "tlsKey": "tlskey123",
+                    },
+                },
+                "global": {
+                    "airflow_operator": {"enabled": True},
+                },
+            },
+            show_only=["charts/airflow-operator/templates/secrets/webhooks-tls.yaml"],
         )
         assert len(docs) == 1
         ## add more validations to add cabundle,tlscert,tlskey
-    
-    def test_airflow_operator_webhooks(self,kube_version):
-        """""Test Airflow Operator Webhook tls"""""
+
+    def test_airflow_operator_webhooks(self, kube_version):
+        """""Test Airflow Operator Webhook tls""" ""
         docs = render_chart(
-        kube_version=kube_version,
-        values={
-                "global":{
-                                "airflow_operator":{
-                                    "enabled": True
-                                },
-                        },
-                },      
-        show_only=[ "charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml",
-                    "charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml",
-                    ],
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "airflow_operator": {"enabled": True},
+                },
+            },
+            show_only=[
+                "charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml",
+                "charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml",
+            ],
         )
         assert len(docs) == 2

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -1,0 +1,34 @@
+from tests import supported_k8s_versions
+from tests.chart_tests.helm_template_generator import render_chart
+import pytest
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestAirflowOperator:
+    def test_airflow_operator_cert_manager(self, kube_version):
+        """Test Airflow operator cert manager with flags."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"airflow-operator": {
+                            "certManager":
+                            { 
+                                "enabled": True
+                            },
+                            },
+                        "global":
+                            {
+                                    "airflow_operator":
+                                    {
+                                        "enabled": True
+                                    },
+                            },
+                    },      
+                        
+            show_only=["charts/airflow-operator/templates/certmanager/selfsigned-issuer.yaml",
+                    "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
+                    ],
+        )
+        assert len(docs) == 2
+    

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -1,6 +1,8 @@
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 import pytest
+from tests import git_root_dir
+from pathlib import Path
 
 
 @pytest.mark.parametrize(
@@ -47,22 +49,9 @@ class TestAirflowOperator:
                     "airflowOperator": {"enabled": True},
                 },
             },
-            show_only=[
-                "charts/airflow-operator/templates/crds/airflow.yaml",
-                "charts/airflow-operator/templates/crds/allocator.yaml",
-                "charts/airflow-operator/templates/crds/apiserver.yaml",
-                "charts/airflow-operator/templates/crds/dagprocessor.yaml",
-                "charts/airflow-operator/templates/crds/pgbouncer.yaml",
-                "charts/airflow-operator/templates/crds/postgres.yaml",
-                "charts/airflow-operator/templates/crds/rbac.yaml",
-                "charts/airflow-operator/templates/crds/redis.yaml",
-                "charts/airflow-operator/templates/crds/runner.yaml",
-                "charts/airflow-operator/templates/crds/scheduler.yaml",
-                "charts/airflow-operator/templates/crds/statsd.yaml",
-                "charts/airflow-operator/templates/crds/triggerer.yaml",
-                "charts/airflow-operator/templates/crds/webserver.yaml",
-                "charts/airflow-operator/templates/crds/worker.yaml",
-            ],
+            show_only=sorted(
+                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/airflow-operator/templates/crds").glob("*")]
+            ),
         )
         assert len(docs) == 14
         for i in range(len(docs)):

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -82,9 +82,8 @@ class TestAirflowOperator:
         )
 
         assert len(docs) == 1
-        expected_data = {'tls.crt': 'dGxzY2VydDEyMw==', 'tls.key': 'dGxza2V5MTIz'}
-        assert docs[0]['data'] == expected_data
-        
+        expected_data = {"tls.crt": "dGxzY2VydDEyMw==", "tls.key": "dGxza2V5MTIz"}
+        assert docs[0]["data"] == expected_data
 
     def test_airflow_operator_webhooks(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -54,4 +54,4 @@ class TestAirflowOperator:
         show_only=["charts/airflow-operator/templates/crds/airflow.yaml",
                 ],
     )
-        assert len(docs) == 2
+        assert len(docs) == 1

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -26,11 +26,13 @@ class TestAirflowOperator:
                 "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
             ],
         )
-        assert len(docs) == 3
+        assert len(docs) == 2
         assert 'Issuer' == docs[0]['kind']
         assert 'Certificate' == docs[1]['kind']
         assert 'cert-manager.io/v1' == docs[0]['apiVersion']
         assert 'cert-manager.io/v1' == docs[1]['apiVersion']
+        assert 'release-name-airflow-operator-serving-cert' == docs[1]['metadata']['name']
+        assert 'release-name-airflow-operator-selfsigned-issuer' == docs[0]['metadata']['name']      
 
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""
@@ -63,6 +65,12 @@ class TestAirflowOperator:
             ],
         )
         assert len(docs) == 14
+        for i in range(len(docs)):
+            assert 'apiextensions.k8s.io/v1' == docs[i]['apiVersion']
+            assert 'CustomResourceDefinition' == docs[i]['kind']
+            assert 'cert-manager.io/inject-ca-from' in docs[i]['metadata']['annotations']
+            assert 'airflow.apache.org' in docs[i]['metadata']['name']
+
 
     def test_airflow_operator_secret(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -117,3 +117,8 @@ class TestAirflowOperator:
             ],
         )
         assert len(docs) == 2
+        assert 'admissionregistration.k8s.io/v1' == docs[0]['apiVersion']
+        assert 'MutatingWebhookConfiguration' == docs[0]['kind']
+        assert 'ValidatingWebhookConfiguration' == docs[1]['kind']
+        assert 'release-name-airflow-operator-mutating-webhook-configuration' == docs[0]['metadata']['name']
+        assert 'release-name-airflow-operator-validating-webhook-configuration' == docs[1]['metadata']['name']

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -54,11 +54,11 @@ class TestAirflowOperator:
             ),
         )
         assert len(docs) == 14
-        for i in range(len(docs)):
-            assert "apiextensions.k8s.io/v1" == docs[i]["apiVersion"]
-            assert "CustomResourceDefinition" == docs[i]["kind"]
-            assert "cert-manager.io/inject-ca-from" in docs[i]["metadata"]["annotations"]
-            assert "airflow.apache.org" in docs[i]["metadata"]["name"]
+        for doc in docs:
+            assert "apiextensions.k8s.io/v1" == doc["apiVersion"]
+            assert "CustomResourceDefinition" == doc["kind"]
+            assert "cert-manager.io/inject-ca-from" in doc["metadata"]["annotations"]
+            assert "airflow.apache.org" in doc["metadata"]["name"]
 
     def test_airflow_operator_secret(self, kube_version):
         """""Test Airflow Operator Webhook tls""" ""

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -32,3 +32,26 @@ class TestAirflowOperator:
         )
         assert len(docs) == 2
     
+    def test_airflow_operator_crd(self, kube_version):
+        """Test Airflow Operator crd"""
+        docs = render_chart(
+        kube_version=kube_version,
+        values={"airflow-operator": {
+                        "crd":
+                        { 
+                            "create": True
+                        },
+                        },
+                    "global":
+                        {
+                                "airflow_operator":
+                                {
+                                    "enabled": True
+                                },
+                        },
+                },      
+                    
+        show_only=["charts/airflow-operator/templates/crds/airflow.yaml",
+                ],
+    )
+        assert len(docs) == 2

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -337,7 +337,7 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             name="astronomer",
-            values={"global": {"operator": {"enabled": True}}},
+            values={"global": {"airflow_operator": {"enabled": True}}},
         )[0]
         assert "__meta_kubernetes_service_label_astronomer_io_platform_release" in doc["data"]["config"]
 
@@ -346,6 +346,6 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             name="astronomer",
-            values={"global": {"operator": {"enabled": False}}},
+            values={"global": {"airflow_operator": {"enabled": False}}},
         )[0]
         assert "__meta_kubernetes_service_label_astronomer_io_platform_release" not in doc["data"]["config"]


### PR DESCRIPTION
## Description

Add unit tests for Airflow Operator chart components

This PR adds comprehensive unit tests for the Airflow Operator chart components in test_airflow_operator.py. The new tests cover:

- Cert Manager configuration testing
  - Verifies proper rendering of self-signed issuer and serving cert certificate
  - Validates when cert manager is enabled

- CRD template testing
  - Tests rendering of all 14 CRD templates when CRD creation is enabled
  - Includes CRDs for core components (airflow, scheduler, webserver)
  - Includes CRDs for supporting services (postgres, redis, etc.)

- Webhook TLS Secret testing
  - Tests webhook TLS secret generation with custom certs
  - Validates proper rendering with provided caBundle, tlsCert and tlsKey

- Webhook Configuration testing
  - Tests rendering of both mutating and validating webhook configurations
  - Verifies default webhook setup

Each test uses parametrized K8s versions to ensure compatibility across supported Kubernetes versions.

## Testing:
- Verified all tests pass locally
- Confirmed proper template rendering for each component
- Validated counts of rendered documents match expectations

## Related Issues

Related astronomer/issues#6822

## Merging 
0.37