### PR TITLE
Fix Cosign Version Format in CI Configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           docker_layer_caching: true
           version: docker23
       - cosign/install:
-          version: "2.2.2"
+          version: "v2.4.1"
       - run:
           name: Login to docker registry
           command: |

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -34,7 +34,7 @@ jobs:
           docker_layer_caching: true
           version: docker23
       - cosign/install:
-          version: "2.2.2"
+          version: "v2.4.1"
       - run:
           name: Login to docker registry
           command: |


### PR DESCRIPTION
## Description

This PR fixes the failed `sign-release-image` job by ensuring the Cosign version is correctly formatted with a leading 'v' prefix as required by the Cosign orb.

## Related Issues

Related astronomer/issues#7188

## Changes
- Updated Cosign version in `.circleci/config.yml` from "2.2.2" to "v2.4.1"
- Updated Cosign version in `.circleci/config.yml.j2` from "2.2.2" to "v2.4.1"

## Root Cause

- The Cosign orb validates version strings using a regex pattern that requires a leading 'v' prefix: `^v([0-9]+\.){0,2}(\*|[0-9]+)$`. 

```
semver='^v([0-9]+\.){0,2}(\*|[0-9]+)$'
if [[ ${COSIGN_VERSION:?} =~ ${semver} ]]; then
    echo "INFO: Custom Cosign Version ${COSIGN_VERSION:?}"
else
    echo "ERROR: Unable to validate cosign version: '${COSIGN_VERSION:?}'"
    exit 1
fi
```

- Our configuration was using "2.2.2" (without the 'v'), causing the validation to fail with:
`ERROR: Unable to validate cosign version: '2.2.2'`

## Testing

- Verified that version "v2.4.1" matches the current default version in the Cosign orb
- This version is the same as the bootstrap_version used in the orb, which should improve stability

## Merging

Everywhere
