### PR TITLE
Added a default images section under deployments.helm config so that those images are picked up in the operator flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
+                - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.15
                 - quay.io/astronomer/ap-houston-api:0.37.0
                 - quay.io/astronomer/ap-init:3.20.5
@@ -389,11 +390,15 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1-1
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
+                - quay.io/astronomer/ap-pgbouncer:1.23.1-1
                 - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
+                - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-statsd-exporter:0.27.2
                 - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - slack_team-software-infra-bot
@@ -416,6 +421,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
+                - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.15
                 - quay.io/astronomer/ap-houston-api:0.37.0
                 - quay.io/astronomer/ap-init:3.20.5
@@ -428,11 +434,15 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.8.2
                 - quay.io/astronomer/ap-openresty:1.27.1-1
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
+                - quay.io/astronomer/ap-pgbouncer:1.23.1-1
                 - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
+                - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-statsd-exporter:0.27.2
                 - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - twistcli

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -33,7 +33,7 @@ def default_spec_parser(doc, args):
         print(f"Processing {doc['kind']} {doc['metadata']['name']}", file=sys.stderr)
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
-        print(f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry')
+        print(f"{doc['kind']} {doc['metadata']['name'].removeprefix('release-name-')} uses quay.io instead of private registry")
         if args.verbose:
             print(json.dumps(doc["spec"]["template"]["spec"]), file=sys.stderr)
 
@@ -49,7 +49,7 @@ def job_template_spec_parser(doc, args):
     item_containers = get_containers_from_spec(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"])
 
     if args.private_registry and "quay.io" in yaml.dump(item_containers):
-        print(f'{doc["kind"]} {doc["metadata"]["name"].removeprefix("release-name-")} uses quay.io instead of private registry')
+        print(f"{doc['kind']} {doc['metadata']['name'].removeprefix('release-name-')} uses quay.io instead of private registry")
         if args.verbose:
             print(
                 json.dumps(doc["spec"]["jobTemplate"]["spec"]["template"]["spec"]),
@@ -64,14 +64,16 @@ def get_images_from_houston_configmap(doc, args):
     houston_config = yaml.safe_load(doc["data"]["production.yaml"])
     keepers = ("authSideCar", "loggingSidecar")
     items = {k: v for k, v in houston_config["deployments"].items() if k in keepers}
-    auth_sidecar_image = f'{items["authSideCar"]["repository"]}:{items["authSideCar"]["tag"]}'
-    logging_sidecar_image = f'{items["loggingSidecar"]["image"]}'
-    images = (auth_sidecar_image, logging_sidecar_image)
+    auth_sidecar_image = f"{items['authSideCar']['repository']}:{items['authSideCar']['tag']}"
+    logging_sidecar_image = f"{items['loggingSidecar']['image']}"
+    images = [auth_sidecar_image, logging_sidecar_image]
     if args.verbose and any("quay.io" in x for x in images):
         print(
             "Houston configmap uses quay.io instead of private registry",
             file=sys.stderr,
         )
+    af_images = houston_config["deployments"]["helm"]["airflow"]["images"]
+    images.extend(f"{image['repository']}:{image['tag']}" for image in af_images.values())
     return images
 
 
@@ -85,7 +87,7 @@ def helm_template(args):
     command = "helm template . --set forceIncompatibleKubernetes=true -f tests/enable_all_features.yaml"
     if args.private_registry:
         command += (
-            " --set global.privateRegistry.repository=example.com/the-private-registry" " --set global.privateRegistry.enabled=True"
+            " --set global.privateRegistry.repository=example.com/the-private-registry --set global.privateRegistry.enabled=True"
         )
 
     if args.verbose:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -236,6 +236,22 @@ data:
       {{- end }}
 
         airflow:
+          images:
+            statsd:
+              repository: "{{ .Values.global.deployments.helm.airflow.images.statsd.repository }}"
+              tag: "{{ .Values.global.deployments.helm.airflow.images.statsd.tag }}"
+            redis:
+              repository: "{{ .Values.global.deployments.helm.airflow.images.redis.repository }}"
+              tag: "{{ .Values.global.deployments.helm.airflow.images.redis.tag }}"
+            pgbouncer:
+              repository: "{{ .Values.global.deployments.helm.airflow.images.pgbouncer.repository }}"
+              tag: "{{ .Values.global.deployments.helm.airflow.images.pgbouncer.tag }}"
+            pgbouncerExporter:
+              repository: "{{ .Values.global.deployments.helm.airflow.images.pgbouncerExporter.repository }}"
+              tag: "{{ .Values.global.deployments.helm.airflow.images.pgbouncerExporter.tag }}"
+            gitSync:
+              repository: "{{ .Values.global.deployments.helm.airflow.images.gitSync.repository }}"
+              tag: "{{ .Values.global.deployments.helm.airflow.images.gitSync.tag }}"
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}
           networkPolicies:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -238,20 +238,21 @@ data:
         airflow:
           images:
             statsd:
-              repository: "{{ .Values.global.deployments.helm.airflow.images.statsd.repository }}"
-              tag: "{{ .Values.global.deployments.helm.airflow.images.statsd.tag }}"
+              repository: "{{ .Values.global.airflow.images.statsd.repository }}"
+              tag: "{{ .Values.global.airflow.images.statsd.tag }}"
             redis:
-              repository: "{{ .Values.global.deployments.helm.airflow.images.redis.repository }}"
-              tag: "{{ .Values.global.deployments.helm.airflow.images.redis.tag }}"
+              repository: "{{ .Values.global.airflow.images.redis.repository }}"
+              tag: "{{ .Values.global.airflow.images.redis.tag }}"
             pgbouncer:
-              repository: "{{ .Values.global.deployments.helm.airflow.images.pgbouncer.repository }}"
-              tag: "{{ .Values.global.deployments.helm.airflow.images.pgbouncer.tag }}"
+              repository: "{{ .Values.global.airflow.images.pgbouncer.repository }}"
+              tag: "{{ .Values.global.airflow.images.pgbouncer.tag }}"
             pgbouncerExporter:
-              repository: "{{ .Values.global.deployments.helm.airflow.images.pgbouncerExporter.repository }}"
-              tag: "{{ .Values.global.deployments.helm.airflow.images.pgbouncerExporter.tag }}"
+              repository: "{{ .Values.global.airflow.images.pgbouncerExporter.repository }}"
+              tag: "{{ .Values.global.airflow.images.pgbouncerExporter.tag }}"
             gitSync:
-              repository: "{{ .Values.global.deployments.helm.airflow.images.gitSync.repository }}"
-              tag: "{{ .Values.global.deployments.helm.airflow.images.gitSync.tag }}"
+              repository: "{{ .Values.global.airflow.images.gitSync.repository }}"
+              tag: "{{ .Values.global.airflow.images.gitSync.tag }}"
+
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}
           networkPolicies:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -149,6 +149,25 @@ houston:
   config:
     nats:
       ackWait: 600000
+    deployments:
+      helm:
+        airflow:
+          images:
+            statsd:
+              repository: quay.io/astronomer/ap-statsd-exporter
+              tag: 0.27.2
+            redis:
+              repository: quay.io/astronomer/ap-redis
+              tag: 7.2.6
+            pgbouncer:
+              repository: quay.io/astronomer/ap-pgbouncer
+              tag: 1.23.1-1
+            pgbouncerExporter:
+              repository: quay.io/astronomer/ap-pgbouncer-exporter
+              tag: 0.18.0
+            gitSync:
+              repository: quay.io/astronomer/ap-git-sync
+              tag: 4.2.3-1
 
   # Worker to connect to NATS
   worker:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -149,25 +149,6 @@ houston:
   config:
     nats:
       ackWait: 600000
-    deployments:
-      helm:
-        airflow:
-          images:
-            statsd:
-              repository: quay.io/astronomer/ap-statsd-exporter
-              tag: 0.27.2
-            redis:
-              repository: quay.io/astronomer/ap-redis
-              tag: 7.2.6
-            pgbouncer:
-              repository: quay.io/astronomer/ap-pgbouncer
-              tag: 1.23.1-1
-            pgbouncerExporter:
-              repository: quay.io/astronomer/ap-pgbouncer-exporter
-              tag: 0.18.0
-            gitSync:
-              repository: quay.io/astronomer/ap-git-sync
-              tag: 4.2.3-1
 
   # Worker to connect to NATS
   worker:

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -51,22 +51,24 @@ def test_houston_configmap():
     assert "node" in prod["elasticsearch"]["client"]
     assert prod["elasticsearch"]["client"]["node"].startswith("http://")
 
-    # Assert that the configMap contains required component tags
-    assert prod["deployments"]["helm"]["airflow"]["images"]["statsd"]["tag"] == "0.27.2"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["redis"]["tag"] == "7.2.6"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["pgbouncer"]["tag"] == "1.23.1-1"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["pgbouncerExporter"]["tag"] == "0.18.0"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["gitSync"]["tag"] == "4.2.3-1"
+    assert not prod["deployments"].get("authSideCar")
+    assert not prod["deployments"].get("loggingSidecar")
 
-    # Assert that the configMap contains required component repositories
-    assert prod["deployments"]["helm"]["airflow"]["images"]["statsd"]["repository"] == "quay.io/astronomer/ap-statsd-exporter"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["redis"]["repository"] == "quay.io/astronomer/ap-redis"
-    assert prod["deployments"]["helm"]["airflow"]["images"]["pgbouncer"]["repository"] == "quay.io/astronomer/ap-pgbouncer"
-    assert (
-        prod["deployments"]["helm"]["airflow"]["images"]["pgbouncerExporter"]["repository"]
-        == "quay.io/astronomer/ap-pgbouncer-exporter"
-    )
-    assert prod["deployments"]["helm"]["airflow"]["images"]["gitSync"]["repository"] == "quay.io/astronomer/ap-git-sync"
+    af_images = prod["deployments"]["helm"]["airflow"]["images"]
+
+    # Assert that the configMap contains airflow component tags
+    assert af_images["statsd"]["tag"]
+    assert af_images["redis"]["tag"]
+    assert af_images["pgbouncer"]["tag"]
+    assert af_images["pgbouncerExporter"]["tag"]
+    assert af_images["gitSync"]["tag"]
+
+    # Assert that the configMap contains image the right airflow component repositories
+    assert af_images["statsd"]["repository"] == "quay.io/astronomer/ap-statsd-exporter"
+    assert af_images["redis"]["repository"] == "quay.io/astronomer/ap-redis"
+    assert af_images["pgbouncer"]["repository"] == "quay.io/astronomer/ap-pgbouncer"
+    assert af_images["pgbouncerExporter"]["repository"] == "quay.io/astronomer/ap-pgbouncer-exporter"
+    assert af_images["gitSync"]["repository"] == "quay.io/astronomer/ap-git-sync"
 
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -16,22 +16,7 @@ def common_test_cases(docs):
 
     local_prod = yaml.safe_load(doc["data"]["local-production.yaml"])
 
-    assert local_prod == {
-        "nats": {"ackWait": 600000},
-        "deployments": {
-            "helm": {
-                "airflow": {
-                    "images": {
-                        "statsd": {"repository": "quay.io/astronomer/ap-statsd-exporter", "tag": "0.27.2"},
-                        "redis": {"repository": "quay.io/astronomer/ap-redis", "tag": "7.2.6"},
-                        "pgbouncer": {"repository": "quay.io/astronomer/ap-pgbouncer", "tag": "1.23.1-1"},
-                        "pgbouncerExporter": {"repository": "quay.io/astronomer/ap-pgbouncer-exporter", "tag": "0.18.0"},
-                        "gitSync": {"repository": "quay.io/astronomer/ap-git-sync", "tag": "4.2.3-1"},
-                    }
-                }
-            }
-        },
-    }
+    assert local_prod == {"nats": {"ackWait": 600000}}
 
     prod = yaml.safe_load(doc["data"]["production.yaml"])
 

--- a/values.yaml
+++ b/values.yaml
@@ -299,25 +299,23 @@ global:
   # https://github.com/argoproj/argo-cd/blob/master/docs/user-guide/sync-waves.md
   enableArgoCDAnnotation: false
 
-  deployments:
-    helm:
-      airflow:
-        images:
-          statsd:
-            repository: quay.io/astronomer/ap-statsd-exporter
-            tag: 0.27.2
-          redis:
-            repository: quay.io/astronomer/ap-redis
-            tag: 7.2.6
-          pgbouncer:
-            repository: quay.io/astronomer/ap-pgbouncer
-            tag: 1.23.1-1
-          pgbouncerExporter:
-            repository: quay.io/astronomer/ap-pgbouncer-exporter
-            tag: 0.18.0
-          gitSync:
-            repository: quay.io/astronomer/ap-git-sync
-            tag: 4.2.3-1
+  airflow:
+    images:
+      statsd:
+        repository: quay.io/astronomer/ap-statsd-exporter
+        tag: 0.27.2
+      redis:
+        repository: quay.io/astronomer/ap-redis
+        tag: 7.2.6
+      pgbouncer:
+        repository: quay.io/astronomer/ap-pgbouncer
+        tag: 1.23.1-1
+      pgbouncerExporter:
+        repository: quay.io/astronomer/ap-pgbouncer-exporter
+        tag: 0.18.0
+      gitSync:
+        repository: quay.io/astronomer/ap-git-sync
+        tag: 4.2.3-1
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:

--- a/values.yaml
+++ b/values.yaml
@@ -299,6 +299,26 @@ global:
   # https://github.com/argoproj/argo-cd/blob/master/docs/user-guide/sync-waves.md
   enableArgoCDAnnotation: false
 
+  deployments:
+    helm:
+      airflow:
+        images:
+          statsd:
+            repository: quay.io/astronomer/ap-statsd-exporter
+            tag: 0.27.2
+          redis:
+            repository: quay.io/astronomer/ap-redis
+            tag: 7.2.6
+          pgbouncer:
+            repository: quay.io/astronomer/ap-pgbouncer
+            tag: 1.23.1-1
+          pgbouncerExporter:
+            repository: quay.io/astronomer/ap-pgbouncer-exporter
+            tag: 0.18.0
+          gitSync:
+            repository: quay.io/astronomer/ap-git-sync
+            tag: 4.2.3-1
+
   # For now we support only pgbouncer with gss api support
   pgbouncer:
     enabled: false


### PR DESCRIPTION
## Description

Added a default images section under deployments.helm config so that those images are picked up in the operator flow
Currently, other components in Airflow (redis, pgb etc) use the tags specified in the operator version and they don't use the tags specified under the airflow chart. This PR changes the behaviour by adding the default image tags under the houston values section.

## Related Issues
Related astronomer/issues#7014

## Testing

Will test on stage after rc2 is released.

## Merging

0.37.0