### PR TITLE
Fix mistaken authSidecar readOnlyRootFilesystem

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -67,8 +67,6 @@ spec:
                 name: {{ template "registry.authHeaderSecret" . }}
                 key: authHeaders
           resources: {{ toYaml (.Values.federation.auth.resources | default .Values.global.authSidecar.resources) | nindent 12 }}
-          securityContext:
-            readOnlyRootFilesystem: true
           readinessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Description

Fix a small addition of readOnlyRootFilesystem to authSidecar that slipped through with https://github.com/astronomer/astronomer/pull/2784

## Related Issues

- https://github.com/astronomer/issues/issues/7482

## Testing

No testing needed. No docs needed. This is just a fix for our dev cycle.

## Merging

Only for 1.0