### PR TITLE
add dag server and client probes support

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -183,32 +183,26 @@ data:
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.server.livenessProbe }}
-          resources: {{- .Values.global.dagOnlyDeployment.server.livenessProbe | toYaml | nindent 12 }}
+          livenessProbe: {{- .Values.global.dagOnlyDeployment.server.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.server.readinessProbe }}
-          resources: {{- .Values.global.dagOnlyDeployment.server.readinessProbe | toYaml | nindent 12 }}
+          readinessProbe: {{- .Values.global.dagOnlyDeployment.server.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
         client:
         {{- if .Values.global.dagOnlyDeployment.resources }}
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.client.livenessProbe }}
-          resources: {{- .Values.global.dagOnlyDeployment.client.livenessProbe | toYaml | nindent 12 }}
+          livenessProbe: {{- .Values.global.dagOnlyDeployment.client.livenessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.client.readinessProbe }}
-          resources: {{- .Values.global.dagOnlyDeployment.client.readinessProbe | toYaml | nindent 12 }}
+          readinessProbe: {{- .Values.global.dagOnlyDeployment.client.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.persistence }}
         persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 10 }}
         {{- end }}
         {{ if .Values.global.dagOnlyDeployment.serviceAccount }}
         serviceAccount: {{- .Values.global.dagOnlyDeployment.serviceAccount | toYaml | nindent 10 }}
-        {{- end }}
-        {{- if .Values.global.dagOnlyDeployment.livenessProbe}}
-        livenessProbe: {{- .Values.global.dagOnlyDeployment.livenessProbe | toYaml | nindent 10 }}
-        {{- end }}
-        {{- if .Values.global.dagOnlyDeployment.readinessProbe}}
-        readinessProbe: {{- .Values.global.dagOnlyDeployment.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -178,11 +178,25 @@ data:
         {{- if .Values.global.dagOnlyDeployment.securityContexts }}
         securityContexts: {{ template "dagOnlyDeployment.securityContexts" . }}
         {{- end }}
-        {{- if .Values.global.dagOnlyDeployment.resources }}
         server:
+        {{- if .Values.global.dagOnlyDeployment.resources }}
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.server.livenessProbe }}
+          resources: {{- .Values.global.dagOnlyDeployment.server.livenessProbe | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.server.readinessProbe }}
+          resources: {{- .Values.global.dagOnlyDeployment.server.readinessProbe | toYaml | nindent 12 }}
+        {{- end }}
         client:
+        {{- if .Values.global.dagOnlyDeployment.resources }}
           resources: {{- .Values.global.dagOnlyDeployment.resources | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.client.livenessProbe }}
+          resources: {{- .Values.global.dagOnlyDeployment.client.livenessProbe | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if .Values.global.dagOnlyDeployment.client.readinessProbe }}
+          resources: {{- .Values.global.dagOnlyDeployment.client.readinessProbe | toYaml | nindent 12 }}
         {{- end }}
         {{- if .Values.global.dagOnlyDeployment.persistence }}
         persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 10 }}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -719,7 +719,8 @@ def test_houston_configmap_with_dagonlydeployment_liveness_probe():
             "global": {
                 "dagOnlyDeployment": {
                     "enabled": True,
-                    "livenessProbe": liveness_probe,
+                    "server": {"livenessProbe": liveness_probe},
+                    "client": {"livenessProbe": liveness_probe},
                     "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
             }
@@ -731,9 +732,10 @@ def test_houston_configmap_with_dagonlydeployment_liveness_probe():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
-    # Validate livenessProbe
-    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["livenessProbe"] == liveness_probe
+    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]["server"]
+    assert "livenessProbe" in prod_yaml["deployments"]["dagDeploy"]["client"]
+    assert prod_yaml["deployments"]["dagDeploy"]["server"]["livenessProbe"] == liveness_probe
+    assert prod_yaml["deployments"]["dagDeploy"]["client"]["livenessProbe"] == liveness_probe
 
 
 def test_houston_configmap_with_dagonlydeployment_readiness_probe():
@@ -751,7 +753,8 @@ def test_houston_configmap_with_dagonlydeployment_readiness_probe():
             "global": {
                 "dagOnlyDeployment": {
                     "enabled": True,
-                    "readinessProbe": readiness_probe,
+                    "server": {"readinessProbe": readiness_probe},
+                    "client": {"readinessProbe": readiness_probe},
                     "image": "quay.io/astronomer/ap-auth:0.22.3",
                 }
             }
@@ -763,9 +766,10 @@ def test_houston_configmap_with_dagonlydeployment_readiness_probe():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
 
-    # Validate readinessProbe
-    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]
-    assert prod_yaml["deployments"]["dagDeploy"]["readinessProbe"] == readiness_probe
+    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]["server"]
+    assert "readinessProbe" in prod_yaml["deployments"]["dagDeploy"]["client"]
+    assert prod_yaml["deployments"]["dagDeploy"]["server"]["readinessProbe"] == readiness_probe
+    assert prod_yaml["deployments"]["dagDeploy"]["client"]["readinessProbe"] == readiness_probe
 
 
 def test_houston_configmap_with_loggingsidecar_liveness_probe():

--- a/values.yaml
+++ b/values.yaml
@@ -133,6 +133,8 @@ global:
     securityContexts:
       pod:
         fsGroup: 50000
+    server: {}
+    client: {}
     resources: {}
     persistence: {}
     readinessProbe: {}

--- a/values.yaml
+++ b/values.yaml
@@ -137,8 +137,6 @@ global:
     client: {}
     resources: {}
     persistence: {}
-    readinessProbe: {}
-    livenessProbe: {}
 
   logging:
     indexNamePrefix: ~


### PR DESCRIPTION
## Description

Add liveliness and readiness support for dag deploy server and client

## Related Issues

- Related https://github.com/astronomer/issues/issues/6745
https://github.com/astronomer/issues/issues/6928

## Testing

QA should be able to pass liveliness and readiness probes for both dag server client and server

## Merging

cherry-pick to release-0.37
