### PR TITLE
Release rc6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.21.3-5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-10
                 - quay.io/astronomer/ap-certgenerator:0.1.11
-                - quay.io/astronomer/ap-commander:0.37.17
+                - quay.io/astronomer/ap-commander:0.37.18
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-3
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.4
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
                 - quay.io/astronomer/ap-grafana:10.4.19
-                - quay.io/astronomer/ap-houston-api:0.37.33
+                - quay.io/astronomer/ap-houston-api:0.37.34
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kibana:8.18.2
                 - quay.io/astronomer/ap-kube-state:2.15.0-1
@@ -414,7 +414,7 @@ workflows:
                 - quay.io/astronomer/ap-base:3.21.3-5
                 - quay.io/astronomer/ap-blackbox-exporter:0.25.0-10
                 - quay.io/astronomer/ap-certgenerator:0.1.11
-                - quay.io/astronomer/ap-commander:0.37.17
+                - quay.io/astronomer/ap-commander:0.37.18
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0
                 - quay.io/astronomer/ap-curator:8.0.21-3
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.4
@@ -426,7 +426,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
                 - quay.io/astronomer/ap-grafana:10.4.19
-                - quay.io/astronomer/ap-houston-api:0.37.33
+                - quay.io/astronomer/ap-houston-api:0.37.34
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kibana:8.18.2
                 - quay.io/astronomer/ap-kube-state:2.15.0-1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 0.37.4-rc5
-appVersion: 0.37.4-rc5
+version: 0.37.4-rc6
+appVersion: 0.37.4-rc6
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 0.37.4-rc5
+version: 0.37.4-rc6
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 0.37.17
+    tag: 0.37.18
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.33
+    tag: 0.37.34
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

1. We are by default disabling ephemeral storage for k8s task pods.
2. We have fixed reuse-values bug for existing deployments for this flow.

## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#6223

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
