### PR TITLE
update houston api and ui images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.1
-                - quay.io/astronomer/ap-astro-ui:0.37.10
+                - quay.io/astronomer/ap-astro-ui:0.37.11
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-16
                 - quay.io/astronomer/ap-base:3.21.3-3
@@ -404,7 +404,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
-                - quay.io/astronomer/ap-houston-api:0.37.17
+                - quay.io/astronomer/ap-houston-api:0.37.19
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0
@@ -433,7 +433,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.1
-                - quay.io/astronomer/ap-astro-ui:0.37.10
+                - quay.io/astronomer/ap-astro-ui:0.37.11
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-16
                 - quay.io/astronomer/ap-base:3.21.3-3
@@ -449,7 +449,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
-                - quay.io/astronomer/ap-houston-api:0.37.17
+                - quay.io/astronomer/ap-houston-api:0.37.19
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.17
+    tag: 0.37.19
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 0.37.10
+    tag: 0.37.11
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

update houston api and ui images
| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-astro-ui | 0.37.10 | 0.37.11 |
| ap-houston-api | 0.37.17 | 0.37.19 |

## Related Issues


- https://github.com/astronomer/issues/issues/7223

## Testing

QA should able to scale the pgbouncer connections by increasing the extraAU and extraCapacity

## Merging

merge to master nad cherry-pick to release-0.37
