### PR TITLE
Revert ap-nginx image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -430,7 +430,7 @@ workflows:
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-5
                 - quay.io/astronomer/ap-nats-server:2.11.10
                 - quay.io/astronomer/ap-nginx-es:1.29.0-1
-                - quay.io/astronomer/ap-nginx:1.12.6
+                - quay.io/astronomer/ap-nginx:1.11.6
                 - quay.io/astronomer/ap-openresty:1.27.1-7
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   nginx:
     repository: quay.io/astronomer/ap-nginx
-    tag: 1.12.6
+    tag: 1.11.6
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend


### PR DESCRIPTION
## Description

This PR reverts the nginx image back to 1.11.6

## Related Issues

Related astronomer/issues#8000

## Testing
N/A

## Merging

Master, 1.0