### PR TITLE
Port certgenerator image configuration to astronomer/astronomer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,6 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
-
                 - quay.io/astronomer/ap-certgenerator:0.1.8
                 - quay.io/astronomer/ap-commander:0.37.13
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,6 +393,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
+                - quay.io/astronomer/ap-certgenerator:0.1.8
                 - quay.io/astronomer/ap-commander:0.37.12
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2
@@ -439,6 +440,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
+                - quay.io/astronomer/ap-certgenerator:0.1.8
                 - quay.io/astronomer/ap-commander:0.37.12
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,6 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
-                - quay.io/astronomer/ap-certgenerator:0.1.8
                 - quay.io/astronomer/ap-commander:0.37.12
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2
@@ -440,7 +439,6 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
-                - quay.io/astronomer/ap-certgenerator:0.1.8
                 - quay.io/astronomer/ap-commander:0.37.12
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -73,9 +73,11 @@ def get_images_from_houston_configmap(doc, args):
             file=sys.stderr,
         )
     git_sync_images = houston_config["deployments"]["helm"]["gitSyncRelay"]["images"]
+    cert_generator_images = houston_config["deployments"]["helm"]["astronomer"]["images"]
     af_images = houston_config["deployments"]["helm"]["airflow"]["images"]
     images.extend(f"{image['repository']}:{image['tag']}" for image in af_images.values())
     images.extend(f"{image['repository']}:{image['tag']}" for image in git_sync_images.values())
+    images.extend(f"{image['repository']}:{image['tag']}" for image in cert_generator_images.values())
     return images
 
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -237,8 +237,8 @@ data:
         astronomer:
           images:
             certgenerator:
-              repository: "{{ .Values.global.certgenerator.repository }}"
-              tag: "{{ .Values.global.certgenerator.tag }}"
+              repository: "{{ .Values.global.certgenerator.images.repository }}"
+              tag: "{{ .Values.global.certgenerator.images.tag }}"
         gitSyncRelay:
           images:
             gitDaemon:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -234,7 +234,11 @@ data:
       {{- if .Values.global.networkNSLabels }}
         networkNSLabels: true
       {{- end }}
-
+        astronomer:
+          images:
+            certgenerator:
+              repository: "{{ .Values.global.certgenerator.repository }}"
+              tag: "{{ .Values.global.certgenerator.tag }}"
         gitSyncRelay:
           images:
             gitDaemon:
@@ -261,9 +265,6 @@ data:
             gitSync:
               repository: "{{ .Values.global.airflow.images.gitSync.repository }}"
               tag: "{{ .Values.global.airflow.images.gitSync.tag }}"
-            certgenerator:
-              repository: "{{ .Values.global.certgenerator.repository }}"
-              tag: "{{ .Values.global.certgenerator.tag }}"
 
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -261,6 +261,9 @@ data:
             gitSync:
               repository: "{{ .Values.global.airflow.images.gitSync.repository }}"
               tag: "{{ .Values.global.airflow.images.gitSync.tag }}"
+            certgenerator:
+              repository: "{{ .Values.global.airflow.images.certgenerator.repository }}"
+              tag: "{{ .Values.global.airflow.images.certgenerator.tag }}"
 
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -262,8 +262,8 @@ data:
               repository: "{{ .Values.global.airflow.images.gitSync.repository }}"
               tag: "{{ .Values.global.airflow.images.gitSync.tag }}"
             certgenerator:
-              repository: "{{ .Values.global.airflow.images.certgenerator.repository }}"
-              tag: "{{ .Values.global.airflow.images.certgenerator.tag }}"
+              repository: "{{ .Values.global.certgenerator.repository }}"
+              tag: "{{ .Values.global.certgenerator.tag }}"
 
           useAstroSecurityManager: true
           {{- if .Values.global.networkPolicy.enabled }}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -94,6 +94,12 @@ def test_houston_configmap_with_custom_images():
                     "gitSync": {"repository": "custom-registry/example/ap-git-sync-relay", "tag": "git-sync-999"},
                 }
             },
+            "certgenerator": {
+                "images": {
+                    "repository": "custom-registry/example/ap-certgenerator",
+                    "tag": "cert-generator-999",
+                }
+            },
         }
     }
 
@@ -105,6 +111,7 @@ def test_houston_configmap_with_custom_images():
 
     af_images = prod["deployments"]["helm"]["airflow"]["images"]
     git_sync_images = prod["deployments"]["helm"]["gitSyncRelay"]["images"]
+    cert_generator_images = prod["deployments"]["helm"]["astronomer"]["images"]
 
     assert af_images["statsd"]["tag"] == "statsd-999"
     assert af_images["redis"]["tag"] == "redis-999"
@@ -113,6 +120,7 @@ def test_houston_configmap_with_custom_images():
     assert af_images["gitSync"]["tag"] == "git-sync-999"
     assert git_sync_images["gitDaemon"]["tag"] == "git-daemon-999"
     assert git_sync_images["gitSync"]["tag"] == "git-sync-999"
+    assert cert_generator_images["certgenerator"]["tag"] == "cert-generator-999"
 
     assert af_images["statsd"]["repository"] == "custom-registry/example/ap-statsd-exporter"
     assert af_images["redis"]["repository"] == "custom-registry/example/ap-redis"
@@ -121,6 +129,7 @@ def test_houston_configmap_with_custom_images():
     assert af_images["gitSync"]["repository"] == "custom-registry/example/ap-git-sync"
     assert git_sync_images["gitDaemon"]["repository"] == "custom-registry/example/ap-git-daemon"
     assert git_sync_images["gitSync"]["repository"] == "custom-registry/example/ap-git-sync-relay"
+    assert cert_generator_images["certgenerator"]["repository"] == "custom-registry/example/ap-certgenerator"
 
 
 def test_houston_configmap_with_namespaceFreeFormEntry_true():

--- a/values.yaml
+++ b/values.yaml
@@ -172,10 +172,6 @@ global:
     #    cpu: "100m"
     #    memory: "386Mi"
 
-  certgenerator:
-    repository: quay.io/astronomer/ap-certgenerator
-    tag: 0.1.8
-
   # Deploy auth sidecar to use openshift native features
   authSidecar:
     enabled: false
@@ -335,6 +331,9 @@ global:
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
         tag: 0.1.11
+  certgenerator:
+    repository: quay.io/astronomer/ap-certgenerator
+    tag: 0.1.8
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:

--- a/values.yaml
+++ b/values.yaml
@@ -171,7 +171,7 @@ global:
     #  limits:
     #    cpu: "100m"
     #    memory: "386Mi"
-  
+
   certgenerator:
     repository: quay.io/astronomer/ap-certgenerator
     tag: 0.1.8

--- a/values.yaml
+++ b/values.yaml
@@ -323,6 +323,9 @@ global:
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2
+      certgenerator:
+        repository: quay.io/astronomer/ap-certgenerator
+        tag: 0.1.8
   gitSyncRelay:
     images:
       gitDaemon:

--- a/values.yaml
+++ b/values.yaml
@@ -332,8 +332,9 @@ global:
         repository: quay.io/astronomer/ap-git-sync-relay
         tag: 0.1.11
   certgenerator:
-    repository: quay.io/astronomer/ap-certgenerator
-    tag: 0.1.8
+    images:
+      repository: quay.io/astronomer/ap-certgenerator
+      tag: 0.1.8
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:

--- a/values.yaml
+++ b/values.yaml
@@ -171,6 +171,10 @@ global:
     #  limits:
     #    cpu: "100m"
     #    memory: "386Mi"
+  
+  certgenerator:
+    repository: quay.io/astronomer/ap-certgenerator
+    tag: 0.1.8
 
   # Deploy auth sidecar to use openshift native features
   authSidecar:
@@ -323,9 +327,6 @@ global:
       xcom:
         repository: quay.io/astronomer/ap-alpine
         tag: 3.21.3-2
-      certgenerator:
-        repository: quay.io/astronomer/ap-certgenerator
-        tag: 0.1.8
   gitSyncRelay:
     images:
       gitDaemon:


### PR DESCRIPTION
## Description

This PR ports the certgenerator image configuration from the astronomer/airflow-chart repository to the astronomer/astronomer repository, enabling the Astronomer platform to manage and deploy the certgenerator component across all Airflow deployments.

## Related Issues

[Related astronomer/issues#638](https://github.com/astronomer/security-issues/issues/638)

## Changes Made

1. Added certgenerator to global airflow images configuration
2. Updated Houston ConfigMap template

## Testing

- Verified Helm template rendering produces correct configuration
![Screenshot 2025-06-02 at 5 37 43 PM](https://github.com/user-attachments/assets/35945b8f-c511-464d-98a5-e6e05a9dd8a8)

## Merging

0.37 and cherrypick everywhere