### PR TITLE
add jobs delete rbac for cleanup activity

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -106,7 +106,7 @@ rules:
   verbs: ["list", "watch"]
 - apiGroups: ["batch"]
   resources: ["jobs"]
-  verbs: ["list", "watch", "create", "delete", "get"]
+  verbs: ["list", "watch", "create", "delete", "get", "deletecollection"]
 - apiGroups: ["batch"]
   resources: ["cronjobs"]
   verbs: ["create", "delete", "get", "list", "patch", "watch", "deletecollection"]


### PR DESCRIPTION
## Description

Add batch jobs delete collection rbac commander for cleanup call

## Related Issues

- https://github.com/astronomer/issues/issues/6707

## Testing

No rbac error on worker when cleanup cron is triggered 

## Merging
cherry-pick to release-0.37
