### PR TITLE
fix commander scc privileges

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -172,7 +172,7 @@ rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
   verbs: ["create", "delete", "get", "patch", "list", "watch"]
-{{ end }} 
+{{ end }}
 {{ end }}
 {{- end }}
 

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -171,8 +171,8 @@ rules:
 {{- if and $useClusterRoles $.Values.global.sccEnabled }}
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  verbs: ["create", "delete", "list", "watch"]
-{{ end }}
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
+{{ end }} 
 {{ end }}
 {{- end }}
 
@@ -196,5 +196,5 @@ metadata:
 rules:
 - apiGroups: ["security.openshift.io"]
   resources: ["securitycontextconstraints"]
-  verbs: ["create", "delete", "list", "watch"]
+  verbs: ["create", "delete", "get", "patch", "list", "watch"]
 {{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -246,7 +246,7 @@ class TestAstronomerCommander:
         expected_rule = {
             "apiGroups": ["security.openshift.io"],
             "resources": ["securitycontextconstraints"],
-            "verbs": ["create", "delete", "list", "watch"],
+            "verbs": ["create", "delete", "get", "patch", "list", "watch"],
         }
         assert cluster_role["kind"] == "ClusterRole"
         assert cluster_role["rules"] == [expected_rule]
@@ -316,7 +316,7 @@ class TestAstronomerCommander:
         expected_rule = {
             "apiGroups": ["security.openshift.io"],
             "resources": ["securitycontextconstraints"],
-            "verbs": ["create", "delete", "list", "watch"],
+            "verbs": ["create", "delete", "get", "patch", "list", "watch"],
         }
         cluster_role = docs[0]
 

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -17,7 +17,7 @@ show_only = [
 commander_expected_result = {
     "apiGroups": ["security.openshift.io"],
     "resources": ["securitycontextconstraints"],
-    "verbs": ["create", "delete", "list", "watch"],
+    "verbs": ["create", "delete", "get", "patch", "list", "watch"],
 }
 
 


### PR DESCRIPTION
## Description

fixes an issue with scc priviges where users switch from sccEnabled to openshiftEnabled back and forth. check issue link for more information

## Related Issues

- https://github.com/astronomer/issues/issues/7085

## Testing

QA should now able to enabled sccEnabled for upgrades 

## Merging

cherry-pick to release-0.36 and release-0.37
