### PR TITLE
update houston api and astro-ui

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -364,7 +364,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
-                - quay.io/astronomer/ap-astro-ui:0.37.1
+                - quay.io/astronomer/ap-astro-ui:0.37.2
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.15
-                - quay.io/astronomer/ap-houston-api:0.37.4
+                - quay.io/astronomer/ap-houston-api:0.37.5
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0
@@ -408,7 +408,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
-                - quay.io/astronomer/ap-astro-ui:0.37.1
+                - quay.io/astronomer/ap-astro-ui:0.37.2
                 - quay.io/astronomer/ap-auth-sidecar:1.27.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-13
                 - quay.io/astronomer/ap-base:3.20.5
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.15
-                - quay.io/astronomer/ap-houston-api:0.37.4
+                - quay.io/astronomer/ap-houston-api:0.37.5
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.14.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.4
+    tag: 0.37.5
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.37.1
+    tag: 0.37.2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update houston api and astro-ui 

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 0.37.4 | 0.37.5 |
| ap-astro-ui | 0.37.1 | 0.37.2 |

## Related Issues

- Related https://github.com/astronomer/issues/issues/6900
- Related https://github.com/astronomer/issues/issues/6980
- Related https://github.com/astronomer/issues/issues/7039
- Related https://github.com/astronomer/issues/issues/6980
- Related https://github.com/astronomer/issues/issues/7037
- Related https://github.com/astronomer/issues/issues/7044
## Testing

QA should refer above issues for more validation

## Merging

cherry-pick to release-0.37
