### PR TITLE
7403 nats read-only root fs

### DIFF
--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -70,7 +70,7 @@ imagePullSecrets:
 
 {{- define "nats.securityContext" -}}
 {{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshiftEnabled ) }}
-{{- omit  .Values.securityContext "runAsUser" | toYaml | nindent 10 }}
+{{- omit .Values.securityContext "runAsUser" | toYaml | nindent 10 }}
 {{- else }}
 {{- .Values.securityContext | toYaml | nindent 10 }}
 {{- end -}}
@@ -81,7 +81,7 @@ imagePullSecrets:
 {{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s" (include "nats.name" . )) .Values.nats.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.nats.serviceAccount.name }}
+{{ default "default" .Values.nats.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
@@ -89,6 +89,6 @@ imagePullSecrets:
 {{- if and .Values.nats.jetstream.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s-jetstream-sa" .Release.Name) .Values.nats.jetstream.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.nats.jetstream.serviceAccount.name }}
+{{ default "default" .Values.nats.jetstream.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -98,7 +98,9 @@ spec:
       containers:
       - name: jetstream-template-fixer
         image: {{ template "dbBootstrapper.image" . }}
-        securityContext: {{ template "nats.securityContext" . }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          {{ template "nats.securityContext" . }}
         resources: {{ toYaml .Values.nats.resources | nindent 10 }}
         command:
         - /bin/sh

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -1,7 +1,7 @@
 ########################################################
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
-{{- if and .Values.nats.createJetStreamJob  -}}
+{{- if and .Values.nats.createJetStreamJob -}}
 {{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled .Values.global.stan.enabled }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 ---
@@ -49,8 +49,8 @@ metadata:
     "helm.sh/hook-weight": "3"
   name: {{ template "jetStream.serviceAccountName" . }}
   labels:
-    tier: jetsream-migrator
-    component: jetsream-migrator
+    tier: jetstream-migrator
+    component: jetstream-migrator
     release: {{ .Release.Name }}
     plane: {{ .Values.global.plane.mode }}
 ---
@@ -66,7 +66,7 @@ metadata:
     app: {{ template "nats.name" . }}
     tier: nats
     version: {{ .Chart.Version }}
-    component: jetsream-migrator
+    component: jetstream-migrator
     release: {{ .Release.Name }}
     plane: {{ .Values.global.plane.mode }}
 spec:
@@ -75,7 +75,7 @@ spec:
       labels:
         app: {{ template "nats.name" . }}
         tier: nats
-        component: jetsream-migrator
+        component: jetstream-migrator
         version: {{ .Chart.Version }}
         release: {{ .Release.Name }}
         plane: {{ .Values.global.plane.mode }}
@@ -106,7 +106,7 @@ spec:
         - |
           {{- if and .Values.global.stan.enabled (not .Values.global.nats.jetStream.enabled) }}
           data=`kubectl get ns {{ .Release.Namespace }} -o=jsonpath='{.metadata.labels.stanEnabled}'`
-          if [[ "$data" = "" ]]  ; then
+          if [[ "$data" = "" ]] ; then
             kubectl delete sts {{ .Release.Name }}-nats --cascade=orphan -n {{ .Release.Namespace }};
             kubectl label namespace {{ .Release.Namespace }} stanEnabled=true;
             kubectl label namespace {{ .Release.Namespace }} jetstreamEnabled-
@@ -115,8 +115,8 @@ spec:
           fi
           {{ else }}
           data=`kubectl get ns {{ .Release.Namespace }} -o=jsonpath='{.metadata.labels.jetstreamEnabled}'`
-          if [[ "$data" = "" ]]  ; then
-            kubectl delete sts {{ .Release.Name }}-nats  -n {{ .Release.Namespace }};
+          if [[ "$data" = "" ]] ; then
+            kubectl delete sts {{ .Release.Name }}-nats -n {{ .Release.Namespace }};
             kubectl label namespace {{ .Release.Namespace }} jetstreamEnabled=true;
             kubectl label namespace {{ .Release.Namespace }} stanEnabled-
           else

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -145,7 +145,9 @@ spec:
       - name: nats
         image: {{ include "nats.image" . }}
         imagePullPolicy: {{ .Values.images.nats.pullPolicy }}
-        securityContext: {{ template "nats.securityContext" . }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          {{ template "nats.securityContext" . }}
         ports:
         - containerPort: 4222
           name: client
@@ -288,11 +290,11 @@ spec:
         imagePullPolicy: {{ .Values.reloader.pullPolicy }}
         securityContext: {{ template "nats.securityContext" . }}
         command:
-         - "nats-server-config-reloader"
-         - "-pid"
-         - "/var/run/nats/nats.pid"
-         - "-config"
-         - "/etc/nats-config/nats.conf"
+          - "nats-server-config-reloader"
+          - "-pid"
+          - "/var/run/nats/nats.pid"
+          - "-config"
+          - "/etc/nats-config/nats.conf"
         volumeMounts:
           - name: config-volume
             mountPath: /etc/nats-config
@@ -305,6 +307,9 @@ spec:
         {{- if .Values.reloader.readinessProbe }}
         readinessProbe: {{ tpl (toYaml .Values.reloader.readinessProbe) . | nindent 10 }}
         {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          {{ template "nats.securityContext" . }}
       {{ end }}
 
       ##############################
@@ -316,19 +321,19 @@ spec:
         imagePullPolicy: {{ .Values.images.exporter.pullPolicy }}
         securityContext: {{ template "nats.securityContext" . }}
         args:
-        - -connz
-        - -routez
-        - -subz
-        - -varz
-        - -prefix=gnatsd
-        - -use_internal_server_id
+          - -connz
+          - -routez
+          - -subz
+          - -varz
+          - -prefix=gnatsd
+          - -use_internal_server_id
         {{- if .Values.nats.jetstream.enabled }}
-        - -jsz=all
+          - -jsz=all
         {{- end }}
-        - http://localhost:8222/
+          - http://localhost:8222/
         ports:
-        - containerPort: 7777
-          name: metrics
+          - containerPort: 7777
+            name: metrics
         resources: {{ toYaml .Values.exporter.resources | nindent 10 }}
         {{- if .Values.exporter.livenessProbe }}
         livenessProbe: {{ tpl (toYaml .Values.exporter.livenessProbe) . | nindent 10 }}
@@ -336,6 +341,9 @@ spec:
         {{- if .Values.exporter.readinessProbe }}
         readinessProbe: {{ tpl (toYaml .Values.exporter.readinessProbe) . | nindent 10 }}
         {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
+          {{ template "nats.securityContext" . }}
       {{ end }}
 
   {{- if and ( or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}

--- a/tests/chart_tests/test_container_read_only_root.py
+++ b/tests/chart_tests/test_container_read_only_root.py
@@ -15,15 +15,19 @@ read_only_root_pods = [
     "alertmanager",
     "commander",
     "configmap-reloader",
+    "elasticsearch-exporter",
+    "jetstream",
     "kibana",
     "kube-state",
-    "metrics-exporter",
+    "nats",
     "prometheus",
 ]
 
 
 class TestAllContainersReadOnlyRoot:
     chart_values = get_all_features()
+    # We disable authSidecar during development of #7394 until that feature is supported
+    chart_values["global"]["authSidecar"] = {"enabled": False}
     default_docs = render_chart(values=chart_values)
     pod_manager_docs = [doc for doc in default_docs if doc["kind"] in pod_managers]
 
@@ -34,9 +38,10 @@ class TestAllContainersReadOnlyRoot:
     )
     def test_all_containers_have_read_only_root(self, doc, request):
         """Test that every container matches our expected configs for ticket https://github.com/astronomer/issues/issues/7394."""
+        param_id = request.node.callspec.id
         c_by_name = get_containers_by_name(doc, include_init_containers=True)
-        for name, container in c_by_name.items():
-            if any(x in name for x in read_only_root_pods):
+        for container in c_by_name.values():
+            if any(x in param_id for x in read_only_root_pods):
                 assert container["securityContext"].get("readOnlyRootFilesystem")
             else:
                 # This assertion ensures that this test is updated whenever we change this property

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -31,7 +31,11 @@ class TestNatsJetstream:
         assert prod["nats"] == {"jetStreamEnabled": True, "tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
-        assert {"runAsUser": 1000, "runAsNonRoot": True} == docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"]
+        assert docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+        }
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test jetstream config with nodeSelector, affinity, and tolerations defaults."""

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -29,6 +29,10 @@ kibana:
 nats:
   nats:
     createJetStreamJob: true
+    reloader:
+      enabled: true
+    exporter:
+      enabled: true
 postgresql:
   replication:
     enabled: true


### PR DESCRIPTION
## Description

- Make nats run with read-only root fs
- Add securityContext to nats-exporter, nats config reloader
- fix typo `s/jetsream/jetstream/g`
- Some whitespace changes to remove extra spacing and indentation inconsistency
- Tweak readOnly tests to check pod name, not container name.

The only place nats writes to is /var/run/nats, and that already had its own volume.

## Related Issues

- <https://github.com/astronomer/issues/issues/7394>
- <https://github.com/astronomer/issues/issues/7403>

## Testing

No special testing is needed. We'll find if anything is wrong during normal testing.

## Merging

This is only for 1.0.