### PR TITLE
update commander image version 1.0.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.03
-                - quay.io/astronomer/ap-commander:1.0.25
+                - quay.io/astronomer/ap-commander:1.0.26
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-dag-deploy:0.7.5

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.25
+    tag: 1.0.26
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

This PR adds below changes to support kerbros and offload database management

Skips database creation when passed from webhook
Skips database deletion when deployments are managed by webhooks
Implemented new logic to fetch current helm release to validate secret configuration

## Related Issues

- Related https://github.com/astronomer/issues/issues/8205

## Testing

QA should follow kerbros setup docs and custom database configuration steps 

## Merging

merge to master and release-1.0
