### PR TITLE
upgrade ap-vendor packages 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,38 +363,41 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
-                - quay.io/astronomer/ap-alertmanager:0.27.0-3
+                - quay.io/astronomer/ap-alertmanager:0.27.0-4
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
+                - quay.io/astronomer/ap-base:3.20.3-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
                 - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.17
+                - quay.io/astronomer/ap-curator:8.0.17-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-grafana:10.4.13
+                - quay.io/astronomer/ap-grafana:10.4.14
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4
+                - quay.io/astronomer/ap-init:3.20.3-1
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
-                - quay.io/astronomer/ap-nats-server:2.10.18-1
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-4
+                - quay.io/astronomer/ap-nats-server:2.10.18-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-15
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-16
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-1
                 - quay.io/astronomer/ap-postgresql:15.10.0
                 - quay.io/astronomer/ap-prometheus:2.53.3
-                - quay.io/astronomer/ap-registry:3.18.9
-                - quay.io/astronomer/ap-vector:0.42.0
+                - quay.io/astronomer/ap-registry:3.20.3-1
+                - quay.io/astronomer/ap-vector:0.44.0-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -402,38 +405,41 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
-                - quay.io/astronomer/ap-alertmanager:0.27.0-3
+                - quay.io/astronomer/ap-alertmanager:0.27.0-4
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.2
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-11
                 - quay.io/astronomer/ap-base:3.18.9
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-3
+                - quay.io/astronomer/ap-base:3.20.3-1
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
                 - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.17
+                - quay.io/astronomer/ap-curator:8.0.17-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.36.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-grafana:10.4.13
+                - quay.io/astronomer/ap-grafana:10.4.14
                 - quay.io/astronomer/ap-houston-api:0.36.6
                 - quay.io/astronomer/ap-init:3.19.4
+                - quay.io/astronomer/ap-init:3.20.3-1
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-3
-                - quay.io/astronomer/ap-nats-server:2.10.18-1
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-4
+                - quay.io/astronomer/ap-nats-server:2.10.18-2
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-6
                 - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-15
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-16
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-1
                 - quay.io/astronomer/ap-postgresql:15.10.0
                 - quay.io/astronomer/ap-prometheus:2.53.3
-                - quay.io/astronomer/ap-registry:3.18.9
-                - quay.io/astronomer/ap-vector:0.42.0
+                - quay.io/astronomer/ap-registry:3.20.3-1
+                - quay.io/astronomer/ap-vector:0.44.0-1
           context:
             - twistcli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,8 +366,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-4
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-11
-                - quay.io/astronomer/ap-base:3.18.9
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-12
                 - quay.io/astronomer/ap-base:3.20.3-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
                 - quay.io/astronomer/ap-commander:0.36.9
@@ -380,14 +379,12 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.14
                 - quay.io/astronomer/ap-houston-api:0.36.6
-                - quay.io/astronomer/ap-init:3.19.4
                 - quay.io/astronomer/ap-init:3.20.3-1
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-4
                 - quay.io/astronomer/ap-nats-server:2.10.18-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-6
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-7
                 - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
@@ -408,8 +405,7 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-4
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-11
-                - quay.io/astronomer/ap-base:3.18.9
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-12
                 - quay.io/astronomer/ap-base:3.20.3-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
                 - quay.io/astronomer/ap-commander:0.36.9
@@ -422,14 +418,12 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.14
                 - quay.io/astronomer/ap-houston-api:0.36.6
-                - quay.io/astronomer/ap-init:3.19.4
                 - quay.io/astronomer/ap-init:3.20.3-1
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-3
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-4
                 - quay.io/astronomer/ap-nats-server:2.10.18-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-6
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-7
                 - quay.io/astronomer/ap-nginx-es:1.27.2
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.27.0-3
+    tag: 0.27.0-4
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.18.9
+    tag: 3.20.3-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.18.9
+    tag: 3.20.3-1
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.17
+    tag: 8.0.17-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-11
+    tag: 1.5.0-12
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.13
+    tag: 10.4.14
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.19.4
+    tag: 3.20.3-1
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.18-1
+    tag: 2.10.18-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-3
+    tag: 0.15.0-4
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-15
+  tag: 1.17.0-16
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-3
+  tag: 0.25.0-4
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.16.0
+  tag: 0.16.0-1
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -4,15 +4,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.19.4
+    tag: 3.20.3-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-6
+    tag: 0.25.6-7
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-3
+    tag: 0.15.0-4
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ global:
     containerdTolerations: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.18.9
+      tag: 3.20.3-1
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform

--- a/values.yaml
+++ b/values.yaml
@@ -154,7 +154,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.42.0
+    tag: 0.44.0-1
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

This PR Update  ap-vendor packages to resolve some of the CVE's for astronomer software 

| Image Name            | old Tag   | New tag   |
| --------------------- | --------- | --------- |
| ap-alertmanager       | 0.27.0-3  | 0.27.0-4  |
| ap-awsesproxy         | 1.5.0-11  | 1.5.0-12  |
| ap-base               | 3.18.9    | 3.20.3-1  |
| ap-blackbox-exporter  | 0.25.0-3  | 0.25.0-4  |
| ap-curator            | 8.0.17    | 8.0.17-1  |
| ap-grafana            | 10.4.13   | 10.4.14   |
| ap-init               | 3.19.4    | 3.20.3-1  |
| ap-nats-exporter      | 0.15.0-3  | 0.15.0-4  |
| ap-nats-server        | 2.10.18-1 | 2.10.18-2 |
| ap-nats-streaming     | 0.25.6-6  | 0.25.6-7  |
| ap-pgbouncer-exporter | 0.18.0    | 0.18.0-1  |
| ap-pgbouncer-krb      | 1.17.0-15 | 1.17.0-16 |
| ap-postgres-exporter  | 0.16.0    | 0.16.0-1  |
| ap-registry           | 3.18.9    | 3.20.3-1  |
| ap-vector             | 0.42.0    | 0.44.0-1  |

## Related Issues

[#6830](https://github.com/astronomer/issues/issues/6830)

## Testing

QA should test with all the images platform should come up without any issues 
## Merging

cherry-picked to 0.37 and 0.36 branches 
