### PR TITLE
Adds Cluster Audit cleanup cron job

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ .Release.Name }}-houston-cleanup-cluster-audits
   labels:
     tier: astronomer
-    component: houston-cleanup
+    component: houston-cleanup-cluster-audits
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -25,9 +25,9 @@ spec:
         metadata:
           labels:
             tier: astronomer
-            component: houston-cleanup
+            component: houston-cleanup-cluster-audits
             release: {{ .Release.Name }}
-            app: houston-cleanup
+            app: houston-cleanup-cluster-audits
             version: {{ .Chart.Version }}
             plane: {{ .Values.global.plane.mode }}
           {{- if or .Values.global.podAnnotations .Values.global.istio.enabled }}

--- a/charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml
@@ -1,0 +1,74 @@
+###############################################
+## Houston Cleanup Cluster Audits CronJob
+###############################################
+{{- if and .Values.houston.cleanupClusterAudits.enabled }}
+{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-houston-cleanup-cluster-audits
+  labels:
+    tier: astronomer
+    component: houston-cleanup
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    plane: {{ .Values.global.plane.mode }}
+spec:
+  schedule: {{ .Values.houston.cleanupClusterAudits.schedule }}
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-cleanup
+            release: {{ .Release.Name }}
+            app: houston-cleanup
+            version: {{ .Chart.Version }}
+            plane: {{ .Values.global.plane.mode }}
+          {{- if or .Values.global.podAnnotations .Values.global.istio.enabled }}
+          annotations:
+          {{- if .Values.global.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+          {{- if .Values.global.podAnnotations }}
+{{ toYaml .Values.global.podAnnotations | indent 12 }}
+          {{- end }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          nodeSelector:
+{{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 12 }}
+          affinity:
+{{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | indent 12 }}
+          tolerations:
+{{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          containers:
+            - name: cleanup
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              args: ["yarn", "cleanup-cluster-audit", "--", "--older-than={{ .Values.houston.cleanupClusterAudits.olderThan }}"]
+              securityContext: {{ toYaml .Values.securityContext | nindent 16 }}
+              resources: {{ toYaml .Values.houston.resources | nindent 16 }}
+              volumeMounts:
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.cleanupClusterAudits.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.cleanupClusterAudits.readinessProbe) . | nindent 16 }}
+              {{- end }}
+              {{- if .Values.houston.cleanupClusterAudits.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.cleanupClusterAudits.livenessProbe) . | nindent 16 }}
+              {{- end }}
+          volumes:
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -66,6 +66,9 @@ data:
       tlsSecretName: {{ .Values.global.tlsSecret }}
       {{- end }}
     # Airflow deployment configuration
+    clusters:
+      audit:
+        retentionDays: {{ .Values.houston.cleanupClusterAudits.olderThan}}
     deployments:
       mode:
         operator:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -269,9 +269,8 @@ houston:
 
     # Cleanup deploy revisions older than this many days
     olderThan: 90
-
-    readinessProbe: { }
-    livenessProbe: { }
+    readinessProbe: {}
+    livenessProbe: {}
 
   # Check for Astronomer Platform Updates
   # This runs as a CronJob

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -258,6 +258,21 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
+  # Cleanup cluster audits in Houston
+  # This runs as a CronJob
+  cleanupClusterAudits:
+    # Enable cleanup CronJob
+    enabled: true
+
+    # Run at 23:49 every night
+    schedule: "49 23 * * *"  # https://crontab.guru/#49_23_*_*_*
+
+    # Cleanup deploy revisions older than this many days
+    olderThan: 90
+
+    readinessProbe: { }
+    livenessProbe: { }
+
   # Check for Astronomer Platform Updates
   # This runs as a CronJob
   updateCheck:

--- a/tests/chart_tests/test_astronomer_houston_cluster_audits.py
+++ b/tests/chart_tests/test_astronomer_houston_cluster_audits.py
@@ -3,6 +3,7 @@ import pytest
 from tests import supported_k8s_versions
 from tests.utils.chart import render_chart
 
+
 @pytest.mark.parametrize(
     "kube_version",
     supported_k8s_versions,

--- a/tests/chart_tests/test_astronomer_houston_cluster_audits.py
+++ b/tests/chart_tests/test_astronomer_houston_cluster_audits.py
@@ -1,0 +1,60 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestAstronomerHoustonClusterAuditsCronJobs:
+    def test_astronomer_cleanup_cluster_audits_cron_defaults(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"cleanupClusterAudits": {"enabled": False}}}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
+    def test_astronomer_cleanup_cluster_audits_cron_feature_enabled(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"cleanupClusterAudits": {"enabled": True}}}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
+        assert docs[0]["metadata"]["labels"]["component"] == "houston-cleanup"
+        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]
+        assert spec["metadata"]["labels"]["component"] == "houston-cleanup"
+        assert docs[0]["spec"]["schedule"] == "49 23 * * *"
+        assert spec["spec"]["containers"][0]["securityContext"] == {"runAsNonRoot": True}
+
+    def test_astronomer_cleanup_cluster_audits_cron_custom_schedule(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "houston": {
+                        "cleanupClusterAudits": {
+                            "enabled": True,
+                            "schedule": "1 2 3 4 5",
+                        }
+                    },
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "CronJob"
+        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
+        assert docs[0]["spec"]["schedule"] == "1 2 3 4 5"

--- a/tests/chart_tests/test_astronomer_houston_cluster_audits.py
+++ b/tests/chart_tests/test_astronomer_houston_cluster_audits.py
@@ -48,7 +48,7 @@ class TestAstronomerHoustonClusterAuditsCronJobs:
                     "houston": {
                         "cleanupClusterAudits": {
                             "enabled": True,
-                            "schedule": "1 2 3 4 5",
+                            "schedule": "1 2 3 * ?",
                         }
                     },
                 }
