### PR TITLE
update vendor packages for cve fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,7 +362,7 @@ workflows:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.1-3
                 - quay.io/astronomer/ap-astro-ui:0.37.14
-                - quay.io/astronomer/ap-auth-sidecar:1.29.0
+                - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-18
                 - quay.io/astronomer/ap-base:3.21.3-5
                 - quay.io/astronomer/ap-blackbox-exporter:0.26.0
@@ -390,16 +390,16 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.6
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-6
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-3
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.20.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-2
-                - quay.io/astronomer/ap-pgbouncer:1.24.1-2
+                - quay.io/astronomer/ap-pgbouncer:1.24.1-4
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:3.5.0
-                - quay.io/astronomer/ap-redis:7.4.3
+                - quay.io/astronomer/ap-redis:8.0.3-1
                 - quay.io/astronomer/ap-registry:3.0.0-1
-                - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.47.0-4
+                - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
+                - quay.io/astronomer/ap-vector:0.52.0
           context:
             - slack_team-software-infra-bot
       - twistcli-scan-docker:
@@ -409,7 +409,7 @@ workflows:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.28.1-3
                 - quay.io/astronomer/ap-astro-ui:0.37.14
-                - quay.io/astronomer/ap-auth-sidecar:1.29.0
+                - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-18
                 - quay.io/astronomer/ap-base:3.21.3-5
                 - quay.io/astronomer/ap-blackbox-exporter:0.26.0
@@ -437,16 +437,16 @@ workflows:
                 - quay.io/astronomer/ap-nginx:1.11.6
                 - quay.io/astronomer/ap-node-exporter:1.9.1
                 - quay.io/astronomer/ap-openresty:1.27.1-6
-                - quay.io/astronomer/ap-pgbouncer-exporter:0.19.0-3
+                - quay.io/astronomer/ap-pgbouncer-exporter:0.20.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-2
-                - quay.io/astronomer/ap-pgbouncer:1.24.1-2
+                - quay.io/astronomer/ap-pgbouncer:1.24.1-4
                 - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
                 - quay.io/astronomer/ap-postgresql:17.4.0
                 - quay.io/astronomer/ap-prometheus:3.5.0
-                - quay.io/astronomer/ap-redis:7.4.3
+                - quay.io/astronomer/ap-redis:8.0.3-1
                 - quay.io/astronomer/ap-registry:3.0.0-1
-                - quay.io/astronomer/ap-statsd-exporter:0.28.0-2
-                - quay.io/astronomer/ap-vector:0.47.0-4
+                - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
+                - quay.io/astronomer/ap-vector:0.52.0
           context:
             - twistcli
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,44 +360,44 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
-                - quay.io/astronomer/ap-alertmanager:0.28.1-3
+                - quay.io/astronomer/ap-alertmanager:0.30.0
                 - quay.io/astronomer/ap-astro-ui:0.37.14
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-18
-                - quay.io/astronomer/ap-base:3.21.3-5
-                - quay.io/astronomer/ap-blackbox-exporter:0.26.0
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-22
+                - quay.io/astronomer/ap-base:2025.12.24
+                - quay.io/astronomer/ap-blackbox-exporter:0.26.0-2
                 - quay.io/astronomer/ap-certgenerator:0.1.12
                 - quay.io/astronomer/ap-commander:0.37.28
-                - quay.io/astronomer/ap-configmap-reloader:0.15.0
-                - quay.io/astronomer/ap-curator:8.0.21-4
+                - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
+                - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.6
-                - quay.io/astronomer/ap-default-backend:0.28.32
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
+                - quay.io/astronomer/ap-default-backend:0.29.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.18.2
                 - quay.io/astronomer/ap-fluentd:1.18.0
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.2.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
-                - quay.io/astronomer/ap-grafana:10.4.19
+                - quay.io/astronomer/ap-grafana:12.2.3
                 - quay.io/astronomer/ap-houston-api:0.37.56
-                - quay.io/astronomer/ap-init:3.21.3-5
+                - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kibana:8.18.2
-                - quay.io/astronomer/ap-kube-state:2.15.0-1
+                - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-5
                 - quay.io/astronomer/ap-nats-server:2.10.19-4
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-14
-                - quay.io/astronomer/ap-nginx-es:1.29.0
+                - quay.io/astronomer/ap-nginx-es:1.29.3
                 - quay.io/astronomer/ap-nginx:1.11.6
-                - quay.io/astronomer/ap-node-exporter:1.9.1
-                - quay.io/astronomer/ap-openresty:1.27.1-6
+                - quay.io/astronomer/ap-node-exporter:1.10.2
+                - quay.io/astronomer/ap-openresty:1.27.1-8
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.20.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-2
                 - quay.io/astronomer/ap-pgbouncer:1.24.1-4
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
+                - quay.io/astronomer/ap-postgres-exporter:0.18.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
-                - quay.io/astronomer/ap-prometheus:3.5.0
+                - quay.io/astronomer/ap-prometheus:3.5.0-3
                 - quay.io/astronomer/ap-redis:8.0.3-1
-                - quay.io/astronomer/ap-registry:3.0.0-1
+                - quay.io/astronomer/ap-registry:3.0.0-5
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
                 - quay.io/astronomer/ap-vector:0.52.0
           context:
@@ -407,44 +407,44 @@ workflows:
             parameters:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
-                - quay.io/astronomer/ap-alertmanager:0.28.1-3
+                - quay.io/astronomer/ap-alertmanager:0.30.0
                 - quay.io/astronomer/ap-astro-ui:0.37.14
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
-                - quay.io/astronomer/ap-awsesproxy:1.5.0-18
-                - quay.io/astronomer/ap-base:3.21.3-5
-                - quay.io/astronomer/ap-blackbox-exporter:0.26.0
+                - quay.io/astronomer/ap-awsesproxy:1.5.0-22
+                - quay.io/astronomer/ap-base:2025.12.24
+                - quay.io/astronomer/ap-blackbox-exporter:0.26.0-2
                 - quay.io/astronomer/ap-certgenerator:0.1.12
                 - quay.io/astronomer/ap-commander:0.37.28
-                - quay.io/astronomer/ap-configmap-reloader:0.15.0
-                - quay.io/astronomer/ap-curator:8.0.21-4
+                - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
+                - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-db-bootstrapper:0.37.6
-                - quay.io/astronomer/ap-default-backend:0.28.32
-                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0
+                - quay.io/astronomer/ap-default-backend:0.29.0
+                - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1
                 - quay.io/astronomer/ap-elasticsearch:8.18.2
                 - quay.io/astronomer/ap-fluentd:1.18.0
                 - quay.io/astronomer/ap-git-daemon:3.21.3-3
                 - quay.io/astronomer/ap-git-sync-relay:0.2.1
                 - quay.io/astronomer/ap-git-sync:4.4.1-2
-                - quay.io/astronomer/ap-grafana:10.4.19
+                - quay.io/astronomer/ap-grafana:12.2.3
                 - quay.io/astronomer/ap-houston-api:0.37.56
-                - quay.io/astronomer/ap-init:3.21.3-5
+                - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kibana:8.18.2
-                - quay.io/astronomer/ap-kube-state:2.15.0-1
+                - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-nats-exporter:0.16.0-5
                 - quay.io/astronomer/ap-nats-server:2.10.19-4
                 - quay.io/astronomer/ap-nats-streaming:0.25.6-14
-                - quay.io/astronomer/ap-nginx-es:1.29.0
+                - quay.io/astronomer/ap-nginx-es:1.29.3
                 - quay.io/astronomer/ap-nginx:1.11.6
-                - quay.io/astronomer/ap-node-exporter:1.9.1
-                - quay.io/astronomer/ap-openresty:1.27.1-6
+                - quay.io/astronomer/ap-node-exporter:1.10.2
+                - quay.io/astronomer/ap-openresty:1.27.1-8
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.20.0
                 - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-2
                 - quay.io/astronomer/ap-pgbouncer:1.24.1-4
-                - quay.io/astronomer/ap-postgres-exporter:0.17.1-2
+                - quay.io/astronomer/ap-postgres-exporter:0.18.1-1
                 - quay.io/astronomer/ap-postgresql:17.4.0
-                - quay.io/astronomer/ap-prometheus:3.5.0
+                - quay.io/astronomer/ap-prometheus:3.5.0-3
                 - quay.io/astronomer/ap-redis:8.0.3-1
-                - quay.io/astronomer/ap-registry:3.0.0-1
+                - quay.io/astronomer/ap-registry:3.0.0-5
                 - quay.io/astronomer/ap-statsd-exporter:0.28.0-3
                 - quay.io/astronomer/ap-vector:0.52.0
           context:

--- a/charts/alertmanager/values.yaml
+++ b/charts/alertmanager/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   alertmanager:
     repository: quay.io/astronomer/ap-alertmanager
-    tag: 0.28.1-3
+    tag: 0.30.0
     pullPolicy: IfNotPresent
 
 podSecurityContext:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -19,7 +19,7 @@ images:
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
-    tag: 3.0.0-1
+    tag: 3.0.0-5
     pullPolicy: IfNotPresent
     # httpSecret: ~
   houston:

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -85,6 +85,7 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+          runAsUser: 0
         resources: {{ toYaml .Values.client.initResources | nindent 10 }}
   {{- end }}
       containers:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -89,6 +89,7 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+          runAsUser: 0
         resources: {{ toYaml .Values.data.initResources | nindent 10 }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -88,6 +88,7 @@ spec:
         command: ["sysctl", "-w", "vm.max_map_count={{ .Values.sysctlInitContainer.sysctlVmMaxMapCount}}"]
         securityContext:
           privileged: true
+          runAsUser: 0
         resources: {{ toYaml .Values.master.initResources | nindent 10 }}
       {{- end }}
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -14,19 +14,19 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-base # needs root permissions for sysctl changes
-    tag: 3.21.3-5
+    tag: 2025.12.24
     pullPolicy: IfNotPresent
   curator:
     repository: quay.io/astronomer/ap-curator
-    tag: 8.0.21-4
+    tag: 8.0.21-8
     pullPolicy: IfNotPresent
   exporter:
     repository: quay.io/astronomer/ap-elasticsearch-exporter
-    tag: 1.9.0
+    tag: 1.9.0-1
     pullPolicy: IfNotPresent
   nginx:
     repository: quay.io/astronomer/ap-nginx-es
-    tag: 1.29.0
+    tag: 1.29.3
     pullPolicy: IfNotPresent
 
 common:

--- a/charts/external-es-proxy/values.yaml
+++ b/charts/external-es-proxy/values.yaml
@@ -7,11 +7,11 @@ replicaCount: 1
 images:
   esproxy:
     repository: quay.io/astronomer/ap-openresty
-    tag: 1.27.1-6
+    tag: 1.27.1-8
     pullPolicy: IfNotPresent
   awsproxy:
     repository: quay.io/astronomer/ap-awsesproxy
-    tag: 1.5.0-18
+    tag: 1.5.0-22
     pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 10.4.19
+    tag: 12.2.3
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/kibana/values.yaml
+++ b/charts/kibana/values.yaml
@@ -9,7 +9,7 @@ images:
     pullPolicy: IfNotPresent
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.21.3-5
+    tag: 2025.12.24
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -9,7 +9,7 @@ tolerations: []
 images:
   kubeState:
     repository: quay.io/astronomer/ap-kube-state
-    tag: 2.15.0-1
+    tag: 2.17.0-2
     pullPolicy: IfNotPresent
 
 securityContext:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -13,7 +13,7 @@ images:
     pullPolicy: IfNotPresent
   defaultBackend:
     repository: quay.io/astronomer/ap-default-backend
-    tag: 0.28.32
+    tag: 0.29.0
     pullPolicy: IfNotPresent
 
 podSecurityContext: {}

--- a/charts/prometheus-blackbox-exporter/values.yaml
+++ b/charts/prometheus-blackbox-exporter/values.yaml
@@ -12,7 +12,7 @@ strategy:
 
 image:
   repository: quay.io/astronomer/ap-blackbox-exporter
-  tag: 0.26.0
+  tag: 0.26.0-2
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.9.1
+  tag: 1.10.2
   pullPolicy: IfNotPresent
 
 service:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.17.1-2
+  tag: 0.18.1-1
   pullPolicy: IfNotPresent
 
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -18,15 +18,15 @@ replicas: 1
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus
-    tag: 3.5.0
+    tag: 3.5.0-3
     pullPolicy: IfNotPresent
   configReloader:
     repository: quay.io/astronomer/ap-configmap-reloader
-    tag: 0.15.0
+    tag: 0.15.0-1
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.12
+    tag: 0.1.14
     pullPolicy: IfNotPresent
 
 

--- a/charts/stan/templates/statefulset.yaml
+++ b/charts/stan/templates/statefulset.yaml
@@ -68,12 +68,10 @@ spec:
         - name: wait-for-nats-server
           securityContext: {{toYaml .Values.securityContext | nindent 12 }}
           command:
-            - "dockerize"
-          args:
-            - "-wait"
-            - "tcp://{{ .Release.Name }}-nats:4222"
-            - "-timeout"
-            - "1m"
+            - sh
+            - -c
+            - |
+              timeout 60 sh -c 'until nc -z {{ .Release.Name }}-nats 4222; do sleep 1; done'
           image: {{ include "stan.init.image" . }}
           imagePullPolicy: {{ .Values.images.init.pullPolicy }}
           env:

--- a/charts/stan/values.yaml
+++ b/charts/stan/values.yaml
@@ -4,7 +4,7 @@
 images:
   init:
     repository: quay.io/astronomer/ap-init
-    tag: 3.21.3-5
+    tag: 2025.12.24
     pullPolicy: IfNotPresent
   stan:
     repository: quay.io/astronomer/ap-nats-streaming

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -214,25 +214,6 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
     # check that the connection is not reset
     assert "postgres" in result, "Expected to find DB connection string after Houston restart"
 
-
-def test_cve_2021_44228_es_client(es_client):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
-    configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_client.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
-
-
-def test_cve_2021_44228_es_data(es_data):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
-    configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_data.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
-
-
-def test_cve_2021_44228_es_master(es_master):
-    """Ensure the running es process has -Dlog4j2.formatMsgNoLookups=true
-    configured."""
-    assert "-Dlog4j2.formatMsgNoLookups=true" in es_master.check_output("/usr/share/elasticsearch/jdk/bin/jps -lv")
-
-
 def test_kibana_index_pod(kibana_index_pod_client):
     """Check kibana index pod completed successfully"""
     command = ["kubectl -n astronomer logs -f  -lcomponent=kibana-default-index"]

--- a/tests/functional_tests/test_config.py
+++ b/tests/functional_tests/test_config.py
@@ -214,6 +214,7 @@ def test_houston_backend_secret_present_after_helm_upgrade_and_container_restart
     # check that the connection is not reset
     assert "postgres" in result, "Expected to find DB connection string after Houston restart"
 
+
 def test_kibana_index_pod(kibana_index_pod_client):
     """Check kibana index pod completed successfully"""
     command = ["kubectl -n astronomer logs -f  -lcomponent=kibana-default-index"]

--- a/values.yaml
+++ b/values.yaml
@@ -31,7 +31,7 @@ global:
     containerdTolerations: []
     certCopier:
       repository: quay.io/astronomer/ap-base
-      tag: 3.21.3-5
+      tag: 2025.12.24
       pullPolicy: IfNotPresent
     priorityClassName: ~
   # Global flag to enable to user to enable/disable Astronomer platform

--- a/values.yaml
+++ b/values.yaml
@@ -136,7 +136,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.7.2
+    tag: 0.7.5
     securityContexts:
       pod:
         fsGroup: 50000
@@ -160,7 +160,7 @@ global:
     enabled: false
     name: sidecar-log-consumer
     repository: quay.io/astronomer/ap-vector
-    tag: 0.47.0-4
+    tag: 0.52.0
     customConfig: false
     indexPattern: ~
     extraEnv: []
@@ -179,7 +179,7 @@ global:
   authSidecar:
     enabled: false
     repository: quay.io/astronomer/ap-auth-sidecar
-    tag: 1.29.0
+    tag: 1.29.3
     pullPolicy: IfNotPresent
     port: 8084
     securityContext: {}
@@ -310,22 +310,22 @@ global:
     images:
       statsd:
         repository: quay.io/astronomer/ap-statsd-exporter
-        tag: 0.28.0-2
+        tag: 0.28.0-3
       redis:
         repository: quay.io/astronomer/ap-redis
-        tag: 7.4.3
+        tag: 8.0.3-1
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
-        tag: 1.24.1-2
+        tag: 1.24.1-4
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.19.0-3
+        tag: 0.20.0
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 4.4.1-2
       xcom:
         repository: quay.io/astronomer/ap-alpine
-        tag: 3.22.1
+        tag: 3.23.2
   gitSyncRelay:
     images:
       gitDaemon:


### PR DESCRIPTION
## Description

This PR change backports all the CVE fixes we have made so far in the master branch to improve our CVE posture on current active releases

## Related Issues

| imageName | oldTag | newTag |
|--------|--------|--------|
| ap-alertmanager | 0.28.1-3 | 0.30.0 |
| ap-auth-sidecar | 1.29.0 | 1.29.3 |
| ap-awsesproxy | 1.5.0-18 | 1.5.0-22 |
| ap-base | 3.21.3-5 | 2025.12.24 | 
| ap-blackbox-exporter | 0.26.0| 0.26.0-2 | 
| ap-configmap-reloader | 0.15.0 |0.15.0-1 | 
| ap-curator |  8.0.21-4 | 8.0.21-8 | 
| ap-default-backend | 0.28.32 | 0.29.0 | 
| ap-elasticsearch-exporter | 1.9.0 | 1.9.0-1 | 
| ap-grafana |10.4.19  | 12.2.3 |
| ap-init | 3.21.3-5 | 2025.12.24 |
| ap-kube-state | 2.15.0-1 | 2.17.0-2 |
| ap-nginx-es| 1.29.0 | 1.29.3 |
| ap-node-exporter| 1.9.1 | 1.10.2 |
| ap-openresty | 1.27.1-6  | 1.27.1-8 |
| ap-pgbouncer-exporter | 0.19.0-3 |  0.20.0   | 
| ap-pgbouncer |1.24.1-2 |. 1.24.1-4 |
| ap-postgres-exporter| 0.17.1-2 | 0.18.1-1 |
| ap-prometheus | 3.5.0 | 3.5.0-3 |
| ap-redis |7.4.3 | 8.0.3-1 |
| ap-registry| 3.0.0-1 | 3.0.0-5 |
| ap-statsd-exporter| 0.28.0-2 | 0.28.0-3 |
| ap-vector|0.47.0-4 | 0.52.0 |

## Testing

QA should do below validation
- after the upgrade of platform they should see no issues within the core components
-  provisioning an airflow deployment with new images should not cause any restarts or miss in the metrics 
- all the components should be in a running state with no errors
- openshift testing has to be performed for authsidecar image changes

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
