### PR TITLE
update git sync version 0.0.3-9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,7 +378,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.20.5
-                - quay.io/astronomer/ap-git-sync-relay:0.1.9
+                - quay.io/astronomer/ap-git-sync-relay:0.0.3-9
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.36.14
@@ -424,7 +424,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.20.5
-                - quay.io/astronomer/ap-git-sync-relay:0.1.9
+                - quay.io/astronomer/ap-git-sync-relay:0.0.3-9
                 - quay.io/astronomer/ap-git-sync:4.2.3-1
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.36.14

--- a/values.yaml
+++ b/values.yaml
@@ -306,11 +306,11 @@ global:
   gitSyncRelay:
     images:
       gitDaemon:
-        repository: "quay.io/astronomer/ap-git-daemon"
-        tag: "3.20.5"
+        repository: quay.io/astronomer/ap-git-daemon
+        tag: 3.20.5
       gitSync:
-        repository: "quay.io/astronomer/ap-git-sync-relay"
-        tag: "0.1.9"
+        repository: quay.io/astronomer/ap-git-sync-relay
+        tag: 0.0.3-9
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:


### PR DESCRIPTION
## Description

update git sync version 0.0.3-9

## Related Issues

- https://github.com/astronomer/issues/issues/7067

## Testing

revert git sync image for 0.36 release

## Merging

cherry-pick to release-0.36
