### PR TITLE
fix commander network policy for metadata reconcilation

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -86,5 +86,8 @@ spec:
     ports:
     - protocol: TCP
       port: {{ .Values.ports.commanderGRPC }}
+    - protocol: TCP
+      port: {{ .Values.ports.commanderHTTP }}
+
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

fix commander network policy to allow inbound from houston for metadata reconcilation

## Related Issues

 https://github.com/astronomer/issues/issues/7824

## Testing

QA should able to create/update/delete deployments with no errors

## Merging

merge to release-1.0 and master
