### PR TITLE
fix component name mismatch for cleanup deploy revision job

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -23,9 +23,9 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston
+            component: houston-cleanup
             release: {{ .Release.Name }}
-            app: houston
+            app: houston-cleanup
             version: {{ .Chart.Version }}
           {{- if or .Values.global.podAnnotations .Values.global.istio.enabled }}
           annotations:

--- a/tests/chart_tests/test_astronomer_houston_deploy_revisions.py
+++ b/tests/chart_tests/test_astronomer_houston_deploy_revisions.py
@@ -30,10 +30,11 @@ class TestAstronomerHoustonDeployRevisionsCronjobs:
         assert len(docs) == 1
         assert docs[0]["kind"] == "CronJob"
         assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-deploy-revisions"
+        assert docs[0]["metadata"]["labels"]["component"] == "houston-cleanup"
+        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]
+        assert spec["metadata"]["labels"]["component"] == "houston-cleanup"
         assert docs[0]["spec"]["schedule"] == "11 23 * * *"
-        assert docs[0]["spec"]["jobTemplate"]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
-            "runAsNonRoot": True
-        }
+        assert spec["spec"]["containers"][0]["securityContext"] == {"runAsNonRoot": True}
 
     def test_astronomer_cleanup_deploy_revisons_cron_custom_schedule(self, kube_version):
         docs = render_chart(


### PR DESCRIPTION
## Description

This PR fixes component name mismatch for cleanup deploy revision job

## Related Issues

- https://github.com/astronomer/issues/issues/7021

## Testing

kubectl get -lcomponent=houston -n astronomer 
should show only houston specific components list

## Merging

cherry-pick to all valid branches
