### PR TITLE
update houston api version 1.0.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.1.11
                 - quay.io/astronomer/ap-git-sync:4.4.1-3
-                - quay.io/astronomer/ap-houston-api:1.0.25
+                - quay.io/astronomer/ap-houston-api:1.0.26
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.25
+    tag: 1.0.26
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api version 1.0.26

## Related Issues

- https://github.com/astronomer/issues/issues/7973

## Testing

QA notes fixes DOD rollback issues

## Merging

merge to master and release-1.0
