### PR TITLE
6266 postgres 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1
-                - quay.io/astronomer/ap-postgresql:16.6.0
+                - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.0.0
@@ -465,7 +465,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1
-                - quay.io/astronomer/ap-postgresql:16.6.0
+                - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.0.0

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 16.6.0
+  tag: 17.4.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

Bump from postgres 16 to 17. This effectively bumps from postgres 15 in 0.37.0 to postgres 17 in 0.37.1. This change requires customers who are using in-cluster postgres to pin their old version of postgres 17. Not doing so is not a destructive operation, but the postgres pod will not come up until the version has been pinned to the prior major version (which is output in the postgres logs) or until the db files are manually upgraded to 17. Customers are advised to never use in-cluster postgres.

## Related Issues

https://github.com/astronomer/issues/issues/6266

## Testing

No extra testing is needed. In-cluster postgres is used during CI so if CI passes then we are good.

## Merging

Merge only to 0.37.