### PR TITLE
update git-sync-relay version 0.1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
-                - quay.io/astronomer/ap-git-sync-relay:0.1.9
+                - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-2
-                - quay.io/astronomer/ap-git-sync-relay:0.1.9
+                - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.10

--- a/values.yaml
+++ b/values.yaml
@@ -326,7 +326,7 @@ global:
         tag: 3.21.3-2
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
-        tag: 0.1.9
+        tag: 0.1.11
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:


### PR DESCRIPTION
## Description

update git-sync-relay version 0.1.11

## Related Issues

- https://github.com/astronomer/issues/issues/7069
- https://github.com/astronomer/issues/issues/7106

## Testing

General QA testing against openshift cluster

## Merging
merge to master and release-0.37
