### PR TITLE
PINF-176 kuiper-reloader 0.1.17 with k8s 1.35 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,7 +450,7 @@ workflows:
                 - quay.io/astronomer/ap-houston-api:1.0.58
                 - quay.io/astronomer/ap-init:2025.12.24
                 - quay.io/astronomer/ap-kube-state:2.17.0-2
-                - quay.io/astronomer/ap-kuiper-reloader:0.1.16
+                - quay.io/astronomer/ap-kuiper-reloader:0.1.17
                 - quay.io/astronomer/ap-nats-exporter:0.17.3-1
                 - quay.io/astronomer/ap-nats-server:2.12.2
                 - quay.io/astronomer/ap-nginx-es:1.29.4

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.16
+    tag: 0.1.17
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

kuiper-reloader 0.1.17 with k8s 1.35 support, which is the last component that needed to be upgraded to 1.35.

## Related Issues

https://linear.app/astronomer/issue/PINF-176/support-kubernetes-135

## Testing

Tests have passed, but I have not deployed this into a k8s cluster.

## Merging

This should be merged to all supported branches.