### PR TITLE
Update Airflow Operator Metrics Service Configuration

### DIFF
--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -1,6 +1,7 @@
-##############################
-## Airflow Operator Service ##
-##############################
+######################################
+## Airflow Operator Metrics Service ##
+######################################
+{{ if .Values.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,10 +16,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: https
+  - name: metrics
     port: {{ .Values.ports.managerContainerPort }}
-    targetPort: {{ ternary "https" .Values.ports.managerUpstreamPort  .Values.manager.metrics.enabled }}
+    targetPort: {{ .Values.ports.managerUpstreamPort }}
     appProtocol: http
     protocol: TCP
   selector:
     component: controller-manager
+{{- end }}

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -11,8 +11,14 @@ metadata:
     chart: {{ template "operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    astronomer_io_platform_release: {{ .Release.Name }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.ports.managerContainerPort }}"
+
   name: {{ .Release.Name }}-aocm-metrics-service
   namespace: '{{ .Release.Namespace }}'
+
 spec:
   type: ClusterIP
   ports:

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Airflow Operator Metrics Service ##
 ######################################
-{{ if .Values.metrics.enabled }}
+{{ if .Values.manager.metrics.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -151,6 +151,13 @@ class TestAirflowOperator:
                 "global": {
                     "airflowOperator": {"enabled": True},
                 },
+                "airflow-operator": {
+                    "manager": {
+                        "metrics": {
+                            "enabled": True,
+                        }
+                    }
+                },
             },
             show_only=sorted(
                 [
@@ -207,9 +214,9 @@ class TestAirflowOperator:
         assert doc["spec"]["ports"] == [
             {
                 "port": 8443,
-                "targetPort": "https",
+                "targetPort": 8080,
                 "protocol": "TCP",
-                "name": "https",
+                "name": "metrics",
                 "appProtocol": "http",
             }
         ]


### PR DESCRIPTION
## Description

This PR updates the Airflow Operator metrics service configuration to enable Prometheus metric collection. Key changes include:

### 1. Service Configuration Changes:
   - Added conditional service creation based on .Values.manager.metrics.enabled
   - Changed port name from https to metrics for clarity
   - Simplified targetPort configuration by removing ternary operator
   - Added appProtocol: http for explicit protocol definition


###   2. Prometheus Integration:
    - Added required Prometheus annotations for service discovery:
          ```
          prometheus.io/scrape: "true"
          prometheus.io/port using 8443
          ```


     - Added astronomer_io_platform_release label for platform identification


###   3. Test Updates:
     - Updated test assertions to reflect new port configurations
     - Added test cases for metrics configuration with enabled state
     - Modified targetPort value from "https" to 8080

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#7016

## Testing

Tested using unittests

## Merging

0.37
