### PR TITLE
update reloader env vars for table name definition

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -137,7 +137,9 @@ spec:
                   key: connection
             - name: DATABASE_SCHEMA_NAME
               value: "houston$default"
-            - name: DATABASE_TABLE_NAME
+            - name: CLUSTER_TABLE_NAME
+              value: Cluster
+            - name: DEPLOYMENT_TABLE_NAME
               value: Deployment
             - name: DATABASE_NAME
               value: {{ .Release.Name }}_houston

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -193,7 +193,8 @@ class TestPrometheusStatefulset:
         c_by_name = get_containers_by_name(docs[0])
         env_vars = {x["name"]: x.get("value", x.get("valueFrom")) for x in c_by_name["filesd-reloader"]["env"]}
         assert env_vars["DATABASE_SCHEMA_NAME"] == "houston$default"
-        assert env_vars["DATABASE_TABLE_NAME"] == "Deployment"
+        assert env_vars["DEPLOYMENT_TABLE_NAME"] == "Deployment"
+        assert env_vars["CLUSTER_TABLE_NAME"] == "Cluster"
         assert env_vars["DATABASE_NAME"] == "release-name_houston"
         assert env_vars["FILESD_FILE_PATH"] == "/prometheusreloader/airflow"
         assert env_vars["ENABLE_DEPLOYMENT_SCRAPING"] == "False"


### PR DESCRIPTION
## Description

Update kuiper reloder with newly defined variable names to identify the tables  

## Related Issues

- Related https://github.com/astronomer/issues/issues/7505

## Testing

QA should able to automatically detect the dataplanes prometheus and metrics population in control plane

## Merging

merge to master
