### PR TITLE
updating ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -425,15 +425,15 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
-                - quay.io/astronomer/ap-node-exporter:1.9.0
+                - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1
-                - quay.io/astronomer/ap-postgresql:15.10.0-1
+                - quay.io/astronomer/ap-postgresql:16.6.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
-                - quay.io/astronomer/ap-redis:7.4.2
+                - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.21.3-2
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
                 - quay.io/astronomer/ap-vector:0.45.0-2
@@ -471,15 +471,15 @@ workflows:
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
-                - quay.io/astronomer/ap-node-exporter:1.9.0
+                - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1
-                - quay.io/astronomer/ap-postgresql:15.10.0-1
+                - quay.io/astronomer/ap-postgresql:16.6.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
-                - quay.io/astronomer/ap-redis:7.4.2
+                - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.21.3-2
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
                 - quay.io/astronomer/ap-vector:0.45.0-2

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 15.10.0-1
+  tag: 16.6.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.9.0
+  tag: 1.9.1
   pullPolicy: IfNotPresent
 
 service:

--- a/values.yaml
+++ b/values.yaml
@@ -306,7 +306,7 @@ global:
         tag: 0.28.0-2
       redis:
         repository: quay.io/astronomer/ap-redis
-        tag: 7.4.2
+        tag: 7.4.2-1
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
         tag: 1.24.0-2


### PR DESCRIPTION
## Description

Image Name | Old Tag | New Tag 
-- | -- | -- |
ap-node-exporter | 1.9.0 | 1.9.1
ap-postgresql | 15.10.0-1  | 16.6.0
ap-redis | 7.4.2 | 7.4.2-1

## Related Issues

https://github.com/astronomer/issues/issues/7106
https://github.com/astronomer/issues/issues/7141
https://github.com/astronomer/issues/issues/7118

## Testing
Generic QA testing

## Merging

cherry-pick to release-0.37, release-0.36
