### PR TITLE
fix cleanup flags with new inputs

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -56,7 +56,7 @@ spec:
               "--older-than={{ .Values.houston.cleanupAirflowDb.olderThan }}",
               "--dry-run={{ .Values.houston.cleanupAirflowDb.dryRun }}",
               "--output-path={{ .Values.houston.cleanupAirflowDb.outputPath }}",
-              "--purge-archive={{ .Values.houston.cleanupAirflowDb.purgeArchive }}",
+              "--drop-archives={{ .Values.houston.cleanupAirflowDb.dropArchives }}",
               "--provider={{ .Values.houston.cleanupAirflowDb.provider }}",
               "--bucket-name={{ .Values.houston.cleanupAirflowDb.bucketName }}",
               "--provider-env-secret-name={{ .Values.houston.cleanupAirflowDb.providerEnvSecretName }}",


### PR DESCRIPTION
## Description

fix cleanup flags with new inputs

## Related Issues

- https://github.com/astronomer/issues/issues/7009
- https://github.com/astronomer/issues/issues/7010

## Testing

cleanup cronjob should adopt new flags

## Merging

cherry-pick to release-0.37
