### PR TITLE
Allow releasing from release-1.0 branch, and other release-#.# branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -483,14 +483,14 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - release-to-internal:
           context:
             - gcp-astronomer-prod
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
           requires:
             - approve-internal-release
             - scenario-unified-1-29-14
@@ -500,7 +500,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - trigger-upgrade-test:
           requires:
             - release-to-internal
@@ -508,7 +508,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - approve-public-release:
           type: approval
           requires:
@@ -518,7 +518,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - release-to-public:
           context:
             - gcp-astronomer-prod
@@ -528,7 +528,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - sign-released-image:
           name: sign-release-image
           context:
@@ -540,7 +540,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
 
   release-bom-workflow:
     jobs:
@@ -577,14 +577,14 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - trigger-feature-stack-release:
           requires:
             - release-to-internal
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
 
 commands:
   push-to-quay-io:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -361,14 +361,14 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - release-to-internal:
           context:
             - gcp-astronomer-prod
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
           requires:
             - approve-internal-release
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
@@ -379,7 +379,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - trigger-upgrade-test:
           requires:
             - release-to-internal
@@ -387,7 +387,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - approve-public-release:
           type: approval
           requires:
@@ -398,7 +398,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - release-to-public:
           context:
             - gcp-astronomer-prod
@@ -408,7 +408,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - sign-released-image:
           name: sign-release-image
           context:
@@ -420,7 +420,7 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
 
   release-bom-workflow:
     jobs:
@@ -457,14 +457,14 @@ workflows:
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
       - trigger-feature-stack-release:
           requires:
             - release-to-internal
           filters:
             branches:
               only:
-                - '/^release-0\.\d+$/'
+                - '/^release-\d+\.\d+$/'
 
 commands:
   push-to-quay-io:


### PR DESCRIPTION
## Description

Our CircleCI configs previously only allowed releasing from branches that start with `release-0.`. This changes that to be `release-(any number).(any number)`

## Related Issues

N/A, release related work

## Testing

No testing needed.

## Merging

Merge everywhere.