### PR TITLE
Update BASE_URL_SPEC, mkdir(parents=True)

### DIFF
--- a/tests/chart_tests/helm_template_generator.py
+++ b/tests/chart_tests/helm_template_generator.py
@@ -34,7 +34,7 @@ from tests import supported_k8s_versions
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master"
+BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master"
 git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
 DEBUG = os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
 default_version = supported_k8s_versions[-1]
@@ -55,7 +55,7 @@ def get_schema_k8s(api_version, kind, kube_version=default_version):
     local_sp = Path(f"{git_root_dir}/tests/k8s_schema/{schema_path}")
     if not local_sp.exists():
         if not local_sp.parent.is_dir():
-            local_sp.parent.mkdir()
+            local_sp.parent.mkdir(parents=True)
         request = requests.get(f"{BASE_URL_SPEC}/{schema_path}", timeout=30)
         request.raise_for_status()
         local_sp.write_text(request.text)


### PR DESCRIPTION
## Description

Update the raw.githubusercontent.com URL for accessing assets from within the GH repo used by the k8s schema file validator.

Also add `parents=True` to `Path.mkdir()` when caching k8s schema files.

## Related Issues

- <https://github.com/astronomer/issues/issues/7102>

## Testing

I've manually tested this by deleting all the schema files and observed them being recreated and producing no diff.

## Merging

Merge everywhere since this is a change in a third party resource that needs to be updated.