### PR TITLE
upgrade ap-postgres-exporter:0.19.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,7 +418,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1
+                - quay.io/astronomer/ap-postgres-exporter:0.19.0
                 - quay.io/astronomer/ap-postgresql:16.6.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
@@ -464,7 +464,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1
+                - quay.io/astronomer/ap-postgres-exporter:0.19.0
                 - quay.io/astronomer/ap-postgresql:16.6.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.17.1
+  tag: 0.19.0
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

Image Name | Old Tag | New Tag 
-- | -- | -- |
ap-postgres-exporter| 0.17.1 | 0.19.0

## Related Issues

https://github.com/astronomer/issues/issues/7106

## Testing
Generic QA testing

## Merging

cherry-pick to release-0.37, release-0.36
