### PR TITLE
update houston api 0.37.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.37.9
+                - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -411,7 +411,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.16
-                - quay.io/astronomer/ap-houston-api:0.37.9
+                - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-1
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.9
+    tag: 0.37.10
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 0.37.10

## Related Issues

- Related https://github.com/astronomer/issues/issues/7104

## Testing

Generic QA testing

## Merging

cherry-pick to release-0.37
