### PR TITLE
adding podselector for controlplane and dataplane in nginx-default ingress.

### DIFF
--- a/charts/nginx/templates/nginx-default-backend-networkpolicy.yaml
+++ b/charts/nginx/templates/nginx-default-backend-networkpolicy.yaml
@@ -25,7 +25,12 @@ spec:
     - podSelector:
         matchLabels:
           tier: {{ template "nginx.name" . }}
-          component: ingress-controller
+          component: cp-ingress-controller
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: {{ template "nginx.name" . }}
+          component: dp-ingress-controller
           release: {{ .Release.Name }}
     ports:
     - protocol: TCP


### PR DESCRIPTION
## Description

Fix Network Policy for Nginx Default Backend, This update is necessary to ensure that both the CP and DP Nginx components can communicate properly with the default backend service, which serves as a catch-all for unmatched requests. Without this fix, users may experience errors when accessing undefined routes.

## Motivation

- After splitting the Nginx ingress controller into separate control plane and data plane components, our functional tests were failing specifically at the test_nginx_can_reach_default_backend test. 
- The root cause is that the current network policy only allows access to the default backend from pods with the old label component: ingress-controller 
- Our new architecture uses components: `cp-ingress-controller` and  `dp-ingress-controller`. 

## Related Issues

Related astronomer/issues#7148

## Changes
Update the NetworkPolicy for the Nginx default backend to allow access from our new CP and DP Nginx components:

```
- podSelector:
        matchLabels:
          tier: {{ template "nginx.name" . }}
          component: cp-ingress-controller
          release: {{ .Release.Name }}
- podSelector:
       matchLabels:
         tier: {{ template "nginx.name" . }}
         component: dp-ingress-controller
         release: {{ .Release.Name }}
```

## Testing

- Verified that the network policy configuration allows both CP and DP Nginx pods to reach the default backend

- Confirmed that the test_nginx_can_reach_default_backend test now passes
![Screenshot 2025-05-05 at 6 11 56 PM](https://github.com/user-attachments/assets/779b6af3-48db-4043-a0ec-bd4545cbac08)


## Merging

1.0