### PR TITLE
Add Docker Image Signing With Cosign

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: docker23
-      - run:
-          name: Install cosign
-          command: |
-            curl -LO https://github.com/sigstore/cosign/releases/download/v2.2.2/cosign-linux-amd64
-            chmod +x cosign-linux-amd64
-            sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+      - cosign/install:
+          version: "2.2.2"
       - run:
           name: Login to docker registry
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
 orbs:
   slack: circleci/slack@4.10.1
   python: circleci/python@2.1.1
+  cosign: cpanato/cosign-orb@2.0.0
 
 parameters:
   scan-docker-images:
@@ -27,6 +28,48 @@ parameters:
     description: "This will trigger QA release workflow."
 
 jobs:
+  sign-released-image:
+    executor: docker-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: docker23
+      - run:
+          name: Install cosign
+          command: |
+            curl -LO https://github.com/sigstore/cosign/releases/download/v2.2.2/cosign-linux-amd64
+            chmod +x cosign-linux-amd64
+            sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+      - run:
+          name: Login to docker registry
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin docker.io
+            echo "$QUAY_PASSWORD" | docker login --username $QUAY_USERNAME --password-stdin quay.io
+      - run:
+          name: Set image tag to sign
+          command: |
+            set -xe
+            # Only sign tagged releases or specific QA releases
+            # For regular release job
+            if [ -n "$NEXT_TAG" ]; then
+              echo "export IMAGE_TAG=$NEXT_TAG" >> $BASH_ENV
+            # For custom QA release job
+            elif [ -n "$IMG_TAG" ]; then
+              echo "export IMAGE_TAG=$IMG_TAG" >> $BASH_ENV
+            else
+              echo "No specific release tag found, skipping image signing"
+              exit 0
+            fi
+      - run:
+          name: Install Python dependencies
+          command: pip install requests
+      - run:
+          name: Sign Docker images with cosign
+          command: |
+            # Execute the signing script with version from environment
+            python bin/sign-images.py --version "${IMAGE_TAG}"
+
   trivy-scan-docker:
     docker:
       - image: cimg/base:current-22.04
@@ -340,6 +383,18 @@ workflows:
         - << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
+      - sign-released-image:
+          name: sign-release-image
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
+          requires:
+            - release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
           slack_notify: false
@@ -515,6 +570,18 @@ workflows:
             - github-repo
           requires:
             - approve-public-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - sign-released-image:
+          name: sign-release-image
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
+          requires:
+            - release-to-public
           filters:
             branches:
               only:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -33,12 +33,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: docker23
-      - run:
-          name: Install cosign
-          command: |
-            curl -LO https://github.com/sigstore/cosign/releases/download/v2.2.2/cosign-linux-amd64
-            chmod +x cosign-linux-amd64
-            sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+      - cosign/install:
+          version: "2.2.2"
       - run:
           name: Login to docker registry
           command: |

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -9,6 +9,7 @@ executors:
 orbs:
   slack: circleci/slack@4.10.1
   python: circleci/python@2.1.1
+  cosign: cpanato/cosign-orb@2.0.0
 
 parameters:
   scan-docker-images:
@@ -25,6 +26,48 @@ parameters:
     description: "This will trigger QA release workflow."
 
 jobs:
+  sign-released-image:
+    executor: docker-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: docker23
+      - run:
+          name: Install cosign
+          command: |
+            curl -LO https://github.com/sigstore/cosign/releases/download/v2.2.2/cosign-linux-amd64
+            chmod +x cosign-linux-amd64
+            sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+      - run:
+          name: Login to docker registry
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin docker.io
+            echo "$QUAY_PASSWORD" | docker login --username $QUAY_USERNAME --password-stdin quay.io
+      - run:
+          name: Set image tag to sign
+          command: |
+            set -xe
+            # Only sign tagged releases or specific QA releases
+            # For regular release job
+            if [ -n "$NEXT_TAG" ]; then
+              echo "export IMAGE_TAG=$NEXT_TAG" >> $BASH_ENV
+            # For custom QA release job
+            elif [ -n "$IMG_TAG" ]; then
+              echo "export IMAGE_TAG=$IMG_TAG" >> $BASH_ENV
+            else
+              echo "No specific release tag found, skipping image signing"
+              exit 0
+            fi
+      - run:
+          name: Install Python dependencies
+          command: pip install requests
+      - run:
+          name: Sign Docker images with cosign
+          command: |
+            # Execute the signing script with version from environment
+            python bin/sign-images.py --version "${IMAGE_TAG}"
+
   trivy-scan-docker:
     docker:
       - image: cimg/base:current-22.04
