### PR TITLE
7402 kube state read-only root fs

### DIFF
--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -53,35 +53,36 @@ spec:
       serviceAccountName: {{ template "kube-state.serviceAccountName" . }}
       {{- include "kube-state.imagePullSecrets" . | nindent 6 }}
       containers:
-      - name: kube-state
-        args:
-      {{- if $useRoles }}
-        - --namespaces={{ $namespaceList }}
-      {{- end }}
-        - --resources={{ .Values.collectors | join "," }}
-      {{- if .Values.extraArgs }}
-          {{- .Values.extraArgs | toYaml | nindent 8 }}
-      {{- end }}
-        image: {{ include "kube-state.image" . }}
-        securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
-        imagePullPolicy: {{ .Values.images.kubeState.pullPolicy }}
-        ports:
-        - name: scrape
-          containerPort: {{ .Values.ports.scrape }}
-        - name: telemetry
-          containerPort: {{ .Values.ports.telemetry }}
-        {{- if .Values.readinessProbe }}
-        readinessProbe: {{ tpl (toYaml .Values.readinessProbe) . | nindent 12 }}
+        - name: kube-state
+          args:
+        {{- if $useRoles }}
+          - --namespaces={{ $namespaceList }}
         {{- end }}
-        {{ if .Values.livenessProbe }}
-        livenessProbe: {{ tpl (toYaml .Values.livenessProbe) . | nindent 12 }}
-        {{ else }}
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: {{ .Values.ports.scrape }}
-          initialDelaySeconds: 5
-          timeoutSeconds: 5
+          - --resources={{ .Values.collectors | join "," }}
+        {{- if .Values.extraArgs }}
+            {{- .Values.extraArgs | toYaml | nindent 10 }}
         {{- end }}
-        resources: {{ toYaml .Values.resources | nindent 12 }}
+          image: {{ include "kube-state.image" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          imagePullPolicy: {{ .Values.images.kubeState.pullPolicy }}
+          ports:
+            - name: scrape
+              containerPort: {{ .Values.ports.scrape }}
+            - name: telemetry
+              containerPort: {{ .Values.ports.telemetry }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe: {{- tpl (toYaml .Values.readinessProbe) . | nindent 12 }}
+          {{- end }}
+          {{ if .Values.livenessProbe }}
+          livenessProbe: {{- tpl (toYaml .Values.livenessProbe) . | nindent 12 }}
+          {{ else }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.ports.scrape }}
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
+          {{- end }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
 {{- end }}

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -64,6 +64,7 @@ spec:
         {{- end }}
           image: {{ include "kube-state.image" . }}
           securityContext:
+            readOnlyRootFilesystem: true
             {{- toYaml .Values.securityContext | nindent 12 }}
           imagePullPolicy: {{ .Values.images.kubeState.pullPolicy }}
           ports:

--- a/tests/chart_tests/test_container_read_only_root.py
+++ b/tests/chart_tests/test_container_read_only_root.py
@@ -15,6 +15,7 @@ read_only_root_pods = [
     "alertmanager",
     "commander",
     "configmap-reloader",
+    "kube-state",
     "metrics-exporter",
     "prometheus",
 ]


### PR DESCRIPTION
## Description

- make kube-state deployment container with `readOnlyRootFilesystem: true`
- Fix inconsistent dict indentation style

Note to reviewers: hide whitespace to make this PR much easier to understand.

## Related Issues

- <https://github.com/astronomer/issues/issues/7402>
- <https://github.com/astronomer/issues/issues/7394>

## Testing

No manual testing is needed.

## Merging

This is only for 1.0.