### PR TITLE
Remove pass as this is causing mismatch of the tokens  in CP and DP

### DIFF
--- a/charts/astronomer/templates/registry-auth-secret.yaml
+++ b/charts/astronomer/templates/registry-auth-secret.yaml
@@ -1,11 +1,10 @@
 #####################################
 ## Astronomer Registry Auth Secret ##
 #####################################
-{{- $pass := randAlphaNum 32 -}}
 {{- $houstonTLSSecretName := printf "%s-houston-jwt-signing-certificate" .Release.Name }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace  $houstonTLSSecretName ) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
-{{- $tlsSecretData := (sha256sum (b64dec (get $secretData "tls.crt")))  | default ($pass ) }}
+{{- $tlsSecretData := (sha256sum (b64dec (get $secretData "tls.crt"))) }}
 {{- if not (.Values.registry.authHeaderSecretName) }}
 kind: Secret
 apiVersion: v1


### PR DESCRIPTION
## Description

This PR removes the random password that we are creating in houston as this is something not useful and causes a new key to be created if houston tls secret object is not accessible. This can cause keys in DP to be different than what is present in CP, which inturn causes auth errors.

## Related Issues

https://github.com/astronomer/issues/issues/7892

## Testing

- No Testing needed, since this is optional.

## Merging

Master, 1.0