### PR TITLE
Updating Cosign Scripts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           docker_layer_caching: true
           version: docker23
       - cosign/install:
-          version: "v2.4.1"
+          version: "v2.5.0"
       - run:
           name: Login to docker registry
           command: |

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -34,7 +34,7 @@ jobs:
           docker_layer_caching: true
           version: docker23
       - cosign/install:
-          version: "v2.4.1"
+          version: "v2.5.0"
       - run:
           name: Login to docker registry
           command: |

--- a/bin/sign-images.py
+++ b/bin/sign-images.py
@@ -138,7 +138,9 @@ def main():
             except (FileNotFoundError, json.JSONDecodeError):
                 print(f"Error: Could not find or parse local file {json_file}")
                 sys.exit(1)
-
+        subprocess.run(
+            ["docker", "login", "quay.io", "-u", os.environ["QUAY_USERNAME"], "-p", os.environ["QUAY_PASSWORD"]], check=True
+        )
         print("Signing Astronomer images...")
         for image_data in data["astronomer"]["images"].values():
             sign_image(image_data["repository"], image_data["tag"], image_data["sha256"], private_key_path, password)

--- a/bin/sign-images.py
+++ b/bin/sign-images.py
@@ -75,7 +75,7 @@ def sign_image(repo, tag, sha, key_path, password=None):
     except subprocess.CalledProcessError:
         pass  # Image is not yet signed
 
-    sign_cmd = ["cosign", "sign", "--key", key_path, digest_reference]
+    sign_cmd = ["cosign", "sign", "--yes", "--key", key_path, digest_reference]
     try:
         subprocess.run(sign_cmd, env=env, check=True)
         print(f"✓ Signed {full_image}")

--- a/bin/sign-images.py
+++ b/bin/sign-images.py
@@ -66,7 +66,7 @@ def sign_image(repo, tag, sha, key_path, password=None):
 
     try:
         subprocess.run(
-            ["cosign", "verify", "--insecure-ignore-tlog", "--key", f"{key_path}.pub", digest_reference],
+            ["cosign", "verify", "--key", f"{key_path}.pub", "--insecure-ignore-tlog", digest_reference],
             check=True,
             capture_output=True,
         )
@@ -75,7 +75,7 @@ def sign_image(repo, tag, sha, key_path, password=None):
     except subprocess.CalledProcessError:
         pass  # Image is not yet signed
 
-    sign_cmd = ["cosign", "sign", "--yes", "--key", key_path, digest_reference]
+    sign_cmd = ["cosign", "sign", "--key", key_path, "--tlog-upload=false", digest_reference]
     try:
         subprocess.run(sign_cmd, env=env, check=True)
         print(f"✓ Signed {full_image}")
@@ -138,9 +138,6 @@ def main():
             except (FileNotFoundError, json.JSONDecodeError):
                 print(f"Error: Could not find or parse local file {json_file}")
                 sys.exit(1)
-        subprocess.run(
-            ["docker", "login", "quay.io", "-u", os.environ["QUAY_USERNAME"], "-p", os.environ["QUAY_PASSWORD"]], check=True
-        )
         print("Signing Astronomer images...")
         for image_data in data["astronomer"]["images"].values():
             sign_image(image_data["repository"], image_data["tag"], image_data["sha256"], private_key_path, password)


### PR DESCRIPTION
## Description

This PR intends to add a flag to skip artifact signature upload to Rekor and also verify without the signature present in Rekor which is used by default in cosign to store signature. 

## Changes Made
 - Added `--tlog-upload=false` flag to skip artifact signatures upload to Rekor. 
 - Added `--insecure-ignore-tlog=true` flag to verify the signature that was not uploaded to Rekor.

## Related Issues

Related astronomer/issues#7334

## Testing

- All Astronomer images for release 0.37.3 have been manually signed using these updated scripts to ensure:
  - Proper cosign functionality with the new version
  - Successful authentication with Quay.io registry
- Tested that the new flags work as expected. 
![Screenshot 2025-06-09 at 3 10 23 PM](https://github.com/user-attachments/assets/78baf59f-d507-4d4c-b1bb-94844569299a)
- Image mentioned in the screenshot is signed:
<img width="529" alt="Screenshot 2025-06-09 at 3 10 55 PM" src="https://github.com/user-attachments/assets/f0de753e-32c3-470d-8c3b-950acb7c505a" />

## Benefits of these changes:
- No third-party dependencies
- Works in air-gapped environments
- Signatures stored only in container registry
- Faster signing/verification (no network calls)

## Cosign Doc referred:
- https://blog.sigstore.dev/cosign-2-0-released/

## Merging

master and 0.37