### PR TITLE
PINF-194 - fix nginx cache volumes for authsidecar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.54
+                - quay.io/astronomer/ap-houston-api:1.0.55
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.16
@@ -431,7 +431,7 @@ workflows:
                 - quay.io/astronomer/ap-openresty:1.27.1-8
                 - quay.io/astronomer/ap-pgbouncer-exporter:0.20.0-1
                 - quay.io/astronomer/ap-pgbouncer-krb:1.25.0-3
-                - quay.io/astronomer/ap-pgbouncer:1.25.0-1
+                - quay.io/astronomer/ap-pgbouncer:1.24.1-4
                 - quay.io/astronomer/ap-postgres-exporter:0.18.1-1
                 - quay.io/astronomer/ap-postgresql:17.7.0
                 - quay.io/astronomer/ap-prometheus:3.8.1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.54
+    tag: 1.0.55
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/values.yaml
+++ b/values.yaml
@@ -310,7 +310,7 @@ global:
         tag: 8.0.3-1
       pgbouncer:
         repository: quay.io/astronomer/ap-pgbouncer
-        tag: 1.25.0-1
+        tag: 1.24.1-4
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
         tag: 0.20.0-1


### PR DESCRIPTION
## Description

PINF-194 - fix nginx cache volumes for authsidecar

## Related Issues

[PINF-194 extraVolumes are missing for the auth sidecar config, and it's causing the creation of a deployment.](https://linear.app/astronomer/issue/PINF-194/extravolumes-are-missing-for-the-auth-sidecar-config-and-its-causing)

## Testing

QA should able to create authsidecar based deployments

## Merging

merge to master and release-1.0
