### PR TITLE
Rework bin/setup-cp-dp-k3d.py

### DIFF
--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -997,7 +997,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--docker-network", default="astronomer-net")
     parser.add_argument("--cp-cluster-name", default="control")
     parser.add_argument(
-        "--data-plane-count",
+        "--dp-count",
         type=int,
         default=1,
         help="Number of data plane clusters to create. Clusters are named data-1, data-2, … Default: '%(default)s'",
@@ -1086,7 +1086,7 @@ def main() -> int:  # noqa: C901
             https_port=args.dp_base_https_port + (i - 1),
             http_port=args.dp_base_http_port + (i - 1),
         )
-        for i in range(1, args.data_plane_count + 1)
+        for i in range(1, args.dp_count + 1)
     )
 
     settings = Settings(


### PR DESCRIPTION
## Description

Rework bin/setup-cp-dp-k3d.py to:
- Support multiple dataplanes with `--dp-count`
- Support installing CP in control mode with `--cp-mode [unified | control]`
- Not explicitly turn on certain components that can be toggled with tags
- Use a single database for all planes, which also exposes the db to the local machine
- Allow specifying multiple helm values files with `--helm-values foo.yaml --helm-values bar.yaml`

```
$ bin/setup-cp-dp-k3d.py --help
usage: setup-cp-dp-k3d.py [-h] [--base-domain BASE_DOMAIN] [--namespace NAMESPACE] [--release-name RELEASE_NAME] [--docker-network DOCKER_NETWORK]
                          [--cp-cluster-name CP_CLUSTER_NAME] [--dp-count DP_COUNT] [--cp-mode CP_MODE] [--cp-https-port CP_HTTPS_PORT]
                          [--cp-http-port CP_HTTP_PORT] [--dp-base-https-port DP_BASE_HTTPS_PORT] [--dp-base-http-port DP_BASE_HTTP_PORT]
                          [--tls-secret-name TLS_SECRET_NAME] [--mkcert-root-ca-secret-name MKCERT_ROOT_CA_SECRET_NAME]
                          [--mkcert-root-ca-secret-key MKCERT_ROOT_CA_SECRET_KEY] [--helm-timeout HELM_TIMEOUT] [--helm-debug] [--helm-deps-update]
                          [--recreate-clusters] [--skip-certs] [--skip-clusters] [--skip-secrets] [--skip-helm] [--skip-dns-reconcile]
                          [--skip-node-registry-check] [--values-dir VALUES_DIR] [--helm-values FILE] [--dp-airflow-db {postgres,mysql}]

Automate Astronomer CP/DP local setup using k3d.

options:
  -h, --help            show this help message and exit
  --base-domain BASE_DOMAIN
  --namespace NAMESPACE
  --release-name RELEASE_NAME
  --docker-network DOCKER_NETWORK
  --cp-cluster-name CP_CLUSTER_NAME
  --dp-count DP_COUNT   Number of data plane clusters to create. Clusters are named data-1, data-2, … Default: '1'
  --cp-mode CP_MODE     Control plane mode to install (unified, control) Default: 'unified'
  --cp-https-port CP_HTTPS_PORT
                        Control plane HTTPS port. Default: '8443'
  --cp-http-port CP_HTTP_PORT
                        Control plane HTTP port. Default: '8080'
  --dp-base-https-port DP_BASE_HTTPS_PORT
                        Base HTTPS port for the first data plane; subsequent data planes increment by 1. Default: '8444'
  --dp-base-http-port DP_BASE_HTTP_PORT
                        Base HTTP port for the first data plane; subsequent data planes increment by 1. Default: '8081'
  --tls-secret-name TLS_SECRET_NAME
  --mkcert-root-ca-secret-name MKCERT_ROOT_CA_SECRET_NAME
  --mkcert-root-ca-secret-key MKCERT_ROOT_CA_SECRET_KEY
  --helm-timeout HELM_TIMEOUT
  --helm-debug
  --helm-deps-update    Run `helm dependency update` before installing (off by default; local charts are already vendored).
  --recreate-clusters   Delete and recreate k3d clusters if they exist
  --skip-certs
  --skip-clusters
  --skip-secrets
  --skip-helm
  --skip-dns-reconcile
  --skip-node-registry-check
                        Skip DP node /etc/hosts pin + registry authorization endpoint check.
  --values-dir VALUES_DIR
                        Directory to write cp-values.yaml + dp-<name>-values.yaml files. Defaults to a temp directory.
  --helm-values FILE    Extra Helm values file passed to both CP and DP installs (can be repeated).
  --dp-airflow-db {postgres,mysql}
                        Database type for Airflow deployments on the data plane (default: postgres).
```

## Related Issues

This work came out of https://linear.app/astronomer/issue/PINF-378/test-flight-lifecycle-from-navigator-to-cp-and-back-to-navigator which required these changes in order to complete.

## Testing

I have been testing this on postgres with multiple DPs. I have not tested mysql.

## Merging

This should only go into >= 0.x