### PR TITLE
Improve image reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,7 +415,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:1.0.4
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21-1
-                - quay.io/astronomer/ap-dag-deploy:0.6.5
+                - quay.io/astronomer/ap-dag-deploy:0.7.0
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.4
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -415,6 +415,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:1.0.4
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21-1
+                - quay.io/astronomer/ap-dag-deploy:0.6.5
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.4
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -63,10 +63,11 @@ def get_images_from_houston_configmap(doc, args):
     """Return a list of images used in the houston configmap."""
     houston_config = yaml.safe_load(doc["data"]["production.yaml"])
     keepers = ("authSideCar", "loggingSidecar")
-    items = {k: v for k, v in houston_config["deployments"].items() if k in keepers}
-    auth_sidecar_image = f"{items['authSideCar']['repository']}:{items['authSideCar']['tag']}"
-    logging_sidecar_image = f"{items['loggingSidecar']['image']}"
-    images = [auth_sidecar_image, logging_sidecar_image]
+    deployment_items = {k: v for k, v in houston_config["deployments"].items() if k in keepers}
+    auth_sidecar_image = f"{deployment_items['authSideCar']['repository']}:{deployment_items['authSideCar']['tag']}"
+    logging_sidecar_image = f"{deployment_items['loggingSidecar']['image']}"
+    dag_server_image = f"{houston_config['deployments']['dagDeploy']['images']['dagServer']['repository']}:{houston_config['deployments']['dagDeploy']['images']['dagServer']['tag']}"
+    images = [auth_sidecar_image, dag_server_image, logging_sidecar_image]
     if args.verbose and any("quay.io" in x for x in images):
         print(
             "Houston configmap uses quay.io instead of private registry",

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -25,6 +25,8 @@ global:
   customLogging:
     awsSecretName: dummy
     enabled: true
+  dagOnlyDeployment:
+    enabled: true
   loggingSidecar:
     enabled: true
   networkPolicy:

--- a/values.yaml
+++ b/values.yaml
@@ -124,7 +124,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.6.5
+    tag: 0.7.0
     securityContexts:
       pod:
         fsGroup: 50000


### PR DESCRIPTION
## Description

- Track ap-dag-deploy in astronomer/astronomer repo.
- Bump ap-dag-deploy to latest version, 0.7.0

## Related Issues

- https://github.com/astronomer/issues/issues/7857

## Testing

No production code is changed, so no testing is needed. dag-server is now tracked in circleci jobs and is reported in local tools.

## Merging

This can be merged to 1.0 and 0.37 (because 0.37 already has dag-deploy 0.7.0), and may be merged into 0.36 if dagServer 0.7.0 is intended for 0.36.