### PR TITLE
 updating ap-pgbouncer-exporter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1
@@ -461,7 +461,7 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.18.0-4
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1

--- a/values.yaml
+++ b/values.yaml
@@ -313,7 +313,7 @@ global:
         tag: 1.24.0-2
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.18.0-4
+        tag: 0.19.0
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 4.2.4


### PR DESCRIPTION
## Description

Image Name | Old Tag | New Tag 
-- | -- | -- |
ap-pgbouncer-exporter| 0.18.0-4 | 0.19.0

## Related Issues

https://github.com/astronomer/issues/issues/7106

## Testing
Generic QA testing

## Merging

cherry-pick to release-0.37, release-0.36