### PR TITLE
Fix nginx-elasticsearch DNS resolution failure in unified mode

### DIFF
--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -57,7 +57,7 @@ data:
 
         location = /auth {
           internal;
-          {{- include "houston.proxypass" . | nindent 10 }}
+          {{- include "houston-proxy" . | nindent 10 }}
           proxy_set_header Content-Length "";
           proxy_set_header X-Original-URI $request_uri;
         }

--- a/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
@@ -54,7 +54,7 @@ data:
 
         location = /auth {
           internal;
-          {{- include "houston.proxypass" . | nindent 10 }}
+          {{- include "houston-proxy" . | nindent 10 }}
           proxy_set_header Content-Length "";
           proxy_set_header X-Original-URI $request_uri;
         }

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -68,7 +68,7 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
-{{- define "houston.proxypass" -}}
+{{- define "houston-proxy" -}}
 {{- if eq .Values.global.plane.mode "unified" -}}
 proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;
 {{- else -}}


### PR DESCRIPTION
## Description

The astronomer-elasticsearch-nginx pod is failing to start in unified mode deployments due to a DNS resolution error:
nginx: [emerg] host not found in upstream "houston.shubham-test22.astro-qa.link" in /etc/nginx/nginx.conf:42
The pod enters a CrashLoopBackOff state because nginx cannot resolve the external Houston hostname during startup validation.

## Root Cause
In unified mode, the nginx configuration attempts to use the external Houston domain `(https://houston.{{ .Values.global.baseDomain }})`  for authentication requests, but:
- The external DNS may not be immediately resolvable from within the cluster
- This creates an unnecessary external dependency when Houston runs in the same cluster

## Related Issues

Related astronomer/issues#XXXX

## Testing

- Verified that the nginx pod started without issues after this change:
<img width="630" height="633" alt="Screenshot 2025-09-03 at 11 50 03 AM" src="https://github.com/user-attachments/assets/cbe6e9da-c66b-4eb6-9540-2e97d4bd338c" />

<img width="823" height="376" alt="Screenshot 2025-09-03 at 11 50 34 AM" src="https://github.com/user-attachments/assets/0cfbcda4-dbc1-4f6a-9717-a1dc21877f7b" />

## Merging

Master