### PR TITLE
Introduced installation mode in Houston configmap so that populating default cluster can be skipepd for non-unified mode

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -55,6 +55,8 @@ data:
       {{- include "jetstreamTLS" . | indent 6 }}
     {{ end }}
 
+    plane:
+      mode: {{ .Values.global.plane.mode }}
 
     helm:
       baseDomain: {{ .Values.global.baseDomain }}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -899,3 +899,24 @@ def test_houston_configmap_with_authsidecar_ingress_allowed_namespaces():
     doc = docs[0]
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     assert prod_yaml["deployments"]["authSideCar"].get("ingressAllowedNamespaces") == ["astronomer", "ingress-namespace"]
+
+
+def test_houston_configmap_with_plane_mode():
+    """Validate the houston configmap should have values in plane mode."""
+    docs = render_chart(
+        values={"global": {"plane": {"mode": "control"}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["plane"]["mode"] == "control"
+
+    docs = render_chart(
+        values={"global": {"plane": {"mode": "unified"}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    assert len(docs) == 1
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod_yaml["plane"]["mode"] == "unified"


### PR DESCRIPTION
## Description

Introduced installation mode in Houston configmap so that populating default cluster can be skipepd for non-unified mode. It would also be used for other future use cases.

## Related Issues
Related astronomer/issues#7379

## Testing

Unit tests

## Merging

main
1.0