### PR TITLE
update platform images includes api enhancements 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.37.5
+                - quay.io/astronomer/ap-houston-api:0.37.6
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.37.5
+                - quay.io/astronomer/ap-houston-api:0.37.6
                 - quay.io/astronomer/ap-init:3.20.5
                 - quay.io/astronomer/ap-kibana:8.12.2
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.5
+    tag: 0.37.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.3
+    tag: 0.1.5
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 0.37.5 | 0.37.6 |
| ap-kuiper-reloader | 0.1.3 | 0.1.5 |


## Related Issues

-  Related https://github.com/astronomer/issues/issues/7048
- Related https://github.com/astronomer/issues/issues/6980
- Related https://github.com/astronomer/issues/issues/7041
- Related https://github.com/astronomer/issues/issues/7042
- Related https://github.com/astronomer/issues/issues/6869

## Testing

General QA testing

## Merging

cherry-pick to release-0.37 
