### PR TITLE
Enhanced Component Plane Verification in Tests

### DIFF
--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -3,9 +3,7 @@ import pytest
 from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
-# Some Values would be added later to these maps
-# "astronomer-jetstream": "dataplane",
-# "astronomer-prometheus": "controlplane",
+
 COMPONENT_PLANE_MAP = {
     "astronomer-houston": "controlplane",
     "astronomer-nginx": "controlplane",
@@ -13,7 +11,8 @@ COMPONENT_PLANE_MAP = {
     "astronomer-elasticsearch": "controlplane",
     "astronomer-commander": "dataplane",
     "astronomer-registry": "dataplane",
-    "astronomer-prometheus": "dataplane",
+    "astronomer-prometheus": "controlplane",
+    "astronomer-prometheus": "dataplane"
 }
 def filter_charts_by_component(charts, component):
     return [chart for chart in charts if chart.get("metadata", {}).get("labels", {}).get("plane") == component]

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -41,59 +41,59 @@ class TestAstronomerCpDpFeature:
 
     def test_astronomer_cp_only(self, kube_version):
         """Test that helm renders the correct templates when only the controlplane is enabled."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(docs, "controlplane")
         assert len(cp_resources) > 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(docs, "dataplane")
         assert len(dp_resources) == 0
 
     def test_astronomer_dp_only(self, kube_version):
         """Test that helm renders the correct templates when only the dataplane is enabled."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(docs, "controlplane")
         assert len(cp_resources) == 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(docs, "dataplane")
         assert len(dp_resources) > 0
 
     def test_astronomer_both_cp_dp_enabled(self, kube_version):
         """Test when both CP and DP features are enabled."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(docs, "controlplane")
         assert len(cp_resources) > 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(docs, "dataplane")
         assert len(dp_resources) > 0
 
     def test_astronomer_both_cp_dp_disabled(self, kube_version):
         """Test when both CP and DP features are disabled."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(docs, "controlplane")
         assert len(cp_resources) == 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(docs, "dataplane")
         assert len(dp_resources) == 0
 
     def test_components_have_correct_plane_labels(self, kube_version):
         """Test that all components have the correct plane labels according to the component map."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
         )
-        component_charts = [chart for chart in charts if self.get_component_name(chart)]
+        component_charts = [doc for doc in docs if self.get_component_name(doc)]
 
         for chart in component_charts:
             component_name = self.get_component_name(chart)
@@ -111,21 +111,21 @@ class TestAstronomerCpDpFeature:
 
     def test_no_components_with_incorrect_plane_labels(self, kube_version):
         """Test that there are no components with plane labels that don't match the component map."""
-        charts = render_chart(
+        docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
         )
 
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(docs, "controlplane")
         assert len(cp_resources) > 0
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(docs, "dataplane")
         assert len(dp_resources) > 0
 
         labeled_resources = [
-            chart
-            for chart in charts
-            if chart.get("metadata", {}).get("labels", {}).get("component")
-            and chart.get("metadata", {}).get("labels", {}).get("plane")
+            doc
+            for doc in docs
+            if doc.get("metadata", {}).get("labels", {}).get("component")
+            and doc.get("metadata", {}).get("labels", {}).get("plane")
         ]
 
         for resource in labeled_resources:

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -14,7 +14,7 @@ COMPONENT_PLANE_MAP = {
     "astronomer-prometheus": "controlplane",
     "astronomer-prometheus": "dataplane"
 }
-def filter_charts_by_component(docs, component):
+def filter_docs_by_component(docs, component):
     return [doc for doc in docs if doc.get("metadata", {}).get("labels", {}).get("plane") == component]
 
 def get_component_name(doc):

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -35,7 +35,7 @@ def create_doc_identifier(doc):
 class TestAstronomerCpDpFeature:
     def test_astronomer_cp_only(self, kube_version):
         """Test that helm renders the correct templates when only the controlplane is enabled."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}},
@@ -54,7 +54,7 @@ class TestAstronomerCpDpFeature:
 
     def test_astronomer_dp_only(self, kube_version):
         """Test that helm renders the correct templates when only the dataplane is enabled."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}},
@@ -73,7 +73,7 @@ class TestAstronomerCpDpFeature:
 
     def test_astronomer_both_cp_dp_enabled(self, kube_version):
         """Test when both Controlplane and Dataplane features are enabled."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -86,7 +86,7 @@ class TestAstronomerCpDpFeature:
 
     def test_astronomer_both_cp_dp_disabled(self, kube_version):
         """Test when both CP and DP features are disabled."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}},
@@ -99,7 +99,7 @@ class TestAstronomerCpDpFeature:
 
     def test_components_have_correct_plane_labels(self, kube_version):
         """Test that all components have the correct plane labels according to the component map."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -127,7 +127,7 @@ class TestAstronomerCpDpFeature:
 
     def test_no_components_with_incorrect_plane_labels(self, kube_version):
         """Test that there are no components with plane labels that don't match the component map."""
-        
+
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -178,8 +178,7 @@ class TestAstronomerCpDpFeature:
             assert component in cp_only_component_names, f"CP component '{component}' not found when only CP is enabled"
 
         dp_only_components = [
-            component for component in PLANE_COMPONENT_MAP["dataplane"] 
-            if component not in PLANE_COMPONENT_MAP["controlplane"]
+            component for component in PLANE_COMPONENT_MAP["dataplane"] if component not in PLANE_COMPONENT_MAP["controlplane"]
         ]
         for component in dp_only_components:
             assert component not in cp_only_component_names, f"DP-only component '{component}' found when only CP is enabled"
@@ -194,8 +193,7 @@ class TestAstronomerCpDpFeature:
         for component in PLANE_COMPONENT_MAP["dataplane"]:
             assert component in dp_only_component_names, f"DP component '{component}' not found when only DP is enabled"
         cp_only_components = [
-            component for component in PLANE_COMPONENT_MAP["controlplane"] 
-            if component not in PLANE_COMPONENT_MAP["dataplane"]
+            component for component in PLANE_COMPONENT_MAP["controlplane"] if component not in PLANE_COMPONENT_MAP["dataplane"]
         ]
         for component in cp_only_components:
             assert component not in dp_only_component_names, f"CP-only component '{component}' found when only DP is enabled"
@@ -204,14 +202,10 @@ class TestAstronomerCpDpFeature:
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
         )
         for component in multi_plane_components:
