### PR TITLE
remove es client duplicate mount path

### DIFF
--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -190,9 +190,6 @@ spec:
         - mountPath: /usr/share/elasticsearch/config/elasticsearch.yml
           name: config
           subPath: elasticsearch.yml
-        - mountPath: /usr/share/elasticsearch/logs
-          name: tmp
-          subPath: logs
       volumes:
       - name: es-config-dir
         emptyDir: {}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -89,7 +89,7 @@ class TestElasticSearch:
             {"mountPath": "/usr/share/elasticsearch/config", "name": "es-config-dir"},
             {"mountPath": "/usr/share/elasticsearch/data", "name": "es-data"},
             {"mountPath": "/usr/share/elasticsearch/logs", "name": "es-client-logs"},
-            {"mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml", "name": "config", "subPath": "elasticsearch.yml"}
+            {"mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml", "name": "config", "subPath": "elasticsearch.yml"},
         ]
 
         assert es_client_containers["es-config-dir-copier"]["volumeMounts"] == [

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -89,8 +89,7 @@ class TestElasticSearch:
             {"mountPath": "/usr/share/elasticsearch/config", "name": "es-config-dir"},
             {"mountPath": "/usr/share/elasticsearch/data", "name": "es-data"},
             {"mountPath": "/usr/share/elasticsearch/logs", "name": "es-client-logs"},
-            {"mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml", "name": "config", "subPath": "elasticsearch.yml"},
-            {"mountPath": "/usr/share/elasticsearch/logs", "name": "tmp", "subPath": "logs"},
+            {"mountPath": "/usr/share/elasticsearch/config/elasticsearch.yml", "name": "config", "subPath": "elasticsearch.yml"}
         ]
 
         assert es_client_containers["es-config-dir-copier"]["volumeMounts"] == [


### PR DESCRIPTION
## Description

remove es client duplicate mount path

## Related Issues

https://github.com/astronomer/issues/issues/7816

## Testing

QA should not see duplicate path errror

## Merging

merge to master and release-1.0
