### PR TITLE
update commander image version 1.0.27

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.03
-                - quay.io/astronomer/ap-commander:1.0.26
+                - quay.io/astronomer/ap-commander:1.0.27
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-dag-deploy:0.7.5

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.26
+    tag: 1.0.27
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

update commander image version 1.0.27

## Related Issues

- Related https://github.com/astronomer/issues/issues/8252

## Testing

passing below formatted labels will no longer cause any server exception

 "pod-security.kubernetes.io/enforce": "baseline"

## Merging

merge to master and release-1.0
