### PR TITLE
update houston api version 1.0.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.0-1
-                - quay.io/astronomer/ap-houston-api:1.0.20
+                - quay.io/astronomer/ap-houston-api:1.0.22
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.20
+    tag: 1.0.22
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api version 1.0.22

## Related Issues

- https://github.com/astronomer/houston-api/pull/2191
- https://github.com/astronomer/issues/issues/7884

## Testing

QA should able to properly upgrade af2 to af3

## Merging

merge to master and release-1.0
