### PR TITLE
ap-base 3.20.5 updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,38 +363,38 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
-                - quay.io/astronomer/ap-alertmanager:0.27.0-4
+                - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-12
-                - quay.io/astronomer/ap-base:3.20.3-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-13
+                - quay.io/astronomer/ap-base:3.20.5
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
                 - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.17-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.36.2
+                - quay.io/astronomer/ap-curator:8.0.17-2
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.0
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.15
                 - quay.io/astronomer/ap-houston-api:0.36.6
-                - quay.io/astronomer/ap-init:3.20.3-1
+                - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-4
-                - quay.io/astronomer/ap-nats-server:2.10.18-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-7
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-5
+                - quay.io/astronomer/ap-nats-server:2.10.18-3
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-8
                 - quay.io/astronomer/ap-nginx-es:1.27.3
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-16
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-1
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
-                - quay.io/astronomer/ap-registry:3.20.3-1
-                - quay.io/astronomer/ap-vector:0.44.0-1
+                - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -402,38 +402,38 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
-                - quay.io/astronomer/ap-alertmanager:0.27.0-4
+                - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.36.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-12
-                - quay.io/astronomer/ap-base:3.20.3-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-4
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-13
+                - quay.io/astronomer/ap-base:3.20.5
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
                 - quay.io/astronomer/ap-commander:0.36.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.17-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.36.2
+                - quay.io/astronomer/ap-curator:8.0.17-2
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.0
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.15
                 - quay.io/astronomer/ap-houston-api:0.36.6
-                - quay.io/astronomer/ap-init:3.20.3-1
+                - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
-                - quay.io/astronomer/ap-nats-exporter:0.15.0-4
-                - quay.io/astronomer/ap-nats-server:2.10.18-2
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-7
+                - quay.io/astronomer/ap-nats-exporter:0.15.0-5
+                - quay.io/astronomer/ap-nats-server:2.10.18-3
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-8
                 - quay.io/astronomer/ap-nginx-es:1.27.3
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1-1
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-16
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-1
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
-                - quay.io/astronomer/ap-registry:3.20.3-1
-                - quay.io/astronomer/ap-vector:0.44.0-1
+                - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - twistcli
 

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.27.0-4
+    tag: 0.27.0-5
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.20.3-1
+    tag: 3.20.5
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.2
+    tag: 0.37.0
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.20.3-1
+    tag: 3.20.5
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.17-1
+    tag: 8.0.17-2
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-12
+    tag: 1.5.0-13
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -15,7 +15,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.2
+    tag: 0.37.0
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.20.3-1
+    tag: 3.20.5
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,15 +6,15 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.18-2
+    tag: 2.10.18-3
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-4
+    tag: 0.15.0-5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.36.2
+    tag: 0.37.0
     pullPolicy: IfNotPresent
 
 

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-16
+  tag: 1.17.0-17
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-4
+  tag: 0.25.0-5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.16.0-1
+  tag: 0.16.0-2
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -4,15 +4,15 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.20.3-1
+    tag: 3.20.5
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-7
+    tag: 0.25.6-8
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.15.0-4
+    tag: 0.15.0-5
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -28,7 +28,7 @@ global:
     containerdTolerations: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.20.3-1
+      tag: 3.20.5
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
@@ -154,7 +154,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.44.0-1
+    tag: 0.44.0-2
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

Update all ap-base derived images to use ap-base:3.20.5

## Related Issues

https://github.com/astronomer/issues/issues/6962

## Testing

No testing was done. These tests will all be covered by normal QA tests.

## Merging

This is just for 0.37. I'm not sure that all of these images will work on 0.36 so we can hold off on that for now.