### PR TITLE
update kuiper reloder version 0.1.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:1.0.38
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kube-state:2.15.0
-                - quay.io/astronomer/ap-kuiper-reloader:0.1.9
+                - quay.io/astronomer/ap-kuiper-reloader:0.1.10
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-5
                 - quay.io/astronomer/ap-nats-server:2.11.10
                 - quay.io/astronomer/ap-nginx-es:1.29.0-1

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.9
+    tag: 0.1.10
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

update kuiper reloder version 0.1.10

## Related Issues

- https://github.com/astronomer/issues/issues/8062

## Testing

QA should no longer see connection pool issue anymore

## Merging

merge to master and release-1.0
