### PR TITLE
Bump ap-houston-api to 1.0.56

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -420,7 +420,7 @@ workflows:
                 - quay.io/astronomer/ap-git-sync-relay:0.2.3
                 - quay.io/astronomer/ap-git-sync:2025.12.24
                 - quay.io/astronomer/ap-grafana:12.2.3
-                - quay.io/astronomer/ap-houston-api:1.0.55
+                - quay.io/astronomer/ap-houston-api:1.0.56
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
                 - quay.io/astronomer/ap-kuiper-reloader:0.1.16

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.0.55
+    tag: 1.0.56
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

| Before | After |
| --- | --- |
| 1.0.55 | 1.0.56

## Related Issues

https://github.com/astronomer/issues/issues/8153

## Testing

QA

## Merging

1.1.0
