### PR TITLE
Relax PR description rule for automated PRs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -36,7 +36,7 @@ jobs:
             ((errors += 1))
           fi
 
-          if [[ "${KTLO}" != "true" ]] && [[ "${AUTOMATED_PR}" != "true" ]] && [[ "${PR_BODY}" != *"astronomer/issues"* && "${PR_BODY}" != *"PINF-"* && "${PR_BODY}" != *"APC-"* ]] ; then
+          if [[ "${KTLO}" != "true" ]] && [[ "${AUTOMATED_PR}" != "true" ]] && [[ "${PR_BODY}" != *"astronomer/issues"* && "${PR_BODY}" != *"PINF-"* && "${PR_BODY}" != *"APC-"* && "${PR_BODY}" != *"PLA-"* ]] ; then
             echo "PR description does not contain an issue link"
             ((errors += 1))
           fi


### PR DESCRIPTION
## Description

Relax PR description validation for automated PRs by skipping the issue link requirement when the `automated-pr` label is present, similar to how KTLO PRs are handled.

PRs from APC BOT will be created with `automated-pr` label and will not have any related issues.

## Related Issues

https://linear.app/astronomer/issue/PLA-143/update-images-in-astronomerastronomer-chart

## Testing

NA

## Merging

NA
