### PR TITLE
add private ca in jwks hook job

### DIFF
--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -57,6 +57,28 @@ spec:
       serviceAccountName: {{ template "commander.serviceAccountName" . }}
       restartPolicy: Always
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
+      initContainers:
+        - name: etc-ssl-certs-copier
+          volumeMounts:
+            - name: etc-ssl-certs
+              mountPath: /etc/ssl/certs_copy
+          image: {{ template "commander.image" . }}
+          imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              if [ -d /etc/ssl/certs ]; then
+                cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
+              else
+                echo "No /etc/ssl/certs directory found, skipping copy."
+              fi
+          resources:
+            limits: {'cpu': '100m', 'memory': '128Mi'}
+            requests: {'cpu': '100m', 'memory': '128Mi'}
+          securityContext:
+            readOnlyRootFilesystem: true
+            {{ toYaml .Values.securityContext | nindent 12 }}
       containers:
         - name: commander
           image: {{ template "commander.image" . }}
@@ -144,6 +166,8 @@ spec:
             {{- end }}
             {{- include "commander_metadataEnv" . | nindent 12 }}
           volumeMounts:
+            - name: etc-ssl-certs
+              mountPath: /etc/ssl/certs
             - name: tmp-workspace
               mountPath: /tmp
             - name: commander-home
@@ -152,6 +176,7 @@ spec:
             - mountPath: /app/metadata.yaml
               name: metadata
               subPath: metadata.yaml
+            {{- include "custom_ca_volume_mounts" . | indent 12 }}
           {{- if .Values.commander.volumeMounts }}
           {{- tpl (toYaml .Values.commander.volumeMounts) $ | nindent 12 }}
           {{- end }}
@@ -189,6 +214,8 @@ spec:
             periodSeconds: 5
         {{- end }}
       volumes:
+        - name: etc-ssl-certs
+          emptyDir: {}
         - name: tmp-workspace
           emptyDir: {}
         {{- if and .Values.global.authSidecar.enabled (eq .Values.global.plane.mode "data") }}
@@ -201,6 +228,7 @@ spec:
         - configMap:
             name: {{ .Release.Name }}-commander-metadata
           name: metadata
+        {{- include "custom_ca_volumes" . | nindent 8 }}
       {{- if .Values.commander.extraVolumes }}
       {{- tpl (toYaml .Values.commander.extraVolumes) $ | nindent 8 }}
       {{- end }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -74,8 +74,7 @@ spec:
                 echo "No /etc/ssl/certs directory found, skipping copy."
               fi
           resources:
-            limits: {'cpu': '100m', 'memory': '128Mi'}
-            requests: {'cpu': '100m', 'memory': '128Mi'}
+            {{ toYaml .Values.certCopier.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
             {{ toYaml .Values.securityContext | nindent 12 }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -73,20 +73,18 @@ spec:
               else
                 echo "No /etc/ssl/certs directory found, skipping copy."
               fi
-          resources:
-            {{ toYaml .Values.certCopier.resources | nindent 12 }}
+          resources: {{ toYaml .Values.commander.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
-            {{ toYaml .Values.securityContext | nindent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
       containers:
         - name: commander
           image: {{ template "commander.image" . }}
           imagePullPolicy: {{ .Values.images.commander.pullPolicy }}
           securityContext:
             readOnlyRootFilesystem: true
-            {{ toYaml .Values.securityContext | nindent 12 }}
-          resources:
-{{ toYaml .Values.commander.resources | indent 12 }}
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources: {{- toYaml .Values.commander.resources | nindent 12 }}
           {{- if .Values.commander.command }}
           command:
             {{- toYaml .Values.commander.command | nindent 12 }}

--- a/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
+++ b/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
@@ -75,9 +75,11 @@ spec:
           volumeMounts:
             - name: jwks-script
               mountPath: /scripts
+            {{- include "custom_ca_volume_mounts" . | indent 12 }}
       volumes:
         - name: jwks-script
           configMap:
             name: {{ .Release.Name }}-commander-jwks-hook-config
             defaultMode: 0755
+        {{- include "custom_ca_volumes" . | nindent 8 }}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -84,9 +84,7 @@ spec:
               else
                 echo "No /etc/ssl/certs directory found, skipping copy."
               fi
-          resources:
-            limits: {'cpu': '100m', 'memory': '128Mi'}
-            requests: {'cpu': '100m', 'memory': '128Mi'}
+          resources: {{- toYaml .Values.registry.resources | nindent 12 }}
           securityContext:
             readOnlyRootFilesystem: true
             {{ toYaml .Values.securityContext | nindent 12 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -549,3 +549,6 @@ ports:
   registryScrape: 5001
   commanderSidecarHTTP: 8080
   commanderSidecarGRPC: 9090
+
+certCopier:
+  resources: {}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -549,6 +549,3 @@ ports:
   registryScrape: 5001
   commanderSidecarHTTP: 8080
   commanderSidecarGRPC: 9090
-
-certCopier:
-  resources: {}

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -847,8 +847,6 @@ class TestElasticSearch:
             values={"global": {"baseDomain": "example.com"}, "plane": {"mode": plane_mode}},
         )
 
-        print(docs)
-
         assert len(docs) == 1, f"Document {docs} should render in {plane_mode} mode"
         assert docs[0]["kind"] == "Ingress"
         assert docs[0]["apiVersion"] == "networking.k8s.io/v1"

--- a/tests/chart_tests/test_registry_statefulset.py
+++ b/tests/chart_tests/test_registry_statefulset.py
@@ -2,6 +2,7 @@ import jmespath
 import pytest
 
 from tests import supported_k8s_versions
+from tests.utils import get_containers_by_name
 from tests.utils.chart import render_chart
 
 
@@ -35,6 +36,12 @@ class TestRegistryStatefulset:
             },
         }
         assert expected_env in doc["spec"]["template"]["spec"]["containers"][0]["env"]
+        c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
+        assert c_by_name["etc-ssl-certs-copier"]["name"] == "etc-ssl-certs-copier"
+        assert c_by_name["etc-ssl-certs-copier"]["resources"] == {
+            "limits": {"cpu": "500m", "memory": "1024Mi"},
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+        }
 
     def test_registry_sts_use_keyfile(self, kube_version):
         """Test some things that should apply to all cases."""


### PR DESCRIPTION
## Description

Mount custom CA volumes platform services
Adds privateCA support for 
- jwks hook job
- commander

## Related Issues

- https://github.com/astronomer/issues/issues/7965

## Testing

QA should able to use the same global.privateCaCerts to mount custom certificates to jwks hook job

## Merging

merge to master and release-1.0
