### PR TITLE
update network policies for airflow components

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
@@ -54,6 +54,21 @@ spec:
         matchLabels:
           component: git-sync-relay
           tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: dag-server
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: airflow-downgrade
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: metacleanup
+          tier: airflow
     {{- end }}
     ports:
     - protocol: TCP

--- a/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
@@ -31,43 +31,19 @@ spec:
     {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
+        matchExpressions:
+        - key: component
+          operator: In
+          values:
+          - dag-server
+          - metacleanup
+          - airflow-downgrade
+          - git-sync-relay
+          - dag-processor
+          - triggerer
+          - worker
+          - scheduler
         matchLabels:
-          component: scheduler
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: worker
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: triggerer
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: dag-processor
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: git-sync-relay
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: dag-server
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: airflow-downgrade
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: metacleanup
           tier: airflow
     {{- end }}
     ports:

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -53,6 +53,21 @@ spec:
         matchLabels:
           component: git-sync-relay
           tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: dag-server
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: airflow-downgrade
+          tier: airflow
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          component: metacleanup
+          tier: airflow
     {{- end }}
     ports:
     - protocol: TCP

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -35,38 +35,19 @@ spec:
           tier: airflow
     - namespaceSelector: {}
       podSelector:
+        matchExpressions:
+        - key: component
+          operator: In
+          values:
+          - dag-server
+          - metacleanup
+          - airflow-downgrade
+          - git-sync-relay
+          - dag-processor
+          - triggerer
+          - worker
+          - scheduler
         matchLabels:
-          component: worker
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: triggerer
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: dag-processor
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: git-sync-relay
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: dag-server
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: airflow-downgrade
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
-        matchLabels:
-          component: metacleanup
           tier: airflow
     {{- end }}
     ports:

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -30,11 +30,6 @@ spec:
     {{- if .Values.global.loggingSidecar.enabled }}
     - namespaceSelector: {}
       podSelector:
-        matchLabels:
-          component: scheduler
-          tier: airflow
-    - namespaceSelector: {}
-      podSelector:
         matchExpressions:
         - key: component
           operator: In

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -265,19 +265,7 @@ class TestElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            },
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -230,41 +230,28 @@ class TestElasticSearch:
         doc = docs[0]
         assert "NetworkPolicy" == doc["kind"]
         assert [
+            {"namespaceSelector": {}, "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}}},
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "scheduler", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "worker", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "triggerer", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+                "podSelector": {
+                    "matchExpressions": [
+                        {
+                            "key": "component",
+                            "operator": "In",
+                            "values": [
+                                "dag-server",
+                                "metacleanup",
+                                "airflow-downgrade",
+                                "git-sync-relay",
+                                "dag-processor",
+                                "triggerer",
+                                "worker",
+                                "scheduler",
+                            ],
+                        }
+                    ],
+                    "matchLabels": {"tier": "airflow"},
+                },
             },
         ] == doc["spec"]["ingress"][0]["from"]
 

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -254,6 +254,30 @@ class TestElasticSearch:
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -265,7 +265,7 @@ class TestElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -277,7 +277,7 @@ class TestElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_elastic_nginx_config_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -369,7 +369,7 @@ class TestExternalElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -346,6 +346,30 @@ class TestExternalElasticSearch:
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
             },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
+            },
+            {
+                "namespaceSelector": {},
+                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -357,7 +357,7 @@ class TestExternalElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            }
+            },
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -322,41 +322,28 @@ class TestExternalElasticSearch:
         doc = docs[0]
         assert doc["kind"] == "NetworkPolicy"
         assert [
+            {"namespaceSelector": {}, "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}}},
             {
                 "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"tier": "airflow", "component": "webserver"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "scheduler", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "worker", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "triggerer", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-processor", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "git-sync-relay", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
+                "podSelector": {
+                    "matchExpressions": [
+                        {
+                            "key": "component",
+                            "operator": "In",
+                            "values": [
+                                "dag-server",
+                                "metacleanup",
+                                "airflow-downgrade",
+                                "git-sync-relay",
+                                "dag-processor",
+                                "triggerer",
+                                "worker",
+                                "scheduler",
+                            ],
+                        }
+                    ],
+                    "matchLabels": {"tier": "airflow"},
+                },
             },
         ] == doc["spec"]["ingress"][0]["from"]
 

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -357,19 +357,7 @@ class TestExternalElasticSearch:
             {
                 "namespaceSelector": {},
                 "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "dag-server", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "airflow-downgrade", "tier": "airflow"}},
-            },
-            {
-                "namespaceSelector": {},
-                "podSelector": {"matchLabels": {"component": "metacleanup", "tier": "airflow"}},
-            },
+            }
         ] == doc["spec"]["ingress"][0]["from"]
 
     def test_external_es_index_pattern_defaults(self, kube_version):


### PR DESCRIPTION
## Description

some of the airflow custom components logs are not whitelisted on sidecar logging method this PR fixes the behavior and allows us to log all component logs in the elasticsearch and reflects back to Astro UI

## Related Issues

fixes https://github.com/astronomer/issues/issues/7178

## Testing
QA should able to see logs for dag server , airflow downgrade .

## Merging

merge to all valid releases
