### PR TITLE
update vendor packages for upstream packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,27 +378,27 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
-                - quay.io/astronomer/ap-grafana:10.4.15
+                - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.5
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
-                - quay.io/astronomer/ap-kube-state:2.14.0
+                - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-5
                 - quay.io/astronomer/ap-nats-server:2.10.18-3
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-8
                 - quay.io/astronomer/ap-nginx-es:1.27.3
                 - quay.io/astronomer/ap-nginx:1.11.3
-                - quay.io/astronomer/ap-node-exporter:1.8.2
+                - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-1
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
-                - quay.io/astronomer/ap-pgbouncer:1.23.1-1
+                - quay.io/astronomer/ap-pgbouncer:1.23.1-4
                 - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
-                - quay.io/astronomer/ap-statsd-exporter:0.27.2
+                - quay.io/astronomer/ap-statsd-exporter:0.28.1
                 - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - slack_team-software-infra-bot
@@ -422,27 +422,27 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
-                - quay.io/astronomer/ap-grafana:10.4.15
+                - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.5
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
-                - quay.io/astronomer/ap-kube-state:2.14.0
+                - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-5
                 - quay.io/astronomer/ap-nats-server:2.10.18-3
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-8
                 - quay.io/astronomer/ap-nginx-es:1.27.3
                 - quay.io/astronomer/ap-nginx:1.11.3
-                - quay.io/astronomer/ap-node-exporter:1.8.2
+                - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-1
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-2
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
-                - quay.io/astronomer/ap-pgbouncer:1.23.1-1
+                - quay.io/astronomer/ap-pgbouncer:1.23.1-4
                 - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
-                - quay.io/astronomer/ap-statsd-exporter:0.27.2
+                - quay.io/astronomer/ap-statsd-exporter:0.28.1
                 - quay.io/astronomer/ap-vector:0.44.0-2
           context:
             - twistcli

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.15
+    tag: 10.4.16
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.14.0
+    tag: 2.15.0
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.8.2
+  tag: 1.9.0
   pullPolicy: IfNotPresent
 
 service:

--- a/values.yaml
+++ b/values.yaml
@@ -303,16 +303,16 @@ global:
     images:
       statsd:
         repository: quay.io/astronomer/ap-statsd-exporter
-        tag: 0.27.2
+        tag: 0.28.1
       redis:
         repository: quay.io/astronomer/ap-redis
         tag: 7.2.6
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
-        tag: 1.23.1-1
+        tag: 1.23.1-4
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.18.0
+        tag: 0.18.0-2
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 4.2.3-1


### PR DESCRIPTION
## Description

update vendor packages for upstream packages

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-grafana | 10.4.15 | 10.4.16 |
| ap-kube-state | 2.14.0 | 2.15.0 |
| ap-node-exporter | 1.8.2 | 1.9.0 |
| ap-pgbouncer-exporter | 0.18.0 | 0.18.0-2 |
| ap-pgbouncer | 1.23.1-1 | 1.23.1-4 | 
| ap-statsd-exporte| 1.27.2 | 0.28.1| 

## Related Issues

NA, generic ktlo work for CVE patches
- https://github.com/astronomer/issues/issues/6791

## Testing

generic QA testing effort

## Merging

cherry-pick to all release branches
