### PR TITLE
update houston api image tag 1.0.43

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.2
                 - quay.io/astronomer/ap-git-sync:2025.11.3
                 - quay.io/astronomer/ap-grafana:12.2.1
-                - quay.io/astronomer/ap-houston-api:1.0.42
+                - quay.io/astronomer/ap-houston-api:1.0.43
                 - quay.io/astronomer/ap-init:2025.11.3
                 - quay.io/astronomer/ap-kube-state:2.16.0
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.14

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.42
+    tag: 1.0.43
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api image tag 1.0.43

## Related Issues

- Related https://github.com/astronomer/issues/issues/7271
- Related https://github.com/astronomer/issues/issues/7967
- Related https://github.com/astronomer/issues/issues/8122
- Related https://github.com/astronomer/issues/issues/8131
- Related to https://github.com/astronomer/issues/issues/8153
- Related to https://github.com/astronomer/issues/issues/8158
- Related https://github.com/astronomer/issues/issues/7981
- Related https://github.com/astronomer/issues/issues/7890
## Testing

Refer above tickets 

## Merging

merge to master and release-1.0