-            planes_with_component = [
-                plane for plane, components in PLANE_COMPONENT_MAP.items()
-                if component in components
-            ]
+            planes_with_component = [plane for plane, components in PLANE_COMPONENT_MAP.items() if component in components]
             occurrences = sum(1 for doc in both_enabled_docs if get_component_name(doc) == component)
 
             expected_count = len(planes_with_component)
             assert occurrences == expected_count, (
-                f"Component '{component}' should appear {expected_count} times "
-                f"(once per plane) but appears {occurrences} times"
+                f"Component '{component}' should appear {expected_count} times (once per plane) but appears {occurrences} times"
             )

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -14,18 +14,18 @@ COMPONENT_PLANE_MAP = {
     "astronomer-prometheus": "controlplane",
     "astronomer-prometheus": "dataplane"
 }
-def filter_charts_by_component(charts, component):
-    return [chart for chart in charts if chart.get("metadata", {}).get("labels", {}).get("plane") == component]
+def filter_charts_by_component(docs, component):
+    return [doc for doc in docs if doc.get("metadata", {}).get("labels", {}).get("plane") == component]
 
-def get_component_name(chart):
+def get_component_name(doc):
     """Extract component name from chart metadata."""
-    return chart.get("metadata", {}).get("labels", {}).get("component")
+    return doc.get("metadata", {}).get("labels", {}).get("component")
 
-def get_chart_identifier(chart):
+def get_chart_identifier(doc):
     """Get a readable identifier for a chart for error messages."""
