### PR TITLE
ap-dag-deploy:0.9.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,7 +411,7 @@ workflows:
                 - quay.io/astronomer/ap-commander:1.0.31
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
-                - quay.io/astronomer/ap-dag-deploy:0.9.1
+                - quay.io/astronomer/ap-dag-deploy:0.9.2
                 - quay.io/astronomer/ap-db-bootstrapper:1.0.5
                 - quay.io/astronomer/ap-default-backend:0.29.0
                 - quay.io/astronomer/ap-elasticsearch-exporter:1.9.0-1

--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ global:
   dagOnlyDeployment:
     enabled: false
     repository: quay.io/astronomer/ap-dag-deploy
-    tag: 0.9.1
+    tag: 0.9.2
     securityContexts:
       pod:
         fsGroup: 50000


### PR DESCRIPTION
## Description

- ap-dag-deploy:v0.9.2 which solves 410 from the expired watch Traceback.

## Related Issues

- <https://linear.app/astronomer/issue/PINF-220>

## Testing

I have manually deployed this image to a cluster and observed the fixed behavior.

## Merging

This is for 1.1.0 and 0.37.7