### PR TITLE
7473 remove global.acme, legacy ingress path syntax

### DIFF
--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -22,20 +22,14 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     {{ include "houston.internalauthurl" . | indent 4 }}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: alertmanager-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "alertmanager.url" . }}
   {{- end }}
@@ -44,15 +38,6 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "alertmanager.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: http
-              {{- end }}
-            {{ else -}}
             pathType: Prefix
             backend:
               service:
@@ -63,6 +48,5 @@ spec:
                   {{- else }}
                   name: http
                   {{- end }}
-            {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -1,7 +1,6 @@
 {{ define "helm.globals" -}}
   {{- $globals := dict -}}
   {{- $_ := set $globals "baseDomain" (default "" .Values.global.baseDomain) -}}
-  {{- $_ := set $globals "acme" (.Values.global.acme) -}}
   {{- $_ := set $globals "rbacEnabled" .Values.global.rbacEnabled -}}
   {{- $_ := set $globals "releaseName" (print .Release.Name | toString) -}}
   {{- $_ := set $globals "releaseNamespace" (print .Release.Namespace | toString) -}}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -22,7 +22,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
@@ -30,34 +29,12 @@ metadata:
       }
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: astronomer-public-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - app.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: app.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  {{ else -}}
   rules:
   - host: app.{{ .Values.global.baseDomain }}
     http:
@@ -69,7 +46,6 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
-  {{- end -}}
 {{- end }}
 ---
 ###############################
@@ -92,7 +68,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
@@ -100,27 +75,12 @@ metadata:
       }
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: astronomer-public-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  {{ else -}}
   rules:
   - host: {{ .Values.global.baseDomain }}
     http:
@@ -132,6 +92,5 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -23,7 +23,6 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/enable-http2: "true"
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
@@ -31,14 +30,9 @@ metadata:
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: houston-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - commander.{{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}
   {{- end }}

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -21,7 +21,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/rewrite-target: /metadata
@@ -30,14 +29,9 @@ metadata:
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: astronomer-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}
   {{- end }}

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -22,7 +22,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^/v1/(registry\/events|alerts|elasticsearch|metrics) {
@@ -36,27 +35,12 @@ metadata:
     {{- toYaml .Values.houston.ingress.annotation  | nindent 4  }}
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: houston-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - houston.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: houston.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-houston
-            servicePort: houston-http
-  {{ else -}}
   rules:
   - host: houston.{{ .Values.global.baseDomain }}
     http:
@@ -68,6 +52,5 @@ spec:
               name: {{ .Release.Name }}-houston
               port:
                 name: houston-http
-  {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -20,7 +20,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
@@ -28,44 +27,15 @@ metadata:
       }
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: astronomer-public-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ .Values.global.baseDomain }}
         - app.{{ .Values.global.baseDomain }}
         - registry.{{ .Values.global.baseDomain }}
         - install.{{ .Values.global.baseDomain }}
   {{- end }}
-  {{ if semverCompare "< 1.19-0" .Capabilities.KubeVersion.Version -}}
-  rules:
-  - host: {{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: app.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-astro-ui
-            servicePort: astro-ui-http
-  - host: registry.{{ .Values.global.baseDomain }}
-    http:
-      paths:
-        - path: /
-          backend:
-            serviceName: {{ .Release.Name }}-registry
-            servicePort: registry-http
-  {{ else -}}
   rules:
   - host: {{ .Values.global.baseDomain }}
     http:
@@ -97,5 +67,4 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
-  {{- end -}}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -22,18 +22,12 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: astronomer-public-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ if eq .Values.global.plane.mode "data" }}registry.{{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}{{ else }}registry.{{ .Values.global.baseDomain }}{{ end }}
   {{- end }}

--- a/charts/kibana/templates/ingress.yaml
+++ b/charts/kibana/templates/ingress.yaml
@@ -20,7 +20,6 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     {{- include "houston.internalauthurl" . | indent 4 }}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
@@ -31,14 +30,9 @@ metadata:
 {{- toYaml .Values.ingressAnnotations| nindent 4 }}
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: kibana-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{- include "kibana.url" . | indent 1 }}
   {{- end }}
@@ -47,15 +41,6 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "kibana.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: kibana-ui
-              {{- end }}
-            {{- else -}}
             pathType: Prefix
             backend:
               service:
@@ -66,5 +51,4 @@ spec:
                   {{- else }}
                   name: kibana-ui
                   {{- end }}
