### PR TITLE
fix elasticsearch and jetstream config

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -51,7 +51,6 @@ data:
 
     {{- if .Values.global.nats.jetStream.enabled }}
     nats:
-      jetStreamEnabled: {{ .Values.global.nats.jetStream.enabled }}
       {{- include "jetstreamTLS" . | nindent 6 }}
     {{- end }}
 

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -116,7 +116,6 @@ spec:
       - name: es-master
         securityContext:
           readOnlyRootFilesystem: true
-          privileged: true
           {{- if .Values.master.securityContext }}
           {{- toYaml .Values.master.securityContext | nindent 10 }}
           {{- else }}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -187,7 +187,6 @@ class TestElasticSearch:
         pod_data = doc["spec"]["template"]["spec"]["containers"][0]
         assert pod_data["securityContext"] == {
             "readOnlyRootFilesystem": True,
-            "privileged": True,
             "snoopy": "dog",
             "woodstock": "bird",
         }

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -28,7 +28,7 @@ class TestNatsJetstream:
 
         assert len(docs) == 3
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-        assert prod["nats"] == {"jetStreamEnabled": True, "tlsEnabled": False}
+        assert prod["nats"] == {"tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
         assert "jetstream" in nats_cm
         assert docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
@@ -65,7 +65,6 @@ class TestNatsJetstream:
         jetStreamCertPrefix = "/etc/houston/jetstream/tls/release-name-jetstream-tls-certificate"
         prod = yaml.safe_load(obj_by_name["ConfigMap-release-name-houston-config"]["data"]["production.yaml"])
         assert prod["nats"] == {
-            "jetStreamEnabled": True,
             "tlsEnabled": True,
             "tls": {
                 "caFile": f"{jetStreamCertPrefix}-client/ca.crt",


### PR DESCRIPTION
## Description

This PR address an issue with privileged container context added incorrectly while refactoring the changes for readOnlyRoot file system

## Related Issues

- https://github.com/astronomer/issues/issues/7819

## Testing

QA should able to provision the deployment without any errors for elasticsearch

## Merging

merge to master and release-1.0
