### PR TITLE
Add COMMANDER_WAIT_ENABLED Environment Variable to Houston Deployment

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -209,8 +209,6 @@ s3:
 {{- end }}
 
 {{- define "houston_environment" }}
-- name: COMMANDER_WAIT_ENABLED
-  value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
 {{- /* Dynamically created envs */ -}}
 {{- range $i, $config := .Values.houston.env }}
 - name: {{ $config.name }}
@@ -270,6 +268,8 @@ s3:
 - name: HOUSTON_SCRIPT_UPDATE_RUNTIME_SERVICE_URL
   value: {{ .Values.houston.updateRuntimeCheck.url }}
 {{- end }}
+- name: COMMANDER_WAIT_ENABLED
+  value: "false"
 
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -264,13 +264,12 @@ s3:
   value: {{ template "houston.nats.servers" . }}
 - name: NATS__CLUSTER_ID
   value: {{ .Release.Name }}-stan
+- name: COMMANDER_WAIT_ENABLED
+  value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
 {{- if .Values.houston.updateRuntimeCheck.enabled }}
 - name: HOUSTON_SCRIPT_UPDATE_RUNTIME_SERVICE_URL
   value: {{ .Values.houston.updateRuntimeCheck.url }}
 {{- end }}
-- name: COMMANDER_WAIT_ENABLED
-  value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
-
 {{- end }}
 
 {{- define "houston_volume_mounts" }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -269,7 +269,7 @@ s3:
   value: {{ .Values.houston.updateRuntimeCheck.url }}
 {{- end }}
 - name: COMMANDER_WAIT_ENABLED
-  value: "false"
+  value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
 
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -209,6 +209,8 @@ s3:
 {{- end }}
 
 {{- define "houston_environment" }}
+- name: COMMANDER_WAIT_ENABLED
+  value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
 {{- /* Dynamically created envs */ -}}
 {{- range $i, $config := .Values.houston.env }}
 - name: {{ $config.name }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -143,7 +143,7 @@ spec:
             - name: COMMANDER_BASE_DOMAIN
               value: {{ .Values.global.baseDomain | default "" | quote }}
             - name: COMMANDER_DATAPLANE_MODE
-              value: {{ .Values.global.dataplane.enabled | default false | quote }}
+              value: {{ if eq .Values.global.plane.mode "data" }}"true"{{ else }}"false"{{ end }}
             - name: COMMANDER_HOUSTON_AUTHORIZATION_URL
               value: {{ .Values.commander.houstonAuthorizationUrl | default "" | quote }}
           volumeMounts:

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -143,7 +143,7 @@ spec:
             - name: COMMANDER_BASE_DOMAIN
               value: {{ .Values.global.baseDomain | default "" | quote }}
             - name: COMMANDER_DATAPLANE_MODE
-              value: {{ if eq .Values.global.plane.mode "data" }}"true"{{ else }}"false"{{ end }}
+              value: {{ .Values.global.plane.mode | quote }}
             - name: COMMANDER_HOUSTON_AUTHORIZATION_URL
               value: {{ .Values.commander.houstonAuthorizationUrl | default "" | quote }}
           volumeMounts:

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -71,6 +71,8 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
+            - name: COMMANDER_WAIT_ENABLED
+              value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
             {{- include "houston_environment" . | indent 12 }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
@@ -157,6 +159,8 @@ spec:
             {{- toYaml .Values.houston.apiArgs | nindent 12 }}
           {{- end }}
           env:
+            - name: COMMANDER_WAIT_ENABLED
+              value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
             {{- include "houston_environment" . | indent 12 }}
             - name: GRPC_VERBOSITY
               value: "INFO"

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -71,9 +71,7 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
-            - name: COMMANDER_WAIT_ENABLED
-              value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
-            {{- include "houston_environment" . | indent 12 }}
+           {{- include "houston_environment" . | indent 12 }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
@@ -159,8 +157,6 @@ spec:
             {{- toYaml .Values.houston.apiArgs | nindent 12 }}
           {{- end }}
           env:
-            - name: COMMANDER_WAIT_ENABLED
-              value: {{ if eq .Values.global.plane.mode "unified" }}"true"{{ else }}"false"{{ end }}
             {{- include "houston_environment" . | indent 12 }}
             - name: GRPC_VERBOSITY
               value: "INFO"

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -50,6 +50,14 @@ class TestHoustonApiDeployment:
         houston_env = c_by_name["houston"]["env"]
         deployments_database_connection_env = next(x for x in houston_env if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION")
         assert deployments_database_connection_env is not None
+        commander_wait_enabled_env = next(x for x in houston_env if x["name"] == "COMMANDER_WAIT_ENABLED")
+        assert commander_wait_enabled_env is not None
+        assert commander_wait_enabled_env["value"] == "true"
+
+        wait_for_db_env = c_by_name["wait-for-db"]["env"]
+        commander_wait_enabled_init_env = next(x for x in wait_for_db_env if x["name"] == "COMMANDER_WAIT_ENABLED")
+        assert commander_wait_enabled_init_env is not None
+        assert commander_wait_enabled_init_env["value"] == "true"
 
     def test_houston_api_deployment_with_helm_set_database(self, kube_version):
         docs = render_chart(

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -50,14 +50,12 @@ class TestHoustonApiDeployment:
         houston_env = c_by_name["houston"]["env"]
         deployments_database_connection_env = next(x for x in houston_env if x["name"] == "DEPLOYMENTS__DATABASE__CONNECTION")
         assert deployments_database_connection_env is not None
-        commander_wait_enabled_env = next(x for x in houston_env if x["name"] == "COMMANDER_WAIT_ENABLED")
-        assert commander_wait_enabled_env is not None
-        assert commander_wait_enabled_env["value"] == "true"
+        env_vars = {x["name"]: x["value"] if x.get("value") else x["valueFrom"] for x in c_by_name["houston"]["env"]}
+        assert env_vars["DEPLOYMENTS__DATABASE__CONNECTION"]["secretKeyRef"]
+        assert env_vars["COMMANDER_WAIT_ENABLED"] == "true"
 
-        wait_for_db_env = c_by_name["wait-for-db"]["env"]
-        commander_wait_enabled_init_env = next(x for x in wait_for_db_env if x["name"] == "COMMANDER_WAIT_ENABLED")
-        assert commander_wait_enabled_init_env is not None
-        assert commander_wait_enabled_init_env["value"] == "true"
+        env_vars = {x["name"]: x["value"] if x.get("value") else x["valueFrom"] for x in c_by_name["wait-for-db"]["env"]}
+        assert env_vars["COMMANDER_WAIT_ENABLED"] == "true"
 
     def test_houston_api_deployment_with_helm_set_database(self, kube_version):
         docs = render_chart(

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -57,6 +57,29 @@ class TestHoustonApiDeployment:
         env_vars = {x["name"]: x["value"] if x.get("value") else x["valueFrom"] for x in c_by_name["wait-for-db"]["env"]}
         assert env_vars["COMMANDER_WAIT_ENABLED"] == "true"
 
+    def test_houston_api_deployment_control_mode(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "control"}}},
+            show_only=["charts/astronomer/templates/houston/api/houston-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Deployment"
+
+        c_by_name = get_containers_by_name(doc, include_init_containers=True)
+
+        houston_env = c_by_name["houston"]["env"]
+        commander_wait_enabled_env = next(x for x in houston_env if x["name"] == "COMMANDER_WAIT_ENABLED")
+        assert commander_wait_enabled_env is not None
+        assert commander_wait_enabled_env["value"] == "false"
+
+        wait_for_db_env = c_by_name["wait-for-db"]["env"]
+        commander_wait_enabled_init_env = next(x for x in wait_for_db_env if x["name"] == "COMMANDER_WAIT_ENABLED")
+        assert commander_wait_enabled_init_env is not None
+        assert commander_wait_enabled_init_env["value"] == "false"
+
     def test_houston_api_deployment_with_helm_set_database(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -3,11 +3,7 @@ import testinfra
 
 from tests.functional_tests.conftest import get_pod_running_containers
 
-container_ignore_list = [
-    "kube-state",
-    "houston",
-    "fluentd",
-]
+container_ignore_list = ["kube-state", "houston", "fluentd", "commander"]
 
 container_list = get_pod_running_containers()
 

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -8,7 +8,7 @@ container_ignore_list = [
     "kube-state",
     "houston",
     "fluentd",
- ]
+]
 
 container_list = get_pod_running_containers()
 

--- a/tests/functional_tests/test_container_no_root.py
+++ b/tests/functional_tests/test_container_no_root.py
@@ -3,7 +3,12 @@ import testinfra
 
 from tests.functional_tests.conftest import get_pod_running_containers
 
-container_ignore_list = ["kube-state", "houston", "fluentd", "commander"]
+container_ignore_list = [
+    "commander",
+    "kube-state",
+    "houston",
+    "fluentd",
+ ]
 
 container_list = get_pod_running_containers()
 


### PR DESCRIPTION
## Description

This PR adds the COMMANDER_WAIT_ENABLED environment variable to both the wait-for-db init container and the main houston container in the Houston deployment, with conditional logic based on the plane mode configuration, so that houston doesn't wait for commander when `control` mode is set. 
This is related to: https://github.com/astronomer/houston-api/commit/8490d76f2cbe6e2efe02d6bc7e3d81403c65dc38

## Changes:

### Houston Deployment

- Implemented conditional logic based on .Values.global.plane.mode:
  - unified mode → COMMANDER_WAIT_ENABLED = "true"
  - control mode → COMMANDER_WAIT_ENABLED = "false"

This ensures that the commander wait functionality is only enabled in unified plane deployments where houston and commander are in same cluster, while remaining disabled in control plane and other deployment modes

### Commander Deployment

- Fixed COMMANDER_DATAPLANE_MODE environment variable to use new plane mode system and give out mode name as output for commander to use:
```
- name: COMMANDER_DATAPLANE_MODE
   value: {{ .Values.global.plane.mode | quote }}
```


## Related Issues

Related astronomer/issues#7136

## Testing

- Tested the manual rendering of the flag:

  - In Control mode `helm template --set global.plane.mode="control"  .  --show-only charts/astronomer/templates/houston/api/houston-deployment.yaml` :
![Screenshot 2025-06-09 at 4 28 28 PM](https://github.com/user-attachments/assets/f29babcb-f287-498c-8acf-c64ce04c2fff)

  - In Unified mode `helm template --set global.plane.mode="unified"  .  --show-only charts/astronomer/templates/houston/api/houston-deployment.yaml`
![Screenshot 2025-06-09 at 4 35 22 PM](https://github.com/user-attachments/assets/4470c42d-3d80-47cf-b3db-c756270e3e1a)


## Merging

1.0