### PR TITLE
Upgrade ES image to use latest chainguard image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ workflows:
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.4
                 - quay.io/astronomer/ap-default-backend:0.28.30
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
-                - quay.io/astronomer/ap-elasticsearch:8.15.5
+                - quay.io/astronomer/ap-elasticsearch:8.18.6
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -10,7 +10,7 @@ tolerations: []
 images:
   es:
     repository: quay.io/astronomer/ap-elasticsearch
-    tag: 8.15.5
+    tag: 8.18.6
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes


### PR DESCRIPTION
## Description

This PR upgrades master branch to use latest ES chainguardimage.

## Related Issues

Related astronomer/issues#7919


## Merging

Master, 1.0