### PR TITLE
update houston 0.36.19 and rc5 tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,7 +381,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.0.3-10
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.36.18
+                - quay.io/astronomer/ap-houston-api:0.36.19
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -427,7 +427,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.0.3-10
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.36.18
+                - quay.io/astronomer/ap-houston-api:0.36.19
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.36.1-rc4
-appVersion: 0.36.1-rc4
+version: 0.36.1-rc5
+appVersion: 0.36.1-rc5
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.36.1-rc4
+version: 0.36.1-rc5
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.36.18
+    tag: 0.36.19
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston 0.36.19 and rc5 tag

## Related Issues

- Related https://github.com/astronomer/issues/issues/6845

## Testing

refer above issue

## Merging

cherry-pick to release-0.36
