### PR TITLE
update prometheus image 3.5.0-2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -437,7 +437,7 @@ workflows:
                 - quay.io/astronomer/ap-pgbouncer:1.24.1
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
                 - quay.io/astronomer/ap-postgresql:17.6.0
-                - quay.io/astronomer/ap-prometheus:2.53.4
+                - quay.io/astronomer/ap-prometheus:3.5.0-2
                 - quay.io/astronomer/ap-redis:7.4.3
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-2

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,7 +18,7 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 2.53.4
+    tag: 3.5.0-2
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader


### PR DESCRIPTION
## Description

update prometheus image 3.5.0-2

## Related Issues

- https://github.com/astronomer/issues/issues/7965

## Testing

NA 

## Merging

merge to master and release-1.0
