### PR TITLE
Add podSecurityContext support across all Astronomer components

### DIFF
--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "astroUI.serviceAccountName" . }}
+      securityContext: {{ toYaml (.Values.astroUI.podSecurityContext)| nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
@@ -47,7 +48,6 @@ spec:
         - name: astro-ui
           image: {{- include "astroUI.image" . | indent 1 }}
           imagePullPolicy: {{ .Values.images.astroUI.pullPolicy }}
-          securityContext: {{ toYaml (.Values.astroUI.podSecurityContext)| nindent 12 }}
           resources:
 {{ toYaml .Values.astroUI.resources | indent 12 }}
           {{- if .Values.astroUI.command }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - name: astro-ui
           image: {{- include "astroUI.image" . | indent 1 }}
           imagePullPolicy: {{ .Values.images.astroUI.pullPolicy }}
+          securityContext: {{ toYaml (.Values.securityContext)| nindent 12 }}
           resources:
 {{ toYaml .Values.astroUI.resources | indent 12 }}
           {{- if .Values.astroUI.command }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: astro-ui
           image: {{- include "astroUI.image" . | indent 1 }}
           imagePullPolicy: {{ .Values.images.astroUI.pullPolicy }}
-          securityContext: {{ toYaml (.Values.securityContext)| nindent 12 }}
+          securityContext: {{ toYaml (.Values.astroUI.podSecurityContext)| nindent 12 }}
           resources:
 {{ toYaml .Values.astroUI.resources | indent 12 }}
           {{- if .Values.astroUI.command }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -53,6 +53,7 @@ spec:
         - name: commander
           image: {{ template "commander.image" . }}
           imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
+          securityContext: {{ toYaml (.Values.securityContext)| nindent 12 }}
           resources:
 {{ toYaml .Values.commander.resources | indent 12 }}
           {{- if .Values.commander.command }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         - name: commander
           image: {{ template "commander.image" . }}
           imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.commander.podSecurityContext| nindent 12 }}
           resources:
 {{ toYaml .Values.commander.resources | indent 12 }}
           {{- if .Values.commander.command }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -41,6 +41,7 @@ spec:
     spec:
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      securityContext: {{ toYaml .Values.commander.podSecurityContext| nindent 8 }}
       affinity:
 {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
       tolerations:
@@ -52,7 +53,6 @@ spec:
         - name: commander
           image: {{ template "commander.image" . }}
           imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
-          securityContext: {{ toYaml .Values.commander.podSecurityContext| nindent 12 }}
           resources:
 {{ toYaml .Values.commander.resources | indent 12 }}
           {{- if .Values.commander.command }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -51,6 +51,7 @@ spec:
             - name: config-syncer
               image: {{ template "commander.image" . }}
               imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
+              securityContext: {{ template "configSyncer.securityContext" . }}
               resources: {{ toYaml .Values.configSyncer.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args:

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "configSyncer.serviceAccountName" . }}
+          securityContext: {{ toYaml .Values.configSyncer.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,6 @@ spec:
             - name: config-syncer
               image: {{ template "commander.image" . }}
               imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
-              securityContext: {{ toYaml .Values.configSyncer.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.configSyncer.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args:

--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -50,7 +50,7 @@ spec:
             - name: config-syncer
               image: {{ template "commander.image" . }}
               imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
-              securityContext: {{ template "configSyncer.securityContext" .  }}
+              securityContext: {{ toYaml .Values.configSyncer.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.configSyncer.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args:

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -50,6 +50,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
           args:
@@ -71,6 +72,7 @@ spec:
             {{- include "houston_environment" . | indent 12 }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           {{- if .Values.houston.bootstrapper.readinessProbe }}
@@ -111,6 +113,7 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
           args:
@@ -71,7 +71,7 @@ spec:
             {{- include "houston_environment" . | indent 12 }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           {{- if .Values.houston.bootstrapper.readinessProbe }}
@@ -112,7 +112,7 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -38,6 +38,7 @@ spec:
     spec:
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
+      securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 8 }}
       affinity:
 {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 8 }}
       tolerations:
@@ -49,7 +50,6 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
           args:
@@ -71,7 +71,6 @@ spec:
             {{- include "houston_environment" . | indent 12 }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           {{- if .Values.houston.bootstrapper.readinessProbe }}
@@ -112,7 +111,6 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,7 @@ spec:
             - name: update-check
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "check-runtime-updates", "--url={{ .Values.houston.updateRuntimeCheck.url }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-runtime-updates.yaml
@@ -50,7 +50,7 @@ spec:
             - name: update-check
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "check-runtime-updates", "--url={{ .Values.houston.updateRuntimeCheck.url }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -49,7 +49,7 @@ spec:
           containers:
             - name: update-check
               image: {{ template "houston.image" . }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.

--- a/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-check-updates-cronjob.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -49,7 +50,7 @@ spec:
           containers:
             - name: update-check
               image: {{ template "houston.image" . }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "cleanup-airflow-db-data", "--",
               "--older-than={{ .Values.houston.cleanupAirflowDb.olderThan }}",

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -50,7 +50,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "cleanup-airflow-db-data", "--",
               "--older-than={{ .Values.houston.cleanupAirflowDb.olderThan }}",

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-airflow-db-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "cleanup-airflow-db-data", "--",
               "--older-than={{ .Values.houston.cleanupAirflowDb.olderThan }}",

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               args: ["yarn", "cleanup-deploy-revisions", "--", "--older-than={{ .Values.houston.cleanupDeployRevisions.olderThan }}"]
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -51,6 +51,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              securityContext: {{ toYaml .Values.securityContext| nindent 16 }}
               args: ["yarn", "cleanup-deploy-revisions", "--", "--older-than={{ .Values.houston.cleanupDeployRevisions.olderThan }}"]
               securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
               args: ["yarn", "cleanup-deploy-revisions", "--", "--older-than={{ .Values.houston.cleanupDeployRevisions.olderThan }}"]
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               volumeMounts:
                 {{- include "houston_volume_mounts" . | indent 16 }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
@@ -50,7 +50,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "cleanup-deployments", "--", "--older-than={{ .Values.houston.cleanupDeployments.olderThan }}", "--dry-run={{ .Values.houston.cleanupDeployments.dryRun }}", "--canary={{ .Values.houston.cleanupDeployments.canary }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "cleanup-deployments", "--", "--older-than={{ .Values.houston.cleanupDeployments.olderThan }}", "--dry-run={{ .Values.houston.cleanupDeployments.dryRun }}", "--canary={{ .Values.houston.cleanupDeployments.canary }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -49,7 +49,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "cleanup-task-usage-data", "--", "--older-than={{ .Values.houston.cleanupTaskUsageData.olderThan }}", "--dry-run={{ .Values.houston.cleanupTaskUsageData.dryRun }}", "--canary={{ .Values.houston.cleanupTaskUsageData.canary }}"]
               volumeMounts:

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-task-data-cronjob.yaml
@@ -37,6 +37,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -49,7 +50,7 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "cleanup-task-usage-data", "--", "--older-than={{ .Values.houston.cleanupTaskUsageData.olderThan }}", "--dry-run={{ .Values.houston.cleanupTaskUsageData.dryRun }}", "--canary={{ .Values.houston.cleanupTaskUsageData.canary }}"]
               volumeMounts:

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
@@ -50,7 +50,7 @@ spec:
             - name: populate-daily-task-metrics
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "populate-daily-task-metrics", "--", "--dry-run={{ .Values.houston.populateDailyTaskMetrics.dryRun }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-daily-task-metrics.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,7 @@ spec:
             - name: populate-daily-task-metrics
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
               args: ["yarn", "populate-daily-task-metrics", "--", "--dry-run={{ .Values.houston.populateDailyTaskMetrics.dryRun }}"]

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
@@ -38,6 +38,7 @@ spec:
           {{- end }}
         spec:
           serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
           affinity:
@@ -50,7 +51,7 @@ spec:
             - name: populate-daily-task-metrics
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "populate-hourly-task-audit-metrics"]
               volumeMounts:

--- a/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-populate-hourly-ta-metrics.yaml
@@ -50,7 +50,7 @@ spec:
             - name: populate-daily-task-metrics
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}
               args: ["yarn", "populate-hourly-task-audit-metrics"]
               volumeMounts:

--- a/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
@@ -56,7 +56,7 @@ spec:
           command: ["yarn"]
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
           args: ["update-deployments-resource-mode"]
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-au-strategy-job.yaml
@@ -41,6 +41,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
@@ -56,7 +57,7 @@ spec:
           command: ["yarn"]
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
           args: ["update-deployments-resource-mode"]
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -43,6 +43,7 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Never
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
       initContainers:
         - name: wait-for-db
@@ -67,7 +68,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             - name: BOOTSTRAP_DB

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -49,7 +49,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
@@ -103,7 +103,7 @@ spec:
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           args: ["yarn", "migrate"]
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
           {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -48,7 +48,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
@@ -67,7 +67,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             - name: BOOTSTRAP_DB
@@ -102,7 +102,7 @@ spec:
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           args: ["yarn", "migrate"]
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
           {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -41,6 +41,7 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
@@ -55,7 +56,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -55,7 +55,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
@@ -73,7 +73,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             - name: BOOTSTRAP_DB
@@ -108,7 +108,7 @@ spec:
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
           args: ["yarn", "upgrade-deployments", "--", "--canary={{ .Values.houston.upgradeDeployments.canary }}"]
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -74,7 +74,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             - name: BOOTSTRAP_DB
@@ -109,7 +109,7 @@ spec:
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
           # If you supply only args for a Container, the default Entrypoint defined in the Docker image is run with the args that you supplied.
           args: ["yarn", "upgrade-deployments", "--", "--canary={{ .Values.houston.upgradeDeployments.canary }}"]
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           volumeMounts:
             {{- include "houston_volume_mounts" . | indent 12 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -41,6 +41,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 8 }}
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
       initContainers:

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
           args:
@@ -66,7 +66,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           {{- if .Values.houston.bootstrapper.readinessProbe }}
           readinessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.readinessProbe) . | nindent 12 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: wait-for-db
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext | nindent 12 }}
           command:
             - "/houston/bin/entrypoint"
           args:
@@ -65,7 +65,7 @@ spec:
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext: {{ toYaml .Values.houston.podSecurityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           {{- if .Values.houston.bootstrapper.readinessProbe }}
           readinessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.readinessProbe) . | nindent 12 }}
@@ -103,7 +103,7 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml (.Values.securityContext)| nindent 12 }}
+          securityContext: {{ toYaml (.Values.houston.podSecurityContext)| nindent 12 }}
           {{- if .Values.houston.worker.command }}
           command:
             {{- toYaml .Values.houston.worker.command | nindent 12 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -164,10 +164,6 @@ houston:
     replicas: 2
     readinessProbe: {}
     livenessProbe: {}
-    podSecurityContext:
-    fsGroup: 1000
-    runAsGroup: 1000
-    runAsUser: 1000
 
   # Automatically upgrade Airflow deployments to the latest
   # version specified by Houston configuration.

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -61,6 +61,10 @@ astroUI:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
   podAnnotations: {}
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsUser: 1000
 
 houston:
   prismaConnectionLimit: 5
@@ -124,6 +128,10 @@ houston:
 
   podAnnotations: {}
 
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsUser: 1000
   env: []
 
   # For example
@@ -156,6 +164,10 @@ houston:
     replicas: 2
     readinessProbe: {}
     livenessProbe: {}
+    podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsUser: 1000
 
   # Automatically upgrade Airflow deployments to the latest
   # version specified by Houston configuration.
@@ -326,6 +338,10 @@ configSyncer:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     name: ""
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsUser: 1000
 
 
 commander:
@@ -356,6 +372,10 @@ commander:
     # initialDelaySeconds: 10
     # periodSeconds: 10
   podAnnotations: {}
+  podSecurityContext:
+    fsGroup: 1000
+    runAsGroup: 1000
+    runAsUser: 1000
 
 
   airGapped:

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -51,7 +51,7 @@ spec:
             imagePullPolicy: {{ .Values.images.curator.pullPolicy }}
             command: ["/bin/sh", "-c"]
             args: ["sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"]
-            securityContext: {{ toYaml .Values.curator.podSecurityContext | nindent 16 }}
+            securityContext: {{ toYaml .Values.curator.securityContext | nindent 16 }}
             resources: {{ toYaml .Values.curator.resources | nindent 16 }}
             volumeMounts:
               - name: config-volume

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -40,6 +40,7 @@ spec:
             version: {{ .Chart.Version }}
         spec:
           serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
+          securityContext: {{ toYaml .Values.curator.podSecurityContext | nindent 12 }}
           nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 12 }}
           affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 12 }}
           tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 12 }}
@@ -50,7 +51,7 @@ spec:
             imagePullPolicy: {{ .Values.images.curator.pullPolicy }}
             command: ["/bin/sh", "-c"]
             args: ["sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"]
-            securityContext: {{ toYaml .Values.curator.securityContext | nindent 16 }}
+            securityContext: {{ toYaml .Values.curator.podSecurityContext | nindent 16 }}
             resources: {{ toYaml .Values.curator.resources | nindent 16 }}
             volumeMounts:
               - name: config-volume

--- a/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.nginx.podSecurityContext | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -232,7 +232,6 @@ curator:
   schedule: "0 1 * * *"
   securityContext: {}
   resources: {}
-  podSecurityContext: {}
 
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -232,6 +232,7 @@ curator:
   schedule: "0 1 * * *"
   securityContext: {}
   resources: {}
+  podSecurityContext: {}
 
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in
@@ -301,6 +302,7 @@ nginx:
   ingressClass: ~
   resources: {}
   securityContext: {}
+  podSecurityContext: {}
 
 # sysctl init container
 # Warning: sysctl changes affect the kernel, and thus, all containers running on the same node.

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -37,6 +37,7 @@ spec:
 {{- end }}
     spec:
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -21,6 +21,7 @@ images:
 securityContext:
   runAsNonRoot: true
 
+podSecurityContext: {}
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/kibana/templates/kibana-deployment.yaml
+++ b/charts/kibana/templates/kibana-deployment.yaml
@@ -37,6 +37,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "kibana.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -16,6 +16,8 @@ securityContext:
   runAsNonRoot: true
   runAsUser: 1000
 
+podSecurityContext: {}
+
 clusterName: "astronomer"
 
 replicas: 1

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -44,6 +44,7 @@ spec:
     {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
     {{- end }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -14,6 +14,8 @@ images:
 
 securityContext:
   runAsNonRoot: true
+  
+podSecurityContext: {}
 
 env: {}
 resources:

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -14,7 +14,7 @@ images:
 
 securityContext:
   runAsNonRoot: true
-  
+
 podSecurityContext: {}
 
 env: {}

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -87,6 +87,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ template "jetStream.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.nats.podSecurityContext | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -65,7 +65,7 @@ nats:
     # timeoutSeconds: 5
 
   podSecurityContext: {}
-  
+
   # Server settings.
   limits:
     maxConnections:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -64,8 +64,6 @@ nats:
     # initialDelaySeconds: 10
     # timeoutSeconds: 5
 
-  podSecurityContext: {}
-
   # Server settings.
   limits:
     maxConnections:

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -64,6 +64,8 @@ nats:
     # initialDelaySeconds: 10
     # timeoutSeconds: 5
 
+  podSecurityContext: {}
+  
   # Server settings.
   limits:
     maxConnections:

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -38,6 +38,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "defaultBackend.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.defaultBackend.podSecurityContext | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/nginx/templates/nginx-deployment.yaml
+++ b/charts/nginx/templates/nginx-deployment.yaml
@@ -42,6 +42,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
 {{- include "nginx.imagePullSecrets" . | indent 6 }}
       containers:
         - name: nginx

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -16,6 +16,7 @@ images:
     tag: 0.28.28
     pullPolicy: IfNotPresent
 
+podSecurityContext: {}
 securityContext:
   runAsUser: 101
   runAsNonRoot: true
@@ -130,6 +131,7 @@ defaultBackend:
   readinessProbe: {}
   livenessProbe: {}
   podAnnotations: {}
+  podSecurityContext: {}
   serviceAccount:
     # Specifies whether a service account should be created
     create: true

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -47,6 +47,7 @@ spec:
 {{- end }}
     spec:
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -9,6 +9,8 @@ image:
 securityContext:
   runAsNonRoot: true
 
+podSecurityContext: {}
+
 internalPort: 5432
 servicePort: 5432
 

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -57,6 +57,8 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 2 }}
       {{- end }}
       serviceAccountName: {{ template "postgresql.serviceAccountName" . }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -58,7 +58,7 @@ spec:
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 2 }}
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ template "postgresql.serviceAccountName" . }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -81,6 +81,8 @@ securityContext:
   runAsUser: 1001
   runAsNonRoot: true
 
+podSecurityContext: {}
+
 ## Pod Service Account
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
 serviceAccount:

--- a/charts/prometheus-blackbox-exporter/templates/deployment.yaml
+++ b/charts/prometheus-blackbox-exporter/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-blackbox-exporter.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -32,7 +32,7 @@ securityContext:
 # Add NET_RAW to enable ICMP
 #    add: ["NET_RAW"]
 
-podSecurityContext:{}
+podSecurityContext: {}
 # These are set in the global values.
 # nodeSelector: {}
 # tolerations: {}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -32,6 +32,7 @@ securityContext:
 # Add NET_RAW to enable ICMP
 #    add: ["NET_RAW"]
 
+podSecurityContext:{}
 # These are set in the global values.
 # nodeSelector: {}
 # tolerations: {}

--- a/tests/chart_tests/test_astronomer_pod_security_contexts.py
+++ b/tests/chart_tests/test_astronomer_pod_security_contexts.py
@@ -1,8 +1,7 @@
 import pytest
 
-from tests import git_root_dir, supported_k8s_versions
+from tests import git_root_dir
 from tests.chart_tests.helm_template_generator import render_chart
-from tests.chart_tests import get_all_features, get_chart_containers
 
 include_kind_list = ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
 
@@ -14,41 +13,29 @@ default_podsecuritycontext = {
 
 pod_manager_data = {
     "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml": {
-        "airflow-operator": {
-            "podSecurityContext": default_podsecuritycontext
-        },
+        "airflow-operator": {"podSecurityContext": default_podsecuritycontext},
         "global": {
             "airflowOperator": {"enabled": True},
         },
     },
     "charts/alertmanager/templates/alertmanager-statefulset.yaml": {
-        "alertmanager": {
-            "podSecurityContext": default_podsecuritycontext
-        },
+        "alertmanager": {"podSecurityContext": default_podsecuritycontext},
         "global": {
             "authSidecar": {"enabled": True},
         },
     },
     "charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml": {
-        "astronomer": {
-            "astroUI": {
-                "podSecurityContext": default_podsecuritycontext
-            }
-        }
+        "astronomer": {"astroUI": {"podSecurityContext": default_podsecuritycontext}}
     },
     "charts/astronomer/templates/commander/commander-deployment.yaml": {
-        "astronomer": {
-            "commander": {
-                "podSecurityContext": default_podsecuritycontext
-            }
-        }
+        "astronomer": {"commander": {"podSecurityContext": default_podsecuritycontext}}
     },
     "charts/astronomer/templates/houston/api/houston-deployment.yaml": {
         "astronomer": {
             "houston": {
                 "podSecurityContext": default_podsecuritycontext,
                 "waitForDB": {"podSecurityContext": default_podsecuritycontext},
-                "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+                "bootstrapper": {"podSecurityContext": default_podsecuritycontext},
             }
         }
     },
@@ -57,23 +44,18 @@ pod_manager_data = {
             "houston": {
                 "worker": {"podSecurityContext": default_podsecuritycontext},
                 "waitForDB": {"podSecurityContext": default_podsecuritycontext},
-                "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+                "bootstrapper": {"podSecurityContext": default_podsecuritycontext},
             }
         }
     },
     "charts/astronomer/templates/registry/registry-statefulset.yaml": {
-        "astronomer": {
-            "registry": {
-                "podSecurityContext": default_podsecuritycontext
-            }
-        }
+        "astronomer": {"registry": {"podSecurityContext": default_podsecuritycontext}}
     },
     "charts/elasticsearch/templates/client/es-client-deployment.yaml": {
         "elasticsearch": {
-        "podSecurityContext": default_podsecuritycontext,
+            "podSecurityContext": default_podsecuritycontext,
         },
-        "global": {
-            "openshiftEnabled": False},
+        "global": {"openshiftEnabled": False},
     },
     "charts/elasticsearch/templates/data/es-data-statefulset.yaml": {
         "elasticsearch": {
@@ -81,20 +63,16 @@ pod_manager_data = {
         }
     },
     "charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml": {
-        "elasticsearch": {
-            "exporter": {"podSecurityContext": default_podsecuritycontext}
-        }
+        "elasticsearch": {"exporter": {"podSecurityContext": default_podsecuritycontext}}
     },
     "charts/elasticsearch/templates/master/es-master-statefulset.yaml": {
         "elasticsearch": {
             "podSecurityContext": default_podsecuritycontext,
         },
-        "global": {"openshiftEnabled":  False},
+        "global": {"openshiftEnabled": False},
     },
     "charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml": {
-        "elasticsearch": {
-            "nginx": {"podSecurityContext": default_podsecuritycontext}
-        }
+        "elasticsearch": {"nginx": {"podSecurityContext": default_podsecuritycontext}}
     },
     "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml": {
         "external-es-proxy": {"podSecurityContext": default_podsecuritycontext},
@@ -105,41 +83,28 @@ pod_manager_data = {
             },
         },
     },
-    "charts/fluentd/templates/fluentd-daemonset.yaml": {
-        "fluentd": {
-        "pod": {"securityContext": default_podsecuritycontext}
-        }
-    },
+    "charts/fluentd/templates/fluentd-daemonset.yaml": {"fluentd": {"pod": {"securityContext": default_podsecuritycontext}}},
     "charts/grafana/templates/grafana-deployment.yaml": {
         "grafana": {
             "podSecurityContext": default_podsecuritycontext,
             "waitForDB": {"podSecurityContext": default_podsecuritycontext},
-            "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+            "bootstrapper": {"podSecurityContext": default_podsecuritycontext},
         },
     },
     "charts/kibana/templates/kibana-deployment.yaml": {
         "kibana": {"podSecurityContext": default_podsecuritycontext},
         "global": {"authSidecar": {"enabled": True}},
     },
-    "charts/kube-state/templates/kube-state-deployment.yaml": {
-        "kube-state": {"podSecurityContext": default_podsecuritycontext}
-    },
+    "charts/kube-state/templates/kube-state-deployment.yaml": {"kube-state": {"podSecurityContext": default_podsecuritycontext}},
     "charts/nats/templates/statefulset.yaml": {
-        "nats": {
-            "podSecurityContext": default_podsecuritycontext},
-            "reloader": {"podSecurityContext": default_podsecuritycontext},
-            "exporter": {"podSecurityContext": default_podsecuritycontext, "enabled": True}
-        },
+        "nats": {"podSecurityContext": default_podsecuritycontext},
+        "reloader": {"podSecurityContext": default_podsecuritycontext},
+        "exporter": {"podSecurityContext": default_podsecuritycontext, "enabled": True},
+    },
     "charts/nginx/templates/nginx-deployment-default.yaml": {
-        "nginx": {
-            "defaultBackend": {
-                "podSecurityContext": default_podsecuritycontext
-                }
-                  }
+        "nginx": {"defaultBackend": {"podSecurityContext": default_podsecuritycontext}}
     },
-    "charts/nginx/templates/nginx-deployment.yaml": {
-        "nginx": {"podSecurityContext": default_podsecuritycontext}
-    },
+    "charts/nginx/templates/nginx-deployment.yaml": {"nginx": {"podSecurityContext": default_podsecuritycontext}},
     "charts/pgbouncer/templates/pgbouncer-deployment.yaml": {
         "pgbouncer": {"podSecurityContext": default_podsecuritycontext},
         "global": {
@@ -148,7 +113,7 @@ pod_manager_data = {
     },
     "charts/postgresql/templates/statefulset-slaves.yaml": {
         "postgresql": {
-            "securityContext":{"fsGroup": 1001},
+            "securityContext": {"fsGroup": 1001},
             "podSecurityContext": default_podsecuritycontext,
             "replication": {"enabled": True},
         },
@@ -158,7 +123,7 @@ pod_manager_data = {
         "prometheus": {
             "podSecurityContext": default_podsecuritycontext,
             "configMapReloader": {"podSecurityContext": default_podsecuritycontext},
-            "filesdReloader": {"podSecurityContext": default_podsecuritycontext}
+            "filesdReloader": {"podSecurityContext": default_podsecuritycontext},
         }
     },
     "charts/prometheus-blackbox-exporter/templates/deployment.yaml": {
@@ -180,6 +145,7 @@ pod_manager_data = {
     },
 }
 
+
 def find_all_pod_manager_templates() -> list[str]:
     """Return a sorted, unique list of all pod manager templates in the chart, relative to git_root_dir."""
     return sorted(
@@ -196,16 +162,12 @@ def test_template_supports_podsecuritycontext(template):
     """Ensure each pod manager template has support for podSecurityContext."""
     values = pod_manager_data[template]
 
-
     docs = render_chart(show_only=template, values=values)
-
 
     assert len(docs) > 0, f"No documents rendered for {template}"
 
-
     for doc in docs:
         if doc.get("kind") in include_kind_list:
-
             pod_spec = doc.get("spec", {}).get("template", {}).get("spec", {})
 
             security_context = pod_spec.get("securityContext")
@@ -217,5 +179,6 @@ def test_template_supports_podsecuritycontext(template):
             assert security_context is not None, f"No securityContext found in {template}"
 
             for key, value in default_podsecuritycontext.items():
-                assert security_context.get(key) == value, \
+                assert security_context.get(key) == value, (
                     f"Expected {key}={value} in securityContext, got {security_context.get(key)}"
+                )

--- a/tests/chart_tests/test_astronomer_pod_security_contexts.py
+++ b/tests/chart_tests/test_astronomer_pod_security_contexts.py
@@ -159,7 +159,7 @@ def find_all_pod_manager_templates() -> list[str]:
 
 @pytest.mark.parametrize("template", list(pod_manager_data.keys()))
 def test_template_supports_podsecuritycontext(template):
-    """Ensure each pod manager template has support for podSecurityContext."""
+    """Test to Ensure each pod manager template has support for podSecurityContext."""
     values = pod_manager_data[template]
 
     docs = render_chart(show_only=template, values=values)

--- a/tests/chart_tests/test_astronomer_pod_security_contexts.py
+++ b/tests/chart_tests/test_astronomer_pod_security_contexts.py
@@ -1,0 +1,221 @@
+import pytest
+
+from tests import git_root_dir, supported_k8s_versions
+from tests.chart_tests.helm_template_generator import render_chart
+from tests.chart_tests import get_all_features, get_chart_containers
+
+include_kind_list = ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+
+default_podsecuritycontext = {
+    "fsGroup": 1000,
+    "runAsGroup": 1000,
+    "runAsUser": 1000,
+}
+
+pod_manager_data = {
+    "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml": {
+        "airflow-operator": {
+            "podSecurityContext": default_podsecuritycontext
+        },
+        "global": {
+            "airflowOperator": {"enabled": True},
+        },
+    },
+    "charts/alertmanager/templates/alertmanager-statefulset.yaml": {
+        "alertmanager": {
+            "podSecurityContext": default_podsecuritycontext
+        },
+        "global": {
+            "authSidecar": {"enabled": True},
+        },
+    },
+    "charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml": {
+        "astronomer": {
+            "astroUI": {
+                "podSecurityContext": default_podsecuritycontext
+            }
+        }
+    },
+    "charts/astronomer/templates/commander/commander-deployment.yaml": {
+        "astronomer": {
+            "commander": {
+                "podSecurityContext": default_podsecuritycontext
+            }
+        }
+    },
+    "charts/astronomer/templates/houston/api/houston-deployment.yaml": {
+        "astronomer": {
+            "houston": {
+                "podSecurityContext": default_podsecuritycontext,
+                "waitForDB": {"podSecurityContext": default_podsecuritycontext},
+                "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+            }
+        }
+    },
+    "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml": {
+        "astronomer": {
+            "houston": {
+                "worker": {"podSecurityContext": default_podsecuritycontext},
+                "waitForDB": {"podSecurityContext": default_podsecuritycontext},
+                "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+            }
+        }
+    },
+    "charts/astronomer/templates/registry/registry-statefulset.yaml": {
+        "astronomer": {
+            "registry": {
+                "podSecurityContext": default_podsecuritycontext
+            }
+        }
+    },
+    "charts/elasticsearch/templates/client/es-client-deployment.yaml": {
+        "elasticsearch": {
+        "podSecurityContext": default_podsecuritycontext,
+        },
+        "global": {
+            "openshiftEnabled": False},
+    },
+    "charts/elasticsearch/templates/data/es-data-statefulset.yaml": {
+        "elasticsearch": {
+            "podSecurityContext": default_podsecuritycontext,
+        }
+    },
+    "charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml": {
+        "elasticsearch": {
+            "exporter": {"podSecurityContext": default_podsecuritycontext}
+        }
+    },
+    "charts/elasticsearch/templates/master/es-master-statefulset.yaml": {
+        "elasticsearch": {
+            "podSecurityContext": default_podsecuritycontext,
+        },
+        "global": {"openshiftEnabled":  False},
+    },
+    "charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml": {
+        "elasticsearch": {
+            "nginx": {"podSecurityContext": default_podsecuritycontext}
+        }
+    },
+    "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml": {
+        "external-es-proxy": {"podSecurityContext": default_podsecuritycontext},
+        "global": {
+            "customLogging": {
+                "awsServiceAccountAnnotation": "aws-annotation-value",
+                "enabled": True,
+            },
+        },
+    },
+    "charts/fluentd/templates/fluentd-daemonset.yaml": {
+        "fluentd": {
+        "pod": {"securityContext": default_podsecuritycontext}
+        }
+    },
+    "charts/grafana/templates/grafana-deployment.yaml": {
+        "grafana": {
+            "podSecurityContext": default_podsecuritycontext,
+            "waitForDB": {"podSecurityContext": default_podsecuritycontext},
+            "bootstrapper": {"podSecurityContext": default_podsecuritycontext}
+        },
+    },
+    "charts/kibana/templates/kibana-deployment.yaml": {
+        "kibana": {"podSecurityContext": default_podsecuritycontext},
+        "global": {"authSidecar": {"enabled": True}},
+    },
+    "charts/kube-state/templates/kube-state-deployment.yaml": {
+        "kube-state": {"podSecurityContext": default_podsecuritycontext}
+    },
+    "charts/nats/templates/statefulset.yaml": {
+        "nats": {
+            "podSecurityContext": default_podsecuritycontext},
+            "reloader": {"podSecurityContext": default_podsecuritycontext},
+            "exporter": {"podSecurityContext": default_podsecuritycontext, "enabled": True}
+        },
+    "charts/nginx/templates/nginx-deployment-default.yaml": {
+        "nginx": {
+            "defaultBackend": {
+                "podSecurityContext": default_podsecuritycontext
+                }
+                  }
+    },
+    "charts/nginx/templates/nginx-deployment.yaml": {
+        "nginx": {"podSecurityContext": default_podsecuritycontext}
+    },
+    "charts/pgbouncer/templates/pgbouncer-deployment.yaml": {
+        "pgbouncer": {"podSecurityContext": default_podsecuritycontext},
+        "global": {
+            "pgbouncer": {"enabled": True},
+        },
+    },
+    "charts/postgresql/templates/statefulset-slaves.yaml": {
+        "postgresql": {
+            "securityContext":{"fsGroup": 1001},
+            "podSecurityContext": default_podsecuritycontext,
+            "replication": {"enabled": True},
+        },
+        "global": {"postgresqlEnabled": True},
+    },
+    "charts/prometheus/templates/prometheus-statefulset.yaml": {
+        "prometheus": {
+            "podSecurityContext": default_podsecuritycontext,
+            "configMapReloader": {"podSecurityContext": default_podsecuritycontext},
+            "filesdReloader": {"podSecurityContext": default_podsecuritycontext}
+        }
+    },
+    "charts/prometheus-blackbox-exporter/templates/deployment.yaml": {
+        "prometheus-blackbox-exporter": {"podSecurityContext": default_podsecuritycontext}
+    },
+    "charts/prometheus-node-exporter/templates/daemonset.yaml": {
+        "prometheus-node-exporter": {"podSecurityContext": default_podsecuritycontext}
+    },
+    "charts/prometheus-postgres-exporter/templates/deployment.yaml": {
+        "prometheus-postgres-exporter": {"podSecurityContext": default_podsecuritycontext},
+        "global": {"prometheusPostgresExporterEnabled": True},
+    },
+    "charts/stan/templates/statefulset.yaml": {
+        "stan": {
+            "stan": {"nats": {"podSecurityContext": default_podsecuritycontext}},
+            "exporter": {"podSecurityContext": default_podsecuritycontext},
+            "waitForNatsServer": {"podSecurityContext": default_podsecuritycontext},
+        }
+    },
+}
+
+def find_all_pod_manager_templates() -> list[str]:
+    """Return a sorted, unique list of all pod manager templates in the chart, relative to git_root_dir."""
+    return sorted(
+        {
+            str(x.relative_to(git_root_dir))
+            for x in (git_root_dir / "charts").rglob("*")
+            if any(sub in x.name for sub in ("deployment", "statefulset", "replicaset", "daemonset")) and "job" not in x.name
+        }
+    )
+
+
+@pytest.mark.parametrize("template", list(pod_manager_data.keys()))
+def test_template_supports_podsecuritycontext(template):
+    """Ensure each pod manager template has support for podSecurityContext."""
+    values = pod_manager_data[template]
+
+
+    docs = render_chart(show_only=template, values=values)
+
+
+    assert len(docs) > 0, f"No documents rendered for {template}"
+
+
+    for doc in docs:
+        if doc.get("kind") in include_kind_list:
+
+            pod_spec = doc.get("spec", {}).get("template", {}).get("spec", {})
+
+            security_context = pod_spec.get("securityContext")
+
+            if not security_context:
+                print(f"No securityContext found in {template}")
+                print(f"Pod spec keys: {pod_spec.keys()}")
+
+            assert security_context is not None, f"No securityContext found in {template}"
+
+            for key, value in default_podsecuritycontext.items():
+                assert security_context.get(key) == value, \
+                    f"Expected {key}={value} in securityContext, got {security_context.get(key)}"


### PR DESCRIPTION
## Description

This PR adds podSecurityContext support for all components in the Astronomer platform.

## Changes

- Added podSecurityContext support to all pod-based resources
- Added comprehensive unit tests to verify podSecurityContext implementation across all components

## Related Issues

Related astronomer/issues#7066

## Testing

- Covered with unittests
![Screenshot 2025-05-21 at 5 39 20 PM](https://github.com/user-attachments/assets/c7de3982-73d8-4328-abd1-abbed19bc605)

## Merging

0.37