### PR TITLE
remove kube-proxy-rbac

### DIFF
--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -52,7 +52,9 @@ service:
 {{ printf "\n" -}}
 - --health-probe-bind-address=:{{ .Values.ports.managerPort }}
 - --leader-elect
+{{ if .Values.manager.metrics.enabled }}
 - --metrics-bind-address=127.0.0.1:{{ .Values.ports.managerUpstreamPort }}
+{{- end -}}
 {{- if .Values.airgapped }}
 - --airgapped
 {{- end -}}

--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -48,8 +48,25 @@ service:
 {{- end -}}
 {{- end }}
 
+{{ define "manager.args" -}}
+{{ printf "\n" -}}
+- --health-probe-bind-address=:{{ .Values.ports.managerPort }}
+- --leader-elect
+- --metrics-bind-address=0.0.0.0:{{ .Values.ports.managerUpstreamPort }}
+{{- if .Values.airgapped }}
+- --airgapped
+{{- end -}}
+{{- if .Values.global.openshiftEnabled }}
+- --openshift
+{{- end -}}
+{{- if .Values.kedaEnabled }}
+- --keda
+{{- end -}}
+{{- end }}
+
 {{ define "manager.containers" -}}
 - name: manager
+  args: {{ include "manager.args" . | indent 2 }}
   command:
     - /manager
   env:

--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -48,25 +48,8 @@ service:
 {{- end -}}
 {{- end }}
 
-{{ define "manager.args" -}}
-{{ printf "\n" -}}
-- --health-probe-bind-address=:{{ .Values.ports.managerPort }}
-- --leader-elect
-- --metrics-bind-address={{ if .Values.manager.metrics.useSecuredEndpoint }}127.0.0.1{{ else }}0.0.0.0{{ end }}:{{ .Values.ports.managerUpstreamPort }}
-{{- if .Values.airgapped }}
-- --airgapped
-{{- end -}}
-{{- if .Values.global.openshiftEnabled }}
-- --openshift
-{{- end -}}
-{{- if .Values.kedaEnabled }}
-- --keda
-{{- end -}}
-{{- end }}
-
 {{ define "manager.containers" -}}
 - name: manager
-  args: {{ include "manager.args" . | indent 2 }}
   command:
     - /manager
   env:
@@ -97,20 +80,6 @@ service:
       path: /readyz
       port: {{ .Values.ports.managerPort }}
   {{- end }}
-{{- if .Values.manager.metrics.useSecuredEndpoint }}
-- name: kube-rbac-proxy
-  args:
-    - --secure-listen-address=0.0.0.0:{{ .Values.ports.managerContainerPort }}
-    - --upstream=http://127.0.0.1:{{ .Values.ports.managerUpstreamPort }}/
-    - --logtostderr=true
-    - --v=10
-  image: {{ include "kube-rbac-proxy.image" . }}
-  imagePullPolicy: {{ .Values.manager.metrics.image.pullPolicy }}
-  resources: {{ toYaml .Values.manager.resources | nindent 4 }}
-  ports:
-    - containerPort: {{ .Values.ports.managerContainerPort }}
-      name: https
-{{- end -}}
 {{- end }}
 
 {{- define "operator.serviceAccountName" -}}
@@ -121,20 +90,11 @@ service:
 {{- end -}}
 {{- end -}}
 
-
 {{ define "operator.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/airflow-operator-controller:{{ .Values.manager.image.tag }}
 {{- else -}}
 {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag }}
-{{- end }}
-{{- end }}
-
-{{ define "kube-rbac-proxy.image" -}}
-{{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-kube-rbac-proxy:{{ .Values.manager.metrics.image.tag }}
-{{- else -}}
-{{ .Values.manager.metrics.image.repository }}:{{ .Values.manager.metrics.image.tag }}
 {{- end }}
 {{- end }}
 

--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -52,7 +52,7 @@ service:
 {{ printf "\n" -}}
 - --health-probe-bind-address=:{{ .Values.ports.managerPort }}
 - --leader-elect
-- --metrics-bind-address=0.0.0.0:{{ .Values.ports.managerUpstreamPort }}
+- --metrics-bind-address=127.0.0.1:{{ .Values.ports.managerUpstreamPort }}
 {{- if .Values.airgapped }}
 - --airgapped
 {{- end -}}

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -1,6 +1,7 @@
-##############################
-## Airflow Operator Service ##
-##############################
+######################################
+## Airflow Operator Metrics Service ##
+######################################
+{{ if .Values.manager.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,15 +11,22 @@ metadata:
     chart: {{ template "operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    astronomer.io/platform-release: {{ .Release.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.ports.managerContainerPort }}"
+
   name: {{ .Release.Name }}-aocm-metrics-service
   namespace: '{{ .Release.Namespace }}'
+
 spec:
   type: ClusterIP
   ports:
-  - name: https
+  - name: metrics
     port: {{ .Values.ports.managerContainerPort }}
-    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort  .Values.manager.metrics.enabled }}
+    targetPort: {{ .Values.ports.managerUpstreamPort }}
     appProtocol: http
     protocol: TCP
   selector:
     component: controller-manager
+{{- end }}

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
   - name: https
     port: {{ .Values.ports.managerContainerPort }}
-    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort  .Values.manager.metrics.useSecuredEndpoint }}
+    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort }}
     appProtocol: http
     protocol: TCP
   selector:

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -17,7 +17,7 @@ spec:
   ports:
   - name: https
     port: {{ .Values.ports.managerContainerPort }}
-    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort }}
+    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort  .Values.manager.metrics.enabled }}
     appProtocol: http
     protocol: TCP
   selector:

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -36,11 +36,6 @@ manager:
   replicas: 1
   metrics:
     enabled: false
