### PR TITLE
PINF-347: Fix PostgreSQL StatefulSet upgrade failure with Chainguard image

### DIFF
--- a/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/charts/postgresql/templates/statefulset-slaves.yaml
@@ -163,6 +163,8 @@ spec:
           successThreshold: 1
         {{- end }}
         volumeMounts:
+        - name: pg-conf
+          mountPath: /var/run/postgresql
         {{- if .Values.persistence.enabled }}
         - name: data
           mountPath: {{ .Values.persistence.mountPath }}
@@ -172,6 +174,8 @@ spec:
         {{- toYaml .Values.slave.extraVolumeMounts | nindent 8 }}
         {{- end }}
       volumes:
+      - name: pg-conf
+        emptyDir: {}
       {{- if .Values.usePasswordFile }}
       - name: postgresql-password
         secret:

--- a/charts/postgresql/templates/statefulset.yaml
+++ b/charts/postgresql/templates/statefulset.yaml
@@ -169,6 +169,8 @@ spec:
           successThreshold: 1
         {{- end }}
         volumeMounts:
+        - mountPath: /var/run/postgresql
+          name: pg-conf
         - mountPath: /tmp
           name: tmp
         {{- if or (.Files.Glob "files/docker-entrypoint-initdb.d/*.{sh,sql,sql.gz}") .Values.initdbScriptsConfigMap .Values.initdbScripts }}

--- a/tests/chart_tests/test_postgres.py
+++ b/tests/chart_tests/test_postgres.py
@@ -31,6 +31,7 @@ class TestPostgresql:
         assert len(sts["spec"]["template"]["spec"]["containers"]) == 1
         containers = get_containers_by_name(doc=sts, include_init_containers=True)
         assert containers["release-name-postgresql"]["volumeMounts"] == [
+            {"mountPath": "/var/run/postgresql", "name": "pg-conf"},
             {"mountPath": "/tmp", "name": "tmp"},
             {"name": "data", "mountPath": "/bitnami/postgresql", "subPath": None},
         ]


### PR DESCRIPTION
## Description

This PR fixes an issue where upgrading from 1.0.1 to 1.1.0/1.1.1 with in-cluster PostgreSQL enabled fails with:
```
chmod: /var/run/postgresql: Read-only file system
PostgreSQL Database directory appears to contain a database; Skipping initialization
postgres: could not access the server configuration file "/bitnami/postgresql/data/postgresql.conf": No such file or directory
```

## Related Issues

https://linear.app/astronomer/issue/PINF-347/add-readonlyrootfilesystem-volume-mounts-for-internal-postgresql

## Testing

- This issue only hapenned during upgrade.

## Merging

Master, 1.0