-            {{- end -}}
 {{- end }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -20,20 +20,14 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     {{- include "houston.internalauthurl" . | nindent 4 }}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
+  {{- if or .Values.global.tlsSecret }}
   tls:
-  {{- if .Values.global.acme }}
-    - secretName: prometheus-tls
-  {{- end }}
-  {{- if .Values.global.tlsSecret }}
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "prometheus.url" . }}
   {{- end }}
@@ -42,15 +36,6 @@ spec:
       http:
         paths:
           - path: /
-            {{ if semverCompare "<1.19-0" .Capabilities.KubeVersion.Version -}}
-            backend:
-              serviceName: {{ template "prometheus.fullname" . }}
-              {{- if .Values.global.authSidecar.enabled  }}
-              servicePort: auth-proxy
-              {{- else }}
-              servicePort: prometheus-data
-              {{- end }}
-            {{- else -}}
             pathType: Prefix
             backend:
               service:
@@ -61,5 +46,4 @@ spec:
                   {{- else }}
                   name: prometheus-data
                   {{- end }}
-            {{- end -}}
 {{- end }}

--- a/tests/chart_tests/README.md
+++ b/tests/chart_tests/README.md
@@ -36,7 +36,6 @@ metadata:
     heritage: Helm
   annotations:
     kubernetes.io/ingress.class: "release-name-nginx"
-    kubernetes.io/tls-acme: "false"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = 'example.com' ) {

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -22,14 +22,16 @@ class TestIngress:
 
         doc = docs[0]
 
-        assert len(doc["metadata"]["annotations"]) >= 4
+        assert len(doc["metadata"]["annotations"]) == 3
 
-        doc["spec"]["rules"] == json.loads(
+        assert doc["spec"]["rules"] == json.loads(
             """
-        [{"host":"example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},
-        {"host":"app.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},
-        {"host":"registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-registry","port":{"name":"registry-http"}}}}]}}]
-        """
+            [{"host":"example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":
+            "release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},{"host":"app.example.com","http":{"paths":[{"path":"/",
+            "pathType":"Prefix","backend":{"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},{"host":
+            "registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":
+            "release-name-registry","port":{"name":"registry-http"}}}}]}}]
+            """
         )
 
     def test_astro_ui_per_host_ingress(self, kube_version):
@@ -44,17 +46,15 @@ class TestIngress:
         assert len(docs) == 2
         assert docs[0]["spec"]["rules"] == json.loads(
             """
-        [
-            {"host":"app.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}}
-        ]
-        """
+            [{"host":"app.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+            {"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}}]
+            """
         )
         assert docs[1]["spec"]["rules"] == json.loads(
             """
-        [
-            {"host":"example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}}
-        ]
-        """
+            [{"host":"example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+            {"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}}]
+            """
         )
 
     def test_registry_per_host_ingress(self, kube_version):
@@ -69,9 +69,9 @@ class TestIngress:
         assert len(docs) == 1
         expected_rules_v1 = json.loads(
             """
-        [
-        {"host":"registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":{"service":{"name":"release-name-registry","port":{"name":"registry-http"}}}}]}}]
-        """
+            [{"host":"registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+            {"service":{"name":"release-name-registry","port":{"name":"registry-http"}}}}]}}]
+            """
         )
         assert docs[0]["spec"]["rules"] == expected_rules_v1
 

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -84,7 +84,6 @@ class TestIngress:
         assert all(doc["apiVersion"] == "networking.k8s.io/v1" for doc in ingresses)
         assert all(doc["kind"] == "Ingress" for doc in ingresses)
         assert all(doc["metadata"]["annotations"]["kubernetes.io/ingress.class"] == "release-name-nginx" for doc in ingresses)
-        assert all(doc["metadata"]["annotations"]["kubernetes.io/tls-acme"] == "false" for doc in ingresses)
 
     def test_kibana_custom_ingress_annotation(self, kube_version):
         """validate kibana to add custom ingress annotation to ingress objects"""


### PR DESCRIPTION
## Description

- Remove global.acme
- Remove legacy ingress path syntaxes
- Clean up some json data in test cases

All of these code is effectively dead code, so this should function as a no-op in all environments.

## Related Issues

- <https://github.com/astronomer/issues/issues/7473>
- <https://github.com/astronomer/issues/issues/7523>

## Testing

No additional testing is needed. These changes will all be covered under normal test flows.

## Merging

This is only meant for 1.0, but this could be backported to older versions. This is all effectively dead code, so backporting is not going to get us much.