### PR TITLE
PINF-189 - ap-dag-deploy:0.9.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:1.0.29
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
-                - quay.io/astronomer/ap-dag-deploy:0.8.1
+                - quay.io/astronomer/ap-dag-deploy:0.9.0
                 - quay.io/astronomer/ap-db-bootstrapper:1.0.5
                 - quay.io/astronomer/ap-default-backend:0.29.0
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1

--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.8.1
+    tag: 0.9.0
     securityContexts:
       pod:
         fsGroup: 50000


### PR DESCRIPTION
## Description

- Solve log spamming bug in ap-dag-deploy
- dag-deploy component supports k8s 1.35

## Related Issues

- <https://github.com/astronomer/issues/issues/8275>
- <https://linear.app/astronomer/issue/PINF-189/dag-downloader-emitting-excessive-logs-before-first-deploy>
- <https://github.com/astronomer/issues/issues/8272>
- <https://linear.app/astronomer/issue/APC-1088/support-kubernetes-135>

## Testing

Since this is a decent refactor, and since we've had a few bugs with dag-deploy, it would be a good idea to run all of our tests. The overall behavior on the application has not changed, just the implementation details, so all existing tests should still be valid.

## Merging

This should go into both 1.1.0 and 0.37.7