### PR TITLE
add fluentd dag processor support

### DIFF
--- a/charts/fluentd/templates/fluentd-configmap.yaml
+++ b/charts/fluentd/templates/fluentd-configmap.yaml
@@ -97,7 +97,7 @@ data:
       @type kubernetes_metadata
     </filter>
 
-    # Filter down by namespace and component (scheduler/webserver/worker/triggerer/git-sync-relay/dag-server/airflow-downgrade/meta-cleanup)
+    # Filter down by namespace and component (scheduler/webserver/worker/triggerer/git-sync-relay/dag-server/airflow-downgrade/meta-cleanup/dag-processor)
     <filter kubernetes.**>
       @type grep
       <regexp>
@@ -117,7 +117,7 @@ data:
       </regexp>
       <regexp>
         key $.kubernetes.labels.component
-        pattern ^(scheduler|webserver|worker|triggerer|git-sync-relay|dag-server|airflow-downgrade|meta-cleanup)$
+        pattern ^(scheduler|webserver|worker|triggerer|git-sync-relay|dag-server|airflow-downgrade|meta-cleanup|dag-processor)$
       </regexp>
     </filter>
 


### PR DESCRIPTION
## Description

add fluentd dag processor support

## Related Issues

Related astronomer/issues#6572

## Testing

QA should see dag processor logs in the UI

## Merging

merge to release-0.37
