### PR TITLE
enable es scc tpl to allow custom service account

### DIFF
--- a/charts/elasticsearch/templates/es-scc.yaml
+++ b/charts/elasticsearch/templates/es-scc.yaml
@@ -1,6 +1,6 @@
-#################################
-### Astronomer Registry Scc   ###
-#################################
+####################################
+### Astronomer Elasticsearch Scc ###
+####################################
 {{- if and .Values.common.serviceAccount.create .Values.common.serviceAccount.sccEnabled .Values.global.sccEnabled }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints

--- a/charts/elasticsearch/templates/es-scc.yaml
+++ b/charts/elasticsearch/templates/es-scc.yaml
@@ -1,0 +1,42 @@
+#################################
+### Astronomer Registry Scc   ###
+#################################
+{{- if and .Values.common.serviceAccount.create .Values.common.serviceAccount.sccEnabled .Values.global.sccEnabled }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  name: {{ template "elasticsearch.serviceAccountName" . }}-anyuid
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "elasticsearch.serviceAccountName" . }}
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: null
+{{- end }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -42,6 +42,7 @@ common:
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ~
+    sccEnabled: true
 
   env:
     CLUSTER_NAME: "astronomer"

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -151,7 +151,7 @@ class TestRegistryStatefulset:
         assert docs[0]["kind"] == "SecurityContextConstraints"
         assert docs[0]["apiVersion"] == "security.openshift.io/v1"
         assert docs[0]["metadata"]["name"] == "release-name-registry-anyuid"
-        assert docs[0]["users"] == ["system:serviceaccount:astronomer:release-name-registry"]
+        assert docs[0]["users"] == ["system:serviceaccount:default:release-name-registry"]
 
     @pytest.mark.skip(reason="This test needs rework")
     def test_astronomer_registry_statefulset_with_podSecurityContext_disabled(self, kube_version):

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -138,6 +138,24 @@ class TestRegistryStatefulset:
         )
         assert len(docs) == 0
 
+
+    def test_astronomer_registry_statefulset_with_scc_enabled(self, kube_version):
+        """Test that helm renders scc template for astronomer registry."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"registry": {"serviceAccount": {
+                "create": True,
+                "sccEnabled": True }}}},
+            show_only=[
+                "charts/astronomer/templates/registry/registry-scc.yaml",
+            ],
+        )
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "SecurityContextConstraints"
+        assert docs[0]["apiVersion"] == "security.openshift.io/v1"
+        assert docs[0]["metadata"]["name"] == "release-name-registry-anyuid"
+        assert docs[0]["users"]  == ["system:serviceaccount:astronomer:release-name-registry"]
+
     @pytest.mark.skip(reason="This test needs rework")
     def test_astronomer_registry_statefulset_with_podSecurityContext_disabled(self, kube_version):
         """Test that helm renders statefulset template for astronomer

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -138,14 +138,11 @@ class TestRegistryStatefulset:
         )
         assert len(docs) == 0
 
