### PR TITLE
ap-astro-ui 1.0.30, ap-houston-api 1.0.50

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.30.0
-                - quay.io/astronomer/ap-astro-ui:1.0.29
+                - quay.io/astronomer/ap-astro-ui:1.0.30
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.03
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.48
+                - quay.io/astronomer/ap-houston-api:1.0.50
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.14

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.48
+    tag: 1.0.50
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 1.0.29
+    tag: 1.0.30
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

| Image | Before | After |
| --- | --- | --- |
| ap-houston-api | 1.0.48 | 1.0.50 |
| ap-astro-ui | 1.0.29 | 1.0.30 |

## Related Issues

Related astronomer/issues/issues/7773
https://linear.app/astronomer/issue/PLX-112/cluster-is-logging-out-frequently-for-some-time-once-user-creates-new
https://linear.app/astronomer/issue/PLX-106/env-variables-added-twice-and-labels-are-not-added-when-passed-in
https://linear.app/astronomer/issue/PLX-106/env-variables-added-twice-and-labels-are-not-added-when-passed-in

## Testing

N/A

## Merging

1.1.0