@@ -63,4 +63,4 @@ class TestAstronomerHoustonClusterAuditsCronJobs:
         doc = docs[0]
         assert doc["kind"] == "CronJob"
         assert doc["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
-        assert doc["spec"]["schedule"] == "1 2 3 4 5"
+        assert doc["spec"]["schedule"] == "1 2 3 * ?"

--- a/tests/chart_tests/test_astronomer_houston_cluster_audits.py
+++ b/tests/chart_tests/test_astronomer_houston_cluster_audits.py
@@ -29,12 +29,15 @@ class TestAstronomerHoustonClusterAuditsCronJobs:
         )
 
         assert len(docs) == 1
-        assert docs[0]["kind"] == "CronJob"
-        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
-        assert docs[0]["metadata"]["labels"]["component"] == "houston-cleanup"
-        spec = docs[0]["spec"]["jobTemplate"]["spec"]["template"]
-        assert spec["metadata"]["labels"]["component"] == "houston-cleanup"
-        assert docs[0]["spec"]["schedule"] == "49 23 * * *"
+
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
+        assert doc["metadata"]["labels"]["component"] == "houston-cleanup-cluster-audits"
+        spec = doc["spec"]["jobTemplate"]["spec"]["template"]
+        assert spec["metadata"]["labels"]["component"] == "houston-cleanup-cluster-audits"
+        assert spec["metadata"]["labels"]["app"] == "houston-cleanup-cluster-audits"
+        assert doc["spec"]["schedule"] == "49 23 * * *"
         assert spec["spec"]["containers"][0]["securityContext"] == {"runAsNonRoot": True}
 
     def test_astronomer_cleanup_cluster_audits_cron_custom_schedule(self, kube_version):
@@ -56,6 +59,8 @@ class TestAstronomerHoustonClusterAuditsCronJobs:
         )
 
         assert len(docs) == 1
-        assert docs[0]["kind"] == "CronJob"
-        assert docs[0]["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
-        assert docs[0]["spec"]["schedule"] == "1 2 3 4 5"
+
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["metadata"]["name"] == "release-name-houston-cleanup-cluster-audits"
+        assert doc["spec"]["schedule"] == "1 2 3 4 5"

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -295,6 +295,9 @@ custom_service_account_names = {
     "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deploy-revisions-cronjob.yaml": {
         "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
     },
+    "charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml": {
+        "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
+    },
     "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml": {
         "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
     },

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -78,6 +78,15 @@ astronomer:
         exec:
           command:
           - /bin/true
+    cleanupClusterAudits:
+      livenessProbe:
+        exec:
+          command:
+            - /bin/true
+      readinessProbe:
+        exec:
+          command:
+            - /bin/true
     cleanupDeployments:
       livenessProbe:
         exec:


### PR DESCRIPTION
## Description

This PR adds a cron job for cleaning up the cluster audits table. The audits have a configurable retention period after which they are clean up. It follows the already existing cron job pattern.
The corresponding houston PR (merged) is: https://github.com/astronomer/houston-api/pull/2056

## Related Issues

Related astronomer/issues#7370

## Testing
- Unit Tests
---

- Ran the command
```
 helm template . --set global.astronomer.houston.cleanupClusterAudits.enabled=true --kube-version=1.32.5 --show-only charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml
```
to generate the cron job. It is generating fine.

---
- Ran the command
```
 helm template . --set global.astronomer.houston.cleanupClusterAudits.enabled=true --kube-version=1.32.5 --show-only charts/astronomer/templates/houston/houston-configmap.yaml
```
 to generate the houston configmap

```
 # Airflow deployment configuration
    clusters:
      audit:
        retentionDays: 90
    deployments:
      mode:
```
It has correct value.

## Merging

1.0
