### PR TITLE
PR to remove promproxy from unified mode

### DIFF
--- a/charts/prometheus/templates/prometheus-federate-ingress.yaml
+++ b/charts/prometheus/templates/prometheus-federate-ingress.yaml
@@ -1,7 +1,7 @@
 ########################################
 ## Prometheus Federate Ingress ##
 ########################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq .Values.global.plane.mode "data" }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:

--- a/charts/prometheus/templates/prometheus-federation-auth-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-federation-auth-configmap.yaml
@@ -1,7 +1,7 @@
 ##########################################
 ## Prometheus Federation Auth Configmap ##
 ##########################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq .Values.global.plane.mode "data" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/prometheus/templates/prometheus-federation-auth-deployment.yaml
+++ b/charts/prometheus/templates/prometheus-federation-auth-deployment.yaml
@@ -1,7 +1,7 @@
 ###########################################
 ## Prometheus Federation Auth Deployment ##
 ###########################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq .Values.global.plane.mode "data" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/prometheus/templates/prometheus-federation-auth-service.yaml
+++ b/charts/prometheus/templates/prometheus-federation-auth-service.yaml
@@ -1,7 +1,7 @@
 ########################################
 ## Prometheus Federation Auth Service ##
 ########################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq .Values.global.plane.mode "data" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -158,7 +158,7 @@ spec:
             name: filesd
         - name: prometheus
           image: {{ include "prometheus.image" . }}
