### PR TITLE
update airflow operator version 1.5.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/airflow-operator-controller:1.5.1
+                - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.37.1
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
@@ -406,7 +406,7 @@ workflows:
           matrix:
             parameters:
               docker_image:
-                - quay.io/astronomer/airflow-operator-controller:1.5.1
+                - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.37.1
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -1,7 +1,7 @@
 images:
   manager:
     repository: quay.io/astronomer/airflow-operator-controller
-    tag: 1.5.1
+    tag: 1.5.2
     pullPolicy: IfNotPresent
 
 crd:


### PR DESCRIPTION
## Description


release notes: https://github.com/astronomer/airflow-operator/releases/tag/1.5.2

## Related Issues

- - https://github.com/astronomer/issues/issues/6959

## Testing

General QA validation

## Merging

merge to master
