### PR TITLE
Add ENV variables needed by Kuiper reloader

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -142,6 +142,10 @@ spec:
               value: {{ .Release.Name }}_houston
             - name: FILESD_FILE_PATH
               value: /prometheusreloader/airflow
+            - name: ENABLE_DEPLOYMENT_SCRAPING
+              value: "False"
+            - name: ENABLE_CLUSTER_SCRAPING
+              value: "False"
 {{- if .Values.filesdReloader.extraEnv }}
 {{ toYaml .Values.filesdReloader.extraEnv | indent 12 }}
 {{- end }}

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -192,6 +192,8 @@ class TestPrometheusStatefulset:
         assert env_vars["DATABASE_TABLE_NAME"] == "Deployment"
         assert env_vars["DATABASE_NAME"] == "release-name_houston"
         assert env_vars["FILESD_FILE_PATH"] == "/prometheusreloader/airflow"
+        assert env_vars["ENABLE_DEPLOYMENT_SCRAPING"] == "False"
+        assert env_vars["ENABLE_CLUSTER_SCRAPING"] == "False"
         assert c_by_name["filesd-reloader"]["volumeMounts"] == [{"mountPath": "/prometheusreloader/airflow", "name": "filesd"}]
 
     def test_prometheus_filesd_reloader_extraenv_enabled(self, kube_version):


### PR DESCRIPTION
## Description

This PR intends to add env vars to prometheus chart which are needed by kuiper reloader component.

## Related Issues

Related astronomer/issues#7505

## Testing
- Added unittests for the vars.
- All unittests Passed.
<img width="1156" height="772" alt="image" src="https://github.com/user-attachments/assets/08f078f9-d3f2-4f84-b6db-900f4935ee89" />

## Merging

1.0