### PR TITLE
Remove redundant serviceAccountName in es-client-deployment

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -92,7 +92,6 @@ spec:
         readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
         {{- end }}
   {{- end }}
-      serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:
       - name: es-client
         securityContext:


### PR DESCRIPTION
## Description

Remove duplicate serviceAccountName from es-client-deployment that was introduced in https://github.com/astronomer/astronomer/pull/2428/files#diff-7efc2adb130709e5d46c8d396d03530e644ad6b74499bc6dda3cf48885c5ee9f

This supersedes https://github.com/astronomer/astronomer/pull/2544

## Related Issues

- <https://github.com/astronomer/issues/issues/7099>

## Testing

No extra testing is needed.

## Merging

This should be merged everywhere that https://github.com/astronomer/astronomer/pull/2428 was merged to.