@@ -291,6 +334,18 @@ workflows:
         - << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
+      - sign-released-image:
+          name: sign-release-image
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
+          requires:
+            - release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
           slack_notify: false
@@ -387,6 +442,18 @@ workflows:
             - github-repo
           requires:
             - approve-public-release
+          filters:
+            branches:
+              only:
+                - '/^release-0\.\d+$/'
+      - sign-released-image:
+          name: sign-release-image
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
+          requires:
+            - release-to-public
           filters:
             branches:
               only:

--- a/bin/sign-images.py
+++ b/bin/sign-images.py
@@ -2,6 +2,7 @@
 """
 Script to sign all container images in the Astronomer release JSON using cosign.
 """
+
 import json
 import os
 import subprocess
@@ -9,9 +10,9 @@ import sys
 import getpass
 import requests
 import base64
-from pathlib import Path
 import argparse
 import tempfile
+
 
 def check_requirements():
     """Check if required tools are installed."""
@@ -22,13 +23,20 @@ def check_requirements():
         print("Error: cosign is not installed. Please install it first.")
         print("Visit https://github.com/sigstore/cosign for installation instructions.")
         sys.exit(1)
-    
+
+    # Check for Python dependencies
     try:
-        import requests
+        import importlib.util
+
+        if importlib.util.find_spec("requests") is None:
+            print("Error: Python 'requests' module is not installed.")
+            print("Install it using: pip install requests")
+            sys.exit(1)
     except ImportError:
         print("Error: Python 'requests' module is not installed.")
         print("Install it using: pip install requests")
         sys.exit(1)
+
 
 def write_key_file(env_var_name, file_path):
     """Write a base64-encoded key from environment variable to a file."""
@@ -36,70 +44,72 @@ def write_key_file(env_var_name, file_path):
     if not encoded_key:
         print(f"Error: Environment variable {env_var_name} not found.")
         sys.exit(1)
-    
+
     try:
         decoded_key = base64.b64decode(encoded_key)
-        with open(file_path, 'wb') as key_file:
+        with open(file_path, "wb") as key_file:
             key_file.write(decoded_key)
         os.chmod(file_path, 0o600)  # Set secure permissions
         return True
-    except Exception as e:
+    except (base64.binascii.Error, OSError) as e:
         print(f"Error decoding or writing key from {env_var_name}: {e}")
         sys.exit(1)
+
 
 def sign_image(repo, tag, sha, key_path, password=None):
     """Sign a container image with cosign."""
     full_image = f"{repo}:{tag}"
     digest_reference = f"{full_image}@sha256:{sha}"
-    
+
     print(f"Signing image: {full_image} with SHA: {sha}")
-    
+
     try:
         subprocess.run(
             ["cosign", "verify", "--insecure-ignore-tlog", "--key", f"{key_path}.pub", digest_reference],
             check=True,
-            capture_output=True
+            capture_output=True,
         )
         print(f"Image already signed: {full_image}")
         return
     except subprocess.CalledProcessError:
         pass  # Image is not yet signed
-    
+
     env = os.environ.copy()
     if password:
         env["COSIGN_PASSWORD"] = password
-    
+
     sign_cmd = ["cosign", "sign", "--key", key_path, digest_reference]
     try:
-        result = subprocess.run(sign_cmd, env=env, check=True)
+        subprocess.run(sign_cmd, env=env, check=True)
         print(f"✓ Signed {full_image}")
     except subprocess.CalledProcessError as e:
         print(f"Error signing {full_image}: {e}")
         sys.exit(1)
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Sign container images in an Astronomer release.')
-    parser.add_argument('--version', '-v', help='Version tag to sign (e.g., 0.36.0)', required=False)
+    parser = argparse.ArgumentParser(description="Sign container images in an Astronomer release.")
+    parser.add_argument("--version", "-v", help="Version tag to sign (e.g., 0.36.0)", required=False)
     args = parser.parse_args()
-    
+
     check_requirements()
