### PR TITLE
Remove Duplicate serviceAccountName Key in Helm Chart

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -92,7 +92,6 @@ spec:
         readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
         {{- end }}
   {{- end }}
-      serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:
       - name: es-client
         securityContext:


### PR DESCRIPTION
**Description:**
This PR fixes a linting issue caused by a duplicate serviceAccountName key in the Helm chart configuration.

**Fix applied:**
The duplicate key was located at line 95 of file "es-client-deployment.yaml" and has been removed.
Keeping only one instance ensures the chart passes the linting process and prevents potential conflicts during deployment.

Error was reproducable with following steps:

```
make lint
touch helmfile.yaml
helmfile lint \
       --environment nonprod && \
touch .build/lint.done
Adding repo astronomer https://artifactory2.westpac.co.nz/helm-astronomer-virtual
"astronomer" has been added to your repositories

in ./helmfile.yaml: [exit status 1

COMMAND:
 kustomize build /tmp/chartify3710637956/airflow-astro-nonprod/astronomer/astronomer --output /tmp/chartify3710637956/airflow-astro-nonprod/astronomer/astronomer/all.patched.yaml

OUTPUT:
 Error: map[string]interface {}(nil): yaml: unmarshal errors:
   line 50: mapping key "serviceAccountName" already defined at line 36]
make: *** [Makefile:66: .build/lint.done] Error 1

```
Error Details:

```
Error: map[string]interface {}(nil): yaml: unmarshal errors:  
   line 50: mapping key "serviceAccountName" already defined at line 36  
```

