### PR TITLE
Fix Repository URL and Version Format in release-bom Script

### DIFF
--- a/bin/release-bom
+++ b/bin/release-bom
@@ -29,7 +29,7 @@ if [[ "${#@}" -eq 0 ]] ; then
   exit 1
 fi
 
-version="$1"
+version="${1#v}"
 shift
 repo_url="https://updates.astronomer.io/astronomer-software/releases"
 bucket_path="gs://updates.astronomer.io/astronomer-software/releases"


### PR DESCRIPTION
## Description

The release-bom script is failing with a "Repository not found" error due to two issues:
1. Missing separator between the repository URL and version tag in the pip install command (this is only for 0.36 release branch)
2. The version format needs to be without the 'v' prefix when generating the JSON filename. 

## Related Issues

Related astronomer/issues#7109

## Testing

- Ran the script as SSH session in CircleCI and was able. to publish 0.36.1.json: https://updates.astronomer.io/astronomer-software/releases/astronomer-0.36.1.json

- Script:
![Screenshot 2025-03-25 at 1 16 38 PM](https://github.com/user-attachments/assets/e30baf54-2df4-4039-a34b-0f83dac15631)

- Logs:
![Screenshot 2025-03-25 at 1 20 30 PM](https://github.com/user-attachments/assets/b64754d5-1c03-4cc5-a6d1-aebfe497c9d3)


## Merging

Everywhere 