-
     def test_astronomer_registry_statefulset_with_scc_enabled(self, kube_version):
         """Test that helm renders scc template for astronomer registry."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"astronomer": {"registry": {"serviceAccount": {
-                "create": True,
-                "sccEnabled": True }}}},
+            values={"astronomer": {"registry": {"serviceAccount": {"create": True, "sccEnabled": True}}}},
             show_only=[
                 "charts/astronomer/templates/registry/registry-scc.yaml",
             ],
@@ -154,7 +151,7 @@ class TestRegistryStatefulset:
         assert docs[0]["kind"] == "SecurityContextConstraints"
         assert docs[0]["apiVersion"] == "security.openshift.io/v1"
         assert docs[0]["metadata"]["name"] == "release-name-registry-anyuid"
-        assert docs[0]["users"]  == ["system:serviceaccount:astronomer:release-name-registry"]
+        assert docs[0]["users"] == ["system:serviceaccount:astronomer:release-name-registry"]
 
     @pytest.mark.skip(reason="This test needs rework")
     def test_astronomer_registry_statefulset_with_podSecurityContext_disabled(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -658,7 +658,6 @@ class TestElasticSearch:
             assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
             assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
 
-
     def test_astronomer_registry_statefulset_with_scc_disabled(self, kube_version):
         """Test that helm renders scc template for astronomer
         elasticsearch with SA disabled."""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -681,3 +681,7 @@ class TestElasticSearch:
             ],
         )
         assert len(docs) == 1
+        assert docs[0]["kind"] == "SecurityContextConstraints"
+        assert docs[0]["apiVersion"] == "security.openshift.io/v1"
+        assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-anyuid"
+        assert docs[0]["users"]  == ["system:serviceaccount:astronomer:release-name-elasticsearch"]

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -657,3 +657,16 @@ class TestElasticSearch:
         for doc in docs:
             assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
             assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+
+
+    def test_astronomer_registry_statefulset_with_scc_disabled(self, kube_version):
+        """Test that helm renders scc template for astronomer
+        elasticsearch with SA disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={},
+            show_only=[
+                "charts/elasticsearch/templates/es-scc.yaml",
+            ],
+        )
+        assert len(docs) == 0

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -684,4 +684,4 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "SecurityContextConstraints"
         assert docs[0]["apiVersion"] == "security.openshift.io/v1"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-anyuid"
-        assert docs[0]["users"]  == ["system:serviceaccount:astronomer:release-name-elasticsearch"]
+        assert docs[0]["users"] == ["system:serviceaccount:astronomer:release-name-elasticsearch"]

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -684,4 +684,4 @@ class TestElasticSearch:
         assert docs[0]["kind"] == "SecurityContextConstraints"
         assert docs[0]["apiVersion"] == "security.openshift.io/v1"
         assert docs[0]["metadata"]["name"] == "release-name-elasticsearch-anyuid"
-        assert docs[0]["users"] == ["system:serviceaccount:astronomer:release-name-elasticsearch"]
+        assert docs[0]["users"] == ["system:serviceaccount:default:release-name-elasticsearch"]

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -658,7 +658,7 @@ class TestElasticSearch:
             assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
             assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
 
-    def test_astronomer_registry_statefulset_with_scc_disabled(self, kube_version):
+    def test_elasticsearch_statefulset_with_scc_disabled(self, kube_version):
         """Test that helm renders scc template for astronomer
         elasticsearch with SA disabled."""
         docs = render_chart(
@@ -669,3 +669,15 @@ class TestElasticSearch:
             ],
         )
         assert len(docs) == 0
