### PR TITLE
Security Context Configuration and Probes Fixes 

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml
@@ -52,7 +52,6 @@ spec:
             - name: cleanup
               image: {{ template "houston.image" . }}
               imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               args: ["yarn", "cleanup-deploy-revisions", "--", "--older-than={{ .Values.houston.cleanupDeployRevisions.olderThan }}"]
               securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
               resources: {{ toYaml .Values.houston.resources | nindent 16 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -93,7 +93,7 @@ spec:
         - name: houston
           image: {{ template "houston.image" . }}
           imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
-          securityContext: {{ toYaml (.Values.houston.podSecurityContext) | nindent 12 }}
+          securityContext: {{ toYaml (.Values.securityContext) | nindent 12 }}
           {{- if .Values.houston.worker.command }}
           command:
             {{- toYaml .Values.houston.worker.command | nindent 12 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -58,23 +58,11 @@ spec:
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             {{- include "houston_environment" . | indent 12 }}
-          {{- if .Values.houston.waitForDB.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.waitForDB.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.waitForDB.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.waitForDB.livenessProbe) . | nindent 12 }}
-          {{- end }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
-          {{- if .Values.houston.bootstrapper.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.bootstrapper.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: BOOTSTRAP_DB
               valueFrom:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -53,6 +53,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "registry.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.registry.podSecurityContext| nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:
@@ -61,7 +62,6 @@ spec:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
 {{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.registry.podSecurityContext| nindent 8 }}
 {{- end }}
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
       containers:

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -86,12 +86,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.client.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
   {{- end }}
       containers:
       - name: es-client

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -90,12 +90,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.data.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -89,12 +89,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.master.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -56,12 +56,6 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.waitForDB.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.waitForDB.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.waitForDB.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.waitForDB.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: GF_DATABASE_URL
               valueFrom:
@@ -73,12 +67,6 @@ spec:
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.bootstrapper.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.bootstrapper.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.bootstrapper.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.bootstrapper.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: BOOTSTRAP_DB
               valueFrom:

--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -58,8 +58,9 @@ spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
         fsGroup: {{ .Values.securityContext.fsGroup }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- if .Values.podSecurityContext }}
+        {{- toYaml (omit .Values.podSecurityContext "fsGroup") | nindent 4 }}
+        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "postgresql.serviceAccountName" . }}
       {{- if and .Values.volumePermissions.enabled .Values.persistence.enabled }}

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -85,12 +85,6 @@ spec:
             - name: NATS__URL
               value: "nats://{{ .Release.Name }}-nats:4222"
           resources: {{ toYaml .Values.init.resources | nindent 12 }}
-          {{- if .Values.waitForNatsServer.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.waitForNatsServer.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.waitForNatsServer.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.waitForNatsServer.livenessProbe) . | nindent 12 }}
-          {{- end }}
       containers:
         - name: stan
           image: {{ include "stan.image" . }}


### PR DESCRIPTION
## Description

This PR addresses several security context configuration issues across multiple Helm templates, improving consistency and fixing structural problems, and also removed unnecessary liveness and readiness probes from init containers 

## Related Issues

astronomer/issues#7294
astronomer/issues#7289
astronomer/issues#7066

## Changes Made

### Duplicate Security Context Removal

 - Removed duplicate `securityContext` declaration:
     - charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml

### Init Container Probe Cleanup

Removed unnecessary liveness and readiness probes from init containers in:

- charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
- charts/elasticsearch/templates/client/es-client-deployment.yaml
- charts/elasticsearch/templates/data/es-data-statefulset.yaml
- charts/elasticsearch/templates/master/es-master-statefulset.yaml
- charts/grafana/templates/grafana-deployment.yaml
- charts/stan/templates/statefulset.yaml

Note: Init containers typically don't need health probes as they run to completion before the main containers start.

### Template Structure Consistency

- Moved securityContext to appear after nodeSelector for consistent template ordering
    - charts/astronomer/templates/registry/registry-statefulset.yaml

## Merging

0.37