### PR TITLE
update houston 1.0.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-6
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
                 - quay.io/astronomer/ap-git-sync:4.4.1-3
-                - quay.io/astronomer/ap-houston-api:1.0.30
+                - quay.io/astronomer/ap-houston-api:1.0.33
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.30
+    tag: 1.0.33
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston 1.0.33

## Related Issues
- https://github.com/astronomer/houston-api/pull/2226

## Testing

QA should not see duplicate volumes err

## Merging

merge to master and release-1.0
