### PR TITLE
Update helm, kind, gcloud versions. Use latest ci-runer.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
 
   release_bom:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-06
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - checkout
       - run:
@@ -164,7 +164,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2025-06
+      - image: quay.io/astronomer/ci-pre-commit:2025-07
     resource_class: small
     steps:
       - checkout
@@ -189,7 +189,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-06
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     # https://circleci.com/docs/using-docker/#x86
     resource_class: large
     parallelism: 4
@@ -226,7 +226,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-06
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     parameters:
       qa_release:
         type: boolean
@@ -245,7 +245,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-06
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -284,7 +284,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-06
+      - image: quay.io/astronomer/ci-helm-release:2025-07
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -13,7 +13,7 @@ metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
 ap_build_tag = "24.04.1"  # https://quay.io/repository/astronomer/ap-build?tab=tags&tag=latest
-ci_runner_version = "2025-06"  # This should be the current YYYY-MM
+ci_runner_version = "2025-07"  # This should be the current YYYY-MM
 machine_image_version = "ubuntu-2204:2024.11.1"  # https://circleci.com/developer/machine/image/ubuntu-2204
 
 

--- a/bin/install-ci-tools
+++ b/bin/install-ci-tools
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 set -xeuo pipefail
 
-KIND_VERSION="0.27.0" # https://github.com/kubernetes-sigs/kind/releases
-HELM_VERSION="3.17.3" # https://github.com/helm/helm/releases
-GCLOUD_VERSION="519.0.0"
+KIND_VERSION="0.29.0" # https://github.com/kubernetes-sigs/kind/releases
+HELM_VERSION="3.18.4" # https://github.com/helm/helm/releases
+GCLOUD_VERSION="529.0.0"
 MKCERT_VERSION="1.4.4" # https://github.com/FiloSottile/mkcert/tags
 
 OS=$(uname | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description

- Use helm 3.18.4
- Use latest ci-image runner that includes helm 3.18.4
- Use latest kind, gcloud

## Related Issues

- https://github.com/astronomer/issues/issues/7452

## Testing

No manual testing needed.

## Merging

This is for all 0.x versions, which use a different structure for determining helm version than 1.0.