### PR TITLE
Use kerberos pgbouncer image if kerberos is enabled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -379,7 +379,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
                 - quay.io/astronomer/ap-grafana:10.4.19
-                - quay.io/astronomer/ap-houston-api:0.37.54
+                - quay.io/astronomer/ap-houston-api:0.37.55
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kibana:8.18.2
                 - quay.io/astronomer/ap-kube-state:2.15.0-1
@@ -391,7 +391,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-6
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-22
+                - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-1
                 - quay.io/astronomer/ap-pgbouncer:1.24.1-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
                 - quay.io/astronomer/ap-postgresql:17.4.0
@@ -426,7 +426,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
                 - quay.io/astronomer/ap-grafana:10.4.19
-                - quay.io/astronomer/ap-houston-api:0.37.54
+                - quay.io/astronomer/ap-houston-api:0.37.55
                 - quay.io/astronomer/ap-init:3.21.3-5
                 - quay.io/astronomer/ap-kibana:8.18.2
                 - quay.io/astronomer/ap-kube-state:2.15.0-1
@@ -438,7 +438,7 @@ workflows:
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-6
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-3
-                - quay.io/astronomer/ap-pgbouncer-krb:1.17.0-22
+                - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-1
                 - quay.io/astronomer/ap-pgbouncer:1.24.1-2
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
                 - quay.io/astronomer/ap-postgresql:17.4.0

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -79,6 +79,9 @@ data:
       enableHoustonInternalAuthorization: {{ include "houston.InternalAuthorization" . }}
       dagOnlyDeployment: {{ .Values.global.dagOnlyDeployment.enabled }}
       namespaceFreeFormEntry: {{ .Values.global.namespaceFreeFormEntry }}
+      manualConnectionStrings:
+        enabled: {{ default false .Values.global.manualConnectionStrings.enabled }}
+      upsertExtraIniAllowed: {{ default false .Values.global.upsertExtraIniAllowed }}
       # Airflow chart settings
       # Static helm configurations for this chart are found below.
       chart:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 0.37.54
+    tag: 0.37.55
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/pgbouncer/templates/_helpers.yaml
+++ b/charts/pgbouncer/templates/_helpers.yaml
@@ -50,29 +50,17 @@
 
 {{- define "pgbouncer_environment" }}
 - name: DB_USER
-  valueFrom:
-    secretKeyRef:
-      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
-      key: {{ default "username" .Values.global.pgbouncer.credentialsSecret.usernameKey }}
-      optional: false
+  value: postgres
 - name: DB_PASSWORD
-  valueFrom:
-    secretKeyRef:
-      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
-      key: {{ default "password" .Values.global.pgbouncer.credentialsSecret.passwordKey }}
-      optional: false
+  value: postgres
 - name: DB_HOST
-  value: {{ default "astronomer-postgresql.astronomer.svc.cluster.local" .Values.global.pgbouncer.host | quote }}
+  value: "astronomer-postgresql.astronomer.svc.cluster.local"
 - name: DB_PORT
-  value: {{ default "5432" (toString .Values.global.pgbouncer.servicePort) | quote }}
+  value: "5432"
 - name: POOL_MODE
   value: session
 - name: ADMIN_USERS
-  valueFrom:
-    secretKeyRef:
-      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
-      key: {{ default "username" .Values.global.pgbouncer.credentialsSecret.usernameKey }}
-      optional: false
+  value: postgres
 - name: AUTH_TYPE
   value: plain
 - name: LOG_DISCONNECTIONS

--- a/charts/pgbouncer/templates/_helpers.yaml
+++ b/charts/pgbouncer/templates/_helpers.yaml
@@ -8,12 +8,20 @@
 
 
 {{ define "pgbouncer.image" -}}
