### PR TITLE
Remove Probes from Init Containers

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -58,12 +58,6 @@ spec:
             - "echo"
             - "DB ready"
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
-          {{- if .Values.houston.waitForDB.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.waitForDB.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.waitForDB.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.waitForDB.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: DATABASE_URL
               valueFrom:
@@ -76,12 +70,6 @@ spec:
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
-          {{- if .Values.houston.bootstrapper.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.bootstrapper.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: BOOTSTRAP_DB
               valueFrom:

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -58,23 +58,11 @@ spec:
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
           env:
             {{- include "houston_environment" . | indent 12 }}
-          {{- if .Values.houston.waitForDB.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.waitForDB.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.waitForDB.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.waitForDB.livenessProbe) . | nindent 12 }}
-          {{- end }}
         - name: houston-bootstrapper
           image: {{ template "dbBootstrapper.image" . }}
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.houston.resources | nindent 12 }}
-          {{- if .Values.houston.bootstrapper.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.houston.bootstrapper.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.houston.bootstrapper.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: BOOTSTRAP_DB
               valueFrom:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -340,8 +340,6 @@ houston:
     livenessProbe: {}
 
   bootstrapper:
-    readinessProbe: {}
-    livenessProbe: {}
 
   waitForDB:
     readinessProbe: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -342,8 +342,6 @@ houston:
   bootstrapper:
 
   waitForDB:
-    readinessProbe: {}
-    livenessProbe: {}
 
   taskUsageMetrics:
     readinessProbe: {}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -86,12 +86,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.client.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
   {{- end }}
       containers:
       - name: es-client

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -90,12 +90,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.data.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -89,12 +89,6 @@ spec:
         securityContext:
           privileged: true
         resources: {{ toYaml .Values.master.initResources | nindent 10 }}
-        {{- if .Values.sysctlInitContainer.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.livenessProbe) . | nindent 12 }}
-        {{- end }}
-        {{- if .Values.sysctlInitContainer.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.sysctlInitContainer.readinessProbe) . | nindent 12 }}
-        {{- end }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
       containers:

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -67,12 +67,6 @@ spec:
           imagePullPolicy: {{ .Values.images.dbBootstrapper.pullPolicy }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.bootstrapper.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.bootstrapper.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.bootstrapper.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.bootstrapper.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: BOOTSTRAP_DB
               valueFrom:

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -56,12 +56,6 @@ spec:
           imagePullPolicy: IfNotPresent
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.waitForDB.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.waitForDB.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.waitForDB.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.waitForDB.livenessProbe) . | nindent 12 }}
-          {{- end }}
           env:
             - name: GF_DATABASE_URL
               valueFrom:

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -85,12 +85,6 @@ spec:
             - name: NATS__URL
               value: "nats://{{ .Release.Name }}-nats:4222"
           resources: {{ toYaml .Values.init.resources | nindent 12 }}
-          {{- if .Values.waitForNatsServer.readinessProbe }}
-          readinessProbe: {{ tpl (toYaml .Values.waitForNatsServer.readinessProbe) . | nindent 12 }}
-          {{- end }}
-          {{- if .Values.waitForNatsServer.livenessProbe }}
-          livenessProbe: {{ tpl (toYaml .Values.waitForNatsServer.livenessProbe) . | nindent 12 }}
-          {{- end }}
       containers:
         - name: stan
           image: {{ include "stan.image" . }}

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -37,12 +37,9 @@ class TestCustomProbes:
         init_containers = template_spec.get("initContainers", [])
 
         for init_container in init_containers:
-            container_name = init_container.get("name", "unnamed")
-
+            container_name = init_container.get("name")
             assert "livenessProbe" not in init_container, f"Init container '{container_name}' should not have livenessProbe"
-
             assert "readinessProbe" not in init_container, f"Init container '{container_name}' should not have readinessProbe"
-
             assert "startupProbe" not in init_container, f"Init container '{container_name}' should not have startupProbe"
 
 

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -26,6 +26,25 @@ class TestCustomProbes:
             assert container["livenessProbe"] != {}
             assert container["readinessProbe"] != {}
 
+    filtered_docs = [doc for doc in docs if doc["kind"] in include_kind_list]
+
+    @pytest.mark.parametrize("doc", filtered_docs)
+    def test_init_containers_have_no_probes(self, doc):
+        """Ensure init containers do not have liveness or readiness probes."""
+
+        spec = doc.get("spec", {})
+        template_spec = spec.get("template", {}).get("spec", {}) if "template" in spec else spec
+        init_containers = template_spec.get("initContainers", [])
+
+        for init_container in init_containers:
+            container_name = init_container.get("name", "unnamed")
+
+            assert "livenessProbe" not in init_container, f"Init container '{container_name}' should not have livenessProbe"
+
+            assert "readinessProbe" not in init_container, f"Init container '{container_name}' should not have readinessProbe"
+
+            assert "startupProbe" not in init_container, f"Init container '{container_name}' should not have startupProbe"
+
 
 class TestDefaultProbes:
     """Test the default probes. This test is to ensure we keep the default probes during refactoring."""


### PR DESCRIPTION
## Description

This PR removes health check probes (liveness, readiness, and startup probes) from init containers and adds comprehensive tests to ensure they remain absent from future templates.

## Related Issues

Related astronomer/issues#7375

## Motivation

Init containers are designed to run to completion before the main application containers start. Unlike regular containers, init containers don't need health check probes because:

- They have a finite lifecycle and exit when their task is complete
- Kubernetes automatically handles init container completion status
- Probes are unnecessary overhead for containers that aren't meant to run continuously

## Changes Made
 ### Configuration Changes

- Removed `livenessProbe`, `readinessProbe` and `startupProbe` configurations from all init containers

###  Test Coverage

- Added new test class TestCustomProbes.test_init_containers_have_no_probes which runs against all supported Kubernetes resource types (Deployment, DaemonSet, StatefulSet) and Provides clear error messages if probes are accidentally added to init containers. 

## Testing

-  All existing tests pass
![Screenshot 2025-06-20 at 12 12 21 PM](https://github.com/user-attachments/assets/70baae2e-061d-48b2-b689-a2f38810f592)
- New test validates probe removal.


## Merging

0.37.4