### PR TITLE
PINF-76  fix af3 cleanup support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ workflows:
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.24
-                - quay.io/astronomer/ap-commander:1.0.31
+                - quay.io/astronomer/ap-commander:1.0.32
                 - quay.io/astronomer/ap-configmap-reloader:0.15.0-1
                 - quay.io/astronomer/ap-curator:8.0.21-8
                 - quay.io/astronomer/ap-dag-deploy:0.9.2

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.0.31
+    tag: 1.0.32
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

Add airflow3 db cleanup support

## Related Issues

 https://linear.app/astronomer/issue/PINF-76/optimize-airflow-db-clean-up-job-resource-consumption

## Testing

QA should able to triggerer cleanup on airflow3 deployment

## Merging

merge to master and release-1.x
