### PR TITLE
Remove Elasticsearch for deny request since it is being used by Airflow3

### DIFF
--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -31,7 +31,7 @@ metadata:
       }
     {{- else }}
     nginx.ingress.kubernetes.io/configuration-snippet: |
-      location ~ ^/v1/(alerts|elasticsearch|metrics) {
+      location ~ ^/v1/(alerts|metrics) {
         deny all;
         return 403;
       }


### PR DESCRIPTION
## Description

This PR intends to remove Elasticsearch from deny config in CP/DP mode to enable it to send connections to houston to airflow3 deployments

## Related Issues

Related astronomer/issues#

## Testing

- Without this change we were receiving 403 in the deployments:
<img width="1725" height="448" alt="Screenshot 2025-09-03 at 5 53 38 PM" src="https://github.com/user-attachments/assets/731e64af-231d-4aa5-9585-828679da3202" />

- After this change auth is enabled:
<img width="1723" height="994" alt="Screenshot 2025-09-03 at 5 52 07 PM" src="https://github.com/user-attachments/assets/be5e817f-4f80-4a1d-badf-e4d360e78fff" />

## Merging

Master