### PR TITLE
7106 update images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-4
+                - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2
@@ -409,7 +409,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-4
+                - quay.io/astronomer/ap-git-sync:4.2.3-3
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.2
-                - quay.io/astronomer/ap-default-backend:0.28.28
+                - quay.io/astronomer/ap-default-backend:0.28.29
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
@@ -403,7 +403,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.2
-                - quay.io/astronomer/ap-default-backend:0.28.28
+                - quay.io/astronomer/ap-default-backend:0.28.29
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-3
+                - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2
@@ -409,7 +409,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-3
+                - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ workflows:
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2
                 - quay.io/astronomer/ap-registry:3.21.3-2
-                - quay.io/astronomer/ap-statsd-exporter:0.28.1
+                - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
                 - quay.io/astronomer/ap-vector:0.45.0-2
           context:
             - slack_team-software-infra-bot
@@ -430,7 +430,7 @@ workflows:
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2
                 - quay.io/astronomer/ap-registry:3.21.3-2
-                - quay.io/astronomer/ap-statsd-exporter:0.28.1
+                - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
                 - quay.io/astronomer/ap-vector:0.45.0-2
           context:
             - twistcli

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.28
+    tag: 0.28.29
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -303,7 +303,7 @@ global:
     images:
       statsd:
         repository: quay.io/astronomer/ap-statsd-exporter
-        tag: 0.28.1
+        tag: 0.28.0-2
       redis:
         repository: quay.io/astronomer/ap-redis
         tag: 7.4.2

--- a/values.yaml
+++ b/values.yaml
@@ -315,7 +315,7 @@ global:
         tag: 0.18.0-4
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.3-4
+        tag: 4.2.3-3
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2

--- a/values.yaml
+++ b/values.yaml
@@ -315,7 +315,7 @@ global:
         tag: 0.18.0-4
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.3-3
+        tag: 4.2.4
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2


### PR DESCRIPTION
## Description

Update some images to latest versions available in quay.

old version | new version
--- | ---
quay.io/astronomer/ap-default-backend:0.28.28 | quay.io/astronomer/ap-default-backend:0.28.29
quay.io/astronomer/ap-git-sync:4.2.3-4 | quay.io/astronomer/ap-git-sync:4.2.4
quay.io/astronomer/ap-statsd-exporter:0.28.1 | quay.io/astronomer/ap-statsd-exporter:0.28.0-2

The above data is from `git diff master.. --word-diff .circleci/config.yml | grep -- -quay | sed 's/.*-\(quay.*\)-\]{+\(quay.io.*\)+\}/\1 | \2/g'`

## Related Issues

https://github.com/astronomer/issues/issues/7106

## Testing

I have not tested these changes. There are no significant version bumps. Normal testing is sufficient.

## Merging

Merge everywhere.