### PR TITLE
fix ingress controller component tags

### DIFF
--- a/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
+++ b/charts/alertmanager/templates/alertmanager-networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: ingress-controller
+          component: cp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     ports:

--- a/charts/astronomer/templates/astro-ui/astro-ui-networkpolicy.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-networkpolicy.yaml
@@ -39,7 +39,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: ingress-controller
+          component: cp-ingress-controller
     {{- end }}
     ports:
     - protocol: TCP

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: cp-ingress-controller
+          component: {{ ternary "cp-ingress-controller" "dp-ingress-controller" (eq .Values.global.plane.mode "unified") }} cp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     {{- end }}

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: ingress-controller
+          component: cp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     {{- end }}

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: {{ ternary "cp-ingress-controller" "dp-ingress-controller" (eq .Values.global.plane.mode "unified") }} cp-ingress-controller
+          component: {{ ternary "cp-ingress-controller" "dp-ingress-controller" (eq .Values.global.plane.mode "unified") }}
           release: {{ .Release.Name }}
     {{- end }}
     {{- end }}

--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -44,7 +44,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: {{ ternary "cp-ingress-controller" "dp-ingress-controller" (eq .Values.global.plane.mode "unified") }}
+          component: dp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -39,7 +39,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: ingress-controller
+          component: cp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     - podSelector:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -99,7 +99,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: ingress-controller
+          component: cp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
     ports:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -99,7 +99,7 @@ spec:
     - podSelector:
         matchLabels:
           tier: nginx
-          component: cp-ingress-controller
+          component: {{ ternary "cp-ingress-controller" "dp-ingress-controller" (eq .Values.global.plane.mode "unified") }}
           release: {{ .Release.Name }}
     {{- end }}
     ports:

--- a/tests/chart_tests/test_authsidecar.py
+++ b/tests/chart_tests/test_authsidecar.py
@@ -395,5 +395,5 @@ class TestAuthSidecar:
         assert "NetworkPolicy" == doc["kind"]
         podSelectors = doc["spec"]["ingress"][0]["from"]
         assert {
-            "podSelector": {"matchLabels": {"component": "ingress-controller", "release": "release-name", "tier": "nginx"}}
+            "podSelector": {"matchLabels": {"component": "dp-ingress-controller", "release": "release-name", "tier": "nginx"}}
         } in podSelectors


### PR DESCRIPTION
## Description

Fix network policies and correctly use the ingress components matching the plane modes

## Related Issues

- https://github.com/astronomer/issues/issues/7824

## Testing

QA should see correct network policies when different modes are selected

## Merging

merge to master and release-1.0
