### PR TITLE
Update Houston event URL and registry events configuration

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -499,7 +499,7 @@ tlsEnabled: false
 {{- define "houston.eventsUrl" -}}
 {{- if (eq .Values.global.plane.mode "data") }}
 https://houston.{{ .Values.global.baseDomain }}/v1/authorization
-{{- else }}
+{{- else -}}
 http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events
 {{- end }}
 {{- end -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -495,3 +495,11 @@ tlsEnabled: false
 {{ toYaml .Values.securityContext | indent 16 }}
 {{- end }}
 {{- end }}
+
+{{- define "houston.eventsUrl" -}}
+{{- if (eq .Values.global.plane.mode "data") }}
+https://houston.{{ .Values.global.baseDomain }}/v1/authorization
+{{- else }}
+http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events
+{{- end }}
+{{- end -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -497,7 +497,7 @@ tlsEnabled: false
 {{- end }}
 
 {{- define "houston.eventsUrl" -}}
-{{- if (eq .Values.global.plane.mode "data") }}
+{{- if (eq .Values.global.plane.mode "data") -}}
 https://houston.{{ .Values.global.baseDomain }}/v1/authorization
 {{- else -}}
 http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -69,7 +69,7 @@ data:
     notifications:
       endpoints:
         - name: "houston"
-          url: "http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events"
+          url: {{ include "houston.eventsUrl" . | quote }}
           timeout: {{ .Values.registry.notifications.timeout }}
           threshold: 10
           backoff: 1s

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -89,9 +89,7 @@ class Test_Registry_Configmap:
 
         config = yaml.safe_load(doc["data"]["config.yml"])
 
-        assert "notifications" in config
-        assert "endpoints" in config["notifications"]
-        assert len(config["notifications"]["endpoints"]) > 0
+        assert config.get("notifications", {}).get("endpoints", [])
 
         houston_endpoint = next(
             (endpoint for endpoint in config["notifications"]["endpoints"] if endpoint["name"] == "houston"),

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -83,7 +83,6 @@ class Test_Registry_Configmap:
                     "houston": {
                         "eventUrl": "/v1/authorization"
                     },
-                    "registry": {}
                 }
             },
             show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
@@ -110,7 +109,3 @@ class Test_Registry_Configmap:
         assert houston_endpoint is not None
         actual_url = houston_endpoint["url"].strip()
         assert actual_url == "https://houston.example.com/v1/authorization"
-
-    
-
-

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -73,17 +73,10 @@ class Test_Registry_Configmap:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "global": {
-                    "baseDomain": "astronomer.example.com",
-                    "plane": {
-                        "mode": "data"
-                    }
-                },
+                "global": {"baseDomain": "astronomer.example.com", "plane": {"mode": "data"}},
                 "astronomer": {
-                    "houston": {
-                        "eventUrl": "/v1/authorization"
-                    },
-                }
+                    "houston": {"eventUrl": "/v1/authorization"},
+                },
             },
             show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
         )

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -97,4 +97,4 @@ class Test_Registry_Configmap:
             (endpoint for endpoint in config["notifications"]["endpoints"] if endpoint["name"] == "houston"),
             None,
         )
-        assert houston_endpoint == "https://houston.example.com/v1/authorization"
+        assert houston_endpoint['url'] == "https://houston.example.com/v1/authorization"

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -93,12 +93,8 @@ class Test_Registry_Configmap:
         assert "endpoints" in config["notifications"]
         assert len(config["notifications"]["endpoints"]) > 0
 
-        houston_endpoint = None
-        for endpoint in config["notifications"]["endpoints"]:
-            if endpoint["name"] == "houston":
-                houston_endpoint = endpoint
-                break
-
-        assert houston_endpoint is not None
-        actual_url = houston_endpoint["url"].strip()
-        assert actual_url == "https://houston.example.com/v1/authorization"
+        houston_endpoint = next(
+            (endpoint for endpoint in config["notifications"]["endpoints"] if endpoint["name"] == "houston"),
+            None,
+        )
+        assert houston_endpoint == "https://houston.example.com/v1/authorization"

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -97,4 +97,4 @@ class Test_Registry_Configmap:
             (endpoint for endpoint in config["notifications"]["endpoints"] if endpoint["name"] == "houston"),
             None,
         )
-        assert houston_endpoint['url'] == "https://houston.example.com/v1/authorization"
+        assert houston_endpoint["url"] == "https://houston.example.com/v1/authorization"


### PR DESCRIPTION
## Description

This PR adds the correct houston auth endpoint which needs to be used by Registry. 

## Related Issues

Related astronomer/issues#7358

## Testing

- Verified that the setup is working as expected in data mode.
- Unittests are passing as expected.

## Merging

1.0