### PR TITLE
Respect global.clusterRoles in Vector ClusterRole and ClusterRoleBinding templates

### DIFF
--- a/charts/nginx/templates/controlplane/nginx-cp-role.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-role.yaml
@@ -4,6 +4,7 @@
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 {{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.clusterRoles }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:
@@ -98,5 +99,6 @@ rules:
       - update
       - patch
       - delete
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/nginx/templates/dataplane/nginx-dp-role.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-role.yaml
@@ -4,6 +4,7 @@
 {{- if eq .Values.global.plane.mode "data" }}
 {{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.clusterRoles }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:
@@ -97,5 +98,6 @@ rules:
       - update
       - patch
       - delete
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/vector/templates/vector-clusterrole.yaml
+++ b/charts/vector/templates/vector-clusterrole.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector ClusterRole
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if and .Values.global.rbacEnabled .Values.global.clusterRoles (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) }}
 {{- if .Values.global.rbacEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/vector/templates/vector-clusterrole.yaml
+++ b/charts/vector/templates/vector-clusterrole.yaml
@@ -1,8 +1,9 @@
 ###########################################################################
 # Vector ClusterRole
 ###########################################################################
-{{- if and .Values.global.rbacEnabled .Values.global.clusterRoles (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) }}
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- if .Values.global.rbacEnabled }}
+{{- if .Values.global.clusterRoles }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}
 metadata:
@@ -23,5 +24,6 @@ rules:
   verbs:
   - "watch"
   - "list"
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/tests/chart_tests/test_nginx.py
+++ b/tests/chart_tests/test_nginx.py
@@ -495,13 +495,7 @@ class TestNginxClusterRoles:
     def test_nginx_cp_clusterrole_rbac_enabled(self, kube_version):
         """Test that helm renders nginx control plane ClusterRole when all conditions are met."""
         # Test control plane mode
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "control"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "control"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -516,7 +510,7 @@ class TestNginxClusterRoles:
         assert doc["metadata"]["labels"]["tier"] == "nginx"
         assert doc["metadata"]["labels"]["plane"] == "control"
         assert len(doc["rules"]) > 0
-        
+
         # Test unified plane mode (should also work for control plane template)
         values["global"]["plane"]["mode"] = "unified"
         docs = render_chart(
@@ -530,13 +524,7 @@ class TestNginxClusterRoles:
 
     def test_nginx_dp_clusterrole_rbac_enabled(self, kube_version):
         """Test that helm renders nginx data plane ClusterRole when all conditions are met."""
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -554,13 +542,7 @@ class TestNginxClusterRoles:
     def test_nginx_clusterrole_disabled_conditions(self, kube_version):
         """Test that nginx ClusterRoles are not rendered when required conditions are not met."""
         # Test with rbacEnabled=False (control plane)
-        values = {
-            "global": {
-                "rbacEnabled": False,
-                "clusterRoles": True,
-                "plane": {"mode": "control"}
-            }
-        }
+        values = {"global": {"rbacEnabled": False, "clusterRoles": True, "plane": {"mode": "control"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -569,13 +551,7 @@ class TestNginxClusterRoles:
         assert len(docs) == 0
 
         # Test with clusterRoles=False (control plane)
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": False,
-                "plane": {"mode": "control"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": False, "plane": {"mode": "control"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -584,13 +560,7 @@ class TestNginxClusterRoles:
         assert len(docs) == 0
 
         # Test with data plane mode for control plane template (should not render)
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -599,13 +569,7 @@ class TestNginxClusterRoles:
         assert len(docs) == 0
 
         # Test data plane template with wrong plane mode (unified/control should not render)
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "control"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "control"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -614,13 +578,7 @@ class TestNginxClusterRoles:
         assert len(docs) == 0
 
         # Test data plane template with rbacEnabled=False
-        values = {
-            "global": {
-                "rbacEnabled": False,
-                "clusterRoles": True,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": False, "clusterRoles": True, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -629,13 +587,7 @@ class TestNginxClusterRoles:
         assert len(docs) == 0
 
         # Test data plane template with clusterRoles=False
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": False,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": False, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,

--- a/tests/chart_tests/test_vector.py
+++ b/tests/chart_tests/test_vector.py
@@ -114,13 +114,7 @@ class TestVector:
     def test_vector_clusterrole_rbac_enabled(self, kube_version):
         """Test that helm renders a good ClusterRole template for vector when all conditions are met."""
         # Test data plane mode
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -135,7 +129,7 @@ class TestVector:
         assert doc["metadata"]["labels"]["tier"] == "logging"
         assert doc["metadata"]["labels"]["component"] == "vector"
         assert len(doc["rules"]) > 0
-        
+
         # Verify the rules contain expected permissions
         rule = doc["rules"][0]
         assert "namespaces" in rule["resources"]
@@ -157,13 +151,7 @@ class TestVector:
     def test_vector_clusterrole_disabled_conditions(self, kube_version):
         """Test that vector ClusterRole is not rendered when required conditions are not met."""
         # Test with rbacEnabled=False
-        values = {
-            "global": {
-                "rbacEnabled": False,
-                "clusterRoles": True,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": False, "clusterRoles": True, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -172,13 +160,7 @@ class TestVector:
         assert len(docs) == 0
 
         # Test with clusterRoles=False
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": False,
-                "plane": {"mode": "data"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": False, "plane": {"mode": "data"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,
@@ -187,13 +169,7 @@ class TestVector:
         assert len(docs) == 0
 
         # Test with control plane mode (should not render)
-        values = {
-            "global": {
-                "rbacEnabled": True,
-                "clusterRoles": True,
-                "plane": {"mode": "control"}
-            }
-        }
+        values = {"global": {"rbacEnabled": True, "clusterRoles": True, "plane": {"mode": "control"}}}
         docs = render_chart(
             kube_version=kube_version,
             values=values,


### PR DESCRIPTION
## Description

Update Vector ClusterRole and ClusterRoleBinding templates to honor `global.clusterRoles` value

This change ensures that the Vector ClusterRole and ClusterRoleBinding are only rendered if `global.clusterRoles` is true, in addition to the existing checks for RBAC and plane mode. This prevents cluster-scoped resources from being created when not permitted, enabling installations in RBAC-restricted environments.

### Impact
- Prevents install failures on clusters where users do not have permission to create cluster-scoped resources.
- Addresses issue encountered in unified mode with clusterRoles: false.

## Related Issues

Related astronomer/issues#8065

## Testing

Added test coverage for the vector ClusterRole template to verify it only renders when rbacEnabled, clusterRoles, and plane mode (data/unified) conditions are all met.

## Merging

1.0.1
