### PR TITLE
Bumps houston api image version to 0.37.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -416,7 +416,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
-                - quay.io/astronomer/ap-houston-api:0.37.11
+                - quay.io/astronomer/ap-houston-api:0.37.12
                 - quay.io/astronomer/ap-init:3.21.3-2
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -462,7 +462,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.2.4
                 - quay.io/astronomer/ap-grafana:10.4.17
-                - quay.io/astronomer/ap-houston-api:0.37.11
+                - quay.io/astronomer/ap-houston-api:0.37.12
                 - quay.io/astronomer/ap-init:3.21.3-2
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.11
+    tag: 0.37.12
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Bump houston API to 0.37.12

## Related Issues

Related astronomer/issues#7060

## Testing

Already tested via unit tests and deploying in GKE cluster

## Merging

0.37
