### PR TITLE
update gitsync images in houston config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,6 +377,8 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
+                - quay.io/astronomer/ap-git-daemon:3.20.5
+                - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.7
@@ -421,6 +423,8 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.12.2
                 - quay.io/astronomer/ap-fluentd:1.17.1
+                - quay.io/astronomer/ap-git-daemon:3.20.5
+                - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.7

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -72,8 +72,10 @@ def get_images_from_houston_configmap(doc, args):
             "Houston configmap uses quay.io instead of private registry",
             file=sys.stderr,
         )
+    git_sync_images = houston_config["deployments"]["helm"]["gitSyncRelay"]["images"]
     af_images = houston_config["deployments"]["helm"]["airflow"]["images"]
     images.extend(f"{image['repository']}:{image['tag']}" for image in af_images.values())
+    images.extend(f"{image['repository']}:{image['tag']}" for image in git_sync_images.values())
     return images
 
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -238,11 +238,11 @@ data:
         gitSyncRelay:
           images:
             gitDaemon:
-              repository: "quay.io/astronomer/ap-git-daemon"
-              tag: "3.20.5"
+              repository: {{ .Values.global.gitSyncRelay.images.gitDaemon.repository }}
+              tag: {{ .Values.global.gitSyncRelay.images.gitDaemon.tag }}
             gitSync:
-              repository: "quay.io/astronomer/ap-git-sync-relay"
-              tag: "0.1.9"
+              repository: {{ .Values.global.gitSyncRelay.images.gitSync.repository }}
+              tag: {{ .Values.global.gitSyncRelay.images.gitSync.tag }}
 
         airflow:
           images:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -235,6 +235,15 @@ data:
         networkNSLabels: true
       {{- end }}
 
+        gitSyncRelay:
+          images:
+            gitDaemon:
+              repository: "quay.io/astronomer/ap-git-daemon"
+              tag: "3.20.5"
+            gitSync:
+              repository: "quay.io/astronomer/ap-git-sync-relay"
+              tag: "0.1.9"
+
         airflow:
           images:
             statsd:

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -55,6 +55,7 @@ def test_houston_configmap():
     assert not prod["deployments"].get("loggingSidecar")
 
     af_images = prod["deployments"]["helm"]["airflow"]["images"]
+    git_sync_images = prod["deployments"]["helm"]["gitSyncRelay"]["images"]
 
     # Assert that the configMap contains airflow component tags
     assert af_images["statsd"]["tag"]
@@ -69,6 +70,8 @@ def test_houston_configmap():
     assert af_images["pgbouncer"]["repository"] == "quay.io/astronomer/ap-pgbouncer"
     assert af_images["pgbouncerExporter"]["repository"] == "quay.io/astronomer/ap-pgbouncer-exporter"
     assert af_images["gitSync"]["repository"] == "quay.io/astronomer/ap-git-sync"
+    assert git_sync_images["gitDaemon"]["repository"] == "quay.io/astronomer/ap-git-daemon"
+    assert git_sync_images["gitSync"]["repository"] == "quay.io/astronomer/ap-git-sync-relay"
 
     with pytest.raises(KeyError):
         # Ensure sccEnabled is not defined by default

--- a/values.yaml
+++ b/values.yaml
@@ -316,6 +316,14 @@ global:
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 4.2.3-1
+  gitSyncRelay:
+    images:
+      gitDaemon:
+        repository: "quay.io/astronomer/ap-git-daemon"
+        tag: "3.20.5"
+      gitSync:
+        repository: "quay.io/astronomer/ap-git-sync-relay"
+        tag: "0.1.9"
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:


### PR DESCRIPTION
## Description

update gitsync images in houston config

## Related Issues

- https://github.com/astronomer/issues/issues/7047

## Testing

QA should see latest git sync images while upgrading existing git sync deployments

## Merging

cherry-pick to release-0.37
