### PR TITLE
Fix stan to include ControlPlane

### DIFF
--- a/charts/stan/templates/configmap.yaml
+++ b/charts/stan/templates/configmap.yaml
@@ -1,7 +1,7 @@
 ####################
 ## STAN ConfigMap ##
 ####################
-{{- if not .Values.global.nats.jetStream.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/stan/templates/configmap.yaml
+++ b/charts/stan/templates/configmap.yaml
@@ -1,7 +1,7 @@
 ####################
 ## STAN ConfigMap ##
 ####################
-{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.controlplane.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/stan/templates/initdb.yaml
+++ b/charts/stan/templates/initdb.yaml
@@ -3,7 +3,7 @@
 #################
 {{- if not .Values.global.nats.jetStream.enabled }}
 {{- if eq .Values.store.type "sql" }}
-{{- if .Values.store.sql.initdb.enabled }}
+{{- if and .Values.store.sql.initdb.enabled .Values.global.dataplane.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/stan/templates/initdb.yaml
+++ b/charts/stan/templates/initdb.yaml
@@ -3,7 +3,7 @@
 #################
 {{- if not .Values.global.nats.jetStream.enabled }}
 {{- if eq .Values.store.type "sql" }}
-{{- if and .Values.store.sql.initdb.enabled .Values.global.dataplane.enabled }}
+{{- if and .Values.store.sql.initdb.enabled .Values.global.controlplane.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/stan/templates/natsservicerole.yaml
+++ b/charts/stan/templates/natsservicerole.yaml
@@ -2,7 +2,7 @@
 ## STAN Service Role ##
 #######################
 {{- if not .Values.global.nats.jetStream.enabled }}
-{{- if .Values.stan.nats.serviceRoleAuth.enabled }}
+{{- if and .Values.stan.nats.serviceRoleAuth.enabled .Values.global.dataplane.enabled }}
 apiVersion: nats.io/v1alpha2
 kind: NatsServiceRole
 metadata:

--- a/charts/stan/templates/natsservicerole.yaml
+++ b/charts/stan/templates/natsservicerole.yaml
@@ -2,7 +2,7 @@
 ## STAN Service Role ##
 #######################
 {{- if not .Values.global.nats.jetStream.enabled }}
-{{- if and .Values.stan.nats.serviceRoleAuth.enabled .Values.global.dataplane.enabled }}
+{{- if and .Values.stan.nats.serviceRoleAuth.enabled .Values.global.controlplane.enabled }}
 apiVersion: nats.io/v1alpha2
 kind: NatsServiceRole
 metadata:

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -2,7 +2,7 @@
 ## STAN Pod Disruption Budget ##
 ################################
 {{- if not .Values.global.nats.jetStream.enabled }}
-{{- if and .Values.global.podDisruptionBudgetsEnabled .Values.global.dataplane.enabled }}
+{{- if and .Values.global.podDisruptionBudgetsEnabled .Values.global.controlplane.enabled }}
 apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/stan/templates/pod-disruption-budget.yaml
+++ b/charts/stan/templates/pod-disruption-budget.yaml
@@ -2,7 +2,7 @@
 ## STAN Pod Disruption Budget ##
 ################################
 {{- if not .Values.global.nats.jetStream.enabled }}
-{{- if .Values.global.podDisruptionBudgetsEnabled }}
+{{- if and .Values.global.podDisruptionBudgetsEnabled .Values.global.dataplane.enabled }}
 apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/stan/templates/service.yaml
+++ b/charts/stan/templates/service.yaml
@@ -1,7 +1,7 @@
 ##################
 ## STAN Service ##
 ##################
-{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled  }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.controlplane.enabled  }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/stan/templates/service.yaml
+++ b/charts/stan/templates/service.yaml
@@ -1,7 +1,7 @@
 ##################
 ## STAN Service ##
 ##################
-{{- if not .Values.global.nats.jetStream.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled  }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/stan/templates/stan-networkpolicy.yaml
+++ b/charts/stan/templates/stan-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##########################
 ## Stan NetworkPolicy   ##
 ##########################
-{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled}}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.controlplane.enabled}}
 {{- if .Values.global.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/stan/templates/stan-networkpolicy.yaml
+++ b/charts/stan/templates/stan-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ##########################
 ## Stan NetworkPolicy   ##
 ##########################
-{{- if not .Values.global.nats.jetStream.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled}}
 {{- if .Values.global.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##########################
 ## Stan  ServiceAccount ##
 ##########################
-{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) }}
+{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) .Values.global.dataplane.enabled}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/stan/templates/stan-serviceaccount.yaml
+++ b/charts/stan/templates/stan-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##########################
 ## Stan  ServiceAccount ##
 ##########################
-{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) .Values.global.dataplane.enabled}}
+{{- if and .Values.stan.serviceAccount.create .Values.global.rbacEnabled (not .Values.global.nats.jetStream.enabled ) .Values.global.controlplane.enabled}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 ######################
 ## STAN Statefulset ##
 ######################
-{{- if not .Values.global.nats.jetStream.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -1,7 +1,7 @@
 ######################
 ## STAN Statefulset ##
 ######################
-{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.dataplane.enabled }}
+{{- if and (not .Values.global.nats.jetStream.enabled) .Values.global.controlplane.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -196,6 +196,21 @@ class TestNatsJetstream:
 
         assert len(docs) == 0
 
+    def test_jetstream_job_disable_dataplane_flag(self, kube_version):
+        """Test that jetstream job is disabled when dataplane is disabled."""
+        values = {
+            "global": {"controlplane": {"enabled": False}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[
+                "charts/nats/templates/jetstream-job.yaml",
+            ],
+        )
+
+        assert len(docs) == 0
+
 
 @pytest.mark.parametrize(
     "scc_enabled,create_jetstream_job,jetstream_enabled,global_jetstream_enabled,stan_enabled,expected_docs",

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -244,3 +244,16 @@ class TestNatsStatefulSet:
         assert len(docs) == 1
         doc = docs[0]
         assert "sampleannotation" in doc["spec"]["template"]["metadata"]["annotations"]["app.test.io"]
+
+    def test_nats_disable_with_dataplane_flag(self, kube_version):
+        """Test that nats statefulset is not rendered when dataplane is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "charts/nats/templates/jetstream-job-scc.yaml",
+                "charts/nats/templates/statefulset.yaml",
+            ],
+            values={ "global": {"controlplane": {"enabled": False}},
+            },
+        )
+        assert len(docs) == 0


### PR DESCRIPTION
## Description

This PR includes Control Plane flag for he STAN and Nats resources. 

## Related Issues

Related astronomer/issues#7134

## Changes

- Added .Values.global.controlplane.enabled check to all conditional STAN/NATS template renderings
- Added test cases to verify JetStream job and NATS charts are disabled when controlplane is disabled

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

- Unit tests pass, confirming correct rendering of templates based on flag combinations
- Verified locally that resources are only created when both controlplane and NATS flags are enabled
![Screenshot 2025-04-26 at 1 18 22 AM](https://github.com/user-attachments/assets/9ef383d2-fec3-4c65-91f0-f82a2d36660f)

