### PR TITLE
Bump astro UI to 1.0.33

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -404,7 +404,7 @@ workflows:
               docker_image:
                 - quay.io/astronomer/airflow-operator-controller:1.5.2
                 - quay.io/astronomer/ap-alertmanager:0.30.0
-                - quay.io/astronomer/ap-astro-ui:1.0.32
+                - quay.io/astronomer/ap-astro-ui:1.0.33
                 - quay.io/astronomer/ap-auth-sidecar:1.29.3
                 - quay.io/astronomer/ap-awsesproxy:1.5.0-22
                 - quay.io/astronomer/ap-base:2025.12.24

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 1.0.32
+    tag: 1.0.33
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Bump astro UI to 1.0.33

## Related Issues

https://linear.app/astronomer/issue/PLX-131/deployrollback-enabledisable-option-is-not-showing-up-in-ui

## Merging

1.0