### PR TITLE
Image updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,40 +403,40 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
-                - quay.io/astronomer/ap-alertmanager:0.28.1-4
+                - quay.io/astronomer/ap-alertmanager:0.28.1-5
                 - quay.io/astronomer/ap-astro-ui:1.0.25
                 - quay.io/astronomer/ap-auth-sidecar:1.29.2
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-19
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-20
                 - quay.io/astronomer/ap-base:3.21.3-6
                 - quay.io/astronomer/ap-commander:1.0.21
                 - quay.io/astronomer/ap-configmap-reloader:0.14.0
-                - quay.io/astronomer/ap-curator:8.0.21-6
+                - quay.io/astronomer/ap-curator:8.0.21-7
                 - quay.io/astronomer/ap-dag-deploy:0.7.2
                 - quay.io/astronomer/ap-db-bootstrapper:1.0.1
                 - quay.io/astronomer/ap-default-backend:0.28.34
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.18.6-2
-                - quay.io/astronomer/ap-git-daemon:3.21.3-6
+                - quay.io/astronomer/ap-git-daemon:2025.11.3
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
-                - quay.io/astronomer/ap-git-sync:4.4.1-3
+                - quay.io/astronomer/ap-git-sync:2025.11.3
                 - quay.io/astronomer/ap-grafana:12.2.0
                 - quay.io/astronomer/ap-houston-api:1.0.40
-                - quay.io/astronomer/ap-init:3.21.3-5
+                - quay.io/astronomer/ap-init:2025.11.3
                 - quay.io/astronomer/ap-kube-state:2.15.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.12
-                - quay.io/astronomer/ap-nats-exporter:0.16.0-5
-                - quay.io/astronomer/ap-nats-server:2.11.10
+                - quay.io/astronomer/ap-nats-exporter:0.16.0-6
+                - quay.io/astronomer/ap-nats-server:2.12.1
                 - quay.io/astronomer/ap-nginx-es:1.29.2
                 - quay.io/astronomer/ap-nginx:1.12.6
                 - quay.io/astronomer/ap-openresty:1.27.1-7
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-20
                 - quay.io/astronomer/ap-pgbouncer:1.24.1-2
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1-1
+                - quay.io/astronomer/ap-postgres-exporter:0.18.1
                 - quay.io/astronomer/ap-postgresql:17.6.0
                 - quay.io/astronomer/ap-prometheus:3.5.0-3
                 - quay.io/astronomer/ap-redis:8.0.3-1
-                - quay.io/astronomer/ap-registry:3.0.0-1
+                - quay.io/astronomer/ap-registry:3.0.0-4
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
                 - quay.io/astronomer/ap-vector:0.51.0
           context:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.28.1-4
+    tag: 0.28.1-5
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.0.0-1
+    tag: 3.0.0-4
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -18,7 +18,7 @@ images:
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.21-6
+    tag: 8.0.21-7
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -11,7 +11,7 @@ images:
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-19
+    tag: 1.5.0-20
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -6,11 +6,11 @@
 images:
   nats:
     repository: quay.io/astronomer/ap-nats-server
-    tag: 2.11.10
+    tag: 2.12.1
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-nats-exporter
-    tag: 0.16.0-5
+    tag: 0.16.0-6
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.17.1-1
+  tag: 0.18.1
   pullPolicy: IfNotPresent
 
 

--- a/values.yaml
+++ b/values.yaml
@@ -310,15 +310,15 @@ global:
         tag: 0.19.0-1
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
-        tag: 4.4.1-3
+        tag: 2025.11.3
       xcom:
         repository: quay.io/astronomer/ap-init
-        tag: 3.21.3-5
+        tag: 2025.11.3
   gitSyncRelay:
     images:
       gitDaemon:
         repository: quay.io/astronomer/ap-git-daemon
-        tag: 3.21.3-6
+        tag: 2025.11.3
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
         tag: 0.2.2


### PR DESCRIPTION
## Description

Following the changes done here https://github.com/astronomer/ap-vendor/pull/1089/files#diff-d6d33c811c97ac35c65b9d550ecc5be5be3f85445d8ee0f3bc158a38cc4b8580 
The images have been updated for 1.0.1 to use chainguard base image.

## Related Issues

Related astronomer/issues#7707

## Testing

N/A

## Merging

Master, 1.0