### PR TITLE
update prometheus no cluster role test cases

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -128,7 +128,7 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
-            - name: DATABASE_SCHEMA
+            - name: DATABASE_SCHEMA_NAME
               value: "houston$default"
             - name: DATABASE_TABLE_NAME
               value: Deployment

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.2
+    tag: 0.1.3
     pullPolicy: IfNotPresent
 
 

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -186,6 +186,11 @@ class TestPrometheusStatefulset:
         assert len(docs) == 1
         self.prometheus_common_tests(docs[0])
         c_by_name = get_containers_by_name(docs[0])
+        env_vars = {x["name"]: x.get("value", x.get("valueFrom")) for x in c_by_name["filesd-reloader"]["env"]}
+        assert env_vars["DATABASE_SCHEMA_NAME"] == "houston$default"
+        assert env_vars["DATABASE_TABLE_NAME"] == "Deployment"
+        assert env_vars["DATABASE_NAME"] == "release-name_houston"
+        assert env_vars["FILESD_FILE_PATH"] == "/prometheusreloader/airflow"
         assert c_by_name["filesd-reloader"]["volumeMounts"] == [{"mountPath": "/prometheusreloader/airflow", "name": "filesd"}]
 
     def test_prometheus_filesd_reloader_extraenv_enabled(self, kube_version):


### PR DESCRIPTION
## Description

update prometheus no cluster role test cases

## Related Issues

https://github.com/astronomer/issues/issues/6342

## Testing

QA should see status indicator similar to defaults with cluster role disabled

## Merging

cherry-pick to release-0.37
