### PR TITLE
 updating ap-vendor packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,14 +417,14 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.27.1-5
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
-                - quay.io/astronomer/ap-pgbouncer:1.24.0-2
+                - quay.io/astronomer/ap-pgbouncer:1.24.1
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.45.0-2
+                - quay.io/astronomer/ap-vector:0.46.1
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -463,14 +463,14 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.27.1-5
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
-                - quay.io/astronomer/ap-pgbouncer:1.24.0-2
+                - quay.io/astronomer/ap-pgbouncer:1.24.1
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.2-1
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.45.0-2
+                - quay.io/astronomer/ap-vector:0.46.1
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -158,7 +158,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.45.0-2
+    tag: 0.46.1
     customConfig: false
     indexPattern: ~
     extraEnv: []
@@ -314,7 +314,7 @@ global:
         tag: 7.4.2-1
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
-        tag: 1.24.0-2
+        tag: 1.24.1
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
         tag: 0.19.0-1


### PR DESCRIPTION
## Description

## Description
Image Name |  old  Tag| New tag |
-- | -- | -- |
ap-pgbouncer | 1.24.0-1 |  1.24.1
ap-vector |  0.45.0-2  |  0.46.1

## Related Issues

https://github.com/astronomer/issues/issues/7217
https://github.com/astronomer/issues/issues/7215

## Testing

Tested and validated the metrics and logs with vector 

## Merging

cherry-pick into release-0.37 and release-0.36
