### PR TITLE
update commander version 0.36.12 and airflow chart 1.13.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.21.3-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.27
-                - quay.io/astronomer/ap-commander:0.36.10
+                - quay.io/astronomer/ap-commander:0.36.12
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.18
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.1
@@ -415,7 +415,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.21.3-1
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-6
                 - quay.io/astronomer/ap-cli-install:0.26.27
-                - quay.io/astronomer/ap-commander:0.36.10
+                - quay.io/astronomer/ap-commander:0.36.12
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.18
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.13.8
+airflowChartVersion: 1.13.9
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.36.10
+    tag: 0.36.12
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander version 0.36.12 and airflow chart 1.13.9

## Related Issues

- https://github.com/astronomer/issues/issues/7085

## Testing

QA should able to upgrade existing kube executor deployments with not uid and gid issues

## Merging

merge to release-0.36
