### PR TITLE
Add configurable client_max_body_size to NGINX Elasticsearch ConfigMap

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -20,7 +20,7 @@ data:
 
     http {
       access_log /dev/stdout;
-      client_max_body_size {{ .Values.nginx.proxy.maxBodySize }};
+      client_max_body_size {{ .Values.nginx.maxBodySize }};
 
       upstream elasticsearch {
         server {{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}:{{ .Values.common.ports.http }};

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -20,6 +20,7 @@ data:
 
     http {
       access_log /dev/stdout;
+      client_max_body_size {{ .Values.nginx.proxy.maxBodySize }};
 
       upstream elasticsearch {
         server {{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}:{{ .Values.common.ports.http }};

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -302,8 +302,7 @@ nginx:
   ingressClass: ~
   resources: {}
   securityContext: {}
-  proxy:
-    maxBodySize: "100M"
+  maxBodySize: "100M"
 
 # sysctl init container
 # Warning: sysctl changes affect the kernel, and thus, all containers running on the same node.

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -302,6 +302,8 @@ nginx:
   ingressClass: ~
   resources: {}
   securityContext: {}
+  proxy:
+    maxBodySize: "100M"
 
 # sysctl init container
 # Warning: sysctl changes affect the kernel, and thus, all containers running on the same node.

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -285,7 +285,7 @@ class TestElasticSearch:
         """Test that custom max body size is properly set."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"elasticsearch": {"nginx": {"maxBodySize": "200M"}}},
+            values={"elasticsearch": {"nginx": {"maxBodySize": "123456789M"}}},
             show_only=[
                 "charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml",
             ],
@@ -294,7 +294,7 @@ class TestElasticSearch:
         assert len(docs) == 1
         doc = docs[0]
         nginx_config = " ".join(doc["data"]["nginx.conf"].split())
-        assert "client_max_body_size 200M" in nginx_config
+        assert "client_max_body_size 123456789M" in nginx_config
 
     def test_elastic_nginx_config_pattern_defaults_and_index_prefix_overrides(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search with index prefix overrides."""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -279,6 +279,22 @@ class TestElasticSearch:
                 "location ~ ^/ { deny all; } } }",
             ]
         )
+        assert "client_max_body_size 100M" in nginx_config
+
+    def test_elastic_nginx_config_custom_max_body_size(self, kube_version):
+        """Test that custom max body size is properly set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"elasticsearch": {"nginx": {"proxy": {"maxBodySize": "200M"}}}},
+            show_only=[
+                "charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        nginx_config = " ".join(doc["data"]["nginx.conf"].split())
+        assert "client_max_body_size 200M" in nginx_config
 
     def test_elastic_nginx_config_pattern_defaults_and_index_prefix_overrides(self, kube_version):
         """Test External Elasticsearch Service Index Pattern Search with index prefix overrides."""

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -285,7 +285,7 @@ class TestElasticSearch:
         """Test that custom max body size is properly set."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"elasticsearch": {"nginx": {"proxy": {"maxBodySize": "200M"}}}},
+            values={"elasticsearch": {"nginx": {"maxBodySize": "200M"}}},
             show_only=[
                 "charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml",
             ],


### PR DESCRIPTION
## Description

This pull request adds the client_max_body_size directive to the NGINX Elasticsearch ConfigMap, defaulting to 100M and making it configurable through Helm values.

## Motivation

- The client_max_body_size directive in NGINX controls the maximum allowed size of client request bodies. 
- Setting this value appropriately helps prevent issues with large requests being rejected while still providing protection against excessive resource consumption.

## Changes

- Added client_max_body_size directive to the HTTP block in the NGINX Elasticsearch ConfigMap
- Set the default value to 100M
- Made the value configurable via Helm values
- Added unit tests to verify the directive is present with both default and custom values

## Related Issues

Related astronomer/issues#7164

## Testing

- Unit tests have been added to verify that:
     - The directive is present in the default configuration
     - Custom values are properly applied when specified

## Merging

0.37.1
