### PR TITLE
fix dag processor config

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -513,7 +513,7 @@ data:
             securityContexts:
               pod:
                 runAsNonRoot: true
-                
+
           # dagProcessor settings
           dagProcessor:
             securityContexts:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -363,12 +363,6 @@ data:
               rollingUpdate:
                 maxUnavailable: 1
 
-          dagProcessor:
-            {{ if .Values.global.openshiftEnabled }}
-            securityContexts:
-              pod:
-                runAsNonRoot: true
-            {{ end  }}
 
           airflowLocalSettings: |
             # This pod mutation hook runs for all pods dynamically created by Airflow
@@ -516,6 +510,12 @@ data:
 
           # migrateDatabaseJob  settings
           migrateDatabaseJob:
+            securityContexts:
+              pod:
+                runAsNonRoot: true
+                
+          # dagProcessor settings
+          dagProcessor:
             securityContexts:
               pod:
                 runAsNonRoot: true

--- a/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
@@ -47,6 +47,11 @@ spec:
     - namespaceSelector: {}
       podSelector:
         matchLabels:
+          component: dag-processor
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
           component: git-sync-relay
           tier: airflow
     {{- end }}

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -46,6 +46,11 @@ spec:
     - namespaceSelector: {}
       podSelector:
         matchLabels:
+          component: dag-processor
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
           component: git-sync-relay
           tier: airflow
     {{- end }}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -253,7 +253,7 @@ class TestElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -253,7 +253,7 @@ class TestElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -248,12 +248,12 @@ class TestElasticSearch:
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
+                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            },
+                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -250,6 +250,10 @@ class TestElasticSearch:
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -342,6 +342,10 @@ class TestExternalElasticSearch:
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -345,7 +345,7 @@ class TestExternalElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -345,7 +345,7 @@ class TestExternalElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -340,12 +340,12 @@ class TestExternalElasticSearch:
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
+                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
             },
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            },
+                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -66,7 +66,6 @@ class TestPrometheusStatefulset:
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
-        print(c_by_name["prometheus"]["args"])
         assert "--log.level=debug" in c_by_name["prometheus"]["args"]
 
     def test_prometheus_with_multiple_extraFlags(self, kube_version):
@@ -84,7 +83,6 @@ class TestPrometheusStatefulset:
         )
         assert len(docs) == 1
         c_by_name = get_containers_by_name(docs[0])
-        print(c_by_name["prometheus"]["args"])
         assert "--enable-feature=remote-write-receiver" in c_by_name["prometheus"]["args"]
         assert "--enable-feature=agent" in c_by_name["prometheus"]["args"]
 


### PR DESCRIPTION
## Description

Add relevant nwtwork policies for dag processor siercar logging container

## Related Issues

- Related astronomer/issues#6572

## Testing

QA should able to see logs when sidecar logging is enabled

## Merging

merge to release-0.37
