### PR TITLE
PINF-290 - Adds mysql airflow database support in local CP/DP setup

### DIFF
--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -666,7 +666,7 @@ elasticsearch:
 """
 
 
-MYSQL_ROOT_PASSWORD = "rootpassword"
+MYSQL_ROOT_PASSWORD = os.environ.get("MYSQL_ROOT_PASSWORD", "rootpassword")
 MYSQL_IMAGE = "mysql:8.0"
 
 
@@ -753,8 +753,13 @@ def _deploy_mysql(*, context: str, namespace: str, release_name: str) -> None:
     _print(f"Waiting for MySQL pod to become ready ({svc_name})")
     _run(
         [
-            "kubectl", "--context", context, "-n", namespace,
-            "wait", "--for=condition=available",
+            "kubectl",
+            "--context",
+            context,
+            "-n",
+            namespace,
+            "wait",
+            "--for=condition=available",
             f"deployment/{svc_name}",
             "--timeout=180s",
         ],
@@ -762,19 +767,26 @@ def _deploy_mysql(*, context: str, namespace: str, release_name: str) -> None:
     )
 
 
-def _create_astronomer_bootstrap_secret_mysql(
-    *, context: str, namespace: str, release_name: str
-) -> None:
+def _create_astronomer_bootstrap_secret_mysql(*, context: str, namespace: str, release_name: str) -> None:
     """Create (or update) the astronomer-bootstrap secret with a MySQL connection string."""
     svc_name = _mysql_service_name(release_name)
     conn = f"mysql://root:{MYSQL_ROOT_PASSWORD}@{svc_name}.{namespace}.svc.cluster.local:3306"
 
     secret_yaml = _run(
         [
-            "kubectl", "--context", context, "-n", namespace,
-            "create", "secret", "generic", "astronomer-bootstrap",
+            "kubectl",
+            "--context",
+            context,
+            "-n",
+            namespace,
+            "create",
+            "secret",
+            "generic",
+            "astronomer-bootstrap",
             f"--from-literal=connection={conn}",
-            "--dry-run=client", "-o", "yaml",
+            "--dry-run=client",
+            "-o",
+            "yaml",
         ],
         check=True,
     ).stdout
@@ -1129,7 +1141,9 @@ def main() -> int:  # noqa: C901
 
             h = ms.start("Create astronomer-bootstrap secret (MySQL) in DP")
             _create_astronomer_bootstrap_secret_mysql(
-                context=dp_context, namespace=settings.namespace, release_name=settings.release_name,
+                context=dp_context,
+                namespace=settings.namespace,
+                release_name=settings.release_name,
             )
             ms.done(h)
 


### PR DESCRIPTION
## Description

This PR adds mysql airflow database support in local CP/DP setup.

Command to create mysql db:
```
python3 bin/setup-cp-dp-k3d.py --skip-certs --dp-airflow-db=mysql
```

## Related Issues

https://linear.app/astronomer/issue/PINF-290/create-a-fully-local-dev-environment-for-apc

## Testing

Tested locally
<img width="1447" height="455" alt="Screenshot 2026-03-03 at 5 34 37 PM" src="https://github.com/user-attachments/assets/69fcdf34-6583-47ec-8286-9eb0387689e1" />



<img width="1723" height="478" alt="Screenshot 2026-03-03 at 5 34 22 PM" src="https://github.com/user-attachments/assets/39017ff3-7260-4c95-b2a1-32cf21384618" />

## Merging
main