### PR TITLE
airflow3 pod mutation hook tpl enhancements

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -400,9 +400,12 @@ data:
               PodDefaults.SIDECAR_CONTAINER.image = xcom_sidecar_image
             except ImportError:
               warnings.warn(
-                "Airflow CNCF Provider not installed by default.",
-                "This will bypass custom images for xcom and defaults to alpine.",
-                "Refer https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html to install the provider.")
+                """Airflow CNCF Provider not installed by default.
+                This will bypass custom images for xcom and defaults to alpine.
+                Refer https://airflow.apache.org/docs/apache-airflow-providers-cncf-kubernetes/stable/index.html
+                to install the provider.
+                """
+              )
             def pod_mutation_hook_deprecated(pod):
               from airflow.contrib.kubernetes.pod import Pod
               extra_labels = {


### PR DESCRIPTION
## Description

In airflow3 most of the providers are removed and are made optional to be included by customers.
Due to this new constraint the old method of imports will no longer work and have to conditionally enable the imports not to fail if those are not available

## Related Issues

- https://github.com/astronomer/issues/issues/7654

## Testing

<img width="1719" height="887" alt="image" src="https://github.com/user-attachments/assets/954bc797-f511-4809-9f1f-6668d6c113c8" />


## Merging

merge to master and 0.37
