### PR TITLE
add commander metadata ingress for dataplane

### DIFF
--- a/charts/astronomer/templates/commander/commander-grpc.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc.yaml
@@ -1,6 +1,6 @@
-#####################
-## Houston Ingress ##
-#####################
+############################
+## Commander GRPC Ingress ##
+############################
 {{- if and .Values.global.dataplane.baseDomain .Values.global.dataplane.enabled }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}

--- a/charts/astronomer/templates/commander/commander-grpc.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc.yaml
@@ -5,9 +5,9 @@
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
-  name: {{ .Release.Name }}-commander-grpc-ingress
+  name: {{ .Release.Name }}-commander-api-ingress
   labels:
-    component: grpc-ingress
+    component: api-ingress
     tier: astronomer
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -45,7 +45,7 @@ spec:
   {{- end }}
   {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
   rules:
-  - host: commandergrpc.{{ .Values.global.dataplane.baseDomain }}
+  - host: commanderapi.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
         - path: /
@@ -54,7 +54,7 @@ spec:
             servicePort: commander-grpc
   {{ else -}}
   rules:
-  - host: commandergrpc.{{ .Values.global.dataplane.baseDomain }}
+  - host: commanderapi.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
         - path: /

--- a/charts/astronomer/templates/commander/commander-grpc.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc.yaml
@@ -5,9 +5,9 @@
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
-  name: {{ .Release.Name }}-commander-metadata-ingress
+  name: {{ .Release.Name }}-commander-grpc-ingress
   labels:
-    component: metadata-ingress
+    component: grpc-ingress
     tier: astronomer
     release: {{ .Release.Name }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -20,6 +20,8 @@ metadata:
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+    nginx.ingress.kubernetes.io/enable-http2: "true"
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
@@ -43,24 +45,24 @@ spec:
   {{- end }}
   {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
   rules:
-  - host: houston.{{ .Values.global.baseDomain }}
+  - host: commandergrpc.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
         - path: /
           backend:
             serviceName: {{ .Release.Name }}-commander
-            servicePort: commander-http
+            servicePort: commander-grpc
   {{ else -}}
   rules:
-  - host: {{ .Values.global.dataplane.baseDomain }}
+  - host: commandergrpc.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
-        - path: /metadata
+        - path: /
           pathType: Prefix
           backend:
             service:
               name: {{ .Release.Name }}-commander
               port:
-                name: commander-http
+                name: commander-grpc
   {{- end -}}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-grpc.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc.yaml
@@ -41,11 +41,11 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
   {{- end }}
       hosts:
-        - houston.{{ .Values.global.baseDomain }}
+        - commander.{{ .Values.global.baseDomain }}
   {{- end }}
   {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
   rules:
-  - host: commanderapi.{{ .Values.global.dataplane.baseDomain }}
+  - host: commander.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
         - path: /
@@ -54,7 +54,7 @@ spec:
             servicePort: commander-grpc
   {{ else -}}
   rules:
-  - host: commanderapi.{{ .Values.global.dataplane.baseDomain }}
+  - host: commander.{{ .Values.global.dataplane.baseDomain }}
     http:
       paths:
         - path: /

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -1,0 +1,66 @@
+#####################
+## Houston Ingress ##
+#####################
+{{- if and .Values.global.dataplane.baseDomain .Values.global.dataplane.enabled }}
+kind: Ingress
+apiVersion: {{ template "apiVersion.Ingress" . }}
+metadata:
+  name: {{ .Release.Name }}-commander-metadata-ingress
+  labels:
+    component: metadata-ingress
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    plane: dataplane
+  annotations:
+    {{- if .Values.global.authSidecar.enabled  }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- else }}
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
+    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- end }}
+
+    {{- if .Values.commander.ingress.annotation  }}
+    {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}
+    {{- end }}
+spec:
+  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  tls:
+  {{- if .Values.global.acme }}
+    - secretName: commander-tls
+  {{- end }}
+  {{- if .Values.global.tlsSecret }}
+    - secretName: {{ .Values.global.tlsSecret }}
+  {{- end }}
+      hosts:
+        - houston.{{ .Values.global.dataplane.baseDomain }}
+  {{- end }}
+  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
+  rules:
+  - host: {{ .Values.global.dataplane.baseDomain }}
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ .Release.Name }}-commander
+            servicePort: commander-http
+  {{ else -}}
+  rules:
+  - host: {{ .Values.global.dataplane.baseDomain }}
+    http:
+      paths:
+        - path: /metadata
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-commander
+              port:
+                name: commander-http
+  {{- end -}}
+{{- end }}

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -1,6 +1,6 @@
-#####################
-## Houston Ingress ##
-#####################
+################################
+## Commander Metadata Ingress ##
+################################
 {{- if and .Values.global.dataplane.baseDomain .Values.global.dataplane.enabled }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -39,7 +39,7 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
   {{- end }}
       hosts:
-        - houston.{{ .Values.global.dataplane.baseDomain }}
+        - {{ .Values.global.dataplane.baseDomain }}
   {{- end }}
   {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
   rules:

--- a/charts/astronomer/templates/commander/ingress.yaml
+++ b/charts/astronomer/templates/commander/ingress.yaml
@@ -1,0 +1,66 @@
+#####################
+## Houston Ingress ##
+#####################
+{{- if and .Values.global.dataplane.baseDomain .Values.global.dataplane.enabled }}
+kind: Ingress
+apiVersion: {{ template "apiVersion.Ingress" . }}
+metadata:
+  name: {{ .Release.Name }}-commander-metadata-ingress
+  labels:
+    component: metadata-ingress
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    plane: dataplane
+  annotations:
+    {{- if .Values.global.authSidecar.enabled  }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- else }}
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
+    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- end }}
+
+    {{- if .Values.commander.ingress.annotation  }}
+    {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}
+    {{- end }}
+spec:
+  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  tls:
+  {{- if .Values.global.acme }}
+    - secretName: houston-tls
+  {{- end }}
+  {{- if .Values.global.tlsSecret }}
+    - secretName: {{ .Values.global.tlsSecret }}
+  {{- end }}
+      hosts:
+        - houston.{{ .Values.global.baseDomain }}
+  {{- end }}
+  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
+  rules:
+  - host: houston.{{ .Values.global.baseDomain }}
+    http:
+      paths:
+        - path: /
+          backend:
+            serviceName: {{ .Release.Name }}-commander
+            servicePort: commander-http
+  {{ else -}}
+  rules:
+  - host: {{ .Values.global.dataplane.baseDomain }}
+    http:
+      paths:
+        - path: /metadata
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-commander
+              port:
+                name: commander-http
+  {{- end -}}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -10,6 +10,7 @@ global:
 
   dataplane:
     enabled: true
+    baseDomain: ~
   controlplane:
     enabled: true
   # List of secrets containing private CA certificates


### PR DESCRIPTION
## Description

This PR adds commander ingress object to support metadata and grpc endpoint over https for cross communication

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#XXXX

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.