### PR TITLE
update ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,39 +386,39 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
-                - quay.io/astronomer/ap-alertmanager:0.28.0-1
+                - quay.io/astronomer/ap-alertmanager:0.28.1
                 - quay.io/astronomer/ap-astro-ui:0.37.10
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-15
-                - quay.io/astronomer/ap-base:3.21.3-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-7
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-16
+                - quay.io/astronomer/ap-base:3.21.3-3
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-8
                 - quay.io/astronomer/ap-commander:0.37.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.21
+                - quay.io/astronomer/ap-curator:8.0.21-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.3
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-git-daemon:3.21.3-2
+                - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
-                - quay.io/astronomer/ap-git-sync:4.2.4
+                - quay.io/astronomer/ap-git-sync:4.2.4-1
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.17
-                - quay.io/astronomer/ap-init:3.21.3-2
+                - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
-                - quay.io/astronomer/ap-nats-exporter:0.16.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.19
+                - quay.io/astronomer/ap-nats-exporter:0.16.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.19-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1
+                - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
@@ -432,39 +432,39 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
-                - quay.io/astronomer/ap-alertmanager:0.28.0-1
+                - quay.io/astronomer/ap-alertmanager:0.28.1
                 - quay.io/astronomer/ap-astro-ui:0.37.10
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-15
-                - quay.io/astronomer/ap-base:3.21.3-2
-                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-7
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-16
+                - quay.io/astronomer/ap-base:3.21.3-3
+                - quay.io/astronomer/ap-blackbox-exporter:0.25.0-8
                 - quay.io/astronomer/ap-commander:0.37.9
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.21
+                - quay.io/astronomer/ap-curator:8.0.21-1
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.3
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
                 - quay.io/astronomer/ap-elasticsearch:8.15.5
                 - quay.io/astronomer/ap-fluentd:1.17.1
-                - quay.io/astronomer/ap-git-daemon:3.21.3-2
+                - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
-                - quay.io/astronomer/ap-git-sync:4.2.4
+                - quay.io/astronomer/ap-git-sync:4.2.4-1
                 - quay.io/astronomer/ap-grafana:10.4.17
                 - quay.io/astronomer/ap-houston-api:0.37.17
-                - quay.io/astronomer/ap-init:3.21.3-2
+                - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
-                - quay.io/astronomer/ap-nats-exporter:0.16.0-1
-                - quay.io/astronomer/ap-nats-server:2.10.19
+                - quay.io/astronomer/ap-nats-exporter:0.16.0-2
+                - quay.io/astronomer/ap-nats-server:2.10.19-1
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-10
                 - quay.io/astronomer/ap-nginx-es:1.27.4-3
                 - quay.io/astronomer/ap-nginx:1.11.5
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-4
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-19
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
+                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
                 - quay.io/astronomer/ap-pgbouncer:1.24.0-2
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1
+                - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.28.0-1
+    tag: 0.28.1
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,11 +14,11 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.21.3-2
+    tag: 3.21.3-3
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.21
+    tag: 8.0.21-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-15
+    tag: 1.5.0-16
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.21.3-2
+    tag: 3.21.3-3
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.10.19
+    tag: 2.10.19-1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.16.0-1
+    tag: 0.16.0-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -3,7 +3,7 @@
 #############################
 image:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-19
+  tag: 1.17.0-20
   pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.25.0-7
+  tag: 0.25.0-8
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.17.1
+  tag: 0.17.1-1
   pullPolicy: IfNotPresent
 
 

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -4,7 +4,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.21.3-2
+    tag: 3.21.3-3
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming
@@ -12,7 +12,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.16.0-1
+    tag: 0.16.0-2
     pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ global:
     containerdTolerations: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.21.3-2
+      tag: 3.21.3-3
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform
@@ -317,10 +317,10 @@ global:
         tag: 1.24.0-2
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.19.0
+        tag: 0.19.0-1
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.4
+        tag: 4.2.4-1
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2
@@ -328,7 +328,7 @@ global:
     images:
       gitDaemon:
         repository: quay.io/astronomer/ap-git-daemon
-        tag: 3.21.3-2
+        tag: 3.21.3-3
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
         tag: 0.1.11


### PR DESCRIPTION
## Description
Image Name |  old  Tag| New tag |
-- | -- | -- |
ap-blackbox-exporter | 0.25.0-7 | 0.25.0-8
ap-registry| 3.0.0 | 3.0.0-1
ap-postgres-exporter| 0.17.1 | 0.17.1-1
ap-nats-streaming| 0.25.6-10 | 0.25.6-11
ap-nats-server| 2.10.19 | 2.10.19-1
ap-nats-exporter| 0.16.0-1 | 0.16.0-2
ap-init | 3.21.3-2 | 3.21.3-3
ap-curator | 8.0.21 | 8.0.21-1
ap-awsesproxy| 1.5.0-15 | 1.5.0-16
git-daemon  | 3.21.3-2 | 3.21.3-3
git-sync-relay | 0.0.3-11 | 0.0.3-12
git-sync | 4.4.0 | 4.4.0-1
ap-pgbouncer-exporter | 0.19.0 | 0.19.0-1
ap-pgbouncer-krb |1.17.0-19 | 1.17.0-20
ap-base | 3.21.3-2 | 3.21.3-3
certCopier | 3.21.3-2 | 3.21.3-3
ap-alertmanager | 0.28.0-1 | 0.28.1

## Related Issues

https://github.com/astronomer/issues/issues/7214
https://github.com/astronomer/issues/issues/7212
https://github.com/astronomer/issues/issues/7215
https://github.com/astronomer/issues/issues/7216

## Testing

General QA 

## Merging

cherry-picked into release-0.37 and release-0.36 
