### PR TITLE
fix registry events url for dataplane config

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -498,7 +498,7 @@ tlsEnabled: false
 
 {{- define "houston.eventsUrl" -}}
 {{- if (eq .Values.global.plane.mode "data") -}}
-https://houston.{{ .Values.global.baseDomain }}/v1/authorization
+https://houston.{{ .Values.global.baseDomain }}/v1/registry/events
 {{- else -}}
 http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events
 {{- end }}


### PR DESCRIPTION
## Description

fix registry events url for dataplane config

## Related Issues

Related https://github.com/astronomer/issues/issues/7358

## Testing

QA should able to verify registry events url had public endpoint config

## Merging

1.0
