### PR TITLE
Add global airgapped flag to control platform

### DIFF
--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -111,7 +111,7 @@ spec:
             - name: COMMANDER_UPGRADE_TIMEOUT
               value: {{ .Values.commander.upgradeTimeout | quote }}
             {{- end }}
-            {{- if .Values.commander.airGapped.enabled }}
+            {{- if or .Values.commander.airGapped.enabled .Values.global.airgappedMode -}}
             - name: COMMANDER_AIRGAPPED
               value: "true"
             {{- end }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-airflow-version-updates-cronjob.yaml
@@ -1,7 +1,7 @@
 ###################################
 ## Houston Update Check CronJob
 ###################################
-{{- if .Values.houston.updateAirflowCheck.enabled }}
+{{- if and .Values.houston.updateAirflowCheck.enabled (not .Values.global.airgappedMode ) }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## Houston Update Check CronJob ##
 ##################################
-{{- if .Values.houston.updateRuntimeCheck.enabled }}
+{{- if and .Values.houston.updateRuntimeCheck.enabled (not .Values.global.airgappedMode )}}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -1,7 +1,7 @@
 ###################################
 ## Houston Update Check CronJob
 ###################################
-{{- if .Values.houston.updateCheck.enabled }}
+{{- if and .Values.houston.updateCheck.enabled (not .Values.global.airgappedMode ) }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -589,6 +589,11 @@ data:
     updateAirflowCheckEnabled: {{ .Values.houston.updateAirflowCheck.enabled }}
     updateRuntimeCheckEnabled: {{ .Values.houston.updateRuntimeCheck.enabled }}
 
+    {{- if .Values.global.airgappedMode -}}
+    airgapped:
+      enabled: {{ .Values.global.airgappedMode }}
+    {{- end -}}
+
   # These are any user-specified config overrides.
   local-production.yaml: |
 {{ toYaml .Values.houston.config | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -58,6 +58,9 @@ global:
   # If RBAC on cluster is enabled
   rbacEnabled: true
 
+  # airgapped mode
+  airgappedMode: false
+
   # whether to create pod disrption budgets by default for platform components
   podDisruptionBudgetsEnabled: true
 


### PR DESCRIPTION
## Description

This PR introduces new airgapped flag to control platform not to use any public config url wrt to cached helm chart, use local runtime versions

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#XXXX

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
