### PR TITLE
Add nginx-cache Volumes and VolumeMounts for External Elasticsearch Proxy

### DIFF
--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -87,6 +87,16 @@ spec:
               subPath: setenv.lua
             - name: tmp
               mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /usr/local/openresty/nginx/client_body_temp
+            - name: nginx-cache
+              mountPath: /usr/local/openresty/nginx/proxy_temp
+            - name: nginx-cache
+              mountPath: /usr/local/openresty/nginx/fastcgi_temp
+            - name: nginx-cache
+              mountPath: /usr/local/openresty/nginx/uwsgi_temp
+            - name: nginx-cache
+              mountPath: /usr/local/openresty/nginx/scgi_temp
 
             {{- if .Values.global.customLogging.trustCaCerts -}}
             {{ $secretName := .Values.global.customLogging.trustCaCerts }}
@@ -149,6 +159,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: nginx-cache
+          emptyDir: {}
         - name: tmp
           emptyDir: {}
         - name: nginx-config-volume

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -30,11 +30,11 @@ class TestExternalElasticSearch:
         )
 
         expected_nginx_mounts = [
-        {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/client_body_temp"},
-        {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/proxy_temp"},
-        {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/fastcgi_temp"},
-        {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/uwsgi_temp"},
-        {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/scgi_temp"},
+            {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/client_body_temp"},
+            {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/proxy_temp"},
+            {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/fastcgi_temp"},
+            {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/uwsgi_temp"},
+            {"name": "nginx-cache", "mountPath": "/usr/local/openresty/nginx/scgi_temp"},
         ]
         assert len(docs) == 4
         deployment, _env_configmap, _configmap, service = docs


### PR DESCRIPTION
## Description

This PR introduces a new nginx-cache volume and associated volumeMounts for the external-es-proxy Deployment template. These directories are required by OpenResty for temporary operations such as proxying, client body buffering, and fastcgi/uwsgi handling.

## Related Issues

Related astronomer/issues#7904

## Testing

- Added Unittests
- Tested on cluster 
<img width="682" height="536" alt="Screenshot 2025-10-07 at 4 21 14 PM" src="https://github.com/user-attachments/assets/910ca9cc-3912-475e-a2df-5d8ec8f18b44" />

- Confirmed that logs were stable after this:
<img width="1903" height="743" alt="Screenshot 2025-10-07 at 4 29 27 PM" src="https://github.com/user-attachments/assets/09e1a863-2aa2-46c7-bfcc-69e1f3efd52d" />

## Merging

Master, 1.0