### PR TITLE
PINF-357: Added a headless service for commander

### DIFF
--- a/charts/astronomer/templates/commander/commander-service-headless.yaml
+++ b/charts/astronomer/templates/commander/commander-service-headless.yaml
@@ -1,0 +1,33 @@
+################################
+## Commander Headless Service ##
+################################
+{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-commander-headless
+  labels:
+    component: commander
+    tier: astronomer
+    release: {{ .Release.Name }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    heritage: {{ .Release.Service }}
+    plane: {{ .Values.global.plane.mode }}
+  {{ if .Values.global.enableArgoCDAnnotation }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+  {{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    component: commander
+    tier: astronomer
+    release: {{ .Release.Name }}
+  ports:
+    - name: commander-grpc
+      protocol: TCP
+      port: {{ .Values.ports.commanderGRPC }}
+      targetPort: {{ .Values.ports.commanderGRPC }}
+      appProtocol: grpc
+{{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -715,3 +715,82 @@ class TestAstronomerCommander:
                 "name": "release-name-flightdeck-backend",
                 "key": "connection",
             }
+
+    @pytest.mark.parametrize(
+        "plane_mode,should_render",
+        [
+            ("data", True),
+            ("unified", True),
+            ("control", False),
+        ],
+    )
+    def test_commander_headless_service_plane_modes(self, kube_version, plane_mode, should_render):
+        """Test that the headless service renders only for data and unified plane modes."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": plane_mode}}},
+            show_only=["charts/astronomer/templates/commander/commander-service-headless.yaml"],
+        )
+
+        if not should_render:
+            assert len(docs) == 0
+            return
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Service"
+        assert doc["apiVersion"] == "v1"
+        assert doc["metadata"]["name"] == "release-name-commander-headless"
+        assert doc["spec"]["clusterIP"] == "None"
+        assert doc["spec"]["type"] == "ClusterIP"
+
+        assert doc["spec"]["selector"] == {
+            "component": "commander",
+            "tier": "astronomer",
+            "release": "release-name",
+        }
+
+        ports = doc["spec"]["ports"]
+        assert len(ports) == 1
+        assert ports[0]["name"] == "commander-grpc"
+        assert ports[0]["port"] == 50051
+        assert ports[0]["targetPort"] == 50051
+        assert ports[0]["protocol"] == "TCP"
+        assert ports[0]["appProtocol"] == "grpc"
+
+    def test_commander_headless_service_labels(self, kube_version):
+        """Test that the headless service has correct labels."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=["charts/astronomer/templates/commander/commander-service-headless.yaml"],
+        )
+
+        assert len(docs) == 1
+        labels = docs[0]["metadata"]["labels"]
+        assert labels["component"] == "commander"
+        assert labels["tier"] == "astronomer"
+        assert labels["release"] == "release-name"
+        assert labels["plane"] == "data"
+
+    def test_commander_headless_service_argocd_annotation(self, kube_version):
+        """Test that the headless service includes ArgoCD annotation when enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "unified"}, "enableArgoCDAnnotation": True}},
+            show_only=["charts/astronomer/templates/commander/commander-service-headless.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["metadata"]["annotations"]["argocd.argoproj.io/sync-wave"] == "-1"
+
+    def test_commander_headless_service_no_argocd_annotation_by_default(self, kube_version):
+        """Test that the headless service does not include ArgoCD annotation by default."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=["charts/astronomer/templates/commander/commander-service-headless.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "annotations" not in docs[0]["metadata"]


### PR DESCRIPTION
## Description

Added a headless service for commander and tests for it

## Related Issues

[PINF-357: Update commander helm chart to add a headless service](https://linear.app/astronomer/issue/PINF-357/update-commander-helm-chart-to-add-a-headless-service)

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
