### PR TITLE
Adds sync cluster cron job

### DIFF
--- a/charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml
+++ b/charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml
@@ -1,0 +1,104 @@
+###############################################
+## Houston Sync Dataplane Clusters CronJob
+###############################################
+{{- if .Values.houston.syncDataplaneClusters.enabled }}
+{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+apiVersion: {{ include "apiVersion.batch.cronjob" . }}
+kind: CronJob
+metadata:
+  name: {{ .Release.Name }}-houston-sync-dataplane-clusters
+  labels:
+    tier: astronomer
+    component: houston-sync-dataplane-clusters
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    plane: {{ .Values.global.plane.mode }}
+spec:
+  schedule: {{ .Values.houston.syncDataplaneClusters.schedule }}
+  # The cron job does not allow concurrent runs; if it is time for a new job run and the previous job run hasn't finished yet, the cron job skips the new job run
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          labels:
+            tier: astronomer
+            component: houston-sync-dataplane-clusters
+            release: {{ .Release.Name }}
+            app: houston-sync-dataplane-clusters
+            version: {{ .Chart.Version }}
+            plane: {{ .Values.global.plane.mode }}
+            {{- include "global.podLabels" . | nindent 12 }}
+          {{- if or .Values.global.podAnnotations .Values.global.istio.enabled }}
+          annotations:
+          {{- if .Values.global.istio.enabled }}
+            sidecar.istio.io/inject: "false"
+          {{- end }}
+          {{- if .Values.global.podAnnotations }}
+{{ toYaml .Values.global.podAnnotations | indent 12 }}
+          {{- end }}
+          {{- end }}
+        spec:
+          serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+          nodeSelector: {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 12 }}
+          affinity: {{- toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 12 }}
+          tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 12 }}
+          restartPolicy: Never
+{{- include "astronomer.imagePullSecrets" . | indent 10 }}
+          initContainers:
+            - name: etc-ssl-certs-copier
+              command:
+                - sh
+                - -c
+                - |
+                  if [ -d /etc/ssl/certs ]; then
+                    cp -r /etc/ssl/certs/* /etc/ssl/certs_copy/
+                  else
+                    echo "No /etc/ssl/certs directory found, skipping copy."
+                  fi
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              securityContext:
+                readOnlyRootFilesystem: true
+                {{- toYaml .Values.securityContext| nindent 16 }}
+              resources: {{- toYaml .Values.houston.resources | nindent 16 }}
+              volumeMounts:
+                - name: etc-ssl-certs
+                  mountPath: /etc/ssl/certs_copy
+          containers:
+            - name: sync-dataplane-clusters
+              image: {{ template "houston.image" . }}
+              imagePullPolicy: {{ .Values.images.houston.pullPolicy }}
+              args: ["yarn", "sync-dataplane-clusters"]
+              securityContext:
+                readOnlyRootFilesystem: true
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              resources: {{- toYaml .Values.houston.resources | nindent 16 }}
+              volumeMounts:
+                - name: etc-ssl-certs
+                  mountPath: /etc/ssl/certs
+                - name: tmp
+                  mountPath: /tmp
+                - name: tmp
+                  mountPath: /houston/node_modules/.cache
+                {{- include "houston_volume_mounts" . | indent 16 }}
+                {{- include "custom_ca_volume_mounts" . | indent 16 }}
+              env:
+                {{- include "houston_environment" . | indent 16 }}
+              {{- if .Values.houston.syncDataplaneClusters.readinessProbe }}
+              readinessProbe: {{ tpl (toYaml .Values.houston.syncDataplaneClusters.readinessProbe) . | nindent 16 }}
+              {{- end }}
+              {{- if .Values.houston.syncDataplaneClusters.livenessProbe }}
+              livenessProbe: {{ tpl (toYaml .Values.houston.syncDataplaneClusters.livenessProbe) . | nindent 16 }}
+              {{- end }}
+          volumes:
+            - name: etc-ssl-certs
+              emptyDir: {}
+            - name: tmp
+              emptyDir: {}
+            {{- include "houston_volumes" . | indent 12 }}
+            {{- include "custom_ca_volumes" . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -322,6 +322,18 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
+  # Sync dataplane clusters in Houston
+  # This runs as a CronJob
+  syncDataplaneClusters:
+    # Enable sync dataplane clusters CronJob
+    enabled: true
+
+    # Default here is to run at the top of every hour https://crontab.guru/#0_*_*_*_*
+    schedule: "0 * * * *"
+
+    readinessProbe: {}
+    livenessProbe: {}
+
   runtimeReleasesConfigMapName: ~
   runtimeReleasesConfig:
     # example of usage:

--- a/tests/chart_tests/test_astronomer_houston_sync_dataplane_clusters.py
+++ b/tests/chart_tests/test_astronomer_houston_sync_dataplane_clusters.py
@@ -1,0 +1,74 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils import get_containers_by_name
+from tests.utils.chart import render_chart
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestAstronomerHoustonSyncDataplaneClustersCronJobs:
+    def test_astronomer_sync_dataplane_clusters_cron_defaults(self, kube_version):
+        """Test that cron job is not created when feature is disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"syncDataplaneClusters": {"enabled": False}}}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml",
+            ],
+        )
+        assert len(docs) == 0
+
+    def test_astronomer_sync_dataplane_clusters_cron_feature_enabled(self, kube_version):
+        """Test that cron job is created with correct configuration when feature is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"syncDataplaneClusters": {"enabled": True}}}},
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["metadata"]["name"] == "release-name-houston-sync-dataplane-clusters"
+        assert doc["metadata"]["labels"]["component"] == "houston-sync-dataplane-clusters"
+        spec = doc["spec"]["jobTemplate"]["spec"]["template"]
+        assert spec["metadata"]["labels"]["component"] == "houston-sync-dataplane-clusters"
+        assert spec["metadata"]["labels"]["app"] == "houston-sync-dataplane-clusters"
+        assert doc["spec"]["schedule"] == "0 * * * *"
+        assert spec["spec"]["containers"][0]["securityContext"] == {"readOnlyRootFilesystem": True, "runAsNonRoot": True}
+
+        # Verify container args
+        c_by_name = get_containers_by_name(doc)
+        assert c_by_name["sync-dataplane-clusters"]["args"] == ["yarn", "sync-dataplane-clusters"]
+
+    def test_astronomer_sync_dataplane_clusters_cron_custom_schedule(self, kube_version):
+        """Test that custom schedule is respected."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "houston": {
+                        "syncDataplaneClusters": {
+                            "enabled": True,
+                            "schedule": "30 * * * *",
+                        }
+                    },
+                }
+            },
+            show_only=[
+                "charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml",
+            ],
+        )
+
+        assert len(docs) == 1
+
+        doc = docs[0]
+        assert doc["kind"] == "CronJob"
+        assert doc["metadata"]["name"] == "release-name-houston-sync-dataplane-clusters"
+        assert doc["spec"]["schedule"] == "30 * * * *"

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -295,6 +295,9 @@ custom_service_account_names = {
     "charts/astronomer/templates/houston/cronjobs/houston-cleanup-cluster-audits-cronjob.yaml": {
         "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
     },
+    "charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml": {
+        "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
+    },
     "charts/astronomer/templates/houston/cronjobs/houston-cleanup-deployments-cronjob.yaml": {
         "astronomer": {"houston": {"serviceAccount": {"create": True, "name": "prothean"}}}
     },

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -149,6 +149,15 @@ astronomer:
         exec:
           command:
           - /bin/true
+    syncDataplaneClusters:
+      livenessProbe:
+        exec:
+          command:
+          - /bin/true
+      readinessProbe:
+        exec:
+          command:
+          - /bin/true
     upgradeDeployments:
       livenessProbe:
         exec:


### PR DESCRIPTION
## Description

This PR adds a cron job to sync the dataplane clusters in control plane.

Design doc: https://www.notion.so/astronomerio/Information-Flow-Between-the-Control-Plane-and-Data-Plane-29d40290af6c818dbbf7cbb37dfc4aae?v=45002f92fdb341c28e1d8bf62d3c3b43&source=copy_link

## Related Issues

Related astronomer/issues#8095

## Testing

- Unit tests
- Ran command for generating the cron job
```
 helm template . --set global.astronomer.houston.syncDataplaneClusters.enabled=true --kube-version=1.32.5 --show-only charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml
---
# Source: astronomer/charts/astronomer/templates/houston/cronjobs/houston-sync-dataplane-clusters-cronjob.yaml
###############################################
## Houston Sync Dataplane Clusters CronJob
###############################################
apiVersion: batch/v1
kind: CronJob
metadata:
  name: release-name-houston-sync-dataplane-clusters
```

## Merging

master, 1.0