### PR TITLE
bump commander and airflow chart versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,7 +424,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
                 - quay.io/astronomer/ap-git-sync:4.4.1-3
                 - quay.io/astronomer/ap-grafana:10.4.17
-                - quay.io/astronomer/ap-houston-api:1.0.35
+                - quay.io/astronomer/ap-houston-api:1.0.36
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.9

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.35
+    tag: 1.0.36
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

bump commander and airflow chart versions 
| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-houston-api | 1.0.35 | 1.0.36 |
| ap-commander | 1.0.18 | 1.0.19 |
| airflowChart | 1.17.12 | 1.17.13 |

## Related Issues

- https://github.com/astronomer/issues/issues/8016

## Testing

refer tagged issues

## Merging

merge to master and release-1.0
