### PR TITLE
Updated Unit Tests for Plane Mode Configuration Standardization

### DIFF
--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -14,7 +14,7 @@ class TestAstronomerCpDpFeature:
         return [chart for chart in charts if chart.get("metadata", {}).get("labels", {}).get("plane") == component]
 
     def test_astronomer_cp_only(self, kube_version):
-        """Test that helm renders the correct templates when only the control is enabled."""
+        """Test that helm renders the correct templates when only the control mode is enabled."""
         charts = render_chart(
             kube_version=kube_version,
             values={"global": {"plane": {"mode": "control"}}},
@@ -26,7 +26,7 @@ class TestAstronomerCpDpFeature:
         assert len(dp_resources) == 0
 
     def test_astronomer_dp_only(self, kube_version):
-        """Test that helm renders the correct templates when only the data is enabled."""
+        """Test that helm renders the correct templates when only the data mode is enabled."""
         charts = render_chart(
             kube_version=kube_version,
             values={"global": {"plane": {"mode": "data"}}},

--- a/tests/chart_tests/test_astronomer_cp_dp_feature.py
+++ b/tests/chart_tests/test_astronomer_cp_dp_feature.py
@@ -14,49 +14,49 @@ class TestAstronomerCpDpFeature:
         return [chart for chart in charts if chart.get("metadata", {}).get("labels", {}).get("plane") == component]
 
     def test_astronomer_cp_only(self, kube_version):
-        """Test that helm renders the correct templates when only the controlplane is enabled."""
+        """Test that helm renders the correct templates when only the control is enabled."""
         charts = render_chart(
             kube_version=kube_version,
-            values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}},
+            values={"global": {"plane": {"mode": "control"}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(charts, "control")
         assert len(cp_resources) > 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(charts, "data")
         assert len(dp_resources) == 0
 
     def test_astronomer_dp_only(self, kube_version):
-        """Test that helm renders the correct templates when only the dataplane is enabled."""
+        """Test that helm renders the correct templates when only the data is enabled."""
         charts = render_chart(
             kube_version=kube_version,
-            values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}},
+            values={"global": {"plane": {"mode": "data"}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(charts, "control")
         assert len(cp_resources) == 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(charts, "data")
         assert len(dp_resources) > 0
 
     def test_astronomer_both_cp_dp_enabled(self, kube_version):
         """Test when both CP and DP features are enabled."""
         charts = render_chart(
             kube_version=kube_version,
-            values={"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": True}}},
+            values={"global": {"plane": {"mode": "unified"}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
-        assert len(cp_resources) > 0
-
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
-        assert len(dp_resources) > 0
+        unified_resources = self.filter_charts_by_component(charts, "unified")
+        assert len(unified_resources) > 0
 
     def test_astronomer_both_cp_dp_disabled(self, kube_version):
         """Test when both CP and DP features are disabled."""
         charts = render_chart(
             kube_version=kube_version,
-            values={"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}},
+            values={"global": {"plane": {"mode": "RandomValue"}}},
         )
-        cp_resources = self.filter_charts_by_component(charts, "controlplane")
+        cp_resources = self.filter_charts_by_component(charts, "control")
         assert len(cp_resources) == 0
 
-        dp_resources = self.filter_charts_by_component(charts, "dataplane")
+        dp_resources = self.filter_charts_by_component(charts, "data")
         assert len(dp_resources) == 0
+
+        unified_resources = self.filter_charts_by_component(charts, "unified")
+        assert len(unified_resources) == 0

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -715,7 +715,7 @@ class TestElasticSearch:
         """Test that helm renders no templates when controlplane is disabled."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"controlplane": {"enabled": False}}},
+            values={"global": {"plane": {"mode": "data"}}},
             show_only=[doc],
         )
         assert len(docs) == 0, f"Document {doc} was rendered when controlplane is disabled"

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -31,7 +31,7 @@ class TestHoustonApiDeployment:
         assert doc["spec"]["template"]["metadata"]["labels"].get("app") == "houston"
         assert doc["spec"]["template"]["metadata"]["labels"].get("tier") == "astronomer"
         assert doc["spec"]["template"]["metadata"]["labels"].get("release") == "release-name"
-        assert doc["spec"]["template"]["metadata"]["labels"].get("plane") == "controlplane"
+        assert doc["spec"]["template"]["metadata"]["labels"].get("plane") == "unified"
 
         labels = doc["spec"]["template"]["metadata"]["labels"]
         assert {
@@ -39,7 +39,7 @@ class TestHoustonApiDeployment:
             "component": "houston",
             "release": "release-name",
             "app": "houston",
-            "plane": "controlplane",
+            "plane": "unified",
         } == {x: labels[x] for x in labels if x != "version"}
 
         c_by_name = get_containers_by_name(doc, include_init_containers=True)

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -254,7 +254,7 @@ class TestNatsStatefulSet:
                 "charts/nats/templates/statefulset.yaml",
             ],
             values={
-                "global": {"controlplane": {"enabled": False}},
+                "global": {"plane": {"mode": "data"}},
             },
         )
         assert len(docs) == 0

--- a/tests/chart_tests/test_nginx_networkpolicy.py
+++ b/tests/chart_tests/test_nginx_networkpolicy.py
@@ -19,7 +19,7 @@ class TestNginxNetworkPolicy:
 
     def test_disabled_networkpolicies(self):
         """Test that NetworkPolicies can be disabled via global settings."""
-        disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": True}}}
+        disabled_values = {"global": {"plane": {"mode": "data"}}}
         docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",
@@ -30,7 +30,7 @@ class TestNginxNetworkPolicy:
         assert len(docs) == 1, f"Expected 1 document, got {len(docs)}"
         assert "release-name-dp-nginx-policy" in docs[0]["metadata"]["name"]
 
-        disabled_values = {"global": {"controlplane": {"enabled": True}, "dataplane": {"enabled": False}}}
+        disabled_values = {"global": {"plane": {"mode": "control"}}}
         docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",

--- a/tests/chart_tests/test_nginx_networkpolicy.py
+++ b/tests/chart_tests/test_nginx_networkpolicy.py
@@ -41,7 +41,7 @@ class TestNginxNetworkPolicy:
         assert len(docs) == 1, f"Expected 1 document, got {len(docs)}"
         assert "release-name-cp-nginx-policy" in docs[0]["metadata"]["name"]
 
-        disabled_values = {"global": {"controlplane": {"enabled": False}, "dataplane": {"enabled": False}}}
+        disabled_values = {"global": {"plane": {"mode": "RandomValue"}}}
         docs = render_chart(
             show_only=[
                 "charts/nginx/templates/controlplane/nginx-cp-networkpolicy.yaml",


### PR DESCRIPTION
## Description

This PR updates our test suite to align with the new standardized plane mode configuration approach implemented in the previous PR. It refactors all tests to use the new global.plane.mode pattern instead of the legacy controlplane.enabled and dataplane.enabled flags

## Changes

- Updated test assertions to check for the new plane mode values ("control", "data", "unified")
- Refactored test values configurations to use global.plane.mode pattern:
    - `{"global": {"plane": {"mode": "control"}}}` replaces `{"global": {"controlplane": {"enabled": true}, "dataplane": {"enabled": false}}}`
    - `{"global": {"plane": {"mode": "data"}}}` replaces `{"global": {"controlplane": {"enabled": false}, "dataplane": {"enabled": true}}}`
    - `{"global": {"plane": {"mode": "unified"}}}` replaces `{"global": {"controlplane": {"enabled": true}, "dataplane": {"enabled": true}}}`
- Added new test cases for "unified" mode configuration

## Related Issues

Related astronomer/issues#XXXX

## Testing

- Ran the full test suite to verify all tests pass with the new configuration pattern
![Screenshot 2025-05-19 at 5 31 14 PM](https://github.com/user-attachments/assets/faccf4e4-877e-4d75-84a1-bf355ffb7a0f)


## Merging

1.0