### PR TITLE
update kuiper reloader version 0.1.14

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:1.0.41
                 - quay.io/astronomer/ap-init:2025.11.3
                 - quay.io/astronomer/ap-kube-state:2.16.0
-                - quay.io/astronomer/ap-kuiper-reloader:0.1.13
+                - quay.io/astronomer/ap-kuiper-reloader:0.1.14
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-6
                 - quay.io/astronomer/ap-nats-server:2.12.1
                 - quay.io/astronomer/ap-nginx-es:1.29.2

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.13
+    tag: 0.1.14
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

fixes incorrect db url construction 

## Related Issues

- https://github.com/astronomer/issues/issues/8134

## Testing

QA should not db does not exists when dbboostrapper is used with db name 

## Merging
merge to master and release-1.0
