### PR TITLE
update vector logging image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,7 +467,7 @@ workflows:
                 - quay.io/astronomer/ap-redis:7.4.3
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.46.1
+                - quay.io/astronomer/ap-vector:0.47.0-4
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -511,7 +511,7 @@ workflows:
                 - quay.io/astronomer/ap-redis:7.4.3
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.46.1
+                - quay.io/astronomer/ap-vector:0.47.0-4
           context:
             - twistcli
 

--- a/values.yaml
+++ b/values.yaml
@@ -151,7 +151,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.46.1
+    tag: 0.47.0-4
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

7612 vector sidecar termination fix

## Related Issues

- https://github.com/astronomer/issues/issues/7612

## Testing

QA should able to validate sidecar termination works properly even with empty file

## Merging

merge to master, release-0.37
