### PR TITLE
Add checksum annotation for NATS JetStream TLS certificate to Houston worker

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -560,7 +560,6 @@ Generate JetStream TLS checksum annotation
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
 {{- $actualCert := (get $secretData "tls.crt") | b64dec | sha256sum }}
-{{- $fallbackChecksum := printf "template-checksum-%s" $jetStreamTLSSecretName | sha256sum }}
-checksum/jetstream-tls-cert: {{ $actualCert | default $fallbackChecksum }}
+checksum/jetstream-tls-cert: {{ $actualCert }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -550,3 +550,19 @@ elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDoma
 {{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.cluster.local.:9200
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate JetStream TLS checksum annotation
+*/}}
+{{- define "houston.jetStreamTLSChecksum" -}}
+{{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
+{{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
+{{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
+{{- $secretData := (get $secretObj "data") | default dict }}
+{{- if $secretData }}
+checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
+{{- else }}
+checksum/jetstream-tls-cert: {{ printf "template-checksum-%s" $jetStreamTLSSecretName | sha256sum }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -559,10 +559,8 @@ Generate JetStream TLS checksum annotation
 {{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
 {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
 {{- $secretData := (get $secretObj "data") | default dict }}
-{{- if $secretData }}
-checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
-{{- else }}
-checksum/jetstream-tls-cert: {{ printf "template-checksum-%s" $jetStreamTLSSecretName | sha256sum }}
-{{- end }}
+{{- $actualCert := (get $secretData "tls.crt") | b64dec | sha256sum }}
+{{- $fallbackChecksum := printf "template-checksum-%s" $jetStreamTLSSecretName | sha256sum }}
+checksum/jetstream-tls-cert: {{ $actualCert | default $fallbackChecksum }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         {{- $secretData := (get $secretObj "data") | default dict }}
         {{- if $secretData }}
         checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
+        {{- else }}
+        checksum/jetstream-tls-cert: {{ printf "template-checksum-%s-%t-%t" $jetStreamTLSSecretName | sha256sum }}
         {{- end }}
         {{- end }}
         {{- if .Values.global.podAnnotations }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -32,17 +32,7 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
-        checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
-        {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        {{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
-        {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
-        {{- $secretData := (get $secretObj "data") | default dict }}
-        {{- if $secretData }}
-        checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
-        {{- else }}
-        checksum/jetstream-tls-cert: {{ printf "template-checksum-%s-%t-%t" $jetStreamTLSSecretName | sha256sum }}
-        {{- end }}
-        {{- end }}
+        {{- include "houston.jetStreamTLSChecksum" . | nindent 8 }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
+        checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
         {{- include "houston.jetStreamTLSChecksum" . | nindent 8 }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -33,6 +33,9 @@ spec:
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
         checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
+        {{- if .Values.global.ssl.enabled }}
+        checksum/jetstream-tls-cert: {{ include (print $.Template.BasePath "/secret-nats-jetstream-tls.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -33,8 +33,13 @@ spec:
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
         checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
-        {{- if .Values.global.ssl.enabled }}
-        checksum/jetstream-tls-cert: {{ include (print $.Template.BasePath "/secret-nats-jetstream-tls.yaml") . | sha256sum }}
+        {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
+        {{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
+        {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
+        {{- $secretData := (get $secretObj "data") | default dict }}
+        {{- if $secretData }}
+        checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
+        {{- end }}
         {{- end }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -39,6 +39,8 @@ spec:
         {{- $secretData := (get $secretObj "data") | default dict }}
         {{- if $secretData }}
         checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
+        {{- else }}
+        checksum/jetstream-tls-cert: {{ printf "template-checksum-%s-%t-%t" $jetStreamTLSSecretName | sha256sum }}
         {{- end }}
         {{- end }}
         {{- if .Values.global.podAnnotations }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -33,16 +33,7 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
-        {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
-        {{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
-        {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
-        {{- $secretData := (get $secretObj "data") | default dict }}
-        {{- if $secretData }}
-        checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
-        {{- else }}
-        checksum/jetstream-tls-cert: {{ printf "template-checksum-%s-%t-%t" $jetStreamTLSSecretName | sha256sum }}
-        {{- end }}
-        {{- end }}
+        {{- include "houston.jetStreamTLSChecksum" . | nindent 8 }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -33,8 +33,13 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
-        {{- if .Values.global.ssl.enabled }}
-        checksum/jetstream-tls-cert: {{ include (print $.Template.BasePath "/secret-nats-jetstream-tls.yaml") . | sha256sum }}
+        {{- if and .Values.global.nats.jetStream.enabled .Values.global.nats.jetStream.tls }}
+        {{- $jetStreamTLSSecretName := printf "%s-client" (include "nats.jestreamTLSSecret" . ) }}
+        {{- $secretObj := (lookup "v1" "Secret" .Release.Namespace $jetStreamTLSSecretName) | default dict }}
+        {{- $secretData := (get $secretObj "data") | default dict }}
+        {{- if $secretData }}
+        checksum/jetstream-tls-cert: {{ sha256sum (b64dec (get $secretData "tls.crt")) }}
+        {{- end }}
         {{- end }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -33,6 +33,9 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
+        {{- if .Values.global.ssl.enabled }}
+        checksum/jetstream-tls-cert: {{ include (print $.Template.BasePath "/secret-nats-jetstream-tls.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
         {{- end }}

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -129,7 +129,7 @@ class TestNatsJetstream:
                 # Check that the jetstream TLS checksum annotation exists when TLS is enabled
                 assert "checksum/jetstream-tls-cert" in annotations
                 # Verify it's not empty
-                assert annotations["checksum/jetstream-tls-cert"] != ""
+                assert annotations["checksum/jetstream-tls-cert"]
 
     def test_nats_with_jetstream_disabled_with_custom_flag(self, kube_version):
         """Test that jetstream feature  is disabled completely with createJetStreamJob."""

--- a/tests/chart_tests/test_nats_jetstream.py
+++ b/tests/chart_tests/test_nats_jetstream.py
@@ -124,6 +124,12 @@ class TestNatsJetstream:
                 "name": "nats-jetstream-client-tls-volume",
                 "secret": {"secretName": "release-name-jetstream-tls-certificate-client"},
             } in obj_by_name[item]["spec"]["template"]["spec"]["volumes"]
+            for item in ["Deployment-release-name-houston", "Deployment-release-name-houston-worker"]:
+                annotations = obj_by_name[item]["spec"]["template"]["metadata"]["annotations"]
+                # Check that the jetstream TLS checksum annotation exists when TLS is enabled
+                assert "checksum/jetstream-tls-cert" in annotations
+                # Verify it's not empty
+                assert annotations["checksum/jetstream-tls-cert"] != ""
 
     def test_nats_with_jetstream_disabled_with_custom_flag(self, kube_version):
         """Test that jetstream feature  is disabled completely with createJetStreamJob."""


### PR DESCRIPTION
## Description

This PR adds a conditional checksum annotation to the Houston worker deployment to ensure the pod restarts when the NATS JetStream TLS client certificate changes.

## Related Issues

Related astronomer/issues#7901
https://github.com/astronomer/issues/issues/7818
https://github.com/astronomer/issues/issues/7351

## Testing

- Rendered the output locally, added a default checksum since the secret doesn't exist during helm template:
<img width="1362" height="797" alt="Screenshot 2025-09-25 at 7 20 01 PM" src="https://github.com/user-attachments/assets/986cce9a-fed1-4555-a0c8-0e55bfaf2bf2" />


## Merging

Master, 1.0