### PR TITLE
update vendor packages with new ap-base changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,9 +350,9 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.37.4
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-13
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-14
                 - quay.io/astronomer/ap-base:3.21.3-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-6
                 - quay.io/astronomer/ap-commander:0.37.4
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.18
@@ -361,31 +361,31 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-git-daemon:3.20.5
+                - quay.io/astronomer/ap-git-daemon:3.21.3-1
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-1
+                - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.9
-                - quay.io/astronomer/ap-init:3.20.5
+                - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-5
-                - quay.io/astronomer/ap-nats-server:2.10.18-3
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-8
+                - quay.io/astronomer/ap-nats-server:2.10.18-4
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-9
                 - quay.io/astronomer/ap-nginx-es:1.27.4
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-2
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-2
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
-                - quay.io/astronomer/ap-pgbouncer:1.23.1-4
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-3
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-18
+                - quay.io/astronomer/ap-pgbouncer:1.24.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-3
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-redis:7.2.6
-                - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-registry:3.21.3-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
-                - quay.io/astronomer/ap-vector:0.45.0
+                - quay.io/astronomer/ap-vector:0.45.0-1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -396,9 +396,9 @@ workflows:
                 - quay.io/astronomer/ap-alertmanager:0.27.0-5
                 - quay.io/astronomer/ap-astro-ui:0.37.4
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-13
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-14
                 - quay.io/astronomer/ap-base:3.21.3-1
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-5
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-6
                 - quay.io/astronomer/ap-commander:0.37.4
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.18
@@ -407,31 +407,31 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-git-daemon:3.20.5
+                - quay.io/astronomer/ap-git-daemon:3.21.3-1
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-1
+                - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
                 - quay.io/astronomer/ap-houston-api:0.37.9
-                - quay.io/astronomer/ap-init:3.20.5
+                - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.15.0-5
-                - quay.io/astronomer/ap-nats-server:2.10.18-3
-                - quay.io/astronomer/ap-nats-streaming:0.25.6-8
+                - quay.io/astronomer/ap-nats-server:2.10.18-4
+                - quay.io/astronomer/ap-nats-streaming:0.25.6-9
                 - quay.io/astronomer/ap-nginx-es:1.27.4
                 - quay.io/astronomer/ap-nginx:1.11.3
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-2
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-2
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-17
-                - quay.io/astronomer/ap-pgbouncer:1.23.1-4
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-2
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-3
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-18
+                - quay.io/astronomer/ap-pgbouncer:1.24.0-1
+                - quay.io/astronomer/ap-postgres-exporter:0.16.0-3
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.3
                 - quay.io/astronomer/ap-redis:7.2.6
-                - quay.io/astronomer/ap-registry:3.20.5
+                - quay.io/astronomer/ap-registry:3.21.3-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
-                - quay.io/astronomer/ap-vector:0.45.0
+                - quay.io/astronomer/ap-vector:0.45.0-1
           context:
             - twistcli
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.20.5
+    tag: 3.21.3-1
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-13
+    tag: 1.5.0-14
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.20.5
+    tag: 3.21.3-1
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.18-3
+    tag: 2.10.18-4
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-17
+  tag: 1.17.0-18
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-5
+  tag: 0.25.0-6
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.16.0-2
+  tag: 0.16.0-3
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -4,11 +4,11 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.20.5
+    tag: 3.21.3-1
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
-    tag: 0.25.6-8
+    tag: 0.25.6-9
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/values.yaml
+++ b/values.yaml
@@ -154,7 +154,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.45.0
+    tag: 0.45.0-1
     customConfig: false
     indexPattern: ~
     extraEnv: []
@@ -309,24 +309,24 @@ global:
         tag: 7.2.6
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
-        tag: 1.23.1-4
+        tag: 1.24.0-1
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.18.0-2
+        tag: 0.18.0-3
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.3-1
+        tag: 4.2.3-3
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3
   gitSyncRelay:
     images:
       gitDaemon:
-        repository: "quay.io/astronomer/ap-git-daemon"
-        tag: "3.20.5"
+        repository: quay.io/astronomer/ap-git-daemon
+        tag: 3.21.3-1
       gitSync:
-        repository: "quay.io/astronomer/ap-git-sync-relay"
-        tag: "0.1.9"
+        repository: quay.io/astronomer/ap-git-sync-relay
+        tag: 0.1.9
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:


### PR DESCRIPTION
## Description

update vendor packages with new ap-base changes

| imageName | oldTag | newTag |
|--------|--------|--------|
|ap-awsesproxy | 1.5.0-13 | 1.5.0-14 |
| ap-blackbox-exporter| 0.25.0-5  | 0.25.0-6 |
| ap-git-daemon | 3.20.5 | 3.21.3-1 |
| ap-git-sync | 4.2.3-1 | 4.2.3-3 |
| ap-init | 3.20.5 | 3.21.3-1 | 
| ap-nats-server | 2.10.18-3 |2.10.18-4 | 
| ap-nats-streaming |0.25.6-8 | 0.25.6-9 | 
| ap-pgbouncer-exporter | 0.18.0-2 | 0.18.0-3 | 
| ap-pgbouncer-krb | 1.17.0-17  | 1.17.0-18 | 
| ap-pgbouncer | 1.23.1-4 | 1.24.0-1 |
| ap-postgres-exporter | 0.16.0-2 | 0.16.0-3 | 
| ap-registry | 3.20.5 | 3.21.3-1 |
| ap-vector | 0.45.0 | 0.45.0-1 |

## Related Issues

- https://github.com/astronomer/issues/issues/6830

## Testing

General QA testing

## Merging

cherry-pick to master
