### PR TITLE
Update Grafana image to use 12.2.0 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-git-daemon:3.21.3-6
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
                 - quay.io/astronomer/ap-git-sync:4.4.1-3
-                - quay.io/astronomer/ap-grafana:10.4.17
+                - quay.io/astronomer/ap-grafana:12.2.0
                 - quay.io/astronomer/ap-houston-api:1.0.36
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.17
+    tag: 12.2.0
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

This PR intends to use grafana 12.2.0 migrating from 10.4.17

## Related Issues

https://github.com/astronomer/issues/issues/7246

## Testing

- Tested the latest grafana on a live cluster.

## Merging

Master, 1.0