### PR TITLE
update commander version 1.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-16
                 - quay.io/astronomer/ap-base:3.21.3-3
-                - quay.io/astronomer/ap-commander:1.0.7
+                - quay.io/astronomer/ap-commander:1.0.8
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21-1
                 - quay.io/astronomer/ap-dag-deploy:0.7.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.7
+    tag: 1.0.8
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

fix migration issue from 0.37 to 1.x airflow deployments

## Related Issues

- https://github.com/astronomer/issues/issues/7930

## Testing

QA should able to safely migrate 0.37 airflow deployments to 1.0

## Merging

merge to master and release-1.0
