### PR TITLE
Add internal houston authorization support for authsidecar

### DIFF
--- a/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
+++ b/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
@@ -25,8 +25,8 @@ data:
       server_tokens off;
 
       location  = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host {{ include "houston.authSidecar.internalauthurl" . }}
+        proxy_pass {{ include "houston.authSidecar.internalauthurl" . -}}
 {{.Values.global.authSidecar.default_nginx_settings | indent 8  }}
       }
       location @401_auth_error {

--- a/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
+++ b/charts/kibana/templates/kibana-auth-sidecar-configmap.yaml
@@ -25,8 +25,8 @@ data:
       server_tokens off;
 
       location  = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host {{ include "houston.authSidecar.internalauthurl" . }}
+        proxy_pass {{ include "houston.authSidecar.internalauthurl" . -}}
 {{ .Values.global.authSidecar.default_nginx_settings  |  indent 8 }}
       }
       location @401_auth_error {

--- a/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
@@ -25,8 +25,8 @@ data:
       server_tokens off;
 
       location  = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host {{ include "houston.authSidecar.internalauthurl" . }}
+        proxy_pass {{ include "houston.authSidecar.internalauthurl" . -}}
         {{ .Values.global.default_nginx_settings }}
 {{.Values.global.authSidecar.default_nginx_settings | indent 8  }}
       }

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -19,6 +19,13 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{- end }}
 {{- end }}
 
+{{ define "houston.authSidecar.internalauthurl" -}}
+{{ if .Values.global.enableHoustonInternalAuthorization -}}
+http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}.svc.cluster.local:8871/v1/authorization ;
+{{ else -}}
+https://houston.{{ .Values.global.baseDomain }}/v1/authorization ;
+{{- end -}}
+{{- end }}
 
 {{ define "containerd.configToml" -}}
 {{- .Values.global.privateCaCertsAddToHost.containerdConfigToml -}}


### PR DESCRIPTION
## Description

This PR moves all the houston authorization url to internal  endpoints to make all authsidecar requests to be connected  internally using k8s service  allowing services to be up and running  without dns reflection.

## Related Issues

- https://github.com/astronomer/issues/issues/7101

## Testing

Yet to update

## Merging

Yet to update
