### PR TITLE
Add Metadata Environment Variables to Commander Deployment

### DIFF
--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -126,6 +126,22 @@ spec:
             - name: COMMANDER_MANAGE_NAMESPACE_RESOURCE
               value: "false"
             {{- end }}
+            - name: COMMANDER_DATAPLANE_CHART_VERSION
+              value: {{ .Values.commander.dataplaneChartVersion | default "" | quote }}
+            - name: COMMANDER_CLOUD_PROVIDER
+              value: {{ .Values.commander.cloudProvider | default "" | quote }}
+            - name: COMMANDER_VERSION
+              value: {{ .Values.images.commander.tag | default "" | quote }}
+            - name: COMMANDER_URL
+              value: {{ .Values.commander.commanderUrl | default "" | quote }}
+            - name: COMMANDER_DATAPLANE_URL
+              value: {{ .Values.commander.dataplaneUrl | default "" | quote }}
+            - name: COMMANDER_DATAPLANE_ID
+              value: {{ .Values.commander.dataplaneId | default (randAlphaNum 8) | quote }}
+            - name: COMMANDER_REGION
+              value: {{ .Values.commander.region | default "" | quote }}
+            - name: COMMANDER_BASE_DOMAIN
+              value: {{ .Values.global.baseDomain | default "" | quote }}
           volumeMounts:
 {{- if .Values.commander.volumeMounts }}
 {{- tpl (toYaml .Values.commander.volumeMounts) $ | nindent 12 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -418,6 +418,14 @@ commander:
   # Add extra volumes to your commander deployment.
   extraVolumes: []
 
+  # Values for Dataplane Metadata
+  dataplaneChartVersion: ""
+  cloudProvider: ""
+  commanderUrl: ""
+  dataplaneUrl: ""
+  dataplaneId: ""
+  region: ""
+
 registry:
   # flag to bypass secure (tls) authentication to astronomer registry
   enableInsecureAuth: False

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -30,6 +30,15 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
         assert "COMMANDER_MANAGE_NAMESPACE_RESOURCE" not in env_vars
 
+        assert "COMMANDER_DATAPLANE_CHART_VERSION" in env_vars
+        assert "COMMANDER_CLOUD_PROVIDER" in env_vars
+        assert "COMMANDER_VERSION" in env_vars
+        assert "COMMANDER_URL" in env_vars
+        assert "COMMANDER_DATAPLANE_URL" in env_vars
+        assert "COMMANDER_DATAPLANE_ID" in env_vars
+        assert "COMMANDER_REGION" in env_vars
+        assert "COMMANDER_BASE_DOMAIN" in env_vars
+
     def test_astronomer_commander_deployment_upgrade_timeout(self, kube_version):
         """Test that helm renders a good deployment template for
         astronomer/commander.


### PR DESCRIPTION
## Description

This PR adds several new environment variables to the Commander deployment to support metadata configuration. These environment variables allow the Commander service to access and use metadata information such as dataplane chart version, cloud provider, URLs, region, and more.

## Changes

- Added the following environment variables to the Commander deployment:
```
- COMMANDER_DATAPLANE_CHART_VERSION
- COMMANDER_CLOUD_PROVIDER
- COMMANDER_VERSION (using existing tag value)
- COMMANDER_URL
- COMMANDER_DATAPLANE_URL
- COMMANDER_DATAPLANE_ID
- COMMANDER_REGION
- COMMANDER_BASE_DOMAIN
```
- Added corresponding configuration values under the commander section in values.yaml
- Updated tests to verify the presence of the new environment variables

## Related Issues
Related https://github.com/astronomer/issues/issues/7218

## Testing

- Added Unittests
- Tested the deployment locally.
![Screenshot 2025-05-21 at 7 07 27 PM](https://github.com/user-attachments/assets/8d82ab1c-b7c2-4d1e-9d5e-a8a8f971d757)

## Merging

1.0