### PR TITLE
airflow-chart version 1.17.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.03
-                - quay.io/astronomer/ap-commander:1.0.27
+                - quay.io/astronomer/ap-commander:1.0.28
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-dag-deploy:0.8.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.17.15
+airflowChartVersion: 1.17.16
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.27
+    tag: 1.0.28
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

Use airflow-chart version 1.17.16. This will need to be run through CI after https://github.com/astronomer/commander/pull/359 is merged.

## Related Issues

- https://github.com/astronomer/issues/issues/8246
- https://linear.app/astronomer/issue/PINF-19/airflow-kubernetes-provider-rbac-update

## Testing

As stated in the airflow-chart PR, no special testing is needed, but QA may need to adjust tests related to specific RBAC roles if they have anything like that.

## Merging

This is only for 1.0.