-  imagePullSecrets: []
-  image:
-    repository: quay.io/astronomer/airflow-operator-controller
-    tag: 1.5.1
-    pullPolicy: IfNotPresent
   resources:
     limits:
       cpu: 600m

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -38,7 +38,8 @@ webhooks:
   tlsKey: ""
 manager:
   replicas: 1
-  metrics: {}
+  metrics:
+    enabled: true
   imagePullSecrets: []
   image:
     repository: quay.io/astronomer/airflow-operator-controller

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -3,10 +3,6 @@ images:
     repository: quay.io/astronomer/airflow-operator-controller
     tag: 1.5.1
     pullPolicy: IfNotPresent
-  metrics:
-    repository: gcr.io/kubebuilder/kube-rbac-proxy
-    tag: v0.8.0
-    pullPolicy: IfNotPresent
 
 crd:
   create: false
@@ -39,7 +35,7 @@ webhooks:
 manager:
   replicas: 1
   metrics:
-    enabled: true
+    enabled: false
   imagePullSecrets: []
   image:
     repository: quay.io/astronomer/airflow-operator-controller

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -38,8 +38,7 @@ webhooks:
   tlsKey: ""
 manager:
   replicas: 1
-  metrics:
-    useSecuredEndpoint: false
+  metrics: {}
   imagePullSecrets: []
   image:
     repository: quay.io/astronomer/airflow-operator-controller

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -29,10 +29,6 @@ manager:
   replicas: 1
   metrics:
     useSecuredEndpoint: false
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.8.0
-      pullPolicy: IfNotPresent
   imagePullSecrets: []
   image:
     repository: quay.io/astronomer/airflow-operator-controller

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -181,13 +181,6 @@ class TestAirflowOperator:
                 "global": {
                     "airflowOperator": {"enabled": True},
                 },
-                "airflow-operator": {
-                    "manager": {
-                        "metrics": {
-                            "useSecuredEndpoint": True,
-                        }
-                    }
-                },
             },
             show_only=[
                 "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml",

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -181,6 +181,13 @@ class TestAirflowOperator:
                 "global": {
                     "airflowOperator": {"enabled": True},
                 },
+                "airflow-operator": {
+                    "manager": {
+                        "metrics": {
+                            "enabled": True,
+                        }
+                    }
+                },
             },
             show_only=[
                 "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml",
@@ -191,7 +198,7 @@ class TestAirflowOperator:
         c_by_name = get_containers_by_name(docs[0], include_init_containers=False)
         assert "manager" in c_by_name["manager"]["name"]
         assert "--metrics-bind-address=127.0.0.1:8080" in c_by_name["manager"]["args"]
-        assert "kube-rbac-proxy" in c_by_name["kube-rbac-proxy"]["name"]
+        assert "/manager" in c_by_name["manager"]["command"]
         doc = docs[1]
         assert doc["kind"] == "Service"
         assert doc["metadata"]["name"] == "release-name-aocm-metrics-service"

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -151,6 +151,13 @@ class TestAirflowOperator:
                 "global": {
                     "airflowOperator": {"enabled": True},
                 },
+                "airflow-operator": {
+                    "manager": {
+                        "metrics": {
+                            "enabled": True,
+                        }
+                    }
+                },
             },
             show_only=sorted(
                 [
@@ -207,9 +214,9 @@ class TestAirflowOperator:
         assert doc["spec"]["ports"] == [
             {
                 "port": 8443,
-                "targetPort": "https",
+                "targetPort": 8080,
                 "protocol": "TCP",
-                "name": "https",
+                "name": "metrics",
                 "appProtocol": "http",
             }
         ]


### PR DESCRIPTION
## Description

PR to remove kube-proxy-rbac component from operator as this component is not used by us.

## Related Issues

Related astronomer/issues#6969

## Testing

Local Testing and unittests 

## Merging

0.37
