### PR TITLE
remove redundant authsidecar helper images

### DIFF
--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -63,14 +63,6 @@ Create chart name and version as used by the chart label.
 {{- end }}
 {{- end }}
 
-{{ define "authSidecar.image" -}}
-{{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-auth-sidecar:{{ .Values.global.authSidecar.tag }}
-{{- else -}}
-{{ .Values.global.authSidecar.repository }}:{{ .Values.global.authSidecar.tag }}
-{{- end }}
-{{- end }}
-
 {{ define "prometheus.federationAuthSecret" -}}
 {{ default (printf "%s-registry-auth-key" .Release.Name) .Values.global.authHeaderSecretName }}
 {{- end }}


### PR DESCRIPTION
## Description

remove redundant authsidecar helper images

## Related Issues

- Related https://github.com/astronomer/issues/issues/7482

## Testing

Covered by exisiting tests

## Merging

merge to master
