### PR TITLE
rename scc clusterrole conflicts with default commander role

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -183,7 +183,7 @@ rules:
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:
-  name: {{ $.Release.Name }}-commander
+  name: {{ $.Release.Name }}-commander-scc
   labels:
     tier: houston
     release: {{ $.Release.Name }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -48,7 +48,7 @@ subjects:
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $.Release.Name }}-commander
+  name: {{ $.Release.Name }}-commander-scc
   {{- if $.Values.global.enableArgoCDAnnotation }}
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
@@ -56,7 +56,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ $.Release.Name }}-commander
+  name: {{ $.Release.Name }}-commander-scc
 subjects:
   - kind: ServiceAccount
     name: {{ $commanderServiceAccountName }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -262,7 +262,7 @@ class TestAstronomerCommander:
         # Role Bindings
         expected_subject = {
             "kind": "ServiceAccount",
-            "name": "release-name-commander-scc",
+            "name": "release-name-commander",
             "namespace": "default",
         }
 
@@ -270,7 +270,7 @@ class TestAstronomerCommander:
         expected_cluster_role = {
             "apiGroup": "rbac.authorization.k8s.io",
             "kind": "ClusterRole",
-            "name": "release-name-commander-scc",
+            "name": "release-name-commander",
         }
 
         assert cluster_role_binding["roleRef"] == expected_cluster_role

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -270,7 +270,7 @@ class TestAstronomerCommander:
         expected_cluster_role = {
             "apiGroup": "rbac.authorization.k8s.io",
             "kind": "ClusterRole",
-            "name": "release-name-commander",
+            "name": "release-name-commander-scc",
         }
 
         assert cluster_role_binding["roleRef"] == expected_cluster_role

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -262,7 +262,7 @@ class TestAstronomerCommander:
         # Role Bindings
         expected_subject = {
             "kind": "ServiceAccount",
-            "name": "release-name-commander",
+            "name": "release-name-commander-scc",
             "namespace": "default",
         }
 

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -267,13 +267,13 @@ class TestAstronomerCommander:
         }
 
         cluster_role_binding = docs[3]
-        expected_cluster_role = {
+        expected_scc_cluster_role = {
             "apiGroup": "rbac.authorization.k8s.io",
             "kind": "ClusterRole",
-            "name": "release-name-commander",
+            "name": "release-name-commander-scc",
         }
 
-        assert cluster_role_binding["roleRef"] == expected_cluster_role
+        assert cluster_role_binding["roleRef"] == expected_scc_cluster_role
 
         for i in range(4, 6):
             role_binding = docs[i]


### PR DESCRIPTION
## Description

This PR renames the scc specific roles with scc tagged naming not to conflict existing cluster roles causing commander existing roles getting merged with defaults blocking the entire deployment creation,update and other activities

## Related Issues

- https://github.com/astronomer/issues/issues/7093

## Testing

QA with global.sccEnabled + namespacePolls should able to test deployment features

## Merging

cherry-pick to release-0.36