+{{- $kerbRepo := .Values.kerberosImage.repository -}}
+{{- $kerbTag := .Values.kerberosImage.tag -}}
+{{- $repo := .Values.image.repository -}}
+{{- $tag := .Values.image.tag -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/ap-pgbouncer-krb:{{ .Values.image.tag }}
+{{- $kerbRepo = printf "%s/ap-pgbouncer-krb" .Values.global.privateRegistry.repository -}}
+{{- $repo = printf "%s/ap-pgbouncer" .Values.global.privateRegistry.repository -}}
+{{- end -}}
+{{- if .Values.global.kerberos.enabled -}}
+{{- printf "%s:%s" $kerbRepo $kerbTag -}}
 {{- else -}}
-{{ printf "%s:%s" .Values.image.repository .Values.image.tag }}
-{{- end }}
-{{- end }}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}
+{{- end -}}
 
 {{ define "pgbouncer_host" -}}
 {{ printf "%s-pgbouncer" .Release.Name }}
@@ -42,17 +50,29 @@
 
 {{- define "pgbouncer_environment" }}
 - name: DB_USER
-  value: postgres
+  valueFrom:
+    secretKeyRef:
+      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
+      key: {{ default "username" .Values.global.pgbouncer.credentialsSecret.usernameKey }}
+      optional: false
 - name: DB_PASSWORD
-  value: postgres
+  valueFrom:
+    secretKeyRef:
+      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
+      key: {{ default "password" .Values.global.pgbouncer.credentialsSecret.passwordKey }}
+      optional: false
 - name: DB_HOST
-  value: "astronomer-postgresql.astronomer.svc.cluster.local"
+  value: {{ default "astronomer-postgresql.astronomer.svc.cluster.local" .Values.global.pgbouncer.host | quote }}
 - name: DB_PORT
-  value: "5432"
+  value: {{ default "5432" (toString .Values.global.pgbouncer.servicePort) | quote }}
 - name: POOL_MODE
   value: session
 - name: ADMIN_USERS
-  value: postgres
+  valueFrom:
+    secretKeyRef:
+      name: {{ default "astronomer-db" .Values.global.pgbouncer.credentialsSecret.name }}
+      key: {{ default "username" .Values.global.pgbouncer.credentialsSecret.usernameKey }}
+      optional: false
 - name: AUTH_TYPE
   value: plain
 - name: LOG_DISCONNECTIONS

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -59,7 +59,6 @@ spec:
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            {{- include "pgbouncer_environment" . | indent 12 }}
             {{- range $key, $value :=  .Values.env }}
             - name: {{ $key | replace "-" "_" }}
               value: {{ $value | quote }}

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -55,7 +55,7 @@ spec:
       serviceAccountName: {{ template "pgbouncer.serviceAccountName" . }}
       containers:
         - name: pgbouncer
-          image: {{ template "pgbouncer.image" . }}
+          image: {{ include "pgbouncer.image" . | trim }}
           securityContext: {{ toYaml .Values.securityContext| nindent 12 }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
@@ -91,4 +91,31 @@ spec:
               exec:
                 # Allow existing queries clients to complete within 120 seconds
                 command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /etc/pgbouncer
+              readOnly: true
+            {{- if .Values.global.kerberos.enabled }}
+            - name: krb
+              mountPath: /krb
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: pgbouncer-config
+          secret:
+            secretName: {{ template "pgbouncer_config_secret" . }}
+            items:
+              - key: pgbouncer.ini
+                path: pgbouncer.ini
+              - key: users.txt
+                path: users.txt
+        {{- if .Values.global.kerberos.enabled }}
+        - name: krb
+          emptyDir: {}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
 {{- end }}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -6,6 +6,15 @@ image:
   tag: 1.17.0-22
   pullPolicy: IfNotPresent
 
+kerberosImage:
+  repository: quay.io/astronomer/ap-pgbouncer-krb
+  tag: 1.17.0-22
+
+credentialsSecret:
+  name: astronomer-db
+  usernameKey: username
+  passwordKey: password
+
 securityContext:
   runAsNonRoot: true
 

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -8,7 +8,7 @@ image:
 
 kerberosImage:
   repository: quay.io/astronomer/ap-pgbouncer-krb
-  tag: 1.17.0-22
+  tag: 1.25.0-1
 
 securityContext:
   runAsNonRoot: true

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -10,11 +10,6 @@ kerberosImage:
   repository: quay.io/astronomer/ap-pgbouncer-krb
   tag: 1.17.0-22
 
-credentialsSecret:
-  name: astronomer-db
-  usernameKey: username
-  passwordKey: password
-
 securityContext:
   runAsNonRoot: true
 

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -111,6 +111,7 @@ class TestServiceAccounts:
                 "customLogging": {"enabled": True},
                 "prometheusPostgresExporterEnabled": True,
                 "pgbouncer": {"enabled": True},
+                "kerberos": {"enabled": False},
                 "airflowOperator": {"enabled": True},
             },
             "astronomer": {
@@ -159,6 +160,7 @@ class TestServiceAccounts:
                 "customLogging": {"enabled": True},
                 "prometheusPostgresExporterEnabled": True,
                 "pgbouncer": {"enabled": True},
+                "kerberos": {"enabled": False},
                 "airflowOperator": {"enabled": True},
             },
             "astronomer": {

--- a/tests/chart_tests/test_data/enable_all_podsecuritycontexts.yaml
+++ b/tests/chart_tests/test_data/enable_all_podsecuritycontexts.yaml
@@ -233,6 +233,8 @@ global:
     enabled: true
   pgbouncer:
     enabled: true
+  kerberos:
+    enabled: true
   postgresqlEnabled: true
   prometheusPostgresExporterEnabled: true
   openshiftEnabled: false

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -258,6 +258,8 @@ global:
     enabled: true
   pgbouncer:
     enabled: true
+  kerberos:
+    enabled: true
   postgresqlEnabled: true
   prometheusPostgresExporterEnabled: true
 grafana:

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -21,6 +21,8 @@ def common_test_cases(docs):
 
     assert prod["deployments"]["helm"]["airflow"]["useAstroSecurityManager"] is True
     assert prod["deployments"]["disableManageClusterScopedResources"] is False
+    assert prod["deployments"]["manualConnectionStrings"]["enabled"] is False
+    assert prod["deployments"]["upsertExtraIniAllowed"] is False
     assert prod["helm"]["tlsSecretName"] == "astronomer-tls"
     airflow_local_settings = prod["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
     scheduler_update_strategy = prod["deployments"]["helm"]["airflow"]["scheduler"]["strategy"]
@@ -85,6 +87,23 @@ def test_houston_configmap_has_hook_annotations():
     assert annotations.get("helm.sh/hook-weight") == "-1"
     assert annotations.get("helm.sh/hook-delete-policy") == "before-hook-creation"
     assert annotations.get("helm.sh/resource-policy") == "keep"
+
+
+def test_houston_configmap_deployments_manual_connection_strings_override():
+    """Validate manualConnectionStrings/upsertExtraIniAllowed can be configured via global values."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        values={
+            "global": {
+                "manualConnectionStrings": {"enabled": True},
+                "upsertExtraIniAllowed": False,
+            }
+        },
+    )
+
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    assert prod["deployments"]["manualConnectionStrings"]["enabled"] is True
+    assert prod["deployments"]["upsertExtraIniAllowed"] is False
 
 
 def test_houston_configmap_with_custom_images():

--- a/tests/chart_tests/test_pgbouncer.py
+++ b/tests/chart_tests/test_pgbouncer.py
@@ -38,7 +38,7 @@ class TestPGBouncerDeployment:
                     "pgbouncer": {
                         "enabled": True,
                     },
-                    "kerberos": {"enabled": False}
+                    "kerberos": {"enabled": False},
                 },
                 "pgbouncer": {"env": {"foo_key": "foo_value", "bar_key": "bar_value"}},
             },
@@ -58,7 +58,7 @@ class TestPGBouncerDeployment:
                         "enabled": True,
                         "extraLabels": {"test_label": "test_label1"},
                     },
-                    "kerberos": {"enabled": False}
+                    "kerberos": {"enabled": False},
                 },
             },
             show_only=["charts/pgbouncer/templates/pgbouncer-deployment.yaml"],
@@ -120,37 +120,6 @@ class TestPGBouncerDeployment:
 
         c_by_name = get_containers_by_name(doc, include_init_containers=True)
         assert "ap-pgbouncer-krb" in c_by_name["pgbouncer"]["image"]
-
-    def test_env_from_credentials_secret(self, kube_version):
-        secret_name = "astronomer-db"
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=["charts/pgbouncer/templates/pgbouncer-deployment.yaml"],
-            values={
-                "global": {
-                    "pgbouncer": {
-                        "enabled": True,
-                        "credentialsSecret": {
-                            "name": secret_name,
-                            "usernameKey": "user",
-                            "passwordKey": "pass",
-                        },
-                    },
-                    "kerberos": {"enabled": False},
-                }
-            },
-        )
-
-        assert len(docs) == 1
-        doc = docs[0]
-
-        env = get_containers_by_name(doc)["pgbouncer"]["env"]
-        db_user = next(item for item in env if item["name"] == "DB_USER")
-        db_password = next(item for item in env if item["name"] == "DB_PASSWORD")
-
-        assert db_user["valueFrom"]["secretKeyRef"]["name"] == secret_name
-        assert db_user["valueFrom"]["secretKeyRef"]["key"] == "user"
-        assert db_password["valueFrom"]["secretKeyRef"]["key"] == "pass"
 
     def test_kerberos_volume_mount(self, kube_version):
         docs = render_chart(

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -7,6 +7,8 @@ global:
   customLogging:
     awsSecretName: dummy
     enabled: true
+  kerberos:
+    enabled: true
   loggingSidecar:
     enabled: true
   pgbouncer:

--- a/values.yaml
+++ b/values.yaml
@@ -349,7 +349,6 @@ global:
     enabled: false
     gssSupport: true
     krb5ConfSecretName: krb5.conf
-    host: astronomer-postgresql.astronomer.svc.cluster.local
     # we use it only for in cluster postgresql
     # so we can override astronomer-bootstrap secret
     username: postgres

--- a/values.yaml
+++ b/values.yaml
@@ -344,16 +344,24 @@ global:
     enabled: false
     gssSupport: true
     krb5ConfSecretName: krb5.conf
+    host: astronomer-postgresql.astronomer.svc.cluster.local
     # we use it only for in cluster postgresql
     # so we can override astronomer-bootstrap secret
     username: postgres
     password: postgres
     servicePort: "5432"
+    credentialsSecret:
+      name: astronomer-db
+      usernameKey: username
+      passwordKey: password
     extraEnv: []
       # some: thing
       # another: thing
     extraLabels: []
       # do-funky-injection: maybe
+
+kerberos:
+  enabled: false
 
 #################################
 ## Default tagged groups enabled

--- a/values.yaml
+++ b/values.yaml
@@ -355,10 +355,6 @@ global:
     username: postgres
     password: postgres
     servicePort: "5432"
-    credentialsSecret:
-      name: astronomer-db
-      usernameKey: username
-      passwordKey: password
     extraEnv: []
       # some: thing
       # another: thing

--- a/values.yaml
+++ b/values.yaml
@@ -131,6 +131,11 @@ global:
 
   disableManageClusterScopedResources: false
 
+  manualConnectionStrings:
+    enabled: false
+
+  upsertExtraIniAllowed: false
+
   enablePerHostIngress: false
 
   dagOnlyDeployment:


### PR DESCRIPTION
## Description

This PR adds necessary flags in houston to make the kerberos work. It also updates the pgbouncer image based on if kerberos is enabled or not.

## Related Issues

Related astronomer/issues#8204

## Testing

- Unit tests
- Dev tested the changes by manually doing changes in deployment

## Merging

0.37