### PR TITLE
Remove deprecated kube-state-metrics metrics

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -272,7 +272,7 @@ data:
             sum by (namespace) (
                 sum by (namespace, pod) (
                     max by (namespace, pod, container) (
-                        kube_pod_container_resource_requests_memory_bytes{job="{{.Release.Name}}-kube-state"}
+                        kube_pod_container_resource_requests{job="{{.Release.Name}}-kube-state", resource="memory",unit="byte"}
                     ) * on(namespace, pod) group_left() max by (namespace, pod) (
                         kube_pod_status_phase{phase=~"Pending|Running"} == 1
                     )
@@ -283,7 +283,7 @@ data:
             sum by (namespace) (
                 sum by (namespace, pod) (
                     max by (namespace, pod, container) (
-                        kube_pod_container_resource_requests_cpu_cores{job="{{.Release.Name}}-kube-state"}
+                        kube_pod_container_resource_requests{job="{{.Release.Name}}-kube-state", resource="cpu", unit="core"}
                     ) * on(namespace, pod) group_left() max by (namespace, pod) (
                       kube_pod_status_phase{phase=~"Pending|Running"} == 1
                     )
@@ -848,9 +848,9 @@ data:
           expr: |
             sum(namespace:kube_pod_container_resource_requests_cpu_cores:sum)
               /
-            sum(kube_node_status_allocatable_cpu_cores)
+            sum(kube_node_status_allocatable{resource="cpu", unit="core"})
               >
-            (count(kube_node_status_allocatable_cpu_cores)-1) / count(kube_node_status_allocatable_cpu_cores)
+            (count(kube_node_status_allocatable{resource="cpu", unit="core"})-1) / count(kube_node_status_allocatable{resource="cpu", unit="core"})
           for: 5m
           labels:
             severity: warning
@@ -864,11 +864,11 @@ data:
           expr: |
             sum(namespace:kube_pod_container_resource_requests_memory_bytes:sum)
               /
-            sum(kube_node_status_allocatable_memory_bytes)
+            sum(kube_node_status_allocatable{resource="memory",unit="byte"})
               >
-            (count(kube_node_status_allocatable_memory_bytes)-1)
+            (count(kube_node_status_allocatable{resource="memory",unit="byte"})-1)
               /
-            count(kube_node_status_allocatable_memory_bytes)
+            count(kube_node_status_allocatable{resource="memory",unit="byte"})
           for: 5m
           labels:
             severity: warning
@@ -881,7 +881,7 @@ data:
           expr: |
             sum(kube_resourcequota{job="{{.Release.Name}}-kube-state", type="hard", resource="cpu"})
               /
-            sum(kube_node_status_allocatable_cpu_cores)
+            sum(kube_node_status_allocatable{resource="cpu", unit="core"})
               > 1.5
           for: 5m
           labels:
@@ -895,7 +895,7 @@ data:
           expr: |
             sum(kube_resourcequota{job="{{.Release.Name}}-kube-state", type="hard", resource="memory"})
               /
-            sum(kube_node_status_allocatable_memory_bytes{job="node-exporter"})
+            sum(kube_node_status_allocatable{resource="memory",unit="byte", job="node-exporter"})
               > 1.5
           for: 5m
           labels:
@@ -1053,7 +1053,7 @@ data:
             runbook_url:
             summary: Too many pods on '{{`{{ $labels.node }}`}}'
           expr: |
-            count by(node) ( (kube_pod_status_phase{job="{{.Release.Name}}-kube-state",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="{{.Release.Name}}-kube-state"}) ) / max by(node) ( kube_node_status_capacity_pods{job="{{.Release.Name}}-kube-state"} != 1 ) > 0.95
+            count by(node) ( (kube_pod_status_phase{job="{{.Release.Name}}-kube-state",phase="Running"} == 1) * on(instance,pod,namespace,cluster) group_left(node) topk by(instance,pod,namespace,cluster) (1, kube_pod_info{job="{{.Release.Name}}-kube-state"}) ) / max by(node) ( kube_node_status_capacity{job="{{.Release.Name}}-kube-state", resource="pods",unit="integer"} != 1 ) > 0.95
           for: 15m
           labels:
             severity: warning


### PR DESCRIPTION
## Description

The Prometheus alerts ConfigMap uses several metrics that have been deprecated in kube-state-metrics v2. According to the [kube-state-metrics deprecation documentation](https://github.com/kubernetes/kube-state-metrics/blob/release-1.9/docs/README.md#metrics-deprecation), This PR updates our metrics to use the new format.

## Changes

Updated the Prometheus alerts ConfigMap to replace all instances of deprecated metrics with their newer equivalents:

- kube_pod_container_resource_requests_cpu_cores → kube_pod_container_resource_requests{resource="cpu",unit="core"}
- kube_pod_container_resource_requests_memory_bytes → kube_pod_container_resource_requests{resource="memory",unit="byte"}
- kube_node_status_capacity_pods → kube_node_status_capacity{resource="pods",unit="integer"}
- kube_node_status_allocatable_cpu_cores → kube_node_status_allocatable{resource="cpu",unit="core"}
- kube_node_status_allocatable_memory_bytes → kube_node_status_allocatable{resource="memory",unit="byte"}

## Related Issues

Related astronomer/issues#6193

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

1.0