### PR TITLE
Enable Prometheus to use both service label and service annotation when Airflow operator is enabled

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -376,8 +376,7 @@ data:
             regex: __meta_kubernetes_service_label_(.+)
           {{- if .Values.global.airflowOperator.enabled }}
           - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
-            regex: ^\s*{{ .Release.Name }}\s*$
-            action: keep
+            regex: ^{{ .Release.Name }}$
           {{- end }}
           - source_labels: [__meta_kubernetes_service_annotation_astronomer_io_platform_release]
             action: keep

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -375,12 +375,14 @@ data:
           - action: labelmap
             regex: __meta_kubernetes_service_label_(.+)
           {{- if .Values.global.airflowOperator.enabled }}
-          - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
-            regex: ^{{ .Release.Name }}$
-          {{- end }}
+          - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release, __meta_kubernetes_service_annotation_astronomer_io_platform_release]
+            regex: ^{{ .Release.Name }}$|.*
+            action: keep
+          {{- else }}
           - source_labels: [__meta_kubernetes_service_annotation_astronomer_io_platform_release]
             action: keep
             regex: ^{{ .Release.Name }}$
+          {{- end }}
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -11,8 +11,7 @@ prometheus_job = {
 
 airflow_scrape_relabel_config = {
     "source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release"],
-    "action": "keep",
-    "regex": "^\\s*astronomer\\s*$",
+    "regex": "^astronomer$",
 }
 
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -10,9 +10,12 @@ prometheus_job = {
 }
 
 airflow_scrape_relabel_config = {
-    "source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release", "__meta_kubernetes_service_annotation_astronomer_io_platform_release"],
+    "source_labels": [
+        "__meta_kubernetes_service_label_astronomer_io_platform_release",
+        "__meta_kubernetes_service_annotation_astronomer_io_platform_release",
+    ],
     "regex": "^astronomer$|.*",
-    "action": "keep"
+    "action": "keep",
 }
 
 

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -10,8 +10,9 @@ prometheus_job = {
 }
 
 airflow_scrape_relabel_config = {
-    "source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release"],
-    "regex": "^astronomer$",
+    "source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release", "__meta_kubernetes_service_annotation_astronomer_io_platform_release"],
+    "regex": "^astronomer$|.*",
+    "action": "keep"
 }
 
 


### PR DESCRIPTION
## Description

This PR enabled Prometheus to use both service label and service annotation when Airflow operator is enabled

## Related Issues

Related astronomer/issues#6954

## Testing

Tested on Stage and with unittests

## Merging

0.37
