### PR TITLE
add default git sync security context for openshift

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -267,6 +267,13 @@ data:
           # Enabled network polices to restrict the way pods can communicate.
             enabled: true
           {{ end }}
+          {{- if .Values.global.openshiftEnabled }}
+          dags:
+              gitSync:
+                securityContexts:
+                  container:
+                    runAsNonRoot: true
+          {{ end }}
           # Enable FlowerUI flag by default
           flower:
             enabled: true

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -93,3 +93,6 @@ class TestOpenshift:
 
         for component in non_airflow_components_list:
             assert {"runAsNonRoot": True} == airflowConfig[component]["securityContexts"]["pod"]
+
+        gitSyncConfig = airflowConfig["dags"]["gitSync"]
+        assert {"runAsNonRoot": True} == gitSyncConfig["securityContexts"]["container"]


### PR DESCRIPTION
## Description

add default git sync security context for openshift

## Related Issues

- https://github.com/astronomer/issues/issues/7089

## Testing

QA should able to deploy git sync deployment sidecars on airflow components

## Merging

merge to release-0.37
