### PR TITLE
ap-houston-api 0.37.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,7 +405,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
                 - quay.io/astronomer/ap-grafana:10.4.18
-                - quay.io/astronomer/ap-houston-api:0.37.21
+                - quay.io/astronomer/ap-houston-api:0.37.23
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5-1
                 - quay.io/astronomer/ap-kube-state:2.15.0-1
@@ -451,7 +451,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
                 - quay.io/astronomer/ap-grafana:10.4.18
-                - quay.io/astronomer/ap-houston-api:0.37.21
+                - quay.io/astronomer/ap-houston-api:0.37.23
                 - quay.io/astronomer/ap-init:3.21.3-3
                 - quay.io/astronomer/ap-kibana:8.15.5-1
                 - quay.io/astronomer/ap-kube-state:2.15.0-1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.21
+    tag: 0.37.23
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

- ap-houston-api 0.37.23
- Fixes dag-downloader tini configs

## Related Issues

Note: i got the issue number wrong in the branch name.

- https://github.com/astronomer/issues/issues/6714

## Testing

This new image make dag-downloader sidecars launch with `tini` as the first command in `/proc/1/cmdline` and `tini` should show up in `kubectl describe pod` for any pods that have a `dag-downloader` sidecar.

## Merging

Merge to 0.37, 0.36, 0.34, since this is a bugfix.