+
+    def test_elasticsearch_statefulset_with_scc_enabled(self, kube_version):
+        """Test that helm renders scc template for astronomer
+        elasticsearch with SA disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"sccEnabled": True}},
+            show_only=[
+                "charts/elasticsearch/templates/es-scc.yaml",
+            ],
+        )
+        assert len(docs) == 1

--- a/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
@@ -35,11 +35,8 @@
       "format": "int64"
     },
     "runAsNonRoot": {
-      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
     },
     "seLinuxOptions": {
       "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
@@ -2,21 +2,17 @@
   "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
   "properties": {
     "allowPrivilegeEscalation": {
-      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "capabilities": {
       "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
       "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
     },
     "privileged": {
-      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
       "type": [
-        "boolean",
-        "null"
+        "boolean"
       ]
     },
     "procMount": {
@@ -27,11 +23,8 @@
       ]
     },
     "readOnlyRootFilesystem": {
-      "description": "Whether this container has a read-only root filesystem. Default is false.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "runAsGroup": {
       "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.29.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,58 @@
+{
+  "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+  "properties": {
+    "allowPrivilegeEscalation": {
+      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "capabilities": {
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+    },
+    "privileged": {
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "procMount": {
+      "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "readOnlyRootFilesystem": {
+      "description": "Whether this container has a read-only root filesystem. Default is false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "runAsGroup": {
+      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "runAsNonRoot": {
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "seLinuxOptions": {
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+    }
+  },
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
@@ -35,11 +35,8 @@
       "format": "int64"
     },
     "runAsNonRoot": {
-      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
     },
     "seLinuxOptions": {
       "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
@@ -2,21 +2,17 @@
   "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
   "properties": {
     "allowPrivilegeEscalation": {
-      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "capabilities": {
       "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
       "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
     },
     "privileged": {
-      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
       "type": [
-        "boolean",
-        "null"
+        "boolean"
       ]
     },
     "procMount": {
@@ -27,11 +23,8 @@
       ]
     },
     "readOnlyRootFilesystem": {
-      "description": "Whether this container has a read-only root filesystem. Default is false.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "runAsGroup": {
       "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.30.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,58 @@
+{
+  "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+  "properties": {
+    "allowPrivilegeEscalation": {
+      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "capabilities": {
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+    },
+    "privileged": {
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "procMount": {
+      "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "readOnlyRootFilesystem": {
+      "description": "Whether this container has a read-only root filesystem. Default is false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "runAsGroup": {
+      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "runAsNonRoot": {
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "seLinuxOptions": {
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+    }
+  },
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
@@ -35,11 +35,8 @@
       "format": "int64"
     },
     "runAsNonRoot": {
-      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
     },
     "seLinuxOptions": {
       "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
@@ -2,21 +2,17 @@
   "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
   "properties": {
     "allowPrivilegeEscalation": {
-      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "capabilities": {
       "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
       "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
     },
     "privileged": {
-      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
       "type": [
-        "boolean",
-        "null"
+        "boolean"
       ]
     },
     "procMount": {
@@ -27,11 +23,8 @@
       ]
     },
     "readOnlyRootFilesystem": {
-      "description": "Whether this container has a read-only root filesystem. Default is false.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "runAsGroup": {
       "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.31.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,58 @@
+{
+  "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+  "properties": {
+    "allowPrivilegeEscalation": {
+      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "capabilities": {
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+    },
+    "privileged": {
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "procMount": {
+      "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "readOnlyRootFilesystem": {
+      "description": "Whether this container has a read-only root filesystem. Default is false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "runAsGroup": {
+      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "runAsNonRoot": {
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "seLinuxOptions": {
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+    }
+  },
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}

--- a/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
@@ -35,11 +35,8 @@
       "format": "int64"
     },
     "runAsNonRoot": {
-      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
     },
     "seLinuxOptions": {
       "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
@@ -2,21 +2,17 @@
   "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
   "properties": {
     "allowPrivilegeEscalation": {
-      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "capabilities": {
       "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
       "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
     },
     "privileged": {
-      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.",
       "type": [
-        "boolean",
-        "null"
+        "boolean"
       ]
     },
     "procMount": {
@@ -27,11 +23,8 @@
       ]
     },
     "readOnlyRootFilesystem": {
-      "description": "Whether this container has a read-only root filesystem. Default is false.",
-      "type": [
-        "boolean",
-        "null"
-      ]
+          "description": "Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.",
+          "type": "boolean"
     },
     "runAsGroup": {
       "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",

--- a/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
+++ b/tests/k8s_schema/v1.32.0-standalone/securitycontextconstraints-security-v1.json
@@ -1,0 +1,58 @@
+{
+  "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+  "properties": {
+    "allowPrivilegeEscalation": {
+      "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "capabilities": {
+      "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.Capabilities"
+    },
+    "privileged": {
+      "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "procMount": {
+      "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "readOnlyRootFilesystem": {
+      "description": "Whether this container has a read-only root filesystem. Default is false.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "runAsGroup": {
+      "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int64"
+    },
+    "runAsNonRoot": {
+      "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "seLinuxOptions": {
+      "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+      "$ref": "https://kubernetesjsonschema.dev/v1.12.6/_definitions.json#/definitions/io.k8s.api.core.v1.SELinuxOptions"
+    }
+  },
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object"
+}


### PR DESCRIPTION
## Description

enable es scc tpl to allow custom service account

## Related Issues

- https://github.com/astronomer/issues/issues/7131

## Testing

QA should able to bring up elastic components without any custom config changes

## Merging
merge to all valid releases
