### PR TITLE
PINF-563 - fix dag deploy image to not ignore repository in private repo mode

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -483,6 +483,33 @@ tlsEnabled: false
 {{- end -}}
 {{- end }}
 
+{{/*
+Generic helper to get conforming repository and tag with private registry support.
+Returns an object with .repository and .tag fields.
+Usage: {{ $image := include "conforming-repotag" (dict "global" .Values.global "imageConfig" .Values.global.dagOnlyDeployment "defaultImageName" "ap-dag-deploy") | fromYaml }}
+       repository: {{ $image.repository }}
+       tag: {{ $image.tag }}
+*/}}
+{{- define "conforming-repotag" -}}
+{{- $defaultRegistryPrefix := include "defaultRegistryPrefix" . -}}
+{{- $defaultRepo := printf "%s/%s" $defaultRegistryPrefix .defaultImageName -}}
+{{- $tag := .imageConfig.tag | default "latest" -}}
+{{- $configRepo := .imageConfig.repository | default "" -}}
+{{- if and $configRepo (ne $configRepo $defaultRepo) -}}
+{{/* Custom repository provided (different from default) - use it as-is */}}
+repository: {{ $configRepo }}
+tag: {{ $tag }}
+{{- else if .global.privateRegistry.enabled -}}
+{{/* Using default repository with private registry enabled */}}
+repository: {{ printf "%s/%s" .global.privateRegistry.repository .defaultImageName }}
+tag: {{ $tag }}
+{{- else -}}
+{{/* Use default or configured repository */}}
+repository: {{ $configRepo | default $defaultRepo }}
+tag: {{ $tag }}
+{{- end -}}
+{{- end }}
+
 {{- define "configSyncer.securityContext" -}}
 {{- if .Values.configSyncer.securityContext }}
 {{ toYaml .Values.configSyncer.securityContext | indent 16 }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -173,13 +173,13 @@ data:
 
       {{- if .Values.global.dagOnlyDeployment.enabled }}
       # enables dag only deployment for airflow deployments
-      {{- $dagOnlyDeployment := include "dagOnlyDeployment.image" . }}
+      {{- $dagDeployRepoTag := include "conforming-repotag" (dict "global" .Values.global "imageConfig" .Values.global.dagOnlyDeployment "defaultImageName" "ap-dag-deploy") | fromYaml }}
       dagDeploy:
         enabled: {{ .Values.global.dagOnlyDeployment.enabled }}
         images:
           dagServer:
-            repository: {{ (splitList ":"  $dagOnlyDeployment ) | first  }}
-            tag: {{ (splitList ":"  $dagOnlyDeployment ) | last  }}
+            repository: {{ $dagDeployRepoTag.repository }}
+            tag: {{ $dagDeployRepoTag.tag }}
         {{- if .Values.global.dagOnlyDeployment.securityContexts }}
         securityContexts: {{ template "dagOnlyDeployment.securityContexts" . }}
         {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -20,16 +20,12 @@ nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDoma
 {{- end }}
 
 
-{{ define "containerd.configToml" -}}
-{{- .Values.global.privateCaCertsAddToHost.containerdConfigToml -}}
+{{- define "defaultRegistryPrefix" -}}
+quay.io/astronomer
 {{- end }}
 
-{{ define "dagOnlyDeployment.image" -}}
-{{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-dag-deploy:{{ .Values.global.dagOnlyDeployment.tag }}
-{{- else -}}
-{{ .Values.global.dagOnlyDeployment.repository }}:{{ .Values.global.dagOnlyDeployment.tag }}
-{{- end }}
+{{ define "containerd.configToml" -}}
+{{- .Values.global.privateCaCertsAddToHost.containerdConfigToml -}}
 {{- end }}
 
 {{ define "authSidecar.image" -}}


### PR DESCRIPTION
## Description

Partially adresses <https://github.com/astronomer/issues/issues/6189> - for dag-server/day-depoy image only. Introduced a general purpose template that can likely be used to stamp out a uniform fix for most or all other areas though.

## Related Issues

<https://github.com/astronomer/issues/issues/6189>

## Testing

Manually test with
```
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true|grep dagDeploy -A5
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true --set global.dagOnlyDeployment.tag=sometag|grep dagDeploy -A5
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true --set global.privateRegistry.enabled=true --set global.privateRegistry.repository=my.repo/my-astr|grep dagDeploy -A5
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true --set global.privateRegistry.enabled=true --set global.privateRegistry.repository=my.repo/my-astr --set global.dagOnlyDeployment.repository=my.custom.repo/something/my-dag-deploy|grep dagDeploy -A5
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true --set global.privateRegistry.enabled=true --set global.privateRegistry.repository=my.repo/my-ast --set global.dagOnlyDeployment.tag=mytag|grep dagDeploy -A5
helm template . -s charts/astronomer/templates/houston/houston-configmap.yaml --set global.baseDomain=foo --set global.dagOnlyDeployment.enabled=true --set global.privateRegistry.enabled=true --set global.privateRegistry.repository=my.repo/my-astr --set global.dagOnlyDeployment.repository=my.custom.repo/something/my-dag-deploy --set global.dagOnlyDeployment.tag=mytag|grep dagDeploy -A5
```

## Merging

Main, v0.37.x