### PR TITLE
Add 'Yet to update' to forbidden PR description phrases.

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -30,6 +30,11 @@ jobs:
             ((errors += 1))
           fi
 
+          if [[ "${PR_BODY}" == *"Yet to update"* ]] ; then
+            echo "PR description contains 'Yet to update'"
+            ((errors += 1))
+          fi
+
           if [[ "${KTLO}" != "true" ]] && [[ "${PR_BODY}" != *"astronomer/issues"* ]] ; then
             echo "PR description does not contain an issue link"
             ((errors += 1))


### PR DESCRIPTION
## Description

Avoid PR description checks by adding 'Yet to update' to forbidden PR description phrases.

## Related Issues

N/A, KTLO.

## Testing

Not needed, this is just GH workflow stuff, not product code.

## Merging

This only needs to go in master branch.