### PR TITLE
[helm chart][secrets] create astronomer-bootstrap +astronomer-smtp + astronomer-tls

### DIFF
--- a/charts/astronomer/templates/secrets.yaml
+++ b/charts/astronomer/templates/secrets.yaml
@@ -1,0 +1,17 @@
+---
+{{- if .Values.secrets.enabled }}
+{{- range .Values.secrets.list }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .name }}"
+  annotations:
+    "helm.sh/hook": "pre-install"
+data:
+{{- range $key, $val := .value }}
+  {{ $key }}: {{ $val | b64enc | quote }}
+  {{- end }}
+{{- end }}
+type: Opaque
+{{- end }}
+{{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -547,4 +547,22 @@ ports:
   commanderGRPC: 50051
   astroUIHTTP: 8080
   registryHTTP: 5000
-  registryScrape: 5001
+  registryScrape: 
+
+secrets:
+  enabled: false
+  list: {}
+  # - name: astronomer-bootstrap
+  #   value:
+  #     connection: postgres://<username>:<password>:5432
+  # - name: astronomer-smtp
+  #   value:
+  #     connection: smtp://<username>:<password>@<endpoint>/?requireTLS=true
+  # - name: astronomer-tls
+  #   value:
+  #     tls.crt: |
+  #         -----BEGIN CERTIFICATE-----
+  #          -----END CERTIFICATE-----
+  #     tls.key: |
+  #         -----BEGIN RSA PRIVATE KEY-----
+  #         -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
Hello @danielhoherd 

Looking into astronomer documentation to install the chart https://www.astronomer.io/docs/software/install-airgapped, there are 3 secrets that are created manually:

- astronomer-bootstrap 
- astronomer-smtp 
- astronomer-tls

The purpose of this PR is to create a secret.yaml template which allows the creation of multiple secrets. This way there is no need to create secrets manually.
Thanks.