### PR TITLE
Bump version to 1.1.0-rc5

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 1.1.0-rc4
-appVersion: 1.1.0-rc4
+version: 1.1.0-rc5
+appVersion: 1.1.0-rc5
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 1.1.0-rc4
+version: 1.1.0-rc5
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer


### PR DESCRIPTION
## Description

Release 1.1.0-rc5 release

## Related Issues

UI
https://linear.app/astronomer/issue/PLX-126/cve-2026-0861-trivy-scan-fails-due-to-high-vulnerability-in-glibc-for
https://linear.app/astronomer/issue/PLX-2/extra-capacity-shows-mb-should-show-mi

Houston
https://linear.app/astronomer/issue/PLX-93/apc-ui-deployments-returns-unexpected-inaccurate-results
https://linear.app/astronomer/issue/PINF-20/flower-ingress-is-current-broken-due-to-ingress-policy-violation#comment-42dd92c1
https://linear.app/astronomer/issue/PLX-105/update-apc-email-template-outdated-address-branding
https://github.com/astronomer/issues/issues/7271

## Testing

N/A

## Merging

1.1.0
