### PR TITLE
Fix incorrectly rendered yaml doc separators

### DIFF
--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -16,7 +16,7 @@
 {{- end }}
 
 {{- if $shouldCreateResources}}
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/astronomer/templates/commander/commander-rolebinding.yaml
+++ b/charts/astronomer/templates/commander/commander-rolebinding.yaml
@@ -17,7 +17,7 @@
 {{- end }}
 
 {{- if $shouldCreateResources }}
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: {{ if $useClusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
@@ -17,7 +17,7 @@
 {{- end }}''
 
 {{- if $shouldCreateResources -}}
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
@@ -18,7 +18,7 @@
 {{- end }}
 
 {{- if $shouldCreateResources -}}
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: {{ if $useClusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}

--- a/charts/kube-state/templates/kube-state-role.yaml
+++ b/charts/kube-state/templates/kube-state-role.yaml
@@ -13,7 +13,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: {{ if $useClusterRoles }}ClusterRole{{ else }}Role{{ end }}

--- a/charts/kube-state/templates/kube-state-rolebinding.yaml
+++ b/charts/kube-state/templates/kube-state-rolebinding.yaml
@@ -13,7 +13,7 @@
   {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- end }}
 
-{{- range $i, $namespaceName := $namespaces -}}
+{{- range $i, $namespaceName := $namespaces }}
 ---
 apiVersion: {{ template "apiVersion.rbac" . }}
 kind: {{ if $useClusterRoles }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}


### PR DESCRIPTION
## Description

Fix incorrectly rendered yaml doc separators. I found this while looking at something completely unrelated. The way it was rendering before has `enabled---`, which is the error:

```
$ helm template . --kube-version 1.31.0 --set global.baseDomain=example.com --show-only charts/astronomer/templates/commander/commander-rolebinding.yaml | head
---
# Source: astronomer/charts/astronomer/templates/commander/commander-rolebinding.yaml
######################################
## Astronomer Commander RoleBinding ##
######################################
# Either:
# 1. Do not create anything is rbacEnabled is disabled
# 2. Create ClusterRoleBinding if clusterRoles enabled and namespacePools disabled
# 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled---
apiVersion: rbac.authorization.k8s.io/v1
```

And after being fixed it is:

```
$ helm template . --kube-version 1.31.0 --set global.baseDomain=example.com --show-only charts/astronomer/templates/commander/commander-rolebinding.yaml | head
---
# Source: astronomer/charts/astronomer/templates/commander/commander-rolebinding.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: release-name-commander
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: release-name-commander
```

Alternatively, we can remove the `---` in the template if we want to keep the comments in the yaml that helm produces. Currently helm strips out the empty yaml doc that contains only comments.

## Related Issues

<https://github.com/astronomer/issues/issues/7163>

## Testing

These are all comment changes. Unit tests passing is enough for us to be confident in these changes.

## Merging

Merge everywhere these templates are used.