### PR TITLE
7925 improve show docker images.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
 
   release_bom:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-07
+      - image: quay.io/astronomer/ci-helm-release:2025-10
     steps:
       - checkout
       - run:
@@ -139,7 +139,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2025-07
+      - image: quay.io/astronomer/ci-pre-commit:2025-10
     resource_class: small
     steps:
       - checkout
@@ -164,7 +164,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-07
+      - image: quay.io/astronomer/ci-helm-release:2025-10
     # https://circleci.com/docs/using-docker/#x86
     resource_class: large
     parallelism: 4
@@ -200,7 +200,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-07
+      - image: quay.io/astronomer/ci-helm-release:2025-10
     parameters:
       qa_release:
         type: boolean
@@ -219,7 +219,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-07
+      - image: quay.io/astronomer/ci-helm-release:2025-10
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -258,7 +258,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2025-07
+      - image: quay.io/astronomer/ci-helm-release:2025-10
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -424,6 +424,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
                 - quay.io/astronomer/ap-houston-api:1.0.20
+                - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.7"
+    rev: "v0.13.2"
     hooks:
       - id: ruff-check
         args:
@@ -50,7 +50,7 @@ repos:
           - "--unsafe-fixes"
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-json
@@ -65,7 +65,8 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: file-contents-sorter
-        args: ["--ignore-case", "--unique"]
+        args:
+          - "--unique"
         files: '^\.(git|helm)ignore$'
       - id: mixed-line-ending
         args: ["--fix=lf"]
@@ -80,7 +81,7 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.10.0.1
+    rev: v0.11.0.1
     hooks:
       - id: shellcheck
   - repo: https://github.com/astronomer/pre-commit-hooks

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -12,7 +12,7 @@ git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".
 metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
-ci_runner_version = "2025-07"  # This should be the current YYYY-MM
+ci_runner_version = "2025-10"  # This should be the current YYYY-MM
 machine_image_version = "ubuntu-2404:2024.11.1"  # https://circleci.com/developer/machine/image/ubuntu-2204
 
 

--- a/bin/get-all-chart-default-values.py
+++ b/bin/get-all-chart-default-values.py
@@ -128,7 +128,7 @@ def load_chart(chart_path, values=None):
                 subchart_path = download_chart(dep_name, dep_version, dep_repository)
 
             # Recursively load and merge the subchart values
-            subchart_name, subchart_values = load_chart(subchart_path, values.get(dep_name, {}))
+            _subchart_name, subchart_values = load_chart(subchart_path, values.get(dep_name, {}))
             if dep_name in values:
                 values[dep_name] = deep_merge(subchart_values, values[dep_name])
             else:

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -30,7 +30,7 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 4
-        deployment, env_configmap, configmap, service = docs
+        deployment, _env_configmap, _configmap, service = docs
         assert deployment["kind"] == "Deployment"
         assert deployment["apiVersion"] == "apps/v1"
         assert deployment["metadata"]["name"] == "release-name-external-es-proxy"
@@ -79,7 +79,7 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 4
-        deployment, env_configmap, configmap, service = docs
+        deployment, _env_configmap, _configmap, service = docs
         assert deployment["kind"] == "Deployment"
         assert deployment["apiVersion"] == "apps/v1"
         assert deployment["metadata"]["name"] == "release-name-external-es-proxy"
@@ -141,7 +141,7 @@ class TestExternalElasticSearch:
         )
 
         assert len(docs) == 3
-        deployment, service, configmap = docs
+        deployment, service, _configmap = docs
         assert deployment["kind"] == "Deployment"
         assert deployment["apiVersion"] == "apps/v1"
         assert deployment["metadata"]["name"] == "release-name-external-es-proxy"


### PR DESCRIPTION
## Description

- Add more images from values.yaml to `bin/show-docker-images.py` output
- Update pre-commit hooks
- Use latest CI runner
- `pre-commit run --all-files` made some `ruff` changes to non-prod code

## Related Issues

This is a follow-up to https://github.com/astronomer/issues/issues/7925 which includes all configured airflow images including xcom in the `bin/show-docker-images.py` output.

## Testing

No testing needed. This only affects test and dev related code, no shipped product code.

## Merging

This should only go for 1.0. It won't work in older versions.