-    
+
     # Create temporary directory for key files
     with tempfile.TemporaryDirectory() as temp_dir:
         private_key_path = os.path.join(temp_dir, "cosign.key")
         public_key_path = os.path.join(temp_dir, "cosign.key.pub")
-        
+
         # Write keys to temporary files
         print("Writing private key to temporary file...")
         write_key_file("COSIGN_PRIVATE_KEY", private_key_path)
-        
+
         print("Writing public key to temporary file...")
         write_key_file("COSIGN_PUBLIC_KEY", public_key_path)
-        
+
         password = os.environ.get("COSIGN_PASSWORD")
         if not password:
             password = getpass.getpass("Enter password for cosign key: ")
-        
+
         version = args.version
         if not version:
             version = os.environ.get("IMAGE_TAG")
@@ -109,17 +119,17 @@ def main():
                     version = os.environ.get("NEXT_TAG")[1:]
                 else:
                     version = os.environ.get("NEXT_TAG") or os.environ.get("IMG_TAG")
-                
+
         if not version:
             print("Error: No version specified. Use --version or set IMAGE_TAG/NEXT_TAG/IMG_TAG environment variable.")
             sys.exit(1)
-        
+
         print(f"Signing images for version: {version}")
-        
+
         json_url = f"https://updates.astronomer.io/astronomer-software/releases/astronomer-{version}.json"
         try:
             print(f"Fetching data from {json_url}...")
-            response = requests.get(json_url)
+            response = requests.get(json_url, timeout=30)  # Added 30-second timeout
             response.raise_for_status()  # Raise exception for HTTP errors
             data = response.json()
             print("Successfully fetched data from URL")
@@ -135,16 +145,11 @@ def main():
                 sys.exit(1)
 
         print("Signing Astronomer images...")
-        for image_name, image_data in data["astronomer"]["images"].items():
-            sign_image(
-                image_data["repository"],
-                image_data["tag"],
-                image_data["sha256"],
-                private_key_path,
-                password
-            )
-        
+        for image_data in data["astronomer"]["images"].values():
+            sign_image(image_data["repository"], image_data["tag"], image_data["sha256"], private_key_path, password)
+
         print("All images have been processed.")
+
 
 if __name__ == "__main__":
     main()

