### PR TITLE
Update houston image to 0.36.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.0.3-10
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.36.17
+                - quay.io/astronomer/ap-houston-api:0.36.18
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -427,7 +427,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.0.3-10
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.36.17
+                - quay.io/astronomer/ap-houston-api:0.36.18
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.36.17
+    tag: 0.36.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston image

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 0.36.17 | 0.36.18 |

## Related Issues

- Related https://github.com/astronomer/issues/issues/6845

## Testing

General QA testing

## Merging

merge to release-0.36
