### PR TITLE
platform and vendor package CVE fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ workflows:
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.18-5
+                - quay.io/astronomer/ap-nats-server:2.10.19
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
@@ -416,7 +416,7 @@ workflows:
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.18-5
+                - quay.io/astronomer/ap-nats-server:2.10.19
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,8 +348,8 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.0-1
-                - quay.io/astronomer/ap-astro-ui:0.37.4
-                - quay.io/astronomer/ap-auth-sidecar:1.27.4-2
+                - quay.io/astronomer/ap-astro-ui:0.37.5
+                - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-15
                 - quay.io/astronomer/ap-base:3.21.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-7
@@ -357,7 +357,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.2
-                - quay.io/astronomer/ap-default-backend:0.28.29
+                - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
@@ -372,7 +372,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.18-5
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
-                - quay.io/astronomer/ap-nginx-es:1.27.4-2
+                - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-4
@@ -394,8 +394,8 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.0-1
-                - quay.io/astronomer/ap-astro-ui:0.37.4
-                - quay.io/astronomer/ap-auth-sidecar:1.27.4-2
+                - quay.io/astronomer/ap-astro-ui:0.37.5
+                - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-15
                 - quay.io/astronomer/ap-base:3.21.3-2
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-7
@@ -403,7 +403,7 @@ workflows:
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.19-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.2
-                - quay.io/astronomer/ap-default-backend:0.28.29
+                - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
@@ -418,7 +418,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-1
                 - quay.io/astronomer/ap-nats-server:2.10.18-5
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
-                - quay.io/astronomer/ap-nginx-es:1.27.4-2
+                - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.0
                 - quay.io/astronomer/ap-openresty:1.27.1-4

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.37.4
+    tag: 0.37.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.27.4-2
+    tag: 1.27.4-3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,7 +6,7 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.18-5
+    tag: 2.10.19
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.29
+    tag: 0.28.30
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -173,7 +173,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.27.4-2
+    tag: 1.27.4-3
     pullPolicy: IfNotPresent
     port: 8084
     securityContext: {}


### PR DESCRIPTION
## Description

platform and vendor package CVE fixes

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-astro-ui | 0.37.4 | 0.37.5 |
| ap-auth-sidecar | 1.27.4-2 | 1.27.4-3 |
| ap-default-backend | 0.28.29 | 0.28.30 |
| ap-nats-server | 2.10.18-5 | 2.10.19 | 
| ap-nginx-es | 1.27.4-2 | 1.27.4-3 | 

## Related Issues

- https://github.com/astronomer/issues/issues/7106

## Testing
General QA testing

## Merging

merge to master and release-0.37
