### PR TITLE
add dagProcessor openshift support

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -364,6 +364,14 @@ data:
               rollingUpdate:
                 maxUnavailable: 1
 
+          dagProcessor:
+
+            {{ if .Values.global.openshiftEnabled }}
+            securityContexts:
+              pod:
+                runAsNonRoot: true
+            {{ end  }}
+
           airflowLocalSettings: |
             # This pod mutation hook runs for all pods dynamically created by Airflow
             # in Kubernetes (K8s). This includes K8s executor Airflow-workers, which is

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -336,7 +336,6 @@ data:
             safeToEvict: true
 
           scheduler:
-
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
@@ -365,7 +364,6 @@ data:
                 maxUnavailable: 1
 
           dagProcessor:
-
             {{ if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -25,7 +25,7 @@ airflow_components_list = [
     "triggerer",
     "migrateDatabaseJob",
     "cleanup",
-    "dagProcessor"
+    "dagProcessor",
 ]
 
 

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -25,6 +25,7 @@ airflow_components_list = [
     "triggerer",
     "migrateDatabaseJob",
     "cleanup",
+    "dagProcessor"
 ]
 
 


### PR DESCRIPTION
## Description

add dagProcessor openshift support and optimize scc usage

## Related Issues

https://github.com/astronomer/issues/issues/6572

## Testing

QA should able to deploy airflow deployments with dag processor enabled 

## Merging

merge to master and release-0.37
