### PR TITLE
Fix Prometheus Configuration for Airflow Operator Job

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -377,6 +377,7 @@ data:
             regex: __meta_kubernetes_service_label_(.+)
           - source_labels: [__meta_kubernetes_service_label_astronomer_io_platform_release]
             regex: ^{{ .Release.Name }}$
+            action: keep
           - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
             action: keep
             regex: true

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -11,7 +11,11 @@ prometheus_job = {
 
 airflow_scrape_relabel_config = [
     {"action": "labelmap", "regex": "__meta_kubernetes_service_label_(.+)"},
-    {"source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release"], "regex": "^astronomer$"},
+    {
+        "source_labels": ["__meta_kubernetes_service_label_astronomer_io_platform_release"],
+        "regex": "^astronomer$",
+        "action": "keep",
+    },
     {"source_labels": ["__meta_kubernetes_service_annotation_prometheus_io_scrape"], "action": "keep", "regex": True},
     {
         "source_labels": ["__address__", "__meta_kubernetes_service_annotation_prometheus_io_port"],


### PR DESCRIPTION
## Description

Added missing action: keep directive in the Prometheus configuration for the Airflow job's relabel configuration. This fixes an issue where Prometheus would fail to start with the error: "relabel configuration for replace action requires 'target_label' value".

## Changes

Added explicit action: keep to the Airflow job's relabel configuration where we filter based on __meta_kubernetes_service_annotation_astronomer_io_platform_release
Updated corresponding tests to include this required field

## Related Issues

Related astronomer/issues#6954

## Root Cause
Without specifying the action, Prometheus defaults to action: replace which requires a target_label field. However, for this particular relabel configuration, we want to filter metrics rather than replace labels, making keep the appropriate action.

## Testing

Verified Prometheus starts successfully with the updated configuration
All existing tests pass with the updated configuration
Confirmed metrics collection continues to work as expected for Airflow jobs

## Merging
0.37
