### PR TITLE
7394 prometheus read only root

### DIFF
--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -47,7 +47,9 @@ spec:
 {{- include "prometheus-postgres-exporter.imagePullSecrets" . | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ toYaml .Values.securityContext | nindent 12 }}
           args:
           - "--extend.query-path=/etc/config.yaml"
           {{- if .Values.config.disableDefaultMetrics }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -60,7 +60,6 @@ spec:
         - name: auth-proxy
           image: {{ include "authSidecar.image" . }}
           securityContext:
-            readOnlyRootFilesystem: true
             {{ template "prometheus.securityContext" . }}
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -59,7 +59,9 @@ spec:
         {{- if .Values.global.authSidecar.enabled  }}
         - name: auth-proxy
           image: {{ include "authSidecar.image" . }}
-          securityContext: {{ template "prometheus.securityContext" . }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ template "prometheus.securityContext" . }}
           imagePullPolicy: {{ .Values.global.authSidecar.pullPolicy }}
           {{- if .Values.global.authSidecar.resources }}
           resources: {{- toYaml .Values.global.authSidecar.resources | nindent 12 }}
@@ -101,7 +103,9 @@ spec:
             - --volume-dir=/etc/prometheus/config
           image: {{ include "configReloader.image" . }}
           imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}
-          securityContext: {{ template "prometheus.securityContext" . }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ template "prometheus.securityContext" . }}
           resources: {{ toYaml .Values.configMapReloader.resources | nindent 12 }}
           {{- if .Values.configMapReloader.livenessProbe }}
           livenessProbe: {{ tpl (toYaml .Values.configMapReloader.livenessProbe) . | nindent 12 }}
@@ -148,7 +152,9 @@ spec:
         {{- end }}
         - name: prometheus
           image: {{ include "prometheus.image" . }}
-          securityContext: {{ template "prometheus.securityContext" . }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ template "prometheus.securityContext" . }}
           imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           args:

--- a/tests/chart_tests/test_container_read_only_root.py
+++ b/tests/chart_tests/test_container_read_only_root.py
@@ -13,6 +13,7 @@ pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 # This should match tests/functional/unified/test_container_read_only_root.py
 read_only_root_pods = [
     "commander",
+    "configmap-reloader",
     "metrics-exporter",
     "prometheus",
 ]

--- a/tests/chart_tests/test_container_read_only_root.py
+++ b/tests/chart_tests/test_container_read_only_root.py
@@ -14,6 +14,7 @@ pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 read_only_root_pods = [
     "commander",
     "metrics-exporter",
+    "prometheus",
 ]
 
 

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -56,7 +56,10 @@ class TestPrometheusPostgresExporter:
             "periodSeconds": 10,
             "tcpSocket": {"port": 9187},
         }
-        assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {"runAsNonRoot": True}
+        assert c_by_name["prometheus-postgres-exporter"]["securityContext"] == {
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+        }
         spec = docs[1]["spec"]["template"]["spec"]
         assert spec["nodeSelector"] == {}
         assert spec["affinity"] == {}


### PR DESCRIPTION
## Description

- prometheus pod containers run with read-only root. this skips authSidecar though, which will be handled separately.

## Related Issues

- https://github.com/astronomer/issues/issues/7394
- https://github.com/astronomer/issues/issues/7407
- https://github.com/astronomer/issues/issues/7408

## Testing

Unit tests are included, and are sufficient. No QA is needed.

## Merging

This is only for 1.0