### PR TITLE
Enable createJetStreamJob by default

### DIFF
--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -87,7 +87,7 @@ imagePullSecrets:
 
 {{ define "jetStream.serviceAccountName" -}}
 {{- if and .Values.nats.jetStream.serviceAccount.create .Values.global.rbacEnabled -}}
-{{ default (printf "%s-jetStream-sa" .Release.Name) .Values.nats.jetStream.serviceAccount.name }}
+{{ default (printf "%s-jetstream-sa" .Release.Name) .Values.nats.jetStream.serviceAccount.name }}
 {{- else -}}
 {{ default "default" .Values.nats.jetStream.serviceAccount.name }}
 {{- end }}

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -65,7 +65,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{ define "nats.jestreamTLSSecret" -}}
-{{ default (printf "%s-jetstream-tls-certificate" .Release.Name)}}
+{{ default (printf "%s-jetStream-tls-certificate" .Release.Name)}}
 {{- end }}
 
 {{- define "nats.securityContext" -}}
@@ -86,9 +86,9 @@ imagePullSecrets:
 {{- end }}
 
 {{ define "jetStream.serviceAccountName" -}}
-{{- if and .Values.nats.jetstream.serviceAccount.create .Values.global.rbacEnabled -}}
-{{ default (printf "%s-jetstream-sa" .Release.Name) .Values.nats.jetstream.serviceAccount.name }}
+{{- if and .Values.nats.jetStream.serviceAccount.create .Values.global.rbacEnabled -}}
+{{ default (printf "%s-jetStream-sa" .Release.Name) .Values.nats.jetStream.serviceAccount.name }}
 {{- else -}}
-{{ default "default" .Values.nats.jetstream.serviceAccount.name }}
+{{ default "default" .Values.nats.jetStream.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/charts/nats/templates/configmap.yaml
+++ b/charts/nats/templates/configmap.yaml
@@ -83,34 +83,34 @@ data:
     {{- if or .Values.global.nats.jetStream.enabled  .Values.nats.jetStream.enabled }}
     ###################################
     #                                 #
-    # NATS JetStream                  #
+    # NATS jetStream                  #
     #                                 #
     ###################################
-    jetstream {
-      {{- if .Values.nats.jetstream.encryption }}
-      {{- if .Values.nats.jetstream.encryption.key }}
-      key: {{ .Values.nats.jetstream.encryption.key | quote }}
-      {{- else if .Values.nats.jetstream.encryption.secret }}
+    jetStream {
+      {{- if .Values.nats.jetStream.encryption }}
+      {{- if .Values.nats.jetStream.encryption.key }}
+      key: {{ .Values.nats.jetStream.encryption.key | quote }}
+      {{- else if .Values.nats.jetStream.encryption.secret }}
       key: $JS_KEY
       {{- end }}
       {{- end }}
 
-      {{- if .Values.nats.jetstream.memStorage.enabled }}
-      max_mem: {{ .Values.nats.jetstream.memStorage.size }}
+      {{- if .Values.nats.jetStream.memStorage.enabled }}
+      max_mem: {{ .Values.nats.jetStream.memStorage.size }}
       {{- end }}
 
-      {{- if .Values.nats.jetstream.domain }}
-      domain: {{ .Values.nats.jetstream.domain }}
+      {{- if .Values.nats.jetStream.domain }}
+      domain: {{ .Values.nats.jetStream.domain }}
       {{- end }}
 
-      {{- if .Values.nats.jetstream.fileStorage.enabled }}
-      store_dir: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
+      {{- if .Values.nats.jetStream.fileStorage.enabled }}
+      store_dir: {{ .Values.nats.jetStream.fileStorage.storageDirectory }}
 
       max_file:
-      {{- if .Values.nats.jetstream.fileStorage.existingClaim }}
-      {{- .Values.nats.jetstream.fileStorage.claimStorageSize  }}
+      {{- if .Values.nats.jetStream.fileStorage.existingClaim }}
+      {{- .Values.nats.jetStream.fileStorage.claimStorageSize  }}
       {{- else }}
-      {{- .Values.nats.jetstream.fileStorage.size }}
+      {{- .Values.nats.jetStream.fileStorage.size }}
       {{- end }}
       {{- end }}
     }

--- a/charts/nats/templates/configmap.yaml
+++ b/charts/nats/templates/configmap.yaml
@@ -80,7 +80,7 @@ data:
     {{- end }}
     {{- end }}
 
-    {{- if or .Values.global.nats.jetStream.enabled  .Values.nats.jetstream.enabled }}
+    {{- if or .Values.global.nats.jetStream.enabled  .Values.nats.jetStream.enabled }}
     ###################################
     #                                 #
     # NATS JetStream                  #

--- a/charts/nats/templates/jetstream-job-scc.yaml
+++ b/charts/nats/templates/jetstream-job-scc.yaml
@@ -1,7 +1,7 @@
 ###################################
 ### Astronomer Jetstrem Job SCC ###
 ###################################
-{{- if and .Values.global.sccEnabled .Values.nats.createJetStreamJob }}
+{{- if and .Values.global.sccEnabled .Values.global.clusterRoles }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 {{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled }}
 apiVersion: security.openshift.io/v1

--- a/charts/nats/templates/jetstream-job-scc.yaml
+++ b/charts/nats/templates/jetstream-job-scc.yaml
@@ -3,7 +3,7 @@
 ###################################
 {{- if and .Values.global.sccEnabled .Values.global.clusterRoles }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled }}
+{{- if or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -102,6 +102,12 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           {{ template "nats.securityContext" . }}
+        {{- if .Values.nats.readinessProbe }}
+        readinessProbe: {{- tpl (toYaml .Values.nats.readinessProbe) . | nindent 10 }}
+        {{- end }}
+        {{ if .Values.nats.livenessProbe }}
+        livenessProbe: {{- tpl (toYaml .Values.nats.livenessProbe) . | nindent 10 }}
+        {{- end }}
         resources: {{ toYaml .Values.nats.resources | nindent 10 }}
         command:
         - /bin/sh

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -1,7 +1,7 @@
 ########################################################
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
-{{- if .Values.nats.createJetStreamJob -}}
+{{- if .Values.global.clusterRoles -}}
 {{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 ---

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -41,7 +41,7 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}-jetstream-role
   apiGroup: ""
-{{- if .Values.nats.serviceAccount.create }}
+{{- if .Values.nats.jetStream.serviceAccount.create }}
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Platform Namespace label configure Hook ##
 ########################################################
 {{- if .Values.global.clusterRoles -}}
-{{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled }}
+{{- if or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 {{- if .Values.global.rbacEnabled }}
 ---

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -4,6 +4,7 @@
 {{- if .Values.global.clusterRoles -}}
 {{- if or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if .Values.global.rbacEnabled }}
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -40,6 +41,7 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}-jetstream-role
   apiGroup: ""
+{{- if .Values.commander.serviceAccount.create }}
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -53,6 +55,8 @@ metadata:
     component: jetstream-migrator
     release: {{ .Release.Name }}
     plane: {{ .Values.global.plane.mode }}
+{{- end }}
+{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/nats/templates/jetstream-job.yaml
+++ b/charts/nats/templates/jetstream-job.yaml
@@ -41,7 +41,7 @@ roleRef:
   kind: Role
   name: {{ .Release.Name }}-jetstream-role
   apiGroup: ""
-{{- if .Values.commander.serviceAccount.create }}
+{{- if .Values.nats.serviceAccount.create }}
 ---
 kind: ServiceAccount
 apiVersion: v1

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -199,7 +199,7 @@ spec:
           {{- end }}
           {{- end }}
 
-          {{- if and ( or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled }}
+          {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled }}
           - name: {{ template "nats.name" . }}-js-pvc
             mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
           {{- end }}
@@ -327,7 +327,7 @@ spec:
           - -varz
           - -prefix=gnatsd
           - -use_internal_server_id
-        {{- if .Values.nats.jetstream.enabled }}
+        {{- if .Values.nats.jetStream.enabled }}
           - -jsz=all
         {{- end }}
           - http://localhost:8222/
@@ -346,7 +346,7 @@ spec:
           {{ template "nats.securityContext" . }}
       {{ end }}
 
-  {{- if and ( or .Values.nats.jetstream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}
+  {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}
   volumeClaimTemplates:
   #####################################
   #                                   #

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetStream-tls-secret.yaml") . | sha256sum }}
+        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
       {{- end }}
       {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -29,7 +29,7 @@ spec:
       annotations:
         checksum/nats-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetstream-tls-secret.yaml") . | sha256sum }}
+        checksum/nats-tls: {{ include (print $.Template.BasePath "/nats-jetStream-tls-secret.yaml") . | sha256sum }}
       {{- end }}
       {{- if .Values.exporter.enabled }}
         prometheus.io/path: /metrics
@@ -199,9 +199,9 @@ spec:
           {{- end }}
           {{- end }}
 
-          {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled }}
+          {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetStream.fileStorage.enabled }}
           - name: {{ template "nats.name" . }}-js-pvc
-            mountPath: {{ .Values.nats.jetstream.fileStorage.storageDirectory }}
+            mountPath: {{ .Values.nats.jetStream.fileStorage.storageDirectory }}
           {{- end }}
 
           #######################
@@ -346,31 +346,31 @@ spec:
           {{ template "nats.securityContext" . }}
       {{ end }}
 
-  {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetstream.fileStorage.enabled (not .Values.nats.jetstream.fileStorage.existingClaim) }}
+  {{- if and ( or .Values.nats.jetStream.enabled .Values.global.nats.jetStream.enabled ) .Values.nats.jetStream.fileStorage.enabled (not .Values.nats.jetStream.fileStorage.existingClaim) }}
   volumeClaimTemplates:
   #####################################
   #                                   #
-  #  Jetstream New Persistent Volume  #
+  #  jetStream New Persistent Volume  #
   #                                   #
   #####################################
     - metadata:
         name: {{ template "nats.name" . }}-js-pvc
-        {{- if .Values.nats.jetstream.fileStorage.annotations }}
+        {{- if .Values.nats.jetStream.fileStorage.annotations }}
         annotations:
-        {{- range $key, $value := .Values.nats.jetstream.fileStorage.annotations }}
+        {{- range $key, $value := .Values.nats.jetStream.fileStorage.annotations }}
           {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
       spec:
         accessModes:
-        {{- range .Values.nats.jetstream.fileStorage.accessModes }}
+        {{- range .Values.nats.jetStream.fileStorage.accessModes }}
           - {{ . | quote }}
         {{- end }}
         resources:
           requests:
-            storage: {{ .Values.nats.jetstream.fileStorage.size }}
-        {{- if .Values.nats.jetstream.fileStorage.storageClassName }}
-        storageClassName: {{ .Values.nats.jetstream.fileStorage.storageClassName | quote }}
+            storage: {{ .Values.nats.jetStream.fileStorage.size }}
+        {{- if .Values.nats.jetStream.fileStorage.storageClassName }}
+        storageClassName: {{ .Values.nats.jetStream.fileStorage.storageClassName | quote }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -76,7 +76,7 @@ nats:
 
   regenerateCaEachUpgrade: false
 
-  jetstream:
+  jetStream:
     enabled: true
     serviceAccount:
       create: true

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -19,8 +19,6 @@ images:
 
 
 nats:
-  createJetStreamJob: true
-
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to
   # gather the public ip from a node.

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -19,7 +19,7 @@ images:
 
 
 nats:
-  createJetStreamJob: false
+  createJetStreamJob: true
 
   # In case both external access and advertise are enabled
   # then a service account would be required to be able to

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -40,15 +40,13 @@ pod_managers = [
 class TestServiceAccounts:
     def test_serviceaccount_rbac_disabled(self, kube_version):
         """Test that no ServiceAccounts are rendered when rbac is disabled."""
-        docs = render_chart(
-            kube_version=kube_version, values={"global": {"rbacEnabled": False}, "nats": {"nats": {"createJetStreamJob": False}}}
-        )
+        docs = render_chart(kube_version=kube_version, values={"global": {"rbacEnabled": False}})
         service_account_names = [doc["metadata"]["name"] for doc in docs if doc["kind"] == "ServiceAccount"]
         assert not service_account_names, f"Expected no ServiceAccounts but found {service_account_names}"
 
     def test_role_created(self, kube_version):
         """Test that no roles or rolebindings are created when rbac is disabled."""
-        values = {"global": {"rbacEnabled": False}, "nats": {"nats": {"createJetStreamJob": False}}}
+        values = {"global": {"rbacEnabled": False}}
 
         docs = [doc for doc in render_chart(kube_version=kube_version, values=values) if doc["kind"] in ["RoleBinding", "Role"]]
         assert not docs

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -330,7 +330,7 @@ custom_service_account_names = {
         "external-es-proxy": {"serviceAccount": {"create": True, "name": "prothean"}}
     },
     "charts/nats/templates/jetstream-job.yaml": {
-        "nats": {"nats": {"jetstream": {"serviceAccount": {"create": True, "name": "prothean"}}}}
+        "nats": {"nats": {"jetStream": {"serviceAccount": {"create": True, "name": "prothean"}}}}
     },
     "charts/nats/templates/statefulset.yaml": {"nats": {"nats": {"serviceAccount": {"create": True, "name": "prothean"}}}},
     "charts/nginx/templates/nginx-deployment-default.yaml": {

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -26,7 +26,7 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 3
+        assert len(docs) == 7
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["nats"] == {"tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
@@ -161,7 +161,7 @@ class TestNatsJetstream:
     def test_jetstream_job_disable_dataplane_flag(self, kube_version):
         """Test that jetstream job is disabled when dataplane is disabled."""
         values = {
-            "global": {"controlplane": {"enabled": False}},
+            "global": {"plane": {"mode": "data"}},
         }
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -139,7 +139,10 @@ class TestNatsJetstream:
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
-        values = {"global": {"nats": {"jetStream": {"enabled": False }}, "clusterRoles": False }, "nats": {"jetStream": { "enabled" : False }}}
+        values = {
+            "global": {"nats": {"jetStream": {"enabled": False}}, "clusterRoles": False},
+            "nats": {"jetStream": {"enabled": False}},
+        }
         docs = render_chart(
             kube_version=kube_version,
             values=values,

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -26,7 +26,7 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 6
+        assert len(docs) == 7
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["nats"] == {"tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
@@ -55,7 +55,7 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 10
+        assert len(docs) == 11
 
         obj_by_name = {f"{x['kind']}-{x['metadata']['name']}": x for x in docs}
 
@@ -69,9 +69,9 @@ class TestNatsJetstream:
                 "keyFile": f"{jetStreamCertPrefix}-client/tls.key",
             },
         }
-        assert docs[6]["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert docs[6]["spec"]["template"]["spec"]["affinity"] == {}
-        assert docs[6]["spec"]["template"]["spec"]["tolerations"] == []
+        assert docs[7]["spec"]["template"]["spec"]["nodeSelector"] == {}
+        assert docs[7]["spec"]["template"]["spec"]["affinity"] == {}
+        assert docs[7]["spec"]["template"]["spec"]["tolerations"] == []
 
         assert {
             "name": "release-name-jetstream-tls-certificate-client-volume",
@@ -135,7 +135,7 @@ class TestNatsJetstream:
                 "charts/nats/templates/nats-jetstream-tls-secret.yaml",
             ],
         )
-        assert len(docs) == 5
+        assert len(docs) == 6
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
@@ -173,12 +173,8 @@ class TestNatsJetstream:
     "scc_enabled,global_jetstream_enabled,expected_docs",
     [
         (True, True, 1),
-        (True, False, 1),
-        (True, True, 0),
         (True, False, 0),
         (False, True, 0),
-        (False, True, 0),
-        (False, False, 0),
         (False, False, 0),
     ],
 )
@@ -191,11 +187,19 @@ def test_jetstream_job_with_scc(
     values = {
         "global": {
             "sccEnabled": scc_enabled,
+            "clusterRoles": True,
             "nats": {
                 "jetStream": {
                     "enabled": global_jetstream_enabled,
                 },
             },
+        },
+        "nats": {
+        "nats": {
+            "jetStream": {
+                "enabled": global_jetstream_enabled,
+            }
+        }
         }
     }
 

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -195,12 +195,12 @@ def test_jetstream_job_with_scc(
             },
         },
         "nats": {
-        "nats": {
-            "jetStream": {
-                "enabled": global_jetstream_enabled,
+            "nats": {
+                "jetStream": {
+                    "enabled": global_jetstream_enabled,
+                }
             }
-        }
-        }
+        },
     }
 
     docs = render_chart(

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -139,7 +139,7 @@ class TestNatsJetstream:
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
-        values = { "global": {"clusterRoles": True}}
+        values = {"global": {"clusterRoles": True}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -169,19 +169,18 @@ class TestNatsJetstream:
 @pytest.mark.parametrize(
     "scc_enabled,create_jetstream_job,jetstream_enabled,global_jetstream_enabled,expected_docs",
     [
-        (True, False, True, 1),
-        (True, False, False, 1),
-        (True, False, True, 0),
-        (True, False, False, 0),
-        (False, False, True, 0),
-        (False, False, True, 0),
-        (False, False, False, 0),
-        (False, False, False, 0),
+        (True, True, 1),
+        (True, False, 1),
+        (True, True, 0),
+        (True, False, 0),
+        (False, True, 0),
+        (False, True, 0),
+        (False, False, 0),
+        (False, False, 0),
     ],
 )
 def test_jetstream_job_with_scc(
     scc_enabled,
-    jetstream_enabled,
     global_jetstream_enabled,
     expected_docs,
 ):
@@ -194,15 +193,7 @@ def test_jetstream_job_with_scc(
                     "enabled": global_jetstream_enabled,
                 },
             },
-        },
-        "nats": {
-            "nats": {
-                "createJetStreamJob": create_jetstream_job,
-                "jetStream": {
-                    "enabled": jetstream_enabled,
-                },
-            },
-        },
+        }
     }
 
     docs = render_chart(

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -124,7 +124,7 @@ class TestNatsJetstream:
 
     def test_nats_with_jetstream_disabled_with_custom_flag(self, kube_version):
         """Test that jetstream feature  is disabled completely with createJetStreamJob."""
-        values = {"global": {"nats": {"jetStream": {"enabled": False}}}}
+        values = {"global": {"nats": {"jetStream": {"enabled": False}}}, "clusterRoles": False}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -135,12 +135,14 @@ class TestNatsJetstream:
                 "charts/nats/templates/nats-jetstream-tls-secret.yaml",
             ],
         )
-        assert len(docs) == 2
+        assert len(docs) == 6
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
+        values = { "global": {"clusterRoles": True}}
         docs = render_chart(
             kube_version=kube_version,
+            values=values,
             show_only=[
                 "charts/nats/templates/jetstream-job.yaml",
             ],
@@ -167,19 +169,18 @@ class TestNatsJetstream:
 @pytest.mark.parametrize(
     "scc_enabled,create_jetstream_job,jetstream_enabled,global_jetstream_enabled,expected_docs",
     [
-        (True, True, False, True, 1),
-        (True, True, False, False, 1),
-        (True, False, False, True, 0),
-        (True, False, False, False, 0),
-        (False, True, False, True, 0),
-        (False, False, False, True, 0),
-        (False, True, False, False, 0),
-        (False, False, False, False, 0),
+        (True, False, True, 1),
+        (True, False, False, 1),
+        (True, False, True, 0),
+        (True, False, False, 0),
+        (False, False, True, 0),
+        (False, False, True, 0),
+        (False, False, False, 0),
+        (False, False, False, 0),
     ],
 )
 def test_jetstream_job_with_scc(
     scc_enabled,
-    create_jetstream_job,
     jetstream_enabled,
     global_jetstream_enabled,
     expected_docs,

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -39,10 +39,7 @@ class TestNatsJetstream:
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test jetstream config with nodeSelector, affinity, and tolerations defaults."""
-        values = {
-            "global": {"nats": {"jetStream": {"enabled": True, "tls": True}}},
-            "nats": {"nats": {"createJetStreamJob": True}},
-        }
+        values = {"global": {"nats": {"jetStream": {"enabled": True, "tls": True}}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -127,10 +124,7 @@ class TestNatsJetstream:
 
     def test_nats_with_jetstream_disabled_with_custom_flag(self, kube_version):
         """Test that jetstream feature  is disabled completely with createJetStreamJob."""
-        values = {
-            "global": {"nats": {"jetStream": {"enabled": False}}},
-            "nats": {"nats": {"createJetStreamJob": False}},
-        }
+        values = {"global": {"nats": {"jetStream": {"enabled": False}}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -145,12 +139,8 @@ class TestNatsJetstream:
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
-        values = {
-            "nats": {"nats": {"createJetStreamJob": False}},
-        }
         docs = render_chart(
             kube_version=kube_version,
-            values=values,
             show_only=[
                 "charts/nats/templates/jetstream-job.yaml",
             ],

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -26,11 +26,11 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 7
+        assert len(docs) == 6
         prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
         assert prod["nats"] == {"tlsEnabled": False}
         nats_cm = docs[2]["data"]["nats.conf"]
-        assert "jetstream" in nats_cm
+        assert "jetStream" in nats_cm
         assert docs[1]["spec"]["template"]["spec"]["containers"][0]["securityContext"] == {
             "readOnlyRootFilesystem": True,
             "runAsNonRoot": True,
@@ -39,7 +39,7 @@ class TestNatsJetstream:
 
     def test_nats_statefulset_with_jetstream_and_tls(self, kube_version):
         """Test jetstream config with nodeSelector, affinity, and tolerations defaults."""
-        values = {"global": {"nats": {"jetStream": {"enabled": True, "tls": True}}}}
+        values = {"global": {"nats": {"jetStream": {"enabled": True, "tls": True}}}, "clusterRoles": True, "sccEnabled": True}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -55,7 +55,7 @@ class TestNatsJetstream:
             ],
         )
 
-        assert len(docs) == 11
+        assert len(docs) == 10
 
         obj_by_name = {f"{x['kind']}-{x['metadata']['name']}": x for x in docs}
 
@@ -69,9 +69,9 @@ class TestNatsJetstream:
                 "keyFile": f"{jetStreamCertPrefix}-client/tls.key",
             },
         }
-        assert docs[7]["spec"]["template"]["spec"]["nodeSelector"] == {}
-        assert docs[7]["spec"]["template"]["spec"]["affinity"] == {}
-        assert docs[7]["spec"]["template"]["spec"]["tolerations"] == []
+        assert docs[6]["spec"]["template"]["spec"]["nodeSelector"] == {}
+        assert docs[6]["spec"]["template"]["spec"]["affinity"] == {}
+        assert docs[6]["spec"]["template"]["spec"]["tolerations"] == []
 
         assert {
             "name": "release-name-jetstream-tls-certificate-client-volume",
@@ -135,11 +135,11 @@ class TestNatsJetstream:
                 "charts/nats/templates/nats-jetstream-tls-secret.yaml",
             ],
         )
-        assert len(docs) == 6
+        assert len(docs) == 5
 
     def test_jetstream_hook_job_disabled(self, kube_version):
         """Test that jetstream hook job is disabled when createJetStreamJob is disabled."""
-        values = {"global": {"clusterRoles": True}}
+        values = {"global": {"nats": {"jetStream": {"enabled": False }}, "clusterRoles": False }, "nats": {"jetStream": { "enabled" : False }}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -167,7 +167,7 @@ class TestNatsJetstream:
 
 
 @pytest.mark.parametrize(
-    "scc_enabled,create_jetstream_job,jetstream_enabled,global_jetstream_enabled,expected_docs",
+    "scc_enabled,global_jetstream_enabled,expected_docs",
     [
         (True, True, 1),
         (True, False, 1),

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -43,7 +43,6 @@ global:
   taskUsageMetricsEnabled: true
 nats:
   nats:
-    createJetStreamJob: true
     exporter:
       enabled: true
     reloader:

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -47,6 +47,8 @@ nats:
       enabled: true
     reloader:
       enabled: true
+    jetStream:
+      enabled: true
 postgresql:
   replication:
     enabled: true


### PR DESCRIPTION
## Description

This PR enables createJetStreamJob by default since we have removed STAN from our charts so houston needs to NATS job need to be enabled to work without issues.

## Related Issues

Related https://github.com/astronomer/issues/issues/7818
https://github.com/astronomer/issues/issues/7351


## Testing

- Fixed unittests
- No QA Needed since anyways our QA team do this through terraform values file. 

## Merging

Master, 1.0