### PR TITLE
Update the default postgresql image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
                 - quay.io/astronomer/ap-pgbouncer:1.24.1
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
-                - quay.io/astronomer/ap-postgresql:17.4.0
+                - quay.io/astronomer/ap-postgresql:17.6.0
                 - quay.io/astronomer/ap-prometheus:2.53.4
                 - quay.io/astronomer/ap-redis:7.4.3
                 - quay.io/astronomer/ap-registry:3.0.0-1

--- a/charts/postgresql/values.yaml
+++ b/charts/postgresql/values.yaml
@@ -15,7 +15,7 @@ global:
 image:
   registry: quay.io
   repository: astronomer/ap-postgresql
-  tag: 17.4.0
+  tag: 17.6.0
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images


### PR DESCRIPTION
## Description

Updates the default postgresql image to ap-vendor/postgresql:17.6.0

## Related Issues

Related astronomer/issues#7774

## Testing

Spun up a local kind cluster and validated postgres container image spun up and migrations job ran.

## Merging

master / release-1.0
