### PR TITLE
helm 3.18.4

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,7 +7,7 @@ test_k8s_versions:
   - 1.32.5
 tools:
   helm:
-    version: 3.18.2
+    version: 3.18.4
     url: https://github.com/helm/helm
   kind:
     version: 0.29.0


### PR DESCRIPTION
## Description

Use helm 3.18.4

## Related Issues

- https://github.com/astronomer/issues/issues/7452

## Testing

No manual testing needed.

## Merging

This is only for 1.0. We will need a separate PR for 0.x versions because they do not use metadata.yaml to manage the helm version.