### PR TITLE
update houston api 1.0.47

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.46
+                - quay.io/astronomer/ap-houston-api:1.0.47
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.14

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.46
+    tag: 1.0.47
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api 1.0.47

## Related Issues

- Related https://github.com/astronomer/issues/issues/8157

## Testing

refer above ticket

## Merging

merge to master and release-1.0
