### PR TITLE
Registry to Use JWT Authentication in Dataplane Mode

### DIFF
--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry ConfigMap ##
 ###################################
 {{ if and .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -35,20 +35,10 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
   {{- end }}
       hosts:
-        - registry.{{ .Values.global.baseDomain }}
+        - {{ if eq .Values.global.plane.mode "data" }}registry.{{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}{{ else }}registry.{{ .Values.global.baseDomain }}{{ end }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
   rules:
-  - host: registry.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-registry
-            servicePort: registry-http
-  {{ else -}}
-  rules:
-  - host: registry.{{ .Values.global.baseDomain }}
+  - host: {{ if eq .Values.global.plane.mode "data" }}registry.{{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}{{ else }}registry.{{ .Values.global.baseDomain }}{{ end }}
     http:
       paths:
         - path: /
@@ -58,6 +48,5 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
-  {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Ingress ##
 #################################
 {{- if and .Values.global.baseDomain .Values.global.enablePerHostIngress }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Registry NetworkPolicy
 ################################
 {{- if and .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/astronomer/templates/registry/registry-scc.yaml
+++ b/charts/astronomer/templates/registry/registry-scc.yaml
@@ -2,7 +2,7 @@
 ### Astronomer Registry Scc   ###
 #################################
 {{- if and .Values.registry.serviceAccount.create .Values.registry.serviceAccount.sccEnabled }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/astronomer/templates/registry/registry-secret.yaml
+++ b/charts/astronomer/templates/registry/registry-secret.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Secrets ##
 #################################
 {{ if and .Values.global.baseDomain (not .Values.registry.auth.secretName) }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-service.yaml
+++ b/charts/astronomer/templates/registry/registry-service.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Service ##
 #################################
 {{- if and .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-serviceaccount.yaml
+++ b/charts/astronomer/templates/registry/registry-serviceaccount.yaml
@@ -2,7 +2,7 @@
 ## Registry ServiceAccount ##
 #############################
 {{- if and .Values.registry.serviceAccount.create }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -140,15 +140,10 @@ spec:
               - key: config.yml
                 path: config.yml
         {{- if eq .Values.global.plane.mode "data"}}
+        {{- if not .Values.registry.enableInsecureAuth }}
         - name: jwks-certificate
           secret:
             secretName: {{ include "houston.jwtCertificateSecret" . }}
-        {{- end }}
-        {{- if eq .Values.global.plane.mode "unified"}}
-        {{- if not .Values.registry.enableInsecureAuth }}
-        - name: certificate
-          secret:
-            secretName: {{ .Values.global.tlsSecret }}
         {{- end }}
         {{- end }}
         {{ include "custom_ca_volumes" . | indent 8  }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -96,8 +96,8 @@ spec:
             - name: config
               mountPath: /etc/docker/registry
             {{- if not .Values.registry.enableInsecureAuth }}
-            - name: certificate
-              mountPath: /etc/docker/ssl
+            - name: jwks-certificate
+              mountPath: /etc/docker/jwks
             {{- end }}
             - name: data
               mountPath: /var/lib/registry

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -139,10 +139,17 @@ spec:
             items:
               - key: config.yml
                 path: config.yml
+        {{- if eq .Values.global.plane.mode "data"}}
+        - name: jwks-certificate
+          secret:
+            secretName: {{ include "houston.jwtCertificateSecret" . }}
+        {{- end }}
+        {{- if eq .Values.global.plane.mode "unified"}}
         {{- if not .Values.registry.enableInsecureAuth }}
         - name: certificate
           secret:
             secretName: {{ .Values.global.tlsSecret }}
+        {{- end }}
         {{- end }}
         {{ include "custom_ca_volumes" . | indent 8  }}
         {{- if and .Values.registry.gcs.enabled .Values.registry.gcs.useKeyfile }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry StatefulSet ##
 #####################################
 {{- if and .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- if or .Values.registry.gcs.enabled .Values.registry.azure.enabled .Values.registry.s3.enabled }}
 kind: Deployment
 apiVersion: apps/v1

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -1,7 +1,8 @@
 import jmespath
 import pytest
+from pathlib import Path
 
-from tests import supported_k8s_versions
+from tests import git_root_dir, supported_k8s_versions
 from tests.utils.chart import render_chart
 
 
@@ -210,7 +211,12 @@ class TestRegistryStatefulset:
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"plane": {"mode": "control"}}},
-            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
+            show_only=sorted(
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")
+                ]
+            ),
         )
 
         assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -178,3 +178,39 @@ class TestRegistryStatefulset:
         assert docs[0]["kind"] == "StatefulSet"
         assert len(docs[0]["spec"]["template"]["spec"]["volumes"]) == 1
         assert docs[0]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][1] != not_expected_volume_mount
+
+    def test_astronomer_registry_statefulset_enabled_for_data_and_unified_mode(self, kube_version):
+        """Test that helm renders registry statefulset when global.plane.mode is 'data' or 'unified'."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+
+        docs = render_chart(
+        kube_version=kube_version,
+        values={"global": {"plane": {"mode": "unified"}}},
+        show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "StatefulSet"
+        assert doc["apiVersion"] == "apps/v1"
+        assert doc["metadata"]["name"] == "release-name-registry"
+
+    def test_astronomer_registry_statefulset_disabled_for_control_mode(self, kube_version):
+        """Test that helm does not render registry statefulset when global.plane.mode is 'control'."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "control"}}},
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
+        )
+
+        assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -181,23 +181,12 @@ class TestRegistryStatefulset:
         assert len(docs[0]["spec"]["template"]["spec"]["volumes"]) == 1
         assert docs[0]["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][1] != not_expected_volume_mount
 
-    def test_astronomer_registry_statefulset_enabled_for_data_and_unified_mode(self, kube_version):
+    @pytest.mark.parametrize("mode", ["data", "unified"])
+    def test_astronomer_registry_statefulset_enabled_for_data_and_unified_mode(self, kube_version, mode):
         """Test that helm renders registry statefulset when global.plane.mode is 'data' or 'unified'."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "data"}}},
-            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-        assert doc["kind"] == "StatefulSet"
-        assert doc["apiVersion"] == "apps/v1"
-        assert doc["metadata"]["name"] == "release-name-registry"
-
-        docs = render_chart(
-            kube_version=kube_version,
-            values={"global": {"plane": {"mode": "unified"}}},
+            values={"global": {"plane": {"mode": mode}}},
             show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
 

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import jmespath
 import pytest
-from pathlib import Path
 
 from tests import git_root_dir, supported_k8s_versions
 from tests.utils.chart import render_chart
@@ -195,9 +196,9 @@ class TestRegistryStatefulset:
         assert doc["metadata"]["name"] == "release-name-registry"
 
         docs = render_chart(
-        kube_version=kube_version,
-        values={"global": {"plane": {"mode": "unified"}}},
-        show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "unified"}}},
+            show_only=["charts/astronomer/templates/registry/registry-statefulset.yaml"],
         )
 
         assert len(docs) == 1
@@ -212,10 +213,7 @@ class TestRegistryStatefulset:
             kube_version=kube_version,
             values={"global": {"plane": {"mode": "control"}}},
             show_only=sorted(
-                [
-                    str(x.relative_to(git_root_dir))
-                    for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")
-                ]
+                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")]
             ),
         )
 

--- a/tests/chart_tests/test_registry_statefulset.py
+++ b/tests/chart_tests/test_registry_statefulset.py
@@ -53,7 +53,7 @@ class TestRegistryStatefulset:
         assert doc["kind"] == "Deployment"
         assert doc["apiVersion"] == "apps/v1"
         assert doc["metadata"]["name"] == "release-name-registry"
-        assert doc["spec"]["template"]["spec"]["volumes"][2]["name"] == "gcs-keyfile"
+        assert doc["spec"]["template"]["spec"]["volumes"][1]["name"] == "gcs-keyfile"
         assert doc["spec"]["template"]["spec"]["containers"][0]["volumeMounts"][3]["name"] == "gcs-keyfile"
 
     def test_registry_sts_with_registry_persistence_enabled(self, kube_version):


### PR DESCRIPTION
## Description

This PR migrates the Astronomer Registry from TLS certificate authentication to JWT certificate authentication when running in dataplane mode, enabling secure communication between Houston (controlplane) and Registry (dataplane) in multi-cluster deployments.

## Related Issues
- astronomer/issues#7358
- https://github.com/astronomer/issues/issues/7160
- https://github.com/astronomer/issues/issues/7161

## Changes Made

- Authentication Migration
  - **Removed**: TLS certificate mounting (astronomer-tls secret)
  - **Added**: JWT certificate mounting using Houston's JWT signing certificate
  - **Mount Path**: JWT certificate now mounted at /etc/docker/jwks instead of /etc/docker/ssl

- All Registry Components updated to use dataplane mode

## Registry Deployment Behavior

```
| Plane Mode | Registry Deployment | Authentication Method |
|:-----------|:-------------------:|:----------------------|
| `control`  |   Not deployed      | N/A                   |
| `data`     |   Deployed          | JWT Certificate       |
| `unified`  |   Deployed          | JWT Certificate       |
```

## Testing

- All existing tests pass, after test fixes:
![Screenshot 2025-06-13 at 1 59 07 PM](https://github.com/user-attachments/assets/5e734d67-3c38-4386-a506-1391aa56ad77)
- New plane mode tests validate deployment conditions
- Backward compatibility with insecure auth maintained

## Merging

1.0