### PR TITLE
add probes support for cronjob and jobs

### DIFF
--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -61,4 +61,10 @@ spec:
               - "--target-namespaces"
               - "{{ join "," .Values.global.features.namespacePools.namespaces.names }}"
               {{- end }}
+              {{- if .Values.configSyncer.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.configSyncer.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.configSyncer.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.configSyncer.livenessProbe) . | nindent 12 }}
+              {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -62,9 +62,9 @@ spec:
               - "{{ join "," .Values.global.features.namespacePools.namespaces.names }}"
               {{- end }}
               {{- if .Values.configSyncer.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.configSyncer.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.configSyncer.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.configSyncer.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.configSyncer.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.configSyncer.livenessProbe) . | nindent 16 }}
               {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
@@ -60,10 +60,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.updateRuntimeCheck.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.updateRuntimeCheck.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
@@ -59,6 +59,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.updateRuntimeCheck.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.updateRuntimeCheck.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.updateRuntimeCheck.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -59,6 +59,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.updateCheck.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.updateCheck.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.updateCheck.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.updateCheck.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -60,10 +60,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.updateCheck.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.updateCheck.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.updateCheck.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.updateCheck.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.updateCheck.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.updateCheck.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -67,10 +67,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.cleanupAirflowDb.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.cleanupAirflowDb.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -66,6 +66,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.cleanupAirflowDb.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.cleanupAirflowDb.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupAirflowDb.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -58,6 +58,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.cleanupDeployRevisions.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.cleanupDeployRevisions.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -59,10 +59,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.cleanupDeployRevisions.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.cleanupDeployRevisions.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployRevisions.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
@@ -59,6 +59,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.cleanupDeployments.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.cleanupDeployments.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
@@ -60,10 +60,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.cleanupDeployments.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.cleanupDeployments.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupDeployments.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -58,10 +58,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -57,6 +57,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
@@ -59,6 +59,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
@@ -60,10 +60,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
@@ -59,10 +59,10 @@ spec:
               env:
                 {{- include "houston_environment" . | indent 16 }}
               {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
-              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 16 }}
               {{- end }}
               {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
-              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 16 }}
               {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
@@ -58,6 +58,12 @@ spec:
                 {{- include "custom_ca_volume_mounts" . | indent 16 }}
               env:
                 {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.taskUsageMetrics.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.readinessProbe) . | nindent 12 }}
+              {{- end }}
+              {{- if .Values.houston.taskUsageMetrics.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.taskUsageMetrics.livenessProbe) . | nindent 12 }}
+              {{- end }}
           volumes:
             {{- include "houston_volumes" . | indent 12 }}
             {{- include "custom_ca_volumes" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
@@ -68,6 +68,12 @@ spec:
                   name: {{ template "houston.backendSecret" . }}
                   key: connection
             {{- include "houston_environment" . | indent 12 }}
+          {{- if .Values.houston.updateResourceStrategy.readinessProbe }}
+          readinessProbe: {{ tpl (toYaml .Values.houston.updateResourceStrategy.readinessProbe) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.houston.updateResourceStrategy.livenessProbe }}
+          livenessProbe: {{ tpl (toYaml .Values.houston.updateResourceStrategy.livenessProbe) . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -112,6 +112,12 @@ spec:
                   name: {{ template "houston.backendSecret" . }}
                   key: connection
             {{- include "houston_environment" . | indent 12 }}
+          {{- if .Values.houston.dbMigration.readinessProbe }}
+          readinessProbe: {{ tpl (toYaml .Values.houston.dbMigration.readinessProbe) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.houston.dbMigration.livenessProbe }}
+          livenessProbe: {{ tpl (toYaml .Values.houston.dbMigration.livenessProbe) . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -118,6 +118,12 @@ spec:
                   name: {{ template "houston.backendSecret" . }}
                   key: connection
             {{- include "houston_environment" . | indent 12 }}
+          {{- if .Values.houston.upgradeDeployments.readinessProbe }}
+          readinessProbe: {{ tpl (toYaml .Values.houston.upgradeDeployments.readinessProbe) . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.houston.upgradeDeployments.livenessProbe }}
+          livenessProbe: {{ tpl (toYaml .Values.houston.upgradeDeployments.livenessProbe) . | nindent 12 }}
+          {{- end }}
       volumes:
         {{- include "houston_volumes" . | indent 8 }}
         {{- include "custom_ca_volumes" . | indent 8 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -329,10 +329,10 @@ houston:
     annotation: {}
   enableHoustonInternalAuthorization: false
 
-  updateResourceStrategy: 
+  updateResourceStrategy:
     readinessProbe: {}
     livenessProbe: {}
-    
+
   dbMigration:
     readinessProbe: {}
     livenessProbe: {}
@@ -345,7 +345,7 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
-  taskUsageMetrics: 
+  taskUsageMetrics:
     readinessProbe: {}
     livenessProbe: {}
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -345,6 +345,10 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
+  taskUsageMetrics: 
+    readinessProbe: {}
+    livenessProbe: {}
+
 configSyncer:
   enabled: true
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -186,6 +186,9 @@ houston:
     # Only run on deployments marked as canary
     canary: false
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   # Cleanup airflow db data
   # This runs as a CronJob
   cleanupAirflowDb:
@@ -219,6 +222,9 @@ houston:
     # Run cleanup on specific table or list of tables in a comma separated format
     tables: ""
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   # Cleanup task usage data and task audit data in Houston
   # This runs as a CronJob
   cleanupTaskUsageData:
@@ -234,6 +240,9 @@ houston:
     # Only run on deployments marked as canary
     canary: false
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   # Cleanup task usage data and task audit data in Houston
   # This runs as a CronJob
   cleanupDeployRevisions:
@@ -245,6 +254,9 @@ houston:
 
     # Cleanup deploy revisions older than this many days
     olderThan: 90
+
+    readinessProbe: {}
+    livenessProbe: {}
 
   # Check for Astronomer Platform Updates
   # This runs as a CronJob
@@ -316,6 +328,14 @@ houston:
   ingress:
     annotation: {}
   enableHoustonInternalAuthorization: false
+
+  updateResourceStrategy: 
+    readinessProbe: {}
+    livenessProbe: {}
+    
+  dbMigration:
+    readinessProbe: {}
+    livenessProbe: {}
 
   bootstrapper:
     readinessProbe: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -270,6 +270,9 @@ houston:
     # Default here is to run at 00:43 every night https://crontab.guru/#43_0_*_*_*
     schedule: "43 0 * * *"
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   # Populate daily task usage data
   # This runs as a CronJob
 
@@ -280,9 +283,15 @@ houston:
     # Print out the aggregated daily task usage data that should be inserted and skip actual insertion
     dryRun: false
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   populateHourlyTaskAuditMetrics:
     # Run at minute 57 every hour https://crontab.guru/#57_*_*_*_*
     schedule: "57 * * * *"
+
+    readinessProbe: {}
+    livenessProbe: {}
 
   runtimeReleasesConfigMapName: ~
   runtimeReleasesConfig:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -258,6 +258,9 @@ houston:
     # Default here is to run at midnight every night https://crontab.guru/#0_0_*_*_*
     schedule: "0 0 * * *"
 
+    readinessProbe: {}
+    livenessProbe: {}
+
   # Check for Astronomer Runtime Updates
   # This runs as a CronJob
   updateRuntimeCheck:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -363,6 +363,8 @@ configSyncer:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+  readinessProbe: {}
+  livenessProbe: {}
 
 
 commander:

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -56,10 +56,10 @@ spec:
               - name: config-volume
                 mountPath: /etc/config
             {{- if .Values.curator.readinessProbe }}
-            readinessProbe: {{ tpl (toYaml .Values.curator.readinessProbe) . | nindent 12 }}
+            readinessProbe: {{ tpl (toYaml .Values.curator.readinessProbe) . | nindent 16 }}
             {{- end }}
             {{- if .Values.curator.livenessProbe }}
-            livenessProbe: {{ tpl (toYaml .Values.curator.livenessProbe) . | nindent 12 }}
+            livenessProbe: {{ tpl (toYaml .Values.curator.livenessProbe) . | nindent 16 }}
             {{- end }}
           volumes:
             - name: config-volume

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -55,6 +55,12 @@ spec:
             volumeMounts:
               - name: config-volume
                 mountPath: /etc/config
+            {{- if .Values.curator.readinessProbe }}
+            readinessProbe: {{ tpl (toYaml .Values.curator.readinessProbe) . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.curator.livenessProbe }}
+            livenessProbe: {{ tpl (toYaml .Values.curator.livenessProbe) . | nindent 12 }}
+            {{- end }}
           volumes:
             - name: config-volume
               configMap:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -242,6 +242,9 @@ curator:
     unit: "days"
     unit_count: 10
 
+  livenessProbe: {}
+  readinessProbe: {}
+
 exporter:
   podAnnotations: {}
   # Number of exporter instances

--- a/charts/kibana/templates/kibana-default-index-cronjob.yaml
+++ b/charts/kibana/templates/kibana-default-index-cronjob.yaml
@@ -59,5 +59,12 @@ spec:
             echo "Creating Kibana Index Pattern"
             curl --retry 10 --retry-delay 30 --retry-all-errors -XPOST -H 'Content-Type: application/json' -H 'kbn-xsrf: astronomer' --data '{"attributes":{"title":"{{ template "logging.indexNamePrefix" . }}.*","timeFieldName":"@timestamp"}}' http://{{ .Release.Name }}-kibana:5601/api/saved_objects/index-pattern/{{ template "logging.indexNamePrefix" . }}.*?overwrite=false
           fi
+        {{- if .Values.defaultIndexJob.readinessProbe }}
+        readinessProbe: {{ tpl (toYaml .Values.defaultIndexJob.readinessProbe) . | nindent 12 }}
+        {{- end }}
+        {{- if .Values.defaultIndexJob.livenessProbe }}
+        livenessProbe: {{ tpl (toYaml .Values.defaultIndexJob.livenessProbe) . | nindent 12 }}
+        {{- end }}
+
       restartPolicy: Never
 {{ end }}

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -70,3 +70,7 @@ serviceAccount:
 
 podAnnotations: {}
 ingressAnnotations: {}
+
+defaultIndexJob:
+  livenessProbe: {}
+  readinessProbe: {}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,12 +24,15 @@ def get_containers_by_name(doc: dict, *, include_init_containers=False) -> dict:
     doc must be a valid spec for a pod manager. (EG: ds, sts, cronjob, etc.)
     """
 
-    if doc["kind"] in ["Deployment", "StatefulSet", "ReplicaSet", "DaemonSet", "Job"]:
-        containers = doc["spec"]["template"]["spec"].get("containers", [])
-        initContainers = doc["spec"]["template"]["spec"].get("initContainers", [])
-    elif doc["kind"] == "CronJob":
-        containers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("containers", [])
-        initContainers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("initContainers", [])
+    match doc["kind"]:
+        case "Deployment" | "StatefulSet" | "ReplicaSet" | "DaemonSet" | "Job":
+            containers = doc["spec"]["template"]["spec"].get("containers", [])
+            initContainers = doc["spec"]["template"]["spec"].get("initContainers", [])
+        case "CronJob":
+            containers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("containers", [])
+            initContainers = doc["spec"]["jobTemplate"]["spec"]["template"]["spec"].get("initContainers", [])
+        case _:
+            raise ValueError(f"Unhandled kind: {doc['kind']}")
 
     c_by_name = {c["name"]: c for c in containers}
 

--- a/tests/chart_tests/__init__.py
+++ b/tests/chart_tests/__init__.py
@@ -10,7 +10,11 @@ def get_all_features():
 
 
 def get_chart_containers(
-    k8s_version: str, chart_values: dict, exclude_kinds: list[str] | None = None, include_kinds: list[str] | None = None
+    k8s_version: str,
+    chart_values: dict,
+    *,  # force the remaining arguments to be keyword-only
+    exclude_kinds: list[str] | None = None,
+    include_kinds: list[str] | None = None,
 ) -> dict:
     """Return a dict of pod container and initContainer specs in the form of
     {k8s_version}_{release_name}-{pod_name}_{container_name}, with some additional metadata."""

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -41,17 +41,60 @@ astronomer:
       exec:
         command:
         - /bin/true
+  configSyncer:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
   houston:
     bootstrapper:
       livenessProbe:
         exec:
           command:
           - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    cleanupAirflowDb:
+      livenessProbe:
+        exec:
+          command:
           - /bin/true
       readinessProbe:
         exec:
           command:
           - /bin/true
+    cleanupDeployRevisions:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    cleanupDeployments:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    dbMigration:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
           - /bin/true
     livenessProbe:
       exec:
@@ -61,16 +104,59 @@ astronomer:
       exec:
         command:
         - /bin/true
-    waitForDB:
+    taskUsageMetrics:
       livenessProbe:
         exec:
           command:
-          - /bin/true
           - /bin/true
       readinessProbe:
         exec:
           command:
           - /bin/true
+    updateCheck:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    updateResourceStrategy:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    updateRuntimeCheck:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    upgradeDeployments:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+    waitForDB:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
           - /bin/true
     worker:
       livenessProbe:
@@ -92,6 +178,15 @@ astronomer:
         - /bin/true
 elasticsearch:
   client:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  curator:
     livenessProbe:
       exec:
         command:
@@ -141,13 +236,9 @@ elasticsearch:
       exec:
         command:
         - /bin/true
-        - /bin/true
-        - /bin/true
     readinessProbe:
       exec:
         command:
-        - /bin/true
-        - /bin/true
         - /bin/true
 external-es-proxy:
   awsproxy:
@@ -185,13 +276,9 @@ global:
       exec:
         command:
         - /bin/true
-        - /bin/true
-        - /bin/true
     readinessProbe:
       exec:
         command:
-        - /bin/true
-        - /bin/true
         - /bin/true
   customLogging:
     awsServiceAccountAnnotation: "yo imma let you finish but beyonce had the best annotation ever"
@@ -228,6 +315,15 @@ grafana:
         command:
         - /bin/true
 kibana:
+  defaultIndexJob:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
   livenessProbe:
     exec:
       command:
@@ -306,7 +402,6 @@ postgresql:
     exec:
       command:
       - /bin/true
-      - /bin/true
   metrics:
     enabled: true
     livenessProbe:
@@ -321,7 +416,6 @@ postgresql:
   readinessProbe:
     exec:
       command:
-      - /bin/true
       - /bin/true
   replication:
     enabled: true

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -1,0 +1,410 @@
+########################################################################################################
+# This file should enable and customize every available livenessProbe and readinessProbe. This serves as
+# a way to test that every probe is customizable, and as a document about how to configure every probe.
+# In order to test every available probe, this should also enable every available feature.
+########################################################################################################
+
+airflow-operator:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+alertmanager:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+astronomer:
+  astroUI:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  commander:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  houston:
+    bootstrapper:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+          - /bin/true
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+    waitForDB:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+          - /bin/true
+    worker:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+  registry:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+elasticsearch:
+  client:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  data:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  exporter:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  master:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  nginx:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  sysctlInitContainer:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+        - /bin/true
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+        - /bin/true
+        - /bin/true
+external-es-proxy:
+  awsproxy:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+fluentd:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+global:
+  airflowOperator:
+    enabled: true
+  authSidecar:
+    enabled: true
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+        - /bin/true
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+        - /bin/true
+        - /bin/true
+  customLogging:
+    awsServiceAccountAnnotation: "yo imma let you finish but beyonce had the best annotation ever"
+    enabled: true
+  pgbouncer:
+    enabled: true
+  postgresqlEnabled: true
+  prometheusPostgresExporterEnabled: true
+grafana:
+  bootstrapper:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+  waitForDB:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+kibana:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+kube-state:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+nats:
+  exporter:
+    enabled: true
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  nats:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  reloader:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+nginx:
+  defaultBackend:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+pgbouncer:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+postgresql:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+      - /bin/true
+  metrics:
+    enabled: true
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  postgresqlDatabase: kitten_picture_db
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+      - /bin/true
+  replication:
+    enabled: true
+prometheus:
+  configMapReloader:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  filesdReloader:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+prometheus-blackbox-exporter:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+prometheus-node-exporter:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+prometheus-postgres-exporter:
+  livenessProbe:
+    exec:
+      command:
+      - /bin/true
+  readinessProbe:
+    exec:
+      command:
+      - /bin/true
+stan:
+  exporter:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true
+  stan:
+    nats:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
+  waitForNatsServer:
+    livenessProbe:
+      exec:
+        command:
+        - /bin/true
+    readinessProbe:
+      exec:
+        command:
+        - /bin/true

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -1,154 +1,30 @@
 import pytest
 
-from tests import git_root_dir, supported_k8s_versions
+from tests import git_root_dir, supported_k8s_versions, get_containers_by_name
 from tests.chart_tests.helm_template_generator import render_chart
 from tests.chart_tests import get_all_features, get_chart_containers
+import yaml
 
-include_kind_list = ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+include_kind_list = ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet", "CronJob", "Job"]
 
-default_probes = {
-    "livenessProbe": {
-        "exec": {"command": ["shaka"]},
-    },
-    "readinessProbe": {
-        "exec": {"command": ["shaka"]},
-    },
-}
-
-pod_manager_data = {
-    "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml": {
-        "airflow-operator": default_probes,
-        "global": {
-            "airflowOperator": {"enabled": True},
-        },
-    },
-    "charts/alertmanager/templates/alertmanager-statefulset.yaml": {
-        "alertmanager": default_probes,
-        "global": {
-            "authSidecar": {"enabled": True, **default_probes},
-        },
-    },
-    "charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml": {"astronomer": {"astroUI": default_probes}},
-    "charts/astronomer/templates/commander/commander-deployment.yaml": {"astronomer": {"commander": default_probes}},
-    "charts/astronomer/templates/houston/api/houston-deployment.yaml": {
-        "astronomer": {"houston": {**default_probes, "waitForDB": default_probes, "bootstrapper": default_probes}},
-    },
-    "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml": {
-        "astronomer": {"houston": {"worker": default_probes, "waitForDB": default_probes, "bootstrapper": default_probes}},
-    },
-    "charts/astronomer/templates/registry/registry-statefulset.yaml": {"astronomer": {"registry": default_probes}},
-    "charts/elasticsearch/templates/client/es-client-deployment.yaml": {
-        "elasticsearch": {
-            "client": default_probes,
-            "sysctlInitContainer": default_probes,
-        }
-    },
-    "charts/elasticsearch/templates/data/es-data-statefulset.yaml": {
-        "elasticsearch": {
-            "data": default_probes,
-            "sysctlInitContainer": default_probes,
-        }
-    },
-    "charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml": {"elasticsearch": {"exporter": default_probes}},
-    "charts/elasticsearch/templates/master/es-master-statefulset.yaml": {
-        "elasticsearch": {
-            "master": default_probes,
-            "sysctlInitContainer": default_probes,
-        },
-        "global": {"authSidecar": {"enabled": True, **default_probes}},
-    },
-    "charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml": {"elasticsearch": {"nginx": default_probes}},
-    "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml": {
-        "external-es-proxy": {**default_probes, "awsproxy": default_probes},
-        "global": {
-            "customLogging": {
-                "awsServiceAccountAnnotation": "yo imma let you finish but beyonce had the best annotation ever",
-                "enabled": True,
-            },
-        },
-    },
-    "charts/fluentd/templates/fluentd-daemonset.yaml": {"fluentd": default_probes},
-    "charts/grafana/templates/grafana-deployment.yaml": {
-        "grafana": {**default_probes, "waitForDB": default_probes, "bootstrapper": default_probes},
-    },
-    "charts/kibana/templates/kibana-deployment.yaml": {
-        "kibana": default_probes,
-        "global": {"authSidecar": {"enabled": True, **default_probes}},
-    },
-    "charts/kube-state/templates/kube-state-deployment.yaml": {"kube-state": default_probes},
-    "charts/nats/templates/statefulset.yaml": {
-        "nats": {"nats": default_probes, "reloader": default_probes, "exporter": {**default_probes, "enabled": True}}
-    },
-    "charts/nginx/templates/nginx-deployment-default.yaml": {"nginx": {"defaultBackend": default_probes}},
-    "charts/nginx/templates/nginx-deployment.yaml": {"nginx": default_probes},
-    "charts/pgbouncer/templates/pgbouncer-deployment.yaml": {
-        "pgbouncer": default_probes,
-        "global": {
-            "pgbouncer": {"enabled": True},
-        },
-    },
-    "charts/postgresql/templates/statefulset-slaves.yaml": {
-        "postgresql": {
-            "postgresqlDatabase": "kitten_picture_db",
-            **default_probes,
-            "replication": {"enabled": True},
-            "metrics": {**default_probes, "enabled": True},
-        },
-        "global": {"postgresqlEnabled": True},
-    },
-    "charts/postgresql/templates/statefulset.yaml": {"postgresql": default_probes, "global": {"postgresqlEnabled": True}},
-    "charts/prometheus/templates/prometheus-statefulset.yaml": {
-        "prometheus": {**default_probes, "configMapReloader": default_probes, "filesdReloader": default_probes}
-    },
-    "charts/prometheus-blackbox-exporter/templates/deployment.yaml": {"prometheus-blackbox-exporter": default_probes},
-    "charts/prometheus-node-exporter/templates/daemonset.yaml": {"prometheus-node-exporter": default_probes},
-    "charts/prometheus-postgres-exporter/templates/deployment.yaml": {
-        "prometheus-postgres-exporter": default_probes,
-        "global": {"prometheusPostgresExporterEnabled": True},
-    },
-    "charts/stan/templates/statefulset.yaml": {
-        "stan": {
-            "stan": {"nats": default_probes},
-            "exporter": default_probes,
-            "waitForNatsServer": default_probes,
-        }
-    },
-}
+customize_all_probes = yaml.safe_load(
+    ((git_root_dir) / "tests" / "chart_tests" / "test_data" / "enable_all_probes.yaml").read_text()
+)
 
 
-def find_all_pod_manager_templates() -> list[str]:
-    """Return a sorted, unique list of all pod manager templates in the chart, relative to git_root_dir."""
+class TestCustomProbes:
+    docs = render_chart(values=customize_all_probes)
+    filtered_docs = [get_containers_by_name(doc) for doc in docs if doc["kind"] in include_kind_list]
 
-    return sorted(
-        {
-            str(x.relative_to(git_root_dir))
-            for x in (git_root_dir / "charts").rglob("*")
-            if any(sub in x.name for sub in ("deployment", "statefulset", "replicaset", "daemonset")) and "job" not in x.name
-        }
-    )
+    @pytest.mark.parametrize("doc", filtered_docs)
+    def test_template_probes_with_custom_values(self, doc):
+        """Ensure all containers have the ability to customize liveness probes."""
 
-
-def test_pod_manager_list(pod_manager_templates=find_all_pod_manager_templates(), pod_manager_list=pod_manager_data.keys()):
-    """Make sure we are not adding pod manager templates that are not being tested here."""
-    assert pod_manager_templates == sorted(pod_manager_list)
-
-
-@pytest.mark.parametrize("template,values", zip(pod_manager_data.keys(), pod_manager_data.values()), ids=pod_manager_data.keys())
-def test_template_probes_with_custom_values(template, values):
-    """Ensure all containers have the ability to customize liveness probes."""
-
-    docs = render_chart(show_only=template, values=values)
-    assert len(docs) == 1
-    for container in [
-        *docs[0]["spec"]["template"]["spec"]["containers"],
-        *docs[0]["spec"]["template"]["spec"].get("initContainers", []),
-    ]:
-        assert container["livenessProbe"] == default_probes["livenessProbe"], (
-            f"livenessProbe not accurate in {template} container {container['name']}"
-        )
-        assert container["readinessProbe"] == default_probes["readinessProbe"], (
-            f"readinessProbe not accurate in {template} container {container['name']}"
-        )
+        for container in doc.values():
+            assert "livenessProbe" in container
+            assert "readinessProbe" in container
+            assert container["livenessProbe"] != {}
+            assert container["readinessProbe"] != {}
 
 
 class TestDefaultProbes:
@@ -158,22 +34,26 @@ class TestDefaultProbes:
         chart_values = get_all_features()
         containers = {}
         for k8s_version in supported_k8s_versions:
-            k8s_version_containers = get_chart_containers(k8s_version, chart_values, [])
+            k8s_version_containers = get_chart_containers(k8s_version, chart_values)
             print(f"Containers before processing: {k8s_version_containers.keys()}")
             containers = {**containers, **k8s_version_containers}
         return dict(sorted(containers.items()))
 
     chart_containers = init_test_probes()
+
+    # Trim the k8s version because it's not important for this test.
     containers = {
         k.removeprefix(f"{supported_k8s_versions[-1]}_release-name-"): v
         for k, v in chart_containers.items()
         if supported_k8s_versions[-1] in k
     }
     print(f"Container keys after processing: {containers.keys()}")
+
+    # Show only containers that have a liveness or readiness probe.
     current_clp = {k: v["livenessProbe"] for k, v in containers.items() if v.get("livenessProbe")}
     current_crp = {k: v["readinessProbe"] for k, v in containers.items() if v.get("readinessProbe")}
 
-    # expected container liveness probes
+    # Expected container liveness probes. This block should contain all of the expected default liveness probes.
     expected_clp = {
         "alertmanager_auth-proxy": {
             "httpGet": {"path": "/healthz", "port": 8084, "scheme": "HTTP"},
@@ -290,7 +170,7 @@ class TestDefaultProbes:
         "stan_stan": {"httpGet": {"path": "/streaming/serverz", "port": "monitor"}, "initialDelaySeconds": 10, "timeoutSeconds": 5},
     }
 
-    # expected container readiness probes
+    # Expected container readiness probes. This block should contain all of the expected default readiness probes.
     expected_crp = {
         "alertmanager_alertmanager": {
             "httpGet": {"path": "/#/status", "port": 9093},
@@ -393,7 +273,7 @@ class TestDefaultProbes:
     # If any other tests fail, this will not run, so they have to be commented out for this to actually show you where the problem is.
     @pytest.mark.parametrize("current,expected", [(current_clp, expected_clp), (current_crp, expected_crp)])
     def test_probe_lists(self, current, expected):
-        """Test the default livenessProbes for each container."""
+        """Test that the list of probes matches between what is rendered by the current chart version and what is expected."""
         set_difference = set(current.keys()) ^ set(expected.keys())
         assert set_difference == set(), f"Containers not in both lists: {set_difference}"
 


### PR DESCRIPTION
## Description

add probes support for cronjob and jobs


## Related Issues

- https://github.com/astronomer/issues/issues/7289

## Testing

QA should pass liveliness and readiness config for listed services to get covered on the testing

## Merging

merge to master and cherry-pick to release-0.37
