### PR TITLE
0.37.x image updates, 0.37.0-rc1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
-                - quay.io/astronomer/ap-astro-ui:0.36.0
+                - quay.io/astronomer/ap-astro-ui:0.37.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
@@ -378,7 +378,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.15
-                - quay.io/astronomer/ap-houston-api:0.36.6
+                - quay.io/astronomer/ap-houston-api:0.37.0
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
@@ -403,7 +403,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.1
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
-                - quay.io/astronomer/ap-astro-ui:0.36.0
+                - quay.io/astronomer/ap-astro-ui:0.37.0
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
@@ -417,7 +417,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-grafana:10.4.15
-                - quay.io/astronomer/ap-houston-api:0.36.6
+                - quay.io/astronomer/ap-houston-api:0.37.0
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
-                - quay.io/astronomer/ap-commander:0.36.9
+                - quay.io/astronomer/ap-commander:0.37.0
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.0
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
-                - quay.io/astronomer/ap-commander:0.36.9
+                - quay.io/astronomer/ap-commander:0.37.0
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
-                - quay.io/astronomer/ap-commander:0.37.0
+                - quay.io/astronomer/ap-commander:0.37.1
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.0
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
-                - quay.io/astronomer/ap-commander:0.37.0
+                - quay.io/astronomer/ap-commander:0.37.1
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.17-2
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.36.0
-appVersion: 0.36.0
+version: 0.37.0-rc1
+appVersion: 0.37.0-rc1
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.36.0
+version: 0.37.0-rc1
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.37.0
+    tag: 0.37.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.13.5
+airflowChartVersion: 1.13.6
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.36.9
+    tag: 0.37.0
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.36.6
+    tag: 0.37.0
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.36.0
+    tag: 0.37.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

- ap-commander 0.37.1
- ap-houston-api 0.37.0
- ap-astro-ui 0.37.0
- airflowChartVersion 1.13.6
- Astronomer "Software" 0.37.0-rc1

## Related Issues

0.37.0 release related work, somewhat related to <https://github.com/astronomer/issues/issues/6786>

## Testing

No extra testing needed, CI is fine.

## Merging

Merge only into 0.37.0, after <https://github.com/astronomer/commander/pull/259>