### PR TITLE
Bump Houston to 1.0.48 and Astro UI to 1.0.29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.30.0
-                - quay.io/astronomer/ap-astro-ui:1.0.28
+                - quay.io/astronomer/ap-astro-ui:1.0.29
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.03
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.47
+                - quay.io/astronomer/ap-houston-api:1.0.48
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.14

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.47
+    tag: 1.0.48
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 1.0.28
+    tag: 1.0.29
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

This PR bumps Houston API from 1.0.47 to 1.0.48 and Astro UI from 1.0.28 to 1.0.29.

**Changes:**
- Houston API: `1.0.47` → `1.0.48`
- Astro UI: `1.0.28` → `1.0.29`

## Related Issues

Related https://github.com/astronomer/issues/issues/8154
Related https://github.com/astronomer/issues/issues/8193

## Testing

- Verified Houston API 1.0.48 image is available in quay.io
- Verified Astro UI 1.0.29 image is available in quay.io

## Merging

1.0