### PR TITLE
Bump ap-commander to 1.0.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.24
-                - quay.io/astronomer/ap-commander:1.0.29
+                - quay.io/astronomer/ap-commander:1.0.30
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-dag-deploy:0.9.0

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.29
+    tag: 1.0.30
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

| Before | After |
| --- | --- |
| 1.0.29 | 1.0.30

## Related Issues

https://github.com/astronomer/commander/pull/362

## Testing

QA

## Merging

1.1.0
