### PR TITLE
ap-db-bootstrapper:0.37.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.37.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21
-                - quay.io/astronomer/ap-db-bootstrapper:0.37.2
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.3
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
@@ -441,7 +441,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:0.37.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21
-                - quay.io/astronomer/ap-db-bootstrapper:0.37.2
+                - quay.io/astronomer/ap-db-bootstrapper:0.37.3
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.2
+    tag: 0.37.3
     pullPolicy: IfNotPresent
 
 

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -15,7 +15,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.2
+    tag: 0.37.3
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -14,7 +14,7 @@ images:
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper
-    tag: 0.37.2
+    tag: 0.37.3
     pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

Better error handling in db-bootstrapper with quay.io/astronomer/ap-db-bootstrapper:0.37.3

## Related Issues

https://github.com/astronomer/issues/issues/7166

## Testing

No special testing needed.

## Merging

Merge everywhere.