### PR TITLE
Config Syncer to run in Data and Unified Planes Only

### DIFF
--- a/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml
@@ -2,7 +2,7 @@
 ## Config Syncer CronJob
 ###################################
 {{- if and .Values.configSyncer.enabled }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-role.yaml
@@ -6,7 +6,7 @@
 # 2. Create a Cluster Role if namespacePools is disabled
 # 3. Create roles for each namespaces in the namespacePool (+ astronomer namespace) if enabled.
 {{- if and .Values.configSyncer.enabled .Values.global.rbacEnabled .Values.configSyncer.serviceAccount.create }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled (not .Values.global.features.namespacePools.enabled)}}
 {{- $shouldCreateResources := and .Values.global.rbacEnabled (or (and .Values.global.clusterRoles (not .Values.global.features.namespacePools.enabled )) $namespacepoolsRBACresources) }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-rolebinding.yaml
@@ -6,7 +6,7 @@
 # 2. Create ClusterRoleBinding if namespacePools disabled
 # 3. Create RoleBinding for each namespace in the namespacePool (+ astronomer namespace) if enabled
 {{- if and .Values.configSyncer.enabled .Values.global.rbacEnabled .Values.configSyncer.serviceAccount.create }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- $namespacepoolsRBACresources:= and .Values.global.features.namespacePools.createRbac .Values.global.features.namespacePools.enabled }}
 {{- $useClusterRoles := and .Values.global.rbacEnabled (not .Values.global.features.namespacePools.enabled)}}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}

--- a/charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml
+++ b/charts/astronomer/templates/config-syncer/config-syncer-serviceaccount.yaml
@@ -2,7 +2,7 @@
 ## Astronomer ServiceAccount ##
 ###############################
 {{- if and .Values.configSyncer.enabled .Values.global.rbacEnabled .Values.configSyncer.serviceAccount.create }}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -328,7 +328,10 @@ class TestAstronomerConfigSyncer:
                 "astronomer": {"configSyncer": {"enabled": True}},
             },
             show_only=sorted(
-                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/astronomer/templates/config-syncer").glob("*")]
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/astronomer/templates/config-syncer").glob("*")
+                ]
             ),
         )
         assert len(docs) == 0

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 from tests import git_root_dir, supported_k8s_versions
 from tests.utils import get_containers_by_name
@@ -335,9 +336,9 @@ class TestAstronomerConfigSyncer:
     def test_astronomer_config_syncer_rbac_enabled_for_unified_and_data_mode(self, kube_version):
         """Test that helm renders config-syncer cronjob when global.plane.mode is 'data' or 'unified'."""
         docs = render_chart(
-        kube_version=kube_version,
-        values={"global": {"plane": {"mode": "unified"}}},
-        show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "unified"}}},
+            show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
         )
         assert len(docs) == 1
         doc = docs[0]
@@ -346,9 +347,9 @@ class TestAstronomerConfigSyncer:
         assert doc["metadata"]["name"] == "release-name-config-syncer"
 
         docs = render_chart(
-        kube_version=kube_version,
-        values={"global": {"plane": {"mode": "data"}}},
-        show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
         )
 
         assert len(docs) == 1

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -1,6 +1,7 @@
 import pytest
+from pathlib import Path
 
-from tests import supported_k8s_versions
+from tests import git_root_dir, supported_k8s_versions
 from tests.utils import get_containers_by_name
 from tests.utils.chart import render_chart
 
@@ -316,3 +317,42 @@ class TestAstronomerConfigSyncer:
         )
 
         assert len(docs) == 1
+
+    def test_astronomer_config_syncer_all_resources_disabled_for_control_mode(self, kube_version):
+        """Test that config syncer resources are not rendered in control plane mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": "control"}},
+                "astronomer": {"configSyncer": {"enabled": True}},
+            },
+            show_only=sorted(
+                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")]
+            ),
+        )
+        assert len(docs) == 0
+
+    def test_astronomer_config_syncer_rbac_enabled_for_unified_and_data_mode(self, kube_version):
+        """Test that helm renders config-syncer cronjob when global.plane.mode is 'data' or 'unified'."""
+        docs = render_chart(
+        kube_version=kube_version,
+        values={"global": {"plane": {"mode": "unified"}}},
+        show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["apiVersion"] == "batch/v1"
+        assert doc["metadata"]["name"] == "release-name-config-syncer"
+
+        docs = render_chart(
+        kube_version=kube_version,
+        values={"global": {"plane": {"mode": "data"}}},
+        show_only=["charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["apiVersion"] == "batch/v1"
+        assert doc["metadata"]["name"] == "release-name-config-syncer"

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -328,7 +328,7 @@ class TestAstronomerConfigSyncer:
                 "astronomer": {"configSyncer": {"enabled": True}},
             },
             show_only=sorted(
-                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")]
+                [str(x.relative_to(git_root_dir)) for x in Path(f"{git_root_dir}/charts/astronomer/templates/config-syncer").glob("*")]
             ),
         )
         assert len(docs) == 0


### PR DESCRIPTION
## Description

This PR adds plane mode restrictions to the config-syncer component, ensuring it only deploys on data and unified planes where workloads run, and is excluded from control planes. This will be needed by the registry for synchronising the Houston JWKS between dataplanes.

## Related Issues

Related astronomer/issues#7359

## Changes Made
- Added plane mode conditional to all config-syncer templates:
```
{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
``` 
- Added tests for the above change.
 
## Testing
- All existing tests continue to pass
- New tests validate plane mode conditional logic.
![Screenshot 2025-06-13 at 6 19 29 PM](https://github.com/user-attachments/assets/d98d4f09-37a8-48ef-a714-b3bfaaf217c4)
- Tested manual rendering in unified mode:
![Screenshot 2025-06-13 at 6 29 07 PM](https://github.com/user-attachments/assets/4c283152-a470-4c7b-8b76-e44d0821e618)
- Tested manual rendering in data mode:
![Screenshot 2025-06-13 at 6 30 41 PM](https://github.com/user-attachments/assets/7e879cd1-3f1f-4e74-a077-a6a1cf804616)

- Tested manual rendering in control mode:
![Screenshot 2025-06-13 at 6 30 09 PM](https://github.com/user-attachments/assets/42d367ee-7745-45d7-b398-b94ed86872c5)

## Merging

1.0