### PR TITLE
7400 vector daemonset readOnlyRootFilesystem

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -14,9 +14,6 @@ metadata:
 
 data:
   vector-config.yaml: |
-    api:
-      enabled: true
-      address: "0.0.0.0:8686"
     log_schema:
       timestamp_key: "@timestamp"
 

--- a/charts/vector/templates/vector-daemonset.yaml
+++ b/charts/vector/templates/vector-daemonset.yaml
@@ -50,6 +50,7 @@ spec:
       containers:
       - name: vector
         securityContext:
+          readOnlyRootFilesystem: true
           {{- toYaml .Values.vector.securityContext | nindent 10 }}
         image: {{ template "vector.image" . }}
         imagePullPolicy: {{ .Values.vector.image.pullPolicy }}

--- a/charts/vector/templates/vector-daemonset.yaml
+++ b/charts/vector/templates/vector-daemonset.yaml
@@ -30,30 +30,27 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/vector-configmap.yaml") . | sha256sum }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.ports.promScrape | quote }}
-{{- if .Values.global.podAnnotations }}
-{{ toYaml .Values.global.podAnnotations | indent 8 }}
-{{- end }}
-{{- if .Values.podAnnotations }}
-{{ toYaml .Values.podAnnotations | indent 8 }}
-{{- end }}
+        {{- if .Values.global.podAnnotations }}
+        {{- toYaml .Values.global.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       terminationGracePeriodSeconds: 30
     {{- if .Values.priorityClassName }}
-      priorityClassName:  {{ .Values.priorityClassName  }}
+      priorityClassName: {{ .Values.priorityClassName }}
     {{ end }}
       nodeSelector: {{ toYaml (.Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (.Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (.Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ include "vector.serviceAccountName" . }}
-{{- include "vector.imagePullSecrets" . | indent 6 }}
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
+      {{- include "vector.imagePullSecrets" . | nindent 6 }}
+      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
       - name: vector
         securityContext:
-          {{- if .Values.vector.securityContext }}
-{{ toYaml .Values.vector.securityContext | indent 10 }}
-          {{- end }}
+          {{- toYaml .Values.vector.securityContext | nindent 10 }}
         image: {{ template "vector.image" . }}
         imagePullPolicy: {{ .Values.vector.image.pullPolicy }}
         {{- if .Values.vector.livenessProbe }}
@@ -108,7 +105,7 @@ spec:
           value: {{ .Release.Namespace | quote }}
         - name: RELEASE
           value: {{ .Release.Name | quote }}
-        {{- range $key, $value :=  .Values.extraEnv }}
+        {{- range $key, $value := .Values.extraEnv }}
         - name: {{ $key }}
           value: {{ $value | quote }}
         {{- end }}

--- a/tests/chart_tests/test_read_only_root_filesystem.py
+++ b/tests/chart_tests/test_read_only_root_filesystem.py
@@ -29,6 +29,7 @@ read_only_root_pods = [
     "prometheus",
     "registry",
     "update-resource-strategy",
+    "vector",
 ]
 
 

--- a/tests/utils/chart.py
+++ b/tests/utils/chart.py
@@ -158,7 +158,7 @@ def render_chart(
                 command.extend(["--show-only", str(file)])
 
         if DEBUG:
-            print(f"helm command:\n  {shlex.join(command)}")
+            print(f"helm command:\n\n{shlex.join(command)}\n")
 
         try:
             manifests = subprocess.check_output(command, stderr=subprocess.PIPE).decode("utf-8")


### PR DESCRIPTION
## Description

Turn on readOnlyRootFilesystem in vector daemonset.

Also:
- Clean up existing tests that are related to this feature
- Remove vector api server configs since we are not using it
- Better debug helm command formatting

## Related Issues

https://github.com/astronomer/issues/issues/7400

## Testing

I have manually tested this change in an eks dataplane cluster.

## Merging

This is only for 1.0