### PR TITLE
Update sidecar-log-consumer to version 0.45.0 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,7 +385,7 @@ workflows:
                 - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
-                - quay.io/astronomer/ap-vector:0.44.0-2
+                - quay.io/astronomer/ap-vector:0.45.0
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -431,7 +431,7 @@ workflows:
                 - quay.io/astronomer/ap-redis:7.2.6
                 - quay.io/astronomer/ap-registry:3.20.5
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
-                - quay.io/astronomer/ap-vector:0.44.0-2
+                - quay.io/astronomer/ap-vector:0.45.0
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -154,7 +154,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.44.0-2
+    tag: 0.45.0
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

This PR updates the sidecar-log-consumer image tag from 0.44.0-2 to 0.45.0 to incorporate recent improvements to the sidecar loop functionality. The update includes enhanced error handling for the Kubernetes watch process, ensuring more robust handling of timeouts and continuous monitoring of ConfigMap events.

## Related Issues

Related astronomer/issues#6714

## Testing

- Tested that with this new version the pods are terminating without any issues. 

## Merging

0.36