### PR TITLE
6744 annotation tests and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ repository
 server.key
 temp.sh
 test-*
+test-results/junit.xml
 upgrade_test_config.yaml

--- a/.helmignore
+++ b/.helmignore
@@ -39,3 +39,4 @@
 /values.schema.json.example
 /venv
 __pycache__
+test-results/junit.xml

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -42,15 +42,6 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "alertmanager.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: http
-              {{- end }}
-            {{ else -}}
             pathType: Prefix
             backend:
               service:
@@ -61,5 +52,4 @@ spec:
                   {{- else }}
                   name: http
                   {{- end }}
-            {{- end -}}
 {{- end }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -80,7 +80,6 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
-    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -39,23 +39,6 @@ spec:
       hosts:
         - app.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: app.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  {{ else -}}
   rules:
   - host: app.{{ .Values.global.baseDomain }}
     http:
@@ -67,7 +50,6 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
-  {{- end -}}
 {{- end }}
 ---
 ###############################
@@ -86,7 +68,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     {{- if .Values.global.authSidecar.enabled  }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+      {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
@@ -108,16 +90,6 @@ spec:
       hosts:
         - {{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  {{ else -}}
   rules:
   - host: {{ .Values.global.baseDomain }}
     http:
@@ -129,5 +101,4 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
-{{- end }}
 {{- end }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -70,6 +70,9 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
       {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
@@ -77,6 +80,7 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -30,8 +30,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
 
-    {{- if .Values.houston.ingress.annotation  }}
-    {{- toYaml .Values.houston.ingress.annotation  | nindent 4  }}
+    {{- if .Values.houston.ingress.annotation }}
+    {{- toYaml .Values.houston.ingress.annotation | nindent 4 }}
     {{- end }}
 spec:
   {{- if or .Values.global.tlsSecret .Values.global.acme }}
@@ -45,16 +45,6 @@ spec:
       hosts:
         - houston.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: houston.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-houston
-            servicePort: houston-http
-  {{ else -}}
   rules:
   - host: houston.{{ .Values.global.baseDomain }}
     http:
@@ -66,5 +56,4 @@ spec:
               name: {{ .Release.Name }}-houston
               port:
                 name: houston-http
-  {{- end -}}
 {{- end }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -42,30 +42,6 @@ spec:
         - registry.{{ .Values.global.baseDomain }}
         - install.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: app.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: registry.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-registry
-            servicePort: registry-http
-  {{ else -}}
   rules:
   - host: {{ .Values.global.baseDomain }}
     http:
@@ -97,5 +73,4 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
-  {{- end -}}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -35,16 +35,6 @@ spec:
       hosts:
         - registry.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: registry.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-registry
-            servicePort: registry-http
-  {{ else -}}
   rules:
   - host: registry.{{ .Values.global.baseDomain }}
     http:
@@ -56,5 +46,4 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
-  {{- end -}}
 {{- end }}

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -47,24 +47,14 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "kibana.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: kibana-ui
-              {{- end }}
-            {{- else -}}
             pathType: Prefix
             backend:
               service:
                 name: {{ template "kibana.fullname" . }}
                 port:
-                  {{- if .Values.global.authSidecar.enabled  }}
+                  {{- if .Values.global.authSidecar.enabled }}
                   name: auth-proxy
                   {{- else }}
                   name: kibana-ui
                   {{- end }}
-            {{- end -}}
 {{- end }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -42,24 +42,14 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "prometheus.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: prometheus-data
-              {{- end }}
-            {{- else -}}
             pathType: Prefix
             backend:
               service:
                 name: {{ template "prometheus.fullname" . }}
                 port:
-                  {{- if .Values.global.authSidecar.enabled  }}
+                  {{- if .Values.global.authSidecar.enabled }}
                   name: auth-proxy
                   {{- else }}
                   name: prometheus-data
                   {{- end }}
-            {{- end -}}
 {{- end }}

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -16,7 +16,7 @@ class TestGlobabIngressAnnotation:
             values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
             show_only=sorted([str(x.relative_to(git_root_dir)) for x in Path(git_root_dir).rglob("*ingress*.yaml")]),
         )
-        assert len(docs) == 5
+        assert len(docs) == 6
         for doc in docs:
             assert doc["kind"] == "Ingress"
             assert doc["apiVersion"] == "networking.k8s.io/v1"

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -30,7 +30,14 @@ class TestGlobabIngressAnnotation:
             pytest.param(False, id="disable_per_host_ingress"),
         ],
     )
-    def test_global_ingress_per_host_ingress(self, kube_version, enable_per_host_ingress):
+    @pytest.mark.parametrize(
+        "auth_sidecar_enabled",
+        [
+            pytest.param(True, id="auth_sidecar_enabled"),
+            pytest.param(False, id="auth_sidecar_disabled"),
+        ],
+    )
+    def test_global_ingress_per_host_ingress(self, kube_version, enable_per_host_ingress, auth_sidecar_enabled):
         """Test global ingress annotation for platform ingress."""
         docs = render_chart(
             kube_version=kube_version,
@@ -38,6 +45,7 @@ class TestGlobabIngressAnnotation:
                 "global": {
                     "extraAnnotations": {"kubernetes.io/ingress.allow-http": "false"},
                     "enablePerHostIngress": enable_per_host_ingress,
+                    "authSidecar": {"enabled": auth_sidecar_enabled},
                 },
             },
         )

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -16,9 +16,34 @@ class TestGlobabIngressAnnotation:
             values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
             show_only=sorted([str(x.relative_to(git_root_dir)) for x in Path(git_root_dir).rglob("*ingress*.yaml")]),
         )
-        assert len(docs) == 6
+        assert len(docs) == 5
         for doc in docs:
             assert doc["kind"] == "Ingress"
             assert doc["apiVersion"] == "networking.k8s.io/v1"
             assert "passthrough" in doc["metadata"]["annotations"]["route.openshift.io/termination"]
             assert len(doc["metadata"]["annotations"]) >= 4
+
+    @pytest.mark.parametrize(
+        "enable_per_host_ingress",
+        [
+            pytest.param(True, id="enable_per_host_ingress"),
+            pytest.param(False, id="disable_per_host_ingress"),
+        ],
+    )
+    def test_global_ingress_per_host_ingress(self, kube_version, enable_per_host_ingress):
+        """Test global ingress annotation for platform ingress."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "extraAnnotations": {"kubernetes.io/ingress.allow-http": "false"},
+                    "enablePerHostIngress": enable_per_host_ingress,
+                },
+            },
+        )
+
+        ingresses = [doc for doc in docs if doc["kind"] == "Ingress"]
+
+        for doc in ingresses:
+            assert doc["apiVersion"] == "networking.k8s.io/v1"
+            assert doc["metadata"]["annotations"]["kubernetes.io/ingress.allow-http"] == "false"

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -26,8 +26,8 @@ class TestGlobabIngressAnnotation:
     @pytest.mark.parametrize(
         "enable_per_host_ingress",
         [
-            pytest.param(True, id="enable_per_host_ingress"),
-            pytest.param(False, id="disable_per_host_ingress"),
+            pytest.param(True, id="per_host_ingress_enabled"),
+            pytest.param(False, id="per_host_ingress_disabled"),
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -43,9 +43,9 @@ class TestGlobabIngressAnnotation:
             kube_version=kube_version,
             values={
                 "global": {
-                    "extraAnnotations": {"kubernetes.io/ingress.allow-http": "false"},
-                    "enablePerHostIngress": enable_per_host_ingress,
                     "authSidecar": {"enabled": auth_sidecar_enabled},
+                    "enablePerHostIngress": enable_per_host_ingress,
+                    "extraAnnotations": {"kubernetes.io/ingress.allow-http": "false"},
                 },
             },
         )


### PR DESCRIPTION
## Description

- Add annotation tests to verify that all ingresses support extraAnnotations with per-host ingress and without
- Fix one ingress extraAnnotations
- Remove k8s 1.19 ingress block

## Related Issues

Related astronomer/issues#6744

## Testing

Unit tests are covering all cases here, so no extra testing is needed.

## Merging

This is intended for 0.37, but should work with other release branches.