### PR TITLE
update houston api 1.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
-                - quay.io/astronomer/ap-houston-api:1.0.7
+                - quay.io/astronomer/ap-houston-api:1.0.8
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.7
+    tag: 1.0.8
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 1.0.8

## Related Issues

Related https://github.com/astronomer/issues/issues/7817
Related https://github.com/astronomer/issues/issues/7795
Related https://github.com/astronomer/issues/issues/7823


## Testing

QA should able to view workspace settings and permission flow 

## Merging

merge to master and backport to release-1.0
