### PR TITLE
Update environment variable names for consistency

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -196,7 +196,7 @@
   value: {{ .Values.global.plane.domainSuffix }}.{{ .Values.global.baseDomain }}
 - name: COMMANDER_DATAPLANE_MODE
   value: {{ .Values.global.plane.mode | quote }}
-- name: COMMANDER_HOUSTON_JWKS_URL
+- name: COMMANDER_HOUSTON_JWKS_ENDPOINT
   value: {{ .Values.commander.houstonAuthorizationUrl | default "" | quote }}
 {{- end }}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -180,9 +180,9 @@
 - name: COMMANDER_DATAPLANE_CHART_VERSION
   value: "{{ .Chart.Version }}"
 - name: COMMANDER_CLOUD_PROVIDER
-  value: {{ .Values.commander.cloudProvider | default "" | quote }}
+  value: {{ .Values.commander.cloudProvider | default "local" | quote }}
 - name: COMMANDER_REGION
-  value: {{ .Values.commander.region | default "" | quote }}
+  value: {{ .Values.commander.region | default "local" | quote }}
 - name: COMMANDER_VERSION
   value: {{ .Values.images.commander.tag | quote }}
 - name: COMMANDER_DATAPLANE_DATABASE_URL

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -63,7 +63,7 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_REGION"] == "us-west-2"
         assert env_vars["COMMANDER_BASE_DOMAIN"] == "custom-dp-123.example.com"
         assert env_vars["COMMANDER_DATAPLANE_MODE"] == "data"
-        assert env_vars["COMMANDER_HOUSTON_JWKS_URL"] == "https://houston.example.com/auth"
+        assert env_vars["COMMANDER_HOUSTON_JWKS_ENDPOINT"] == "https://houston.example.com/auth"
 
     def test_astronomer_commander_deployment_upgrade_timeout(self, kube_version):
         """Test that helm renders a good deployment template for


### PR DESCRIPTION
## Description

This PR updates variable name and adds default values for COMMANDER_CLOUD_PROVIDER and COMMANDER_REGION as these are required values in commander. 

## Related Issues

Related astronomer/issues#XXXX

## Testing

- The changes are already deployed on cluster with these changes.
- Unittests work as expected. 

## Merging

1.0