### PR TITLE
commander image version 1.0.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -412,7 +412,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.27.4-3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-16
                 - quay.io/astronomer/ap-base:3.21.3-3
-                - quay.io/astronomer/ap-commander:1.0.10
+                - quay.io/astronomer/ap-commander:1.0.11
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
                 - quay.io/astronomer/ap-curator:8.0.21-1
                 - quay.io/astronomer/ap-dag-deploy:0.7.0

--- a/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
+++ b/charts/astronomer/templates/houston/api/houston-networkpolicy.yaml
@@ -74,7 +74,7 @@ spec:
           release: {{ .Release.Name }}
     - podSelector:
         matchLabels:
-          tier: {{ .Release.Name }}
+          tier: astronomer
           component: commander
           release: {{ .Release.Name }}
     {{- if .Values.global.customLogging.enabled }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.10
+    tag: 1.0.11
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

commander image version 1.0.11

## Related Issues

- https://github.com/astronomer/issues/issues/7968

## Testing

QA should able to get commander up and running with no network policy issues

## Merging

merge to master and release-1.0
