### PR TITLE
Add flag for webhook installation in Operator. 

### DIFF
--- a/charts/airflow-operator/templates/manager/webhook-service.yaml
+++ b/charts/airflow-operator/templates/manager/webhook-service.yaml
@@ -24,3 +24,4 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.ports.webhookServiceTargetPort}}
     appProtocol: http
+{{- end }}

--- a/charts/airflow-operator/templates/manager/webhook-service.yaml
+++ b/charts/airflow-operator/templates/manager/webhook-service.yaml
@@ -1,6 +1,7 @@
 ######################################
 ## Airflow Operator WebHook Service ##
 ######################################
+{{ if .Values.webhooks.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml
+++ b/charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml
@@ -1,4 +1,7 @@
-{{ if .Values.global.airflowOperator.enabled }}
+#####################################################
+## Airflow Operator WebHook Mutating Configuration ##
+#####################################################
+{{ if .Values.webhooks.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml
+++ b/charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml
@@ -1,4 +1,7 @@
-{{ if .Values.global.airflowOperator.enabled }}
+#######################################################
+## Airflow Operator WebHook Validating Configuration ##
+#######################################################
+{{ if .Values.webhooks.enabled }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -21,7 +21,7 @@ securityContext:
 
 terminationGracePeriodSeconds: 10
 webhooks:
-  enabled: false      # to enable default webhook service and it's mutating and validating configurations. 
+  enabled: false      # to enable default webhook service and it's mutating and validating configurations.
   useCustomTlsCerts: false
   certSecretName: "webhook-server-cert"
   customCertsSecretName: "webhooks-tls-certs"

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -21,7 +21,7 @@ securityContext:
 
 terminationGracePeriodSeconds: 10
 webhooks:
-  enabled: true
+  enabled: false      # to enable default webhook service and it's mutating and validating configurations. 
   useCustomTlsCerts: false
   certSecretName: "webhook-server-cert"
   customCertsSecretName: "webhooks-tls-certs"

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -21,7 +21,7 @@ securityContext:
 
 terminationGracePeriodSeconds: 10
 webhooks:
-  enabled: false      # to enable default webhook service and it's mutating and validating configurations.
+  enabled: true      # to enable default webhook service and it's mutating and validating configurations.
   useCustomTlsCerts: false
   certSecretName: "webhook-server-cert"
   customCertsSecretName: "webhooks-tls-certs"

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -21,6 +21,7 @@ securityContext:
 
 terminationGracePeriodSeconds: 10
 webhooks:
+  enabled: true
   useCustomTlsCerts: false
   certSecretName: "webhook-server-cert"
   customCertsSecretName: "webhooks-tls-certs"

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -181,6 +181,27 @@ class TestAirflowOperator:
         assert docs[3]["kind"] == "Service"
         assert docs[3]["metadata"]["name"] == "release-name-airflow-operator-webhook-service"
 
+        docs = render_chart(
+            validate_objects=False,
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "airflowOperator": {"enabled": True},
+                },
+                "airflow-operator": {
+                    "webhooks": {"enabled": False},
+                },
+            },
+            show_only=sorted(
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/airflow-operator/templates/manager").glob("*")
+                ]
+            ),
+        )
+        webhook_services = [doc for doc in docs if "webhook" in doc.get("metadata", {}).get("name", "")]
+        assert len(webhook_services) == 0
+
     def test_airflow_operator_manager_metrics_enabled(self, kube_version):
         """Test Airflow Operator manager with metrics endpoints enabled"""
         docs = render_chart(

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -100,6 +100,7 @@ class TestAirflowOperator:
                 "global": {
                     "airflowOperator": {"enabled": True},
                 },
+                "airflow-operator": {"webhooks": {"enabled": True}},
             },
             show_only=sorted(
                 [
@@ -156,7 +157,8 @@ class TestAirflowOperator:
                         "metrics": {
                             "enabled": True,
                         }
-                    }
+                    },
+                    "webhooks": {"enabled": True},
                 },
             },
             show_only=sorted(


### PR DESCRIPTION
## Description

This PR adds a configuration flag to control webhook installation, as webhooks require cluster-admin privileges that may not be available in all environments. By default the setting to `false`, we ensure installations don't fail in restricted environments while still allowing users to enable webhooks when appropriate permissions exist.

### Motivation:

This change addresses a key installation issue with the Airflow Operator chart. Currently, webhook components are always installed when the operator is enabled, which requires cluster-admin privileges. This creates a barrier for users in restricted environments where such privileges aren't available, effectively preventing them from using the operator functionality.

### Changes included:
- Added `webhooks.enabled` flag (defaulted to `false`) in values.yaml
- Modified webhook-service.yaml, mutating-webhook-configuration.yaml, and validating-webhook-configuration.yaml to use this flag
- Added helpful documentation comment explaining the flag's purpose
- Updated test files to include the new configuration parameter



## Related Issues

Related astronomer/issues#7043

## Testing
Verified webhook installation behavior under both configurations:

- With `airflow-operator.webhooks.enabled=true`: Webhooks are successfully deployed
![Screenshot 2025-02-25 at 2 51 45 PM](https://github.com/user-attachments/assets/6f0cc642-f5f3-4e29-901a-3cc16bb27dbd)

- With `airflow-operator.webhooks.enabled=false` (default): No webhook resources are created:
![Screenshot 2025-02-25 at 2 52 22 PM](https://github.com/user-attachments/assets/ab8f8d5b-fe6d-4aaf-820b-6f03e655b1c0)

- Added `airflow-operator.webhooks.enabled=true` in existing unittests to confirm make sure tests work fine

## Overview of current Airflow Operator Chart Controls:
<img width="1317" alt="Screenshot 2025-02-25 at 4 54 59 PM" src="https://github.com/user-attachments/assets/d323133d-77df-4e84-ab4f-9db13c5f2258" />

## Merging

Target branch: 0.37.x (non-blocker that can be included in the next release if there is no additional RC planned)