--- a/bin/sign-images.py
+++ b/bin/sign-images.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+Script to sign all container images in the Astronomer release JSON using cosign.
+"""
+import json
+import os
+import subprocess
+import sys
+import getpass
+import requests
+import base64
+from pathlib import Path
+import argparse
+import tempfile
+
+def check_requirements():
+    """Check if required tools are installed."""
+    # Check for cosign
+    try:
+        subprocess.run(["which", "cosign"], check=True, capture_output=True)
+    except subprocess.CalledProcessError:
+        print("Error: cosign is not installed. Please install it first.")
+        print("Visit https://github.com/sigstore/cosign for installation instructions.")
+        sys.exit(1)
+    
+    try:
+        import requests
+    except ImportError:
+        print("Error: Python 'requests' module is not installed.")
+        print("Install it using: pip install requests")
+        sys.exit(1)
+
+def write_key_file(env_var_name, file_path):
+    """Write a base64-encoded key from environment variable to a file."""
+    encoded_key = os.environ.get(env_var_name)
+    if not encoded_key:
+        print(f"Error: Environment variable {env_var_name} not found.")
+        sys.exit(1)
+    
+    try:
+        decoded_key = base64.b64decode(encoded_key)
+        with open(file_path, 'wb') as key_file:
+            key_file.write(decoded_key)
+        os.chmod(file_path, 0o600)  # Set secure permissions
+        return True
+    except Exception as e:
+        print(f"Error decoding or writing key from {env_var_name}: {e}")
+        sys.exit(1)
+
+def sign_image(repo, tag, sha, key_path, password=None):
+    """Sign a container image with cosign."""
+    full_image = f"{repo}:{tag}"
+    digest_reference = f"{full_image}@sha256:{sha}"
+    
+    print(f"Signing image: {full_image} with SHA: {sha}")
+    
+    try:
+        subprocess.run(
+            ["cosign", "verify", "--insecure-ignore-tlog", "--key", f"{key_path}.pub", digest_reference],
+            check=True,
+            capture_output=True
+        )
+        print(f"Image already signed: {full_image}")
+        return
+    except subprocess.CalledProcessError:
+        pass  # Image is not yet signed
+    
+    env = os.environ.copy()
+    if password:
+        env["COSIGN_PASSWORD"] = password
+    
+    sign_cmd = ["cosign", "sign", "--key", key_path, digest_reference]
+    try:
+        result = subprocess.run(sign_cmd, env=env, check=True)
+        print(f"✓ Signed {full_image}")
+    except subprocess.CalledProcessError as e:
+        print(f"Error signing {full_image}: {e}")
+        sys.exit(1)
+
+def main():
+    parser = argparse.ArgumentParser(description='Sign container images in an Astronomer release.')
+    parser.add_argument('--version', '-v', help='Version tag to sign (e.g., 0.36.0)', required=False)
+    args = parser.parse_args()
+    
+    check_requirements()
+    
+    # Create temporary directory for key files
+    with tempfile.TemporaryDirectory() as temp_dir:
+        private_key_path = os.path.join(temp_dir, "cosign.key")
+        public_key_path = os.path.join(temp_dir, "cosign.key.pub")
+        
+        # Write keys to temporary files
+        print("Writing private key to temporary file...")
+        write_key_file("COSIGN_PRIVATE_KEY", private_key_path)
+        
+        print("Writing public key to temporary file...")
+        write_key_file("COSIGN_PUBLIC_KEY", public_key_path)
+        
+        password = os.environ.get("COSIGN_PASSWORD")
+        if not password:
+            password = getpass.getpass("Enter password for cosign key: ")
+        
+        version = args.version
+        if not version:
+            version = os.environ.get("IMAGE_TAG")
+            if not version:
+                # If tag starts with 'v', remove it
+                if os.environ.get("NEXT_TAG") and os.environ.get("NEXT_TAG").startswith("v"):
+                    version = os.environ.get("NEXT_TAG")[1:]
+                else:
+                    version = os.environ.get("NEXT_TAG") or os.environ.get("IMG_TAG")
+                
+        if not version:
+            print("Error: No version specified. Use --version or set IMAGE_TAG/NEXT_TAG/IMG_TAG environment variable.")
+            sys.exit(1)
+        
+        print(f"Signing images for version: {version}")
+        
+        json_url = f"https://updates.astronomer.io/astronomer-software/releases/astronomer-{version}.json"
+        try:
+            print(f"Fetching data from {json_url}...")
+            response = requests.get(json_url)
+            response.raise_for_status()  # Raise exception for HTTP errors
+            data = response.json()
+            print("Successfully fetched data from URL")
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            print(f"Failed to fetch data from URL: {e}")
+            print("Falling back to local file...")
+            json_file = f"astronomer-{version}.json"
+            try:
+                with open(json_file) as f:
+                    data = json.load(f)
+            except (FileNotFoundError, json.JSONDecodeError):
+                print(f"Error: Could not find or parse local file {json_file}")
+                sys.exit(1)
+
+        print("Signing Astronomer images...")
+        for image_name, image_data in data["astronomer"]["images"].items():
+            sign_image(
+                image_data["repository"],
+                image_data["tag"],
+                image_data["sha256"],
+                private_key_path,
+                password
+            )
+        
+        print("All images have been processed.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR adds image signing capabilities to our CI/CD pipeline using Cosign. It enables us to cryptographically sign our release images to provide stronger security guarantees and verify the authenticity of our published container images.

## Changes

 - Add a new Python script (bin/sign-images.py) that fetches the BOM file for a specified release and signs all Astronomer images with Cosign
 - Update the CircleCI configuration to include a sign-released-image job that runs after release
 - Configure the job to use environment variables from the software-cosign-keys context
 - The script handles base64-encoded keys from environment variables

## Related Issues

Related astronomer/issues#7082

## How It Works

- The script reads COSIGN_PRIVATE_KEY, COSIGN_PUBLIC_KEY, and COSIGN_PASSWORD from environment variables
- It fetches the BOM file for the specific version from updates.astronomer.io
- It signs each Astronomer container image listed in the BOM file using the supplied keys
- It uses temporary files to securely handle the key material
- It verifies each image hasn't already been signed before attempting to sign

## Testing

- Tested the script locally with sample BOM data
- Verified proper handling of base64-encoded keys
- Confirmed the workflow integration with CircleCI

## Merging

Can we merged everywhere. 
