### PR TITLE
Remove sign-released-image job from scan-docker-images workflow.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,18 +379,6 @@ workflows:
         - << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
-      - sign-released-image:
-          name: sign-release-image
-          context:
-            - quay.io
-            - docker.io
-            - software-cosign-keys
-          requires:
-            - release
-          filters:
-            branches:
-              only:
-                - '/^release-0\.\d+$/'
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
           slack_notify: false

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -330,18 +330,6 @@ workflows:
         - << pipeline.parameters.scan-docker-images >>
         - not: << pipeline.parameters.qa-release >>
     jobs:
-      - sign-released-image:
-          name: sign-release-image
-          context:
-            - quay.io
-            - docker.io
-            - software-cosign-keys
-          requires:
-            - release
-          filters:
-            branches:
-              only:
-                - '/^release-0\.\d+$/'
       - trivy-scan-docker:
           report_url: << pipeline.parameters.scan-docker-images-report-url >>
           slack_notify: false


### PR DESCRIPTION
## Description

Remove sign-released-image job from scan-docker-images workflow to fix image scanning, and because it doesn't seem like the right place for that job.

## Related Issues

- <https://github.com/astronomer/issues/issues/7167>

## Testing

No testing needed. This is not related to the product and doesn't change anything about the way the software runs. This is purely a CI fix.

## Merging

Merge everywhere just to be consistent.