### PR TITLE
update nginx ingress 1.11.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.18-4
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-9
                 - quay.io/astronomer/ap-nginx-es:1.27.4-1
-                - quay.io/astronomer/ap-nginx:1.11.3
+                - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-3
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-3
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-server:2.10.18-4
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-9
                 - quay.io/astronomer/ap-nginx-es:1.27.4-1
-                - quay.io/astronomer/ap-nginx:1.11.3
+                - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-3
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-3

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.11.3
+    tag: 1.11.5
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

update nginx ingress 1.11.5

## Related Issues

- https://github.com/astronomer/issues/issues/7110

## Testing

General Ingress Testing

## Merging

cherry-pick to master and all release branches