-    kind = chart.get("kind", "Unknown")
-    name = chart.get("metadata", {}).get("name", "unnamed")
-    namespace = chart.get("metadata", {}).get("namespace", "default")
+    kind = doc.get("kind", "Unknown")
+    name = doc.get("metadata", {}).get("name", "unnamed")
+    namespace = doc.get("metadata", {}).get("namespace", "default")
     return f"{kind}/{namespace}/{name}"
 
 @pytest.mark.parametrize(

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -4,18 +4,14 @@ from tests import supported_k8s_versions
 from tests.chart_tests.helm_template_generator import render_chart
 
 
-COMPONENT_PLANE_MAP = {
-    "astronomer-houston": "controlplane",
-    "astronomer-nginx": "controlplane",
-    "astronomer-astro-ui": "controlplane",
-    "astronomer-elasticsearch": "controlplane",
-    "astronomer-commander": "dataplane",
-    "astronomer-registry": "controlplane",
-    "astronomer-prometheus": "controlplane",
+PLANE_COMPONENT_MAP = {
+    "controlplane": ["houston", "nginx", "astro-ui", "elasticsearch", "registry", "prometheus", "fluentd", "config-syncer"],
+    "dataplane": ["nginx", "commander", "prometheus"],
 }
 
 
 def filter_docs_by_component(docs, component):
+    """Filter templates by component name."""
     return [doc for doc in docs if doc.get("metadata", {}).get("labels", {}).get("plane") == component]
 
 
@@ -39,6 +35,7 @@ def create_doc_identifier(doc):
 class TestAstronomerCpDpFeature:
     def test_astronomer_cp_only(self, kube_version):
         """Test that helm renders the correct templates when only the controlplane is enabled."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}},
@@ -49,8 +46,15 @@ class TestAstronomerCpDpFeature:
         dp_resources = filter_docs_by_component(docs, "dataplane")
         assert len(dp_resources) == 0
 
+        cp_components = PLANE_COMPONENT_MAP["controlplane"]
+        component_names = [get_component_name(doc) for doc in docs]
+
+        for component in cp_components:
+            assert component in component_names, f"CP component '{component}' not found when only CP is enabled"
+
     def test_astronomer_dp_only(self, kube_version):
         """Test that helm renders the correct templates when only the dataplane is enabled."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}},
@@ -61,8 +65,15 @@ class TestAstronomerCpDpFeature:
         dp_resources = filter_docs_by_component(docs, "dataplane")
         assert len(dp_resources) > 0
 
+        dp_components = PLANE_COMPONENT_MAP["dataplane"]
+        component_names = [get_component_name(doc) for doc in docs]
+
+        for component in dp_components:
+            assert component in component_names, f"DP component '{component}' not found when only DP is enabled"
+
     def test_astronomer_both_cp_dp_enabled(self, kube_version):
-        """Test when both CP and DP features are enabled."""
+        """Test when both Controlplane and Dataplane features are enabled."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -75,6 +86,7 @@ class TestAstronomerCpDpFeature:
 
     def test_astronomer_both_cp_dp_disabled(self, kube_version):
         """Test when both CP and DP features are disabled."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}},
@@ -87,6 +99,7 @@ class TestAstronomerCpDpFeature:
 
     def test_components_have_correct_plane_labels(self, kube_version):
         """Test that all components have the correct plane labels according to the component map."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -97,18 +110,24 @@ class TestAstronomerCpDpFeature:
             component_name = get_component_name(chart)
             chart_identifier = create_doc_identifier(chart)
 
-            if component_name not in COMPONENT_PLANE_MAP:
-                continue
-            expected_plane = COMPONENT_PLANE_MAP[component_name]
+            found_in_plane = False
             actual_plane = chart.get("metadata", {}).get("labels", {}).get("plane")
 
-            assert actual_plane == expected_plane, (
-                f"Component '{component_name}' ({chart_identifier}) has incorrect plane label. "
-                f"Expected: '{expected_plane}', Actual: '{actual_plane}'"
-            )
+            for plane, components in PLANE_COMPONENT_MAP.items():
+                if component_name in components:
+                    if plane == actual_plane:
+                        found_in_plane = True
+                        break
+
+            if any(component_name in components for plane, components in PLANE_COMPONENT_MAP.items()):
+                assert found_in_plane, (
+                    f"Component '{component_name}' ({chart_identifier}) has plane label '{actual_plane}' "
+                    f"but is not listed in that plane in PLANE_COMPONENT_MAP"
+                )
 
     def test_no_components_with_incorrect_plane_labels(self, kube_version):
         """Test that there are no components with plane labels that don't match the component map."""
+        
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
@@ -130,9 +149,69 @@ class TestAstronomerCpDpFeature:
             actual_plane = resource.get("metadata", {}).get("labels", {}).get("plane")
             chart_identifier = create_doc_identifier(resource)
 
-            if component in COMPONENT_PLANE_MAP:
-                expected_plane = COMPONENT_PLANE_MAP[component]
-                assert actual_plane == expected_plane, (
-                    f"Resource {chart_identifier} (component: {component}) has incorrect plane label. "
-                    f"Expected: '{expected_plane}', Got: '{actual_plane}'"
-                )
+            if not any(component in components for components in PLANE_COMPONENT_MAP.values()):
+                continue
+
+            assert component in PLANE_COMPONENT_MAP.get(actual_plane, []), (
+                f"Resource {chart_identifier} (component: {component}) has plane label '{actual_plane}' "
+                f"but is not listed in that plane in PLANE_COMPONENT_MAP"
+            )
+
+    def test_multi_plane_components_behavior(self, kube_version):
+        """Test that components appear in the correct planes based on which features are enabled."""
+
+        multi_plane_components = set()
+        for plane, components in PLANE_COMPONENT_MAP.items():
+            for component in components:
+                for other_plane, other_components in PLANE_COMPONENT_MAP.items():
+                    if plane != other_plane and component in other_components:
+                        multi_plane_components.add(component)
+
+        cp_only_docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}},
+        )
+
+        cp_only_component_names = [get_component_name(doc) for doc in cp_only_docs]
+
+        for component in PLANE_COMPONENT_MAP["controlplane"]:
+            assert component in cp_only_component_names, f"CP component '{component}' not found when only CP is enabled"
+
+        dp_only_components = [
+            component for component in PLANE_COMPONENT_MAP["dataplane"] 
+            if component not in PLANE_COMPONENT_MAP["controlplane"]
+        ]
+        for component in dp_only_components:
+            assert component not in cp_only_component_names, f"DP-only component '{component}' found when only CP is enabled"
+
+        dp_only_docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}},
+        )
+
+        dp_only_component_names = [get_component_name(doc) for doc in dp_only_docs]
+
+        for component in PLANE_COMPONENT_MAP["dataplane"]:
+            assert component in dp_only_component_names, f"DP component '{component}' not found when only DP is enabled"
+        cp_only_components = [
+            component for component in PLANE_COMPONENT_MAP["controlplane"] 
+            if component not in PLANE_COMPONENT_MAP["dataplane"]
+        ]
+        for component in cp_only_components:
+            assert component not in dp_only_component_names, f"CP-only component '{component}' found when only DP is enabled"
+        both_enabled_docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
+        )
+        for component in multi_plane_components:
+            planes_with_component = [
+                plane for plane, components in PLANE_COMPONENT_MAP.items()
+                if component in components
+            ]
+            occurrences = sum(1 for doc in both_enabled_docs if get_component_name(doc) == component)
+
+            expected_count = len(planes_with_component)
+            assert occurrences == expected_count, (
+                f"Component '{component}' should appear {expected_count} times "
+                f"(once per plane) but appears {occurrences} times"
+            )

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -21,8 +21,8 @@ def get_component_name(doc):
     """Extract component name from chart metadata."""
     return doc.get("metadata", {}).get("labels", {}).get("component")
 
