### PR TITLE
PINF-217: nil value bug fix

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -753,7 +753,7 @@ Uses randBytes 32 (base64-encoded 32 random bytes) to match the
 entropy of a Fernet key.
 */}}
 {{- define "astronomer.internalServiceToken" -}}
-  {{- if .Values.global.internalServiceAuth.token -}}
+  {{- if and .Values.global.internalServiceAuth .Values.global.internalServiceAuth.token -}}
     {{- .Values.global.internalServiceAuth.token -}}
   {{- else -}}
     {{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-internal-service-auth" .Release.Name) -}}


### PR DESCRIPTION
## Description

Running helm upgrade on astronomer chart with --reuse-values passes a nil value if the release was initially installed from a chart version that didn't have the keyglobal.internalServiceAuth defined. Added a nil-safe check to avoid this so that it creates a new token since it doesn't exist.

## Related Issues

[PINF-217: Implement Authz mechanism for DP local unary gRPC calls](https://linear.app/astronomer/issue/PINF-217/implement-authz-mechanism-for-dp-local-unary-grpc-calls)

Related astronomer/issues#XXXX

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