-          {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+          {{- if eq .Values.global.plane.mode "control" }}
           env:
             - name: FEDERATION_AUTH_TOKEN
               valueFrom:
@@ -185,7 +185,7 @@ spec:
             - {{ . }}
             {{- end }}
           volumeMounts:
-          {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+          {{- if eq .Values.global.plane.mode "control" }}
             - name: federation-auth
               mountPath: /etc/prometheus/federation-auth
               readOnly: true
@@ -234,7 +234,7 @@ spec:
           configMap:
             name: {{ template "prometheus.fullname" . }}-nginx-conf
         {{- end }}
-        {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+        {{- if eq .Values.global.plane.mode "control" }}
         - name: federation-auth
           secret:
             secretName: {{ template "prometheus.federationAuthSecret" . }}

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -374,7 +374,7 @@ def test_custom_serviceaccount_names(template_name):
 
     values = always_merger.merge(get_all_features(), custom_service_account_names[template_name])
     enable_pgsql_sa = {"postgresql": {"serviceAccount": {"enabled": True}}}
-    if "nginx-dp-deployment" in template_name:
+    if "nginx-dp-deployment" in template_name or "prometheus-federation-auth-deployment" in template_name:
         plane_config = {"global": {"plane": {"mode": "data"}}}
         values = always_merger.merge(values, plane_config)
     values = always_merger.merge(values, enable_pgsql_sa)

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -244,7 +244,7 @@ def test_default_serviceaccount_names(template_name):
     """Test that default service account names are rendered correctly."""
 
     default_serviceaccount_names_overrides = {"global": {"rbacEnabled": False}, "postgresql": {"serviceAccount": {"enabled": True}}}
-    if "nginx-dp-deployment" in template_name:
+    if "nginx-dp-deployment" in template_name or "prometheus-federation-auth-deployment" in template_name:
         default_serviceaccount_names_overrides["global"]["plane"] = {"mode": "data"}
     values = always_merger.merge(get_all_features(), default_serviceaccount_names_overrides)
 

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -20,7 +20,7 @@ class TestGlobabIngressAnnotation:
             show_only=sorted(always_rendered_ingress),
         )
 
-        assert len(docs) == 6
+        assert len(docs) == 5
         for doc in docs:
             assert doc["kind"] == "Ingress"
             assert doc["apiVersion"] == "networking.k8s.io/v1"

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -78,7 +78,7 @@ class TestIngress:
     def test_single_ingress_per_host(self, kube_version):
         default_docs = render_chart(values={"global": {"enablePerHostIngress": True}})
         ingresses = [doc for doc in default_docs if doc["kind"].lower() == "Ingress".lower()]
-        assert len(ingresses) == 8
+        assert len(ingresses) == 7
         assert all(len(doc["spec"]["rules"]) == 1 for doc in ingresses)
         assert all(len(doc["spec"]["tls"][0]["hosts"]) == 1 for doc in ingresses)
         assert all(doc["apiVersion"] == "networking.k8s.io/v1" for doc in ingresses)
@@ -90,7 +90,7 @@ class TestIngress:
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/prometheus/templates/ingress.yaml", "charts/prometheus/templates/prometheus-federate-ingress.yaml"],
-            values={"global": {"baseDomain": "example.com"}},
+            values={"global": {"baseDomain": "example.com", "plane": {"mode": "data"}}},
         )
 
         assert len(docs) == 2

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -43,10 +43,10 @@ class TestPrometheusStatefulset:
         assert c_by_name["prometheus"]["image"].startswith("quay.io/astronomer/ap-prometheus:")
         assert c_by_name["prometheus"]["ports"] == [{"containerPort": 9090, "name": "prometheus-data"}]
         assert c_by_name["prometheus"]["volumeMounts"] == [
-        {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
-        {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
-        {"mountPath": "/prometheus", "name": "data"},
-        {"mountPath": "/prometheusreloader/airflow", "name": "filesd"},
+            {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
+            {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
+            {"mountPath": "/prometheus", "name": "data"},
+            {"mountPath": "/prometheusreloader/airflow", "name": "filesd"},
         ]
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
         assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -43,11 +43,10 @@ class TestPrometheusStatefulset:
         assert c_by_name["prometheus"]["image"].startswith("quay.io/astronomer/ap-prometheus:")
         assert c_by_name["prometheus"]["ports"] == [{"containerPort": 9090, "name": "prometheus-data"}]
         assert c_by_name["prometheus"]["volumeMounts"] == [
-            {"mountPath": "/etc/prometheus/federation-auth", "name": "federation-auth", "readOnly": True},
-            {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
-            {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
-            {"mountPath": "/prometheus", "name": "data"},
-            {"mountPath": "/prometheusreloader/airflow", "name": "filesd"},
+        {"mountPath": "/etc/prometheus/config", "name": "prometheus-config-volume"},
+        {"mountPath": "/etc/prometheus/alerts.d", "name": "alert-volume"},
+        {"mountPath": "/prometheus", "name": "data"},
+        {"mountPath": "/prometheusreloader/airflow", "name": "filesd"},
         ]
         assert "persistentVolumeClaimRetentionPolicy" not in doc["spec"]
         assert c_by_name["prometheus"]["livenessProbe"]["initialDelaySeconds"] == 10

--- a/tests/chart_tests/test_tags.py
+++ b/tests/chart_tests/test_tags.py
@@ -37,7 +37,7 @@ def test_tags_monitoring_enabled(template, chart_values=chart_values, kube_versi
     chart_values["tags"] = {"monitoring": True}
     if "auth-sidecar" in template:
         chart_values["global"] = {"plane": {"mode": "control"}, "authSidecar": {"enabled": True}}
-    elif "prometheus-federate-ingress" in template:
+    elif "prometheus-federate-ingress" in template or "prometheus-federation-auth" in template:
         chart_values["global"] = {"plane": {"mode": "data"}}
     else:
         chart_values["global"] = {"plane": {"mode": "unified"}}

--- a/tests/chart_tests/test_tags.py
+++ b/tests/chart_tests/test_tags.py
@@ -35,8 +35,13 @@ chart_values = get_all_features()
 def test_tags_monitoring_enabled(template, chart_values=chart_values, kube_version=newest_supported_kube_version):
     """Test that when monitoring is enabled, the monitoring components are not present."""
     chart_values["tags"] = {"monitoring": True}
+    if "auth-sidecar" in template:
+        chart_values["global"] = {"plane": {"mode": "control"}, "authSidecar": {"enabled": True}}
+    elif "prometheus-federate-ingress" in template:
+        chart_values["global"] = {"plane": {"mode": "data"}}
+    else:
+        chart_values["global"] = {"plane": {"mode": "unified"}}
     docs = render_chart(kube_version=kube_version, values=chart_values, show_only=template)
-
     assert len(docs) >= 1
 
 


### PR DESCRIPTION
## Description

This PR removes promproxy and federation logic from unified mode.

## Related Issues

- https://github.com/astronomer/issues/issues/7864

## Testing

- Added Unittests.

## Merging

Master, 1.0