### PR TITLE
Use the same nginx volumeMounts and command for cp and dp. Fix tests.

### DIFF
--- a/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
@@ -57,9 +57,15 @@ spec:
             - -c
             - |
               cp -r /etc/nginx/* /etc/nginx_copy
+              mkdir /tmp/nginx
+              mkdir /etc/ingress-controller/auth /etc/ingress-controller/geoip /etc/ingress-controller/ssl /etc/ingress-controller/telemetry
           volumeMounts:
             - name: etc-nginx
               mountPath: /etc/nginx_copy
+            - name: tmp
+              mountPath: /tmp
+            - name: etc-ingress-controller
+              mountPath: /etc/ingress-controller
       containers:
         - name: nginx
           securityContext:

--- a/tests/chart_tests/test_nginx.py
+++ b/tests/chart_tests/test_nginx.py
@@ -324,6 +324,12 @@ def test_nginx_deployment_defaults(plane_mode):
     assert len(docs) == 1
     doc = docs[0]
     assert doc["kind"] == "Deployment"
+    names = {
+        "unified": "release-name-cp-nginx",
+        "control": "release-name-cp-nginx",
+        "data": "release-name-dp-nginx",
+    }
+    assert doc["metadata"]["name"] == names[plane_mode]
     assert doc["apiVersion"] == "apps/v1"
     assert doc["spec"]["minReadySeconds"] == 0
     assert doc["spec"]["template"]["spec"]["volumes"] == [

--- a/tests/chart_tests/test_nginx.py
+++ b/tests/chart_tests/test_nginx.py
@@ -296,9 +296,11 @@ def test_nginx_backend_serviceaccount_defaults():
         assert "release-name-nginx-default-backend" == doc["metadata"]["name"]
 
 
-def test_nginx_defaults():
+@pytest.mark.parametrize("plane_mode", ["unified", "control", "data"])
+def test_nginx_deployment_defaults(plane_mode):
     """Test nginx ingress deployment template defaults."""
     docs = render_chart(
+        values={"global": {"plane": {"mode": plane_mode}}},
         show_only=[
             "charts/nginx/templates/controlplane/nginx-cp-deployment.yaml",
             "charts/nginx/templates/dataplane/nginx-dp-deployment.yaml",


### PR DESCRIPTION
## Description

Correct an inconsistency between the cp nginx and dp nginx volumeMounts and command needed for readOnlyRootFilesystem.

## Related Issues

https://github.com/astronomer/issues/issues/7404

## Testing

These configs are known to work in unified, so we don't need any extra QA testing for these. This just makes the feature consistent with what we intended for nginx.

## Merging

This is only for 1.0.