### PR TITLE
Refactor Chart Tests to support Nginx Control and Data plane templates

### DIFF
--- a/tests/chart_tests/test_nginx_networkpolicy.py
+++ b/tests/chart_tests/test_nginx_networkpolicy.py
@@ -16,3 +16,37 @@ class TestNginxNetworkPolicy:
             assert doc["kind"] == "NetworkPolicy"
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert doc["spec"]["podSelector"]["matchLabels"]["tier"] == "nginx"
+
+    def test_disabled_networkpolicies(self):
+        """Test that NetworkPolicies can be disabled via global settings."""
+        disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}}
+        docs = render_chart(
+            show_only=[
+                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+            ],
+            values=disabled_values,
+        )
+        assert len(docs) == 1, f"Expected 1 document, got {len(docs)}"
+        assert "release-name-dp-nginx-policy" in docs[0]["metadata"]["name"]
+
+        disabled_values = {"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}}
+        docs = render_chart(
+            show_only=[
+                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+            ],
+            values=disabled_values,
+        )
+        assert len(docs) == 1, f"Expected 1 document, got {len(docs)}"
+        assert "release-name-cp-nginx-policy" in docs[0]["metadata"]["name"]
+
+        disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}}
+        docs = render_chart(
+            show_only=[
+                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+            ],
+            values=disabled_values,
+        )
+        assert len(docs) == 0

--- a/tests/chart_tests/test_nginx_networkpolicy.py
+++ b/tests/chart_tests/test_nginx_networkpolicy.py
@@ -22,8 +22,8 @@ class TestNginxNetworkPolicy:
         disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}}
         docs = render_chart(
             show_only=[
-                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
-                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+                "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/dataplane/nginx-dp-networkpolicy.yaml",
             ],
             values=disabled_values,
         )
@@ -33,8 +33,8 @@ class TestNginxNetworkPolicy:
         disabled_values = {"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}}
         docs = render_chart(
             show_only=[
-                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
-                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+                "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/dataplane/nginx-dp-networkpolicy.yaml",
             ],
             values=disabled_values,
         )
@@ -44,8 +44,8 @@ class TestNginxNetworkPolicy:
         disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}}
         docs = render_chart(
             show_only=[
-                "charts/nginx/templates/nginx-cp/nginx-cp-networkpolicy.yaml",
-                "charts/nginx/templates/nginx-dp/nginx-dp-networkpolicy.yaml",
+                "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",
+                "charts/nginx/templates/dataplane/nginx-dp-networkpolicy.yaml",
             ],
             values=disabled_values,
         )

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -13,14 +13,13 @@ class TestNginx:
         )
 
         assert len(docs) == 2
-
-        doc = docs[0]
-
-        assert doc["kind"] == "Service"
-        assert doc["apiVersion"] == "v1"
-        assert doc["metadata"]["name"] == "release-name-nginx-cp"
-        assert "loadBalancerIP" not in doc["spec"]
-        assert "loadBalancerSourceRanges" not in doc["spec"]
+        expected_names = ["release-name-nginx-cp", "release-name-nginx-dp"]
+        for doc in docs:
+            assert doc["kind"] == "Service"
+            assert doc["apiVersion"] == "v1"
+            assert doc["metadata"]["name"] in  expected_names
+            assert "loadBalancerIP" not in doc["spec"]
+            assert "loadBalancerSourceRanges" not in doc["spec"]
 
     @pytest.mark.parametrize(
         "service_type,external_traffic_policy,preserve_source_ip",
@@ -48,34 +47,35 @@ class TestNginx:
                 "preserveSourceIP": preserve_source_ip,
             }
         }
-        doc = render_chart(
+        docs = render_chart(
             values=values,
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-        assert doc["spec"]["type"] == service_type
-        assert doc["spec"].get("externalTrafficPolicy") == external_traffic_policy
+        )
+        for doc in docs:
+            assert doc["spec"]["type"] == service_type
+            assert doc["spec"].get("externalTrafficPolicy") == external_traffic_policy
 
     def test_nginx_with_ingress_annotations(self):
         """Deployment should contain the given ingress annotations when they
         are specified."""
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"ingressAnnotations": {"foo1": "foo", "foo2": "foo", "foo3": "foo"}}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        expected_annotations = {"foo1": "foo", "foo2": "foo", "foo3": "foo"}
-        assert all(doc["metadata"]["annotations"][x] == y for x, y in expected_annotations.items())
+        )
+        for doc in docs:
+            expected_annotations = {"foo1": "foo", "foo2": "foo", "foo3": "foo"}
+            assert all(doc["metadata"]["annotations"][x] == y for x, y in expected_annotations.items())
 
     def test_nginx_type_loadbalancer(self):
         """Deployment works with type LoadBalancer and some LB
         customizations."""
-        doc = render_chart(
+        docs = render_chart(
             values={
                 "nginx": {
                     "serviceType": "LoadBalancer",
@@ -91,26 +91,26 @@ class TestNginx:
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        assert doc["spec"]["type"] == "LoadBalancer"
-        assert doc["spec"]["loadBalancerIP"] == "5.5.5.5"
-        assert doc["spec"]["loadBalancerSourceRanges"] == [
-            "1.1.1.1/32",
-            "2.2.2.2/32",
-            "3.3.3.3/32",
-        ]
+        )
+        for doc in docs:
+            assert doc["spec"]["type"] == "LoadBalancer"
+            assert doc["spec"]["loadBalancerIP"] == "5.5.5.5"
+            assert doc["spec"]["loadBalancerSourceRanges"] == [
+                "1.1.1.1/32",
+                "2.2.2.2/32",
+                "3.3.3.3/32",
+            ]
 
     def test_nginx_type_clusterip(self):
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"serviceType": "ClusterIP"}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        assert doc["spec"]["type"] == "ClusterIP"
+        )
+        for doc in docs:
+            assert doc["spec"]["type"] == "ClusterIP"
 
     def test_nginx_type_nodeport(self):  # sourcery skip: class-extract-method
         docs = render_chart(
@@ -122,12 +122,12 @@ class TestNginx:
         )
 
         assert len(docs) == 2
-        doc = docs[0]
-        assert doc["spec"]["type"] == "NodePort"
+        for doc in docs:
+            assert doc["spec"]["type"] == "NodePort"
 
     def test_nginx_type_loadbalancer_omits_nodeports(self):
         httpNodePort, httpsNodePort, metricsNodePort = [30401, 30402, 30403]
-        doc = render_chart(
+        docs = render_chart(
             values={
                 "nginx": {
                     "serviceType": "LoadBalancer",
@@ -140,13 +140,13 @@ class TestNginx:
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        ports = doc["spec"]["ports"]
-        assert not [x for x in ports if "nodePort" in x]
+        )
+        for doc in docs:
+            ports = doc["spec"]["ports"]
+            assert not [x for x in ports if "nodePort" in x]
 
     def test_nginx_type_nodeport_doesnt_require_nodeports(self):
-        doc = render_chart(
+        docs = render_chart(
             values={
                 "nginx": {
                     "serviceType": "NodePort",
@@ -157,13 +157,13 @@ class TestNginx:
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        assert doc["spec"]["type"] == "NodePort"
+        )
+        for doc in docs:
+            assert doc["spec"]["type"] == "NodePort"
 
     def test_nginx_type_nodeport_specifying_nodeports(self):
         httpNodePort, httpsNodePort = [30401, 30402]
-        doc = render_chart(
+        docs = render_chart(
             values={
                 "nginx": {
                     "serviceType": "NodePort",
@@ -175,90 +175,95 @@ class TestNginx:
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        ports = doc["spec"]["ports"]
-        ports_by_name = {x["name"]: x["nodePort"] for x in ports}
-        assert ports_by_name["http"] == httpNodePort
-        assert ports_by_name["https"] == httpsNodePort
+        )
+        for doc in docs:
+            ports = doc["spec"]["ports"]
+            ports_by_name = {x["name"]: x["nodePort"] for x in ports}
+            assert ports_by_name["http"] == httpNodePort
+            assert ports_by_name["https"] == httpsNodePort
 
     def test_nginx_enabled_externalips(self):
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"externalIPs": "1.2.3.4"}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-
-        assert len(doc["spec"]["externalIPs"]) > 0
-        assert "1.2.3.4" in doc["spec"]["externalIPs"]
+        )
+        for doc in docs:
+            assert len(doc["spec"]["externalIPs"]) > 0
+            assert "1.2.3.4" in doc["spec"]["externalIPs"]
 
     def test_nginx_metrics_service_type(self):
-        doc = render_chart(
+        docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-metrics-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-metrics-service.yaml",
             ],
-        )[0]
-        assert doc["spec"]["type"] == "ClusterIP"
-        assert doc["spec"]["ports"][0]["port"] == 10254
+        )
+        for doc in docs:
+            assert doc["spec"]["type"] == "ClusterIP"
+            assert doc["spec"]["ports"][0]["port"] == 10254
 
     def test_nginx_externalTrafficPolicy_defaults(self):
-        doc = render_chart(
+        docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-        assert "Cluster" == doc["spec"]["externalTrafficPolicy"]
+        )
+        for doc in docs:
+            assert "Cluster" == doc["spec"]["externalTrafficPolicy"]
 
     def test_nginx_externalTrafficPolicy_overrides(self):
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"preserveSourceIP": True}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-service.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-service.yaml",
             ],
-        )[0]
-        assert "Local" == doc["spec"]["externalTrafficPolicy"]
+        )
+        for doc in docs:
+            assert "Local" == doc["spec"]["externalTrafficPolicy"]
 
     def test_nginx_allowSnippetAnnotations_defaults(self):
-        doc = render_chart(
+        docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-configmap.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-configmap.yaml",
             ],
-        )[0]
-        assert doc["data"]["allow-snippet-annotations"] == "true"
+        )
+        for doc in docs:
+            assert doc["data"]["allow-snippet-annotations"] == "true"
 
     def test_nginx_enableAnnotationValidations_overrides(self):
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"enableAnnotationValidations": True}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
+        )
         annotationValidation = "--enable-annotation-validation=true"
-        assert annotationValidation in doc["spec"]["template"]["spec"]["containers"][0]["args"]
+        for doc in docs:
+            assert annotationValidation in doc["spec"]["template"]["spec"]["containers"][0]["args"]
 
     def test_nginx_backend_serviceaccount_defaults(self):
         """Test nginx ingress deployment service account defaults."""
-        doc = render_chart(
+        docs = render_chart(
             show_only=["charts/nginx/templates/nginx-default-backend-serviceaccount.yaml"],
-        )[0]
-
-        assert "release-name-nginx-default-backend" == doc["metadata"]["name"]
+        )
+        for doc in docs:
+            assert "release-name-nginx-default-backend" == doc["metadata"]["name"]
 
     def test_nginx_defaults(self):
         """Test nginx ingress deployment template defaults."""
-        doc = render_chart(
+        docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
+        )
         expected_security_context = {
             "runAsUser": 101,
             "runAsNonRoot": True,
@@ -272,66 +277,70 @@ class TestNginx:
         annotationValidation = "--enable-annotation-validation"
         disableLeaderElection = "--disable-leader-election"
 
-        c_by_name = get_containers_by_name(doc)
-        assert doc["spec"]["minReadySeconds"] == 0
-        assert electionId in c_by_name["nginx"]["args"]
-        assert electionTTL not in c_by_name["nginx"]["args"]
-        assert topologyAwareRouting not in c_by_name["nginx"]["args"]
-        assert annotationValidation not in c_by_name["nginx"]["args"]
-        assert disableLeaderElection not in c_by_name["nginx"]["args"]
-        assert expected_security_context == c_by_name["nginx"]["securityContext"]
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc)
+            assert doc["spec"]["minReadySeconds"] == 0
+            assert electionId in c_by_name["nginx"]["args"]
+            assert electionTTL not in c_by_name["nginx"]["args"]
+            assert topologyAwareRouting not in c_by_name["nginx"]["args"]
+            assert annotationValidation not in c_by_name["nginx"]["args"]
+            assert disableLeaderElection not in c_by_name["nginx"]["args"]
+            assert expected_security_context == c_by_name["nginx"]["securityContext"]
 
     def test_nginx_min_ready_seconds_overrides(self):
         """Test nginx ingress deployment template with min ready seconds overrides."""
         minReadySeconds = 300
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"minReadySeconds": minReadySeconds}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
-
-        assert doc["spec"]["minReadySeconds"] == minReadySeconds
+        )
+        for doc in docs:
+            assert doc["spec"]["minReadySeconds"] == minReadySeconds
 
     def test_nginx_election_ttl_overrides(self):
         """Test nginx ingress deployment template with election ttl overrides."""
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"electionTTL": "30s"}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
+        )
         electionTTL = "--election-ttl=30s"
-        c_by_name = get_containers_by_name(doc)
-        assert electionTTL in c_by_name["nginx"]["args"]
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc)
+            assert electionTTL in c_by_name["nginx"]["args"]
 
     def test_nginx_topology_aware_routing_overrides(self):
         """Test nginx ingress deployment template with topology aware routing overrides."""
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"enableTopologyAwareRouting": True}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
+        )
         topologyAwareRouting = "--enable-topology-aware-routing=true"
-        c_by_name = get_containers_by_name(doc)
-        assert topologyAwareRouting in c_by_name["nginx"]["args"]
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc)
+            assert topologyAwareRouting in c_by_name["nginx"]["args"]
 
     def test_nginx_disable_leader_election_overrides(self):
         """Test nginx ingress deployment template with leader election overrides."""
-        doc = render_chart(
+        docs = render_chart(
             values={"nginx": {"disableLeaderElection": True}},
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
-        c_by_name = get_containers_by_name(doc)
+        )
         disableLeaderElection = "--disable-leader-election=true"
-        assert disableLeaderElection in c_by_name["nginx"]["args"]
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc)
+            assert disableLeaderElection in c_by_name["nginx"]["args"]
 
     def test_nginx_security_context_overrides(self):
         """Test nginx ingress deployment template with security context overrides."""
@@ -350,22 +359,22 @@ class TestNginx:
             }
         }
 
-        doc = render_chart(
+        docs = render_chart(
             values=values,
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
                 "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",
             ],
-        )[0]
+        )
         expected_security_context = {
             "runAsUser": 101,
             "runAsNonRoot": True,
             "capabilities": {"drop": ["ALL"], "add": ["NET_BIND_SERVICE"]},
             "allowPrivilegeEscalation": False,
         }
-
-        c_by_name = get_containers_by_name(doc)
-        assert expected_security_context == c_by_name["nginx"]["securityContext"]
+        for doc in docs:
+            c_by_name = get_containers_by_name(doc)
+            assert expected_security_context == c_by_name["nginx"]["securityContext"]
 
     def test_nginx_backend_overrides(self):
         """Test nginx default backend disabled."""

--- a/tests/chart_tests/test_nginx_service.py
+++ b/tests/chart_tests/test_nginx_service.py
@@ -17,7 +17,7 @@ class TestNginx:
         for doc in docs:
             assert doc["kind"] == "Service"
             assert doc["apiVersion"] == "v1"
-            assert doc["metadata"]["name"] in  expected_names
+            assert doc["metadata"]["name"] in expected_names
             assert "loadBalancerIP" not in doc["spec"]
             assert "loadBalancerSourceRanges" not in doc["spec"]
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -25,7 +25,7 @@ def nginx(core_v1_client):
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    pod = get_pod_by_label_selector(core_v1_client, "component=cp-ingress-controller")
+    pod = get_pod_by_label_selector(core_v1_client, "component=dp-ingress-controller")
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace={namespace}")
 
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -25,7 +25,7 @@ def nginx(core_v1_client):
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    pod = get_pod_by_label_selector(core_v1_client, "component=ingress-cp-controller")
+    pod = get_pod_by_label_selector(core_v1_client, "component=cp-ingress-controller")
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace={namespace}")
 
 

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -25,7 +25,7 @@ def nginx(core_v1_client):
     https://testinfra.readthedocs.io/en/latest/examples.html#test-docker-images
     """
 
-    pod = get_pod_by_label_selector(core_v1_client, "component=ingress-controller")
+    pod = get_pod_by_label_selector(core_v1_client, "component=ingress-cp-controller")
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace={namespace}")
 
 


### PR DESCRIPTION
## Description

This PR refactors the chart tests to support iterating through multiple documents returned by `render_chart()`. The main change is converting single document testing pattern to a loop-based approach where we iterate through all returned documents and perform the same validation on each controlplane and dataplane template.

## Key Changes
- Changed individual `doc` variable to `docs` (plural) across all test files
- Maintained all existing assertions but applied them to each document in the CP-DP template.
- Added specific test for disabled network policies in `test_nginx_networkpolicy.py`
- Standardized naming convention for chart test variables

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#7148

## Testing

- All existing tests pass with the new implementation
- Verified the new test_disabled_networkpolicies test functions correctly

## Merging

1.0