### PR TITLE
7394 alertmanager read-only root filesystem

### DIFF
--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -58,7 +58,9 @@ spec:
         - name: alertmanager
           image: {{ template "alertmanager.image" . }}
           imagePullPolicy: {{ .Values.images.alertmanager.pullPolicy }}
-          securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ toYaml .Values.securityContext| nindent 12 }}
           env:
             {{- if .Values.enableNonRFC1918 }}
             - name: POD_IP

--- a/tests/chart_tests/test_container_read_only_root.py
+++ b/tests/chart_tests/test_container_read_only_root.py
@@ -12,6 +12,7 @@ pod_managers = ["Deployment", "StatefulSet", "DaemonSet"]
 # https://github.com/astronomer/issues/issues/7394
 # This should match tests/functional/unified/test_container_read_only_root.py
 read_only_root_pods = [
+    "alertmanager",
     "commander",
     "configmap-reloader",
     "metrics-exporter",


### PR DESCRIPTION
## Description

Make alertmanager run with read-only root filesystem.

## Related Issues

- https://github.com/astronomer/issues/issues/7394
- https://github.com/astronomer/issues/issues/7396

## Testing

Unit tests are included. No special QA steps are needed.

## Merging

This is only for 1.0.