### PR TITLE
update kuiper reloader version 0.1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:1.0.40
                 - quay.io/astronomer/ap-init:2025.11.3
                 - quay.io/astronomer/ap-kube-state:2.15.0
-                - quay.io/astronomer/ap-kuiper-reloader:0.1.12
+                - quay.io/astronomer/ap-kuiper-reloader:0.1.13
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-6
                 - quay.io/astronomer/ap-nats-server:2.12.1
                 - quay.io/astronomer/ap-nginx-es:1.29.2

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.12
+    tag: 0.1.13
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

update kuiper reloader version 0.1.13

## Related Issues

- https://github.com/astronomer/issues/issues/8111

## Testing

refer linked ticket

## Merging

merge to master and release-1.0, 0.37
