### PR TITLE
PLX-301: Add securityContext override for openshift in Gitsync Relay

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -278,7 +278,11 @@ data:
               repository: {{ .Values.global.gitSyncRelay.images.gitSync.repository }}
               tag: {{ .Values.global.gitSyncRelay.images.gitSync.tag }}
           {{ if .Values.global.openshift.enabled }}
+          securityContext: {}
           gitDaemon:
+            securityContext:
+                runAsNonRoot: true
+          gitSync:
             securityContext:
                 runAsNonRoot: true
           {{ end }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -277,6 +277,10 @@ data:
             gitSync:
               repository: {{ .Values.global.gitSyncRelay.images.gitSync.repository }}
               tag: {{ .Values.global.gitSyncRelay.images.gitSync.tag }}
+          {{ if .Values.global.openshift.enabled }}
+          securityContext:
+              runAsNonRoot: true
+          {{ end }}
 
 
         airflow:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -278,8 +278,9 @@ data:
               repository: {{ .Values.global.gitSyncRelay.images.gitSync.repository }}
               tag: {{ .Values.global.gitSyncRelay.images.gitSync.tag }}
           {{ if .Values.global.openshift.enabled }}
-          securityContext:
-              runAsNonRoot: true
+          gitDaemon:
+            securityContext:
+                runAsNonRoot: true
           {{ end }}
 
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -281,9 +281,11 @@ data:
           securityContext: {}
           gitDaemon:
             securityContext:
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
           gitSync:
             securityContext:
+                readOnlyRootFilesystem: true
                 runAsNonRoot: true
           {{ end }}
 

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -119,5 +119,22 @@ class TestOpenshift:
             "readOnlyRootFilesystem": True,
             "runAsNonRoot": True,
         }
+    def test_openshift_disabled_houston_configmap_gitsyncrelay_no_security_overrides(self, kube_version):
+        """Validate gitSyncRelay has no securityContext overrides when openshift is disabled."""
+        docs = render_chart(
+            values={
+                "global": {"openshift": {"enabled": False}},
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+        gitSyncRelayConfig = prod["deployments"]["helm"]["gitSyncRelay"]
+
+        assert "securityContext" not in gitSyncRelayConfig
+        assert "gitDaemon" not in gitSyncRelayConfig
+        assert "gitSync" not in gitSyncRelayConfig
 
     

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -95,3 +95,29 @@ class TestOpenshift:
 
         gitSyncConfig = airflowConfig["dags"]["gitSync"]
         assert {"runAsNonRoot": True} == gitSyncConfig["securityContexts"]["container"]
+
+    def test_openshift_flag_defaults_with_enabled_and_validate_houston_configmap_gitsyncrelay(self, kube_version):
+        """Validate gitSyncRelay securityContext in houston configmap when openshift is enabled."""
+        docs = render_chart(
+            values={
+                "global": {"openshift": {"enabled": True}},
+            },
+            show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        prod = yaml.safe_load(doc["data"]["production.yaml"])
+
+        gitSyncRelayConfig = prod["deployments"]["helm"]["gitSyncRelay"]
+
+        assert gitSyncRelayConfig["securityContext"] == {}
+        assert gitSyncRelayConfig["gitDaemon"]["securityContext"] == {
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+        }
+        assert gitSyncRelayConfig["gitSync"]["securityContext"] == {
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+        }
+
+    

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -119,6 +119,7 @@ class TestOpenshift:
             "readOnlyRootFilesystem": True,
             "runAsNonRoot": True,
         }
+
     def test_openshift_disabled_houston_configmap_gitsyncrelay_no_security_overrides(self, kube_version):
         """Validate gitSyncRelay has no securityContext overrides when openshift is disabled."""
         docs = render_chart(
@@ -136,5 +137,3 @@ class TestOpenshift:
         assert "securityContext" not in gitSyncRelayConfig
         assert "gitDaemon" not in gitSyncRelayConfig
         assert "gitSync" not in gitSyncRelayConfig
-
-    


### PR DESCRIPTION
## Description

This PR overrides security context sent by airflow. chart for openshift setup in gitsyncrelay setup.

## Related Issues

https://linear.app/astronomer/issue/PLX-301/gitsync-tests-failing-with-some-env-dollargit-sync-add-user-has-been

## Testing

- Added the config in openshift cluster:
<img width="827" height="584" alt="Screenshot 2026-04-13 at 6 55 47 PM" src="https://github.com/user-attachments/assets/03e23830-4e4c-4df6-bcd6-24f40762c0ed" />

- All pods and deployment came up fine:
<img width="1440" height="426" alt="image" src="https://github.com/user-attachments/assets/1fcf5830-0c76-486a-b3fb-faec11d68cf3" />


- Dags are also present:
<img width="1346" height="602" alt="image" src="https://github.com/user-attachments/assets/f8cd2fa9-e30f-4d74-b9d7-c9e1880465bc" />


## Merging

Master, 2.0