### PR TITLE
Update Vector and Es Exporter Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ workflows:
                 - quay.io/astronomer/ap-dag-deploy:0.7.2
                 - quay.io/astronomer/ap-db-bootstrapper:1.0.1
                 - quay.io/astronomer/ap-default-backend:0.28.34
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.18.6-2
                 - quay.io/astronomer/ap-git-daemon:3.21.3-6
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
@@ -438,7 +438,7 @@ workflows:
                 - quay.io/astronomer/ap-redis:8.0.3-1
                 - quay.io/astronomer/ap-registry:3.0.0-1
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
-                - quay.io/astronomer/ap-vector:0.47.0-5
+                - quay.io/astronomer/ap-vector:0.51.0
           context:
             - slack_team-software-infra-bot
 

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -22,7 +22,7 @@ images:
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.9.0
+    tag: 1.9.0-1
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -16,7 +16,7 @@ vector:
     runAsUser: 0
   image:
     repository: quay.io/astronomer/ap-vector
-    tag: 0.47.0-5
+    tag: 0.51.0
     pullPolicy: IfNotPresent
   resources: ~
   livenessProbe: ~

--- a/values.yaml
+++ b/values.yaml
@@ -148,7 +148,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.47.0-5
+    tag: 0.51.0
     customConfig: false
     indexPattern: ~
     extraEnv: []


### PR DESCRIPTION
## Description

This PR intends to update vector and ES exporter images for 1.0 with Chubb CVE fixes.

## Related Issues

Related astronomer/issues#8104

## Testing

N/A

## Merging

Master, 1.0