### PR TITLE
update git sync version 4.2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,7 +363,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-4
+                - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2
@@ -409,7 +409,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
                 - quay.io/astronomer/ap-git-sync-relay:0.1.9
-                - quay.io/astronomer/ap-git-sync:4.2.3-4
+                - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
                 - quay.io/astronomer/ap-init:3.21.3-2

--- a/values.yaml
+++ b/values.yaml
@@ -315,7 +315,7 @@ global:
         tag: 0.18.0-4
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.3-4
+        tag: 4.2.4
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2


### PR DESCRIPTION
## Description

update git sync version 4.2.4

## Related Issues

-- https://github.com/astronomer/issues/issues/7106

## Testing

General git sync relay testing

## Merging

merge to all valid branches