-def get_chart_identifier(doc):
-    """Get a readable identifier for a chart for error messages."""
+def create_doc_identifier(doc):
+    """Create a unique identifier for a k8s doc."""
     kind = doc.get("kind", "Unknown")
     name = doc.get("metadata", {}).get("name", "unnamed")
     namespace = doc.get("metadata", {}).get("namespace", "default")


### PR DESCRIPTION
## Description

This PR enhances our testing to verify that all Helm chart components are correctly labeled with their appropriate plane. It introduces a component-to-plane mapping and additional test methods to validate label consistency.

## Related Issues

- Related astronomer/issues#7134
- Related astronomer/issues#7135

## Changes
- Added a centralized `COMPONENT_PLANE_MAP` dictionary that defines which components belong to which plane
- Added helper methods to extract component information from charts
- Added two new test methods:
  - `test_components_have_correct_plane_labels`: Verifies known components have correct plane labels
  - `test_no_components_with_incorrect_plane_labels`: Ensures no resources have mismatched component/plane labels

## Motivation

We need to ensure that our Helm charts consistently apply the correct plane labels to all components, Incorrect plane labels could lead to:

- Components being deployed when they shouldn't be
- Components being omitted when they should be deployed
- Issues with selective deployment of control plane vs. data plane features


## Testing
- This PR is itself a test enhancement, so it directly improves our test coverage. The tests have been run against our current Helm charts to verify correctness.
- The test suite continues to run with our existing parameterized Kubernetes version tests, ensuring compatibility across supported K8s versions.

## Merging

1.0.0
