### PR TITLE
PLX-300: use cspPolicy.cdn.enabled for CDN CSP toggle

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -466,6 +466,28 @@ def apply_houston_deployment_migrations(root: CommentedMap) -> list[MigrationCha
     return all_changes
 
 
+def apply_nginx_csp_policy_migrations(root: CommentedMap) -> list[MigrationChange]:
+    """Migrate ``nginx.cspPolicy.cdnEnabled`` to ``nginx.cspPolicy.cdn.enabled``.
+
+    Aligns customer Helm overrides with chart 2.x / PLX-300 unified nested
+    ``.enabled`` shape under ``nginx.cspPolicy``.
+
+    Parameters:
+        root: The parsed YAML document root.
+
+    Returns:
+        Migration changes applied under ``nginx.cspPolicy``, if any.
+    """
+    nginx = _get_nested_mapping(root, ["nginx"])
+    if nginx is None:
+        return []
+    csp_policy = _get_nested_mapping(nginx, ["cspPolicy"])
+    if csp_policy is None:
+        return []
+    rule = BoolToNested("cdnEnabled", ["cdn", "enabled"], path_prefix="nginx.cspPolicy")
+    return rule.apply(csp_policy)
+
+
 def apply_houston_config_flag_migrations(root: CommentedMap) -> list[MigrationChange]:
     """Apply Houston ``config`` flag migrations (flat booleans -> nested ``.enabled``).
 

--- a/bin/migrate-helm-chart-values-037x-to-2x.py
+++ b/bin/migrate-helm-chart-values-037x-to-2x.py
@@ -38,6 +38,7 @@ from helm_chart_values_migration_shared import (  # noqa: E402
     apply_global_feature_flag_rules,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
+    apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
 )
@@ -358,6 +359,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
 
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
+    all_changes.extend(apply_nginx_csp_policy_migrations(data))
 
     return all_changes
 

--- a/bin/migrate-helm-chart-values-1x-to-2x.py
+++ b/bin/migrate-helm-chart-values-1x-to-2x.py
@@ -39,6 +39,7 @@ from helm_chart_values_migration_shared import (  # noqa: E402
     apply_global_feature_flag_rules,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
+    apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
 )
@@ -66,6 +67,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_global_feature_flag_rules(global_cm))
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
+    all_changes.extend(apply_nginx_csp_policy_migrations(data))
 
     return all_changes
 

--- a/charts/nginx/templates/controlplane/nginx-cp-headers-configmap.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-headers-configmap.yaml
@@ -2,7 +2,13 @@
 ## NGINX Control Plane ConfigMap ##
 ###################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- $cspPolicyEnabled :=  .Values.cspPolicy.cdnEnabled }}
+{{- $cdn := .Values.cspPolicy.cdn | default dict }}
+{{- $cspPolicyEnabled := true }}
+{{- if hasKey $cdn "enabled" }}
+{{- $cspPolicyEnabled = $cdn.enabled }}
+{{- else if hasKey .Values.cspPolicy "cdnEnabled" }}
+{{- $cspPolicyEnabled = .Values.cspPolicy.cdnEnabled }}
+{{- end }}
 {{- $connectsrc :=  eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
 {{- $fontsrc := eq $cspPolicyEnabled true| ternary .Values.cspPolicy.fontsrc "" }}
 {{- $scriptsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.scriptsrc "" }}

--- a/charts/nginx/templates/dataplane/nginx-dp-headers-configmap.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-headers-configmap.yaml
@@ -2,7 +2,13 @@
 ## NGINX Data Plane ConfigMap ##
 ################################
 {{- if eq .Values.global.plane.mode "data" }}
-{{- $cspPolicyEnabled :=  .Values.cspPolicy.cdnEnabled }}
+{{- $cdn := .Values.cspPolicy.cdn | default dict }}
+{{- $cspPolicyEnabled := true }}
+{{- if hasKey $cdn "enabled" }}
+{{- $cspPolicyEnabled = $cdn.enabled }}
+{{- else if hasKey .Values.cspPolicy "cdnEnabled" }}
+{{- $cspPolicyEnabled = .Values.cspPolicy.cdnEnabled }}
+{{- end }}
 {{- $connectsrc :=  eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
 {{- $fontsrc := eq $cspPolicyEnabled true| ternary .Values.cspPolicy.fontsrc "" }}
 {{- $scriptsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.scriptsrc "" }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -139,7 +139,8 @@ defaultBackend:
     name: ~
 
 cspPolicy:
-  cdnEnabled: true
+  cdn:
+    enabled: true
   connectsrc: "cdn.jsdelivr.net"
   fontsrc: "fonts.gstatic.com"
   scriptsrc: "fonts.googleapis.com cdn.jsdelivr.net"

--- a/docs/upgrade-values-migration-037x-to-2x.md
+++ b/docs/upgrade-values-migration-037x-to-2x.md
@@ -297,6 +297,15 @@ environment.**
 | `nats.init.resources.limits.cpu` | `"250m"` | NATS init container CPU limit. | Override if your cluster needs different resource settings. |
 | `nats.init.resources.limits.memory` | `"100Mi"` | NATS init container memory limit. | Override if your cluster needs different resource settings. |
 
+### Nginx Content-Security-Policy (CDN) toggle
+
+If your override sets `nginx.cspPolicy.cdnEnabled`, the migration script
+rewrites it to `nginx.cspPolicy.cdn.enabled` (same as chart 2.x / PLX-300).
+
+| Old Path | New Path |
+|---|---|
+| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.cdn.enabled` |
+
 ### Unchanged Keys (No Migration Needed)
 
 These keys already use the correct schema and are not modified:
@@ -314,7 +323,8 @@ These keys already use the correct schema and are not modified:
 - `global.airflow.*`
 - `global.gitSyncRelay.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- All keys under `nginx`, `grafana`, `prometheus`,
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, migrated as
+  above), `grafana`, `prometheus`,
   `elasticsearch`, `kube-state`, `nats` (except init resources)
 
 ## Rollback

--- a/docs/upgrade-values-migration.md
+++ b/docs/upgrade-values-migration.md
@@ -126,6 +126,15 @@ include `emailConfirmation` → `emailConfirmation.enabled` and
 Run `./bin/migrate-helm-chart-values-1x-to-2x.py --dry-run your-values.yaml`
 to see the exact list for your file.
 
+### Nginx Content-Security-Policy (CDN) toggle
+
+If your override sets the flat CDN toggle under `nginx.cspPolicy`, the
+migration script rewrites it to the nested `.enabled` shape (see PLX-300):
+
+| Old Path | New Path | Type |
+|---|---|---|
+| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.cdn.enabled` | boolean → nested |
+
 ### Houston Config Passthrough Keys
 
 If your values file overrides Houston application config via
@@ -160,7 +169,8 @@ These keys already use the correct schema and are not modified:
 - `global.authSidecar.*`
 - `global.airflowOperator.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- All keys under `nginx`, `grafana`, `prometheus`,
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, which is
+  migrated as described above), `grafana`, `prometheus`,
   `elasticsearch`, `vector`, `kube-state`, `nats`, `tags`
 
 ## Rollback

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -254,10 +254,7 @@ class TestNginxCspPolicyMigration:
         assert result["nginx"]["cspPolicy"]["cdn"]["enabled"] is False
         assert "cdnEnabled" not in result["nginx"]["cspPolicy"]
         assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
-        assert any(
-            c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.cdn.enabled"
-            for c in changes
-        )
+        assert any(c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.cdn.enabled" for c in changes)
 
     def test_no_op_when_csp_policy_missing(self) -> None:
         """No nginx.cspPolicy section produces no nginx CSP migration changes."""

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -236,6 +236,55 @@ class TestBoolToNested:
         assert len(changes) == 1
 
 
+class TestNginxCspPolicyMigration:
+    """``nginx.cspPolicy.cdnEnabled`` -> ``nginx.cspPolicy.cdn.enabled`` (PLX-300)."""
+
+    def test_migrates_cdn_enabled_to_nested(self) -> None:
+        """Full migrate_values rewrites flat cdnEnabled under nginx.cspPolicy."""
+        data = _load_rt(
+            dedent("""\
+                nginx:
+                  cspPolicy:
+                    cdnEnabled: false
+                    connectsrc: "cdn.example.com"
+            """)
+        )
+        changes = migrate_values(data)
+        result = _to_plain(data)
+        assert result["nginx"]["cspPolicy"]["cdn"]["enabled"] is False
+        assert "cdnEnabled" not in result["nginx"]["cspPolicy"]
+        assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
+        assert any(
+            c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.cdn.enabled"
+            for c in changes
+        )
+
+    def test_no_op_when_csp_policy_missing(self) -> None:
+        """No nginx.cspPolicy section produces no nginx CSP migration changes."""
+        data = _load_rt("nginx:\n  replicas: 2\n")
+        changes = migrate_values(data)
+        assert _to_plain(data)["nginx"]["replicas"] == 2
+        assert not any("nginx.cspPolicy" in c.old_path for c in changes)
+
+    def test_idempotent_when_already_nested(self) -> None:
+        """Second migration pass does not alter already-nested cdn.enabled."""
+        data = _load_rt(
+            dedent("""\
+                nginx:
+                  cspPolicy:
+                    cdn:
+                      enabled: true
+                    connectsrc: "x"
+            """)
+        )
+        migrate_values(data)
+        plain_after_first = _to_plain(data)
+        data2 = _load_rt(_dump_rt(data))
+        changes2 = migrate_values(data2)
+        assert _to_plain(data2) == plain_after_first
+        assert not any("nginx.cspPolicy.cdnEnabled" in c.old_path for c in changes2)
+
+
 class TestSubtreeMove:
     """Test the SubtreeMove rule type."""
 


### PR DESCRIPTION
## Description
Rename the nginx CSP “CDN sources” toggle from a flat flag to nested `cdn.enabled`, matching the unified config style.

**Rename:**

| Before | After |
|--------|--------|
| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.cdn.enabled` |

**What changed**

1. **Chart defaults** — Default in `charts/nginx/values.yaml`; both ingress header ConfigMaps read the new key. If `cdn.enabled` is omitted, behavior matches the old default (CDN-related CSP entries on). Old overrides that still set `cdnEnabled` keep working until updated.

2. **Migration** — The 1.x→2.x and 0.37.x→2.x values migration scripts rewrite the old key when present (`helm_chart_values_migration_shared.py` + the two `bin/migrate-helm-chart-values-*.py` entrypoints).

3. **Docs** — Upgrade guides note this mapping and that most other `nginx` keys are unchanged.

4. **Tests** — `TestNginxCspPolicyMigration` in `tests/migration/test_migrate_helm_chart_values.py`.

## Related Issues
- https://linear.app/astronomer/issue/PLX-300/cdnenabled-feature-flag-is-not-as-per-unified-schema

## Testing

- tested migrations work
- ran pytests

## Merging

- Master
- 2.0.0