### PR TITLE
ap-certgenerator:0.1.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -393,7 +393,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
-                - quay.io/astronomer/ap-certgenerator:0.1.8
+                - quay.io/astronomer/ap-certgenerator:0.1.9
                 - quay.io/astronomer/ap-commander:0.37.13
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2
@@ -440,7 +440,7 @@ workflows:
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-17
                 - quay.io/astronomer/ap-base:3.21.3-4
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-9
-                - quay.io/astronomer/ap-certgenerator:0.1.8
+                - quay.io/astronomer/ap-certgenerator:0.1.9
                 - quay.io/astronomer/ap-commander:0.37.13
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-2

--- a/values.yaml
+++ b/values.yaml
@@ -334,7 +334,7 @@ global:
   certgenerator:
     images:
       repository: quay.io/astronomer/ap-certgenerator
-      tag: 0.1.8
+      tag: 0.1.9
 
   # For now we support only pgbouncer with gss api support
   pgbouncer:


### PR DESCRIPTION
## Description

ap-certgenerator:0.1.9 (fix CVEs)

## Related Issues

https://github.com/astronomer/issues/issues/7315

## Testing

No extra QA needed, no docs needed.

## Merging

This change should probably go everywhere since it fixes CVEs, but 0.37 is the main target.