### PR TITLE
Remove remaining tiller references

### DIFF
--- a/.helmignore
+++ b/.helmignore
@@ -36,7 +36,6 @@
 /secrets
 /test
 /tests
-/tiller-rbac
 /values.schema.json.example
 __pycache__
 prof


### PR DESCRIPTION
## Description

Remove remaining tiller files and references. This was supposed to be handled in the beginning of 2024 but it looks like this one file slipped through.

## Related Issues

- <https://github.com/astronomer/issues/issues/6155>

## Testing

No testing needed. No documentation needed. We already removed tiller, but this was a bit of dead code that fell through the cracks.

Tiller is a helm 2 component that we have not used in over 3 years, since [helm 2 was EOL in 2020](https://github.com/helm/helm/releases/tag/v2.17.0).

## Merging

Merge this everywhere.