### PR TITLE
updating ap-gitsync

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,7 +403,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
-                - quay.io/astronomer/ap-git-sync:4.2.4-1
+                - quay.io/astronomer/ap-git-sync:4.4.0-1
                 - quay.io/astronomer/ap-houston-api:0.37.17
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5
@@ -448,7 +448,7 @@ workflows:
                 - quay.io/astronomer/ap-fluentd:1.17.1
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
-                - quay.io/astronomer/ap-git-sync:4.2.4-1
+                - quay.io/astronomer/ap-git-sync:4.4.0-1
                 - quay.io/astronomer/ap-houston-api:0.37.17
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5

--- a/values.yaml
+++ b/values.yaml
@@ -312,7 +312,7 @@ global:
         tag: 0.19.0-1
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.2.4-1
+        tag: 4.4.0-1
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2


### PR DESCRIPTION
## Description

updated ap-gitsync from 4.2.4-1 to 4.4.0-1

## Related Issues

https://github.com/astronomer/issues/issues/7215

## Testing

gitsync deployments should work as expected

## Merging

cherry-picked into all branches 
