### PR TITLE
Standardize security context configuration for all components 

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -274,7 +274,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end }}
           webserver:
             {{ if .Values.configSyncer.enabled }}
@@ -292,7 +292,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end  }}
             resources:
               limits:
@@ -317,7 +317,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end  }}
             resources:
               limits:
@@ -333,7 +333,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end  }}
 
             podDisruptionBudget:
@@ -482,7 +482,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end }}
 
           {{ if .Values.global.openshiftEnabled }}
@@ -496,13 +496,13 @@ data:
           triggerer:
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
 
           # migrateDatabaseJob  settings
           migrateDatabaseJob:
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
 
           {{ end }}
 
@@ -557,7 +557,7 @@ data:
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
-                runAsNonRoot: false
+                runAsNonRoot: true
             {{ end  }}
       {{- end }}
 

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -89,7 +89,7 @@ class TestOpenshift:
         airflowConfig = prod["deployments"]["helm"]["airflow"]
 
         for component in airflow_components_list:
-            assert {"runAsNonRoot": False} == airflowConfig[component]["securityContexts"]["pod"]
+            assert {"runAsNonRoot": True} == airflowConfig[component]["securityContexts"]["pod"]
 
         for component in non_airflow_components_list:
             assert {"runAsNonRoot": True} == airflowConfig[component]["securityContexts"]["pod"]


### PR DESCRIPTION
## Description

This PR standardizes the security context configuration for all components when running in OpenShift mode by setting `runAsNonRoot: true` across all components. Previously, there was inconsistency where some Airflow components used `runAsNonRoot: false` while others used `runAsNonRoot: true`.

## Impact:

Improved security posture by enforcing consistent non-root execution
Simplified configuration and security reviews
Better alignment with OpenShift's security model and best practices

## Related Issues

Related astronomer/issues#6758

## Testing

- Updated unit tests to verify all components now use runAsNonRoot: true
- Deployed to a test OpenShift cluster to confirm all components start successfully
- Patched one of the existing kubeexecutor deployments with `runAsNonRoot: true` and confirmed that the pods came up fine:
![Screenshot 2025-03-07 at 11 17 21 AM](https://github.com/user-attachments/assets/bf10599b-6b1a-4230-8fbd-954f75f5712a)

- Patched one of the celery deployments with `runAsNonRoot: true` and confirmed that the pods came up fine:
![Screenshot 2025-03-07 at 11 35 04 AM](https://github.com/user-attachments/assets/300ec147-b922-4640-aef2-002b6b4516cb)


## Merging

0.36.1
