### PR TITLE
Bump ap-astro-ui 1.0.31, ap-houston-api 1.0.53

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.52
+                - quay.io/astronomer/ap-houston-api:1.0.53
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.16

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.52
+    tag: 1.0.53
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

| Image | Before | After |
| --- | --- | --- |
| ap-houston-api | 1.0.50 | 1.0.53 |
| ap-astro-ui | 1.0.30 | 1.0.31 |

## Related Issues

UI
https://linear.app/astronomer/issue/PLX-126/cve-2026-0861-trivy-scan-fails-due-to-high-vulnerability-in-glibc-for
https://linear.app/astronomer/issue/PLX-2/extra-capacity-shows-mb-should-show-mi

Houston
https://linear.app/astronomer/issue/PLX-93/apc-ui-deployments-returns-unexpected-inaccurate-results
https://linear.app/astronomer/issue/PINF-20/flower-ingress-is-current-broken-due-to-ingress-policy-violation#comment-42dd92c1
https://linear.app/astronomer/issue/PLX-105/update-apc-email-template-outdated-address-branding
https://github.com/astronomer/issues/issues/7271

## Testing

N/A

## Merging

1.1.0
