### PR TITLE
Remove `registry.baseDomain`

### DIFF
--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -34,7 +34,9 @@ spec:
       hosts:
         - {{ .Values.global.baseDomain }}
         - app.{{ .Values.global.baseDomain }}
+      {{- if eq .Values.global.plane.mode "unified" }}
         - registry.{{ .Values.global.baseDomain }}
+      {{- end }}
         - install.{{ .Values.global.baseDomain }}
   {{- end }}
   rules:
@@ -58,6 +60,7 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
+{{- if (eq .Values.global.plane.mode "unified") }}
   - host: registry.{{ .Values.global.baseDomain }}
     http:
       paths:
@@ -68,5 +71,6 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Remove registry.baseDomain exposure from control plane mode ingress configuration. The registry subdomain should only be accessible in unified plane mode.

## Related Issues

Related astronomer/issues#XXXX

## Testing

- No QA needed registry is anyways not used in control plane.
- Added unittest.

## Merging

Master, 1.0