### PR TITLE
update vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,7 +356,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.37.5
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.37.1
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
@@ -364,7 +364,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-4
-                - quay.io/astronomer/ap-grafana:10.4.16
+                - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2
                 - quay.io/astronomer/ap-kibana:8.15.5
@@ -379,10 +379,10 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-4
+                - quay.io/astronomer/ap-postgres-exporter:0.17.1
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.4
-                - quay.io/astronomer/ap-redis:7.2.6
+                - quay.io/astronomer/ap-redis:7.4.2
                 - quay.io/astronomer/ap-registry:3.21.3-2
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
                 - quay.io/astronomer/ap-vector:0.45.0-2
@@ -402,7 +402,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.37.5
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
-                - quay.io/astronomer/ap-db-bootstrapper:0.37.1
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.2
                 - quay.io/astronomer/ap-default-backend:0.28.28
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.8.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
@@ -410,7 +410,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
                 - quay.io/astronomer/ap-git-sync:4.2.3-4
-                - quay.io/astronomer/ap-grafana:10.4.16
+                - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2
                 - quay.io/astronomer/ap-kibana:8.15.5
@@ -425,10 +425,10 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.16.0-4
+                - quay.io/astronomer/ap-postgres-exporter:0.17.1
                 - quay.io/astronomer/ap-postgresql:15.10.0-1
                 - quay.io/astronomer/ap-prometheus:2.53.4
-                - quay.io/astronomer/ap-redis:7.2.6
+                - quay.io/astronomer/ap-redis:7.4.2
                 - quay.io/astronomer/ap-registry:3.21.3-2
                 - quay.io/astronomer/ap-statsd-exporter:0.28.1
                 - quay.io/astronomer/ap-vector:0.45.0-2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.1
+    tag: 0.37.2
     pullPolicy: IfNotPresent
 
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,11 +11,11 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.16
+    tag: 10.4.17
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.1
+    tag: 0.37.2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.1
+    tag: 0.37.2
     pullPolicy: IfNotPresent
 
 

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.16.0-4
+  tag: 0.17.1
   pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -306,7 +306,7 @@ global:
         tag: 0.28.1
       redis:
         repository: quay.io/astronomer/ap-redis
-        tag: 7.2.6
+        tag: 7.4.2
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
         tag: 1.24.0-2


### PR DESCRIPTION
## Description

update vendor packages
| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-db-bootstrapper | 0.37.1 | 0.37.2 |
| ap-grafana | 10.4.16 | 10.4.17 |
| ap-postgres-exporte | 0.16.0-4 | 0.17.1 |
| ap-redis | 7.2.6 | 7.4.2 |

## Related Issues

- https://github.com/astronomer/issues/issues/7106

## Testing

General QA testing

## Merging

cherry-pick to release-0.37, release-0.36, master
