### PR TITLE
PLX-300: flatten cspPolicy.cdn.enabled to cspPolicy.enabled

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -467,12 +467,7 @@ def apply_houston_deployment_migrations(root: CommentedMap) -> list[MigrationCha
 
 
 def apply_nginx_csp_policy_migrations(root: CommentedMap) -> list[MigrationChange]:
-    """Migrate legacy CSP toggle shapes to `nginx.cspPolicy.enabled`.
-
-    Handles two legacy shapes produced by earlier chart versions:
-
-    - `nginx.cspPolicy.cdnEnabled` (original) -> `nginx.cspPolicy.enabled`
-    - `nginx.cspPolicy.cdn.enabled` (PLX-300 intermediate) -> `nginx.cspPolicy.enabled`
+    """Migrate `nginx.cspPolicy.cdnEnabled` to `nginx.cspPolicy.enabled`.
 
     Parameters:
         root: The parsed YAML document root.
@@ -486,28 +481,8 @@ def apply_nginx_csp_policy_migrations(root: CommentedMap) -> list[MigrationChang
     csp_policy = _get_nested_mapping(nginx, ["cspPolicy"])
     if csp_policy is None:
         return []
-
-    changes: list[MigrationChange] = []
-
-    # Migrate flat cdnEnabled -> enabled
     rule = BoolToNested("cdnEnabled", ["enabled"], path_prefix="nginx.cspPolicy")
-    changes.extend(rule.apply(csp_policy))
-
-    # Migrate cdn.enabled (PLX-300 intermediate shape) -> enabled
-    cdn = _get_nested_mapping(csp_policy, ["cdn"])
-    if cdn is not None and "enabled" in cdn:
-        if "enabled" not in csp_policy:
-            csp_policy["enabled"] = cdn["enabled"]
-        _delete_key(csp_policy, "cdn")
-        changes.append(
-            MigrationChange(
-                "nginx.cspPolicy.cdn.enabled",
-                "nginx.cspPolicy.enabled",
-                "Moved nginx.cspPolicy.cdn.enabled -> nginx.cspPolicy.enabled",
-            )
-        )
-
-    return changes
+    return rule.apply(csp_policy)
 
 
 def apply_houston_config_flag_migrations(root: CommentedMap) -> list[MigrationChange]:

--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -1,7 +1,7 @@
 """Shared migration helpers and rules for 1.x / 0.37.x -> 2.x Helm values.
 
-Used by ``migrate-helm-chart-values-1x-to-2x.py`` and
-``migrate-helm-chart-values-037x-to-2x.py`` so feature-flag restructuring stays
+Used by `migrate-helm-chart-values-1x-to-2x.py` and
+`migrate-helm-chart-values-037x-to-2x.py` so feature-flag restructuring stays
 in one place.
 """
 
@@ -413,10 +413,10 @@ def apply_global_feature_flag_rules(global_mapping: CommentedMap | None) -> list
     """Apply global-section feature-flag migrations (1.x / 0.37.x -> 2.x).
 
     Parameters:
-        global_mapping: The ``global`` key from values.yaml, or None.
+        global_mapping: The `global` key from values.yaml, or None.
 
     Returns:
-        All migration changes applied under ``global``.
+        All migration changes applied under `global`.
     """
     if global_mapping is None or not isinstance(global_mapping, CommentedMap):
         return []
@@ -427,13 +427,13 @@ def apply_global_feature_flag_rules(global_mapping: CommentedMap | None) -> list
 
 
 def apply_houston_deployment_migrations(root: CommentedMap) -> list[MigrationChange]:
-    """Apply Houston ``config.deployments`` bool, move, and delete migrations.
+    """Apply Houston `config.deployments` bool, move, and delete migrations.
 
     Parameters:
         root: The parsed YAML document root.
 
     Returns:
-        All migration changes applied under ``astronomer.houston.config.deployments``.
+        All migration changes applied under `astronomer.houston.config.deployments`.
     """
     all_changes: list[MigrationChange] = []
     deployments = _get_nested_mapping(root, ["astronomer", "houston", "config", "deployments"])
@@ -467,16 +467,18 @@ def apply_houston_deployment_migrations(root: CommentedMap) -> list[MigrationCha
 
 
 def apply_nginx_csp_policy_migrations(root: CommentedMap) -> list[MigrationChange]:
-    """Migrate ``nginx.cspPolicy.cdnEnabled`` to ``nginx.cspPolicy.cdn.enabled``.
+    """Migrate legacy CSP toggle shapes to `nginx.cspPolicy.enabled`.
 
-    Aligns customer Helm overrides with chart 2.x / PLX-300 unified nested
-    ``.enabled`` shape under ``nginx.cspPolicy``.
+    Handles two legacy shapes produced by earlier chart versions:
+
+    - `nginx.cspPolicy.cdnEnabled` (original) -> `nginx.cspPolicy.enabled`
+    - `nginx.cspPolicy.cdn.enabled` (PLX-300 intermediate) -> `nginx.cspPolicy.enabled`
 
     Parameters:
         root: The parsed YAML document root.
 
     Returns:
-        Migration changes applied under ``nginx.cspPolicy``, if any.
+        Migration changes applied under `nginx.cspPolicy`, if any.
     """
     nginx = _get_nested_mapping(root, ["nginx"])
     if nginx is None:
@@ -484,22 +486,42 @@ def apply_nginx_csp_policy_migrations(root: CommentedMap) -> list[MigrationChang
     csp_policy = _get_nested_mapping(nginx, ["cspPolicy"])
     if csp_policy is None:
         return []
-    rule = BoolToNested("cdnEnabled", ["cdn", "enabled"], path_prefix="nginx.cspPolicy")
-    return rule.apply(csp_policy)
+
+    changes: list[MigrationChange] = []
+
+    # Migrate flat cdnEnabled -> enabled
+    rule = BoolToNested("cdnEnabled", ["enabled"], path_prefix="nginx.cspPolicy")
+    changes.extend(rule.apply(csp_policy))
+
+    # Migrate cdn.enabled (PLX-300 intermediate shape) -> enabled
+    cdn = _get_nested_mapping(csp_policy, ["cdn"])
+    if cdn is not None and "enabled" in cdn:
+        if "enabled" not in csp_policy:
+            csp_policy["enabled"] = cdn["enabled"]
+        _delete_key(csp_policy, "cdn")
+        changes.append(
+            MigrationChange(
+                "nginx.cspPolicy.cdn.enabled",
+                "nginx.cspPolicy.enabled",
+                "Moved nginx.cspPolicy.cdn.enabled -> nginx.cspPolicy.enabled",
+            )
+        )
+
+    return changes
 
 
 def apply_houston_config_flag_migrations(root: CommentedMap) -> list[MigrationChange]:
-    """Apply Houston ``config`` flag migrations (flat booleans -> nested ``.enabled``).
+    """Apply Houston `config` flag migrations (flat booleans -> nested `.enabled`).
 
-    Handles passthrough config keys under ``astronomer.houston.config`` that
-    Houston PR #2417 migrated to nested ``.enabled`` paths, including keys in
-    nested sub-sections like ``auth.openidConnect`` and ``webserver``.
+    Handles passthrough config keys under `astronomer.houston.config` that
+    Houston PR #2417 migrated to nested `.enabled` paths, including keys in
+    nested sub-sections like `auth.openidConnect` and `webserver`.
 
     Parameters:
         root: The parsed YAML document root.
 
     Returns:
-        All migration changes applied under ``astronomer.houston.config``.
+        All migration changes applied under `astronomer.houston.config`.
     """
     config = _get_nested_mapping(root, ["astronomer", "houston", "config"])
     if config is None:

--- a/charts/nginx/templates/controlplane/nginx-cp-headers-configmap.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-headers-configmap.yaml
@@ -2,15 +2,9 @@
 ## NGINX Control Plane ConfigMap ##
 ###################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- $cdn := .Values.cspPolicy.cdn | default dict }}
-{{- $cspPolicyEnabled := true }}
-{{- if hasKey $cdn "enabled" }}
-{{- $cspPolicyEnabled = $cdn.enabled }}
-{{- else if hasKey .Values.cspPolicy "cdnEnabled" }}
-{{- $cspPolicyEnabled = .Values.cspPolicy.cdnEnabled }}
-{{- end }}
-{{- $connectsrc :=  eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
-{{- $fontsrc := eq $cspPolicyEnabled true| ternary .Values.cspPolicy.fontsrc "" }}
+{{- $cspPolicyEnabled := .Values.cspPolicy.enabled }}
+{{- $connectsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
+{{- $fontsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.fontsrc "" }}
 {{- $scriptsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.scriptsrc "" }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/nginx/templates/dataplane/nginx-dp-headers-configmap.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-headers-configmap.yaml
@@ -2,15 +2,9 @@
 ## NGINX Data Plane ConfigMap ##
 ################################
 {{- if eq .Values.global.plane.mode "data" }}
-{{- $cdn := .Values.cspPolicy.cdn | default dict }}
-{{- $cspPolicyEnabled := true }}
-{{- if hasKey $cdn "enabled" }}
-{{- $cspPolicyEnabled = $cdn.enabled }}
-{{- else if hasKey .Values.cspPolicy "cdnEnabled" }}
-{{- $cspPolicyEnabled = .Values.cspPolicy.cdnEnabled }}
-{{- end }}
-{{- $connectsrc :=  eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
-{{- $fontsrc := eq $cspPolicyEnabled true| ternary .Values.cspPolicy.fontsrc "" }}
+{{- $cspPolicyEnabled := .Values.cspPolicy.enabled }}
+{{- $connectsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.connectsrc "" }}
+{{- $fontsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.fontsrc "" }}
 {{- $scriptsrc := eq $cspPolicyEnabled true | ternary .Values.cspPolicy.scriptsrc "" }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -139,8 +139,7 @@ defaultBackend:
     name: ~
 
 cspPolicy:
-  cdn:
-    enabled: true
+  enabled: true
   connectsrc: "cdn.jsdelivr.net"
   fontsrc: "fonts.gstatic.com"
   scriptsrc: "fonts.googleapis.com cdn.jsdelivr.net"

--- a/docs/upgrade-values-migration-037x-to-2x.md
+++ b/docs/upgrade-values-migration-037x-to-2x.md
@@ -299,14 +299,12 @@ environment.**
 
 ### Nginx Content-Security-Policy toggle
 
-If your override sets `nginx.cspPolicy.cdnEnabled` or the intermediate
-`nginx.cspPolicy.cdn.enabled` shape, the migration script rewrites it to the
-flat `nginx.cspPolicy.enabled`.
+If your override sets `nginx.cspPolicy.cdnEnabled`, the migration script
+rewrites it to `nginx.cspPolicy.enabled`.
 
 | Old Path | New Path |
 |---|---|
 | `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.enabled` |
-| `nginx.cspPolicy.cdn.enabled` | `nginx.cspPolicy.enabled` |
 
 ### Unchanged Keys (No Migration Needed)
 
@@ -325,8 +323,8 @@ These keys already use the correct schema and are not modified:
 - `global.airflow.*`
 - `global.gitSyncRelay.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled` and
-  `nginx.cspPolicy.cdn.enabled`, both migrated as above), `grafana`, `prometheus`,
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, migrated as
+  above), `grafana`, `prometheus`,
   `elasticsearch`, `kube-state`, `nats` (except init resources)
 
 ## Rollback

--- a/docs/upgrade-values-migration-037x-to-2x.md
+++ b/docs/upgrade-values-migration-037x-to-2x.md
@@ -297,14 +297,16 @@ environment.**
 | `nats.init.resources.limits.cpu` | `"250m"` | NATS init container CPU limit. | Override if your cluster needs different resource settings. |
 | `nats.init.resources.limits.memory` | `"100Mi"` | NATS init container memory limit. | Override if your cluster needs different resource settings. |
 
-### Nginx Content-Security-Policy (CDN) toggle
+### Nginx Content-Security-Policy toggle
 
-If your override sets `nginx.cspPolicy.cdnEnabled`, the migration script
-rewrites it to `nginx.cspPolicy.cdn.enabled` (same as chart 2.x / PLX-300).
+If your override sets `nginx.cspPolicy.cdnEnabled` or the intermediate
+`nginx.cspPolicy.cdn.enabled` shape, the migration script rewrites it to the
+flat `nginx.cspPolicy.enabled`.
 
 | Old Path | New Path |
 |---|---|
-| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.cdn.enabled` |
+| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.enabled` |
+| `nginx.cspPolicy.cdn.enabled` | `nginx.cspPolicy.enabled` |
 
 ### Unchanged Keys (No Migration Needed)
 
@@ -323,8 +325,8 @@ These keys already use the correct schema and are not modified:
 - `global.airflow.*`
 - `global.gitSyncRelay.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, migrated as
-  above), `grafana`, `prometheus`,
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled` and
+  `nginx.cspPolicy.cdn.enabled`, both migrated as above), `grafana`, `prometheus`,
   `elasticsearch`, `kube-state`, `nats` (except init resources)
 
 ## Rollback

--- a/docs/upgrade-values-migration.md
+++ b/docs/upgrade-values-migration.md
@@ -126,14 +126,15 @@ include `emailConfirmation` → `emailConfirmation.enabled` and
 Run `./bin/migrate-helm-chart-values-1x-to-2x.py --dry-run your-values.yaml`
 to see the exact list for your file.
 
-### Nginx Content-Security-Policy (CDN) toggle
+### Nginx Content-Security-Policy toggle
 
-If your override sets the flat CDN toggle under `nginx.cspPolicy`, the
-migration script rewrites it to the nested `.enabled` shape (see PLX-300):
+If your override sets the CSP toggle under `nginx.cspPolicy`, the migration
+script rewrites it to the flat `nginx.cspPolicy.enabled`:
 
 | Old Path | New Path | Type |
 |---|---|---|
-| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.cdn.enabled` | boolean → nested |
+| `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.enabled` | boolean → flat |
+| `nginx.cspPolicy.cdn.enabled` | `nginx.cspPolicy.enabled` | nested → flat |
 
 ### Houston Config Passthrough Keys
 
@@ -169,9 +170,9 @@ These keys already use the correct schema and are not modified:
 - `global.authSidecar.*`
 - `global.airflowOperator.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, which is
-  migrated as described above), `grafana`, `prometheus`,
-  `elasticsearch`, `vector`, `kube-state`, `nats`, `tags`
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled` and
+  `nginx.cspPolicy.cdn.enabled`, both migrated as described above), `grafana`,
+  `prometheus`, `elasticsearch`, `vector`, `kube-state`, `nats`, `tags`
 
 ## Rollback
 

--- a/docs/upgrade-values-migration.md
+++ b/docs/upgrade-values-migration.md
@@ -128,13 +128,12 @@ to see the exact list for your file.
 
 ### Nginx Content-Security-Policy toggle
 
-If your override sets the CSP toggle under `nginx.cspPolicy`, the migration
-script rewrites it to the flat `nginx.cspPolicy.enabled`:
+If your override sets `nginx.cspPolicy.cdnEnabled`, the migration script
+rewrites it to `nginx.cspPolicy.enabled`:
 
 | Old Path | New Path | Type |
 |---|---|---|
 | `nginx.cspPolicy.cdnEnabled` | `nginx.cspPolicy.enabled` | boolean → flat |
-| `nginx.cspPolicy.cdn.enabled` | `nginx.cspPolicy.enabled` | nested → flat |
 
 ### Houston Config Passthrough Keys
 
@@ -170,9 +169,9 @@ These keys already use the correct schema and are not modified:
 - `global.authSidecar.*`
 - `global.airflowOperator.*`
 - Most keys under `astronomer` **outside** `astronomer.houston.config`
-- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled` and
-  `nginx.cspPolicy.cdn.enabled`, both migrated as described above), `grafana`,
-  `prometheus`, `elasticsearch`, `vector`, `kube-state`, `nats`, `tags`
+- Most keys under `nginx` (except `nginx.cspPolicy.cdnEnabled`, migrated as
+  described above), `grafana`, `prometheus`, `elasticsearch`, `vector`,
+  `kube-state`, `nats`, `tags`
 
 ## Rollback
 

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -257,24 +257,6 @@ class TestNginxCspPolicyMigration:
         assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
         assert any(c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.enabled" for c in changes)
 
-    def test_migrates_cdn_nested_enabled_to_flat(self) -> None:
-        """PLX-300 intermediate shape cdn.enabled is flattened to cspPolicy.enabled."""
-        data = _load_rt(
-            dedent("""\
-                nginx:
-                  cspPolicy:
-                    cdn:
-                      enabled: false
-                    connectsrc: "cdn.example.com"
-            """)
-        )
-        changes = migrate_values(data)
-        result = _to_plain(data)
-        assert result["nginx"]["cspPolicy"]["enabled"] is False
-        assert "cdn" not in result["nginx"]["cspPolicy"]
-        assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
-        assert any(c.old_path == "nginx.cspPolicy.cdn.enabled" and c.new_path == "nginx.cspPolicy.enabled" for c in changes)
-
     def test_no_op_when_csp_policy_missing(self) -> None:
         """No nginx.cspPolicy section produces no nginx CSP migration changes."""
         data = _load_rt("nginx:\n  replicas: 2\n")

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -237,10 +237,10 @@ class TestBoolToNested:
 
 
 class TestNginxCspPolicyMigration:
-    """``nginx.cspPolicy.cdnEnabled`` -> ``nginx.cspPolicy.cdn.enabled`` (PLX-300)."""
+    """Legacy CSP toggle shapes -> `nginx.cspPolicy.enabled`."""
 
-    def test_migrates_cdn_enabled_to_nested(self) -> None:
-        """Full migrate_values rewrites flat cdnEnabled under nginx.cspPolicy."""
+    def test_migrates_cdnEnabled_to_flat_enabled(self) -> None:
+        """Full migrate_values rewrites flat cdnEnabled -> cspPolicy.enabled."""
         data = _load_rt(
             dedent("""\
                 nginx:
@@ -251,10 +251,29 @@ class TestNginxCspPolicyMigration:
         )
         changes = migrate_values(data)
         result = _to_plain(data)
-        assert result["nginx"]["cspPolicy"]["cdn"]["enabled"] is False
+        assert result["nginx"]["cspPolicy"]["enabled"] is False
         assert "cdnEnabled" not in result["nginx"]["cspPolicy"]
+        assert "cdn" not in result["nginx"]["cspPolicy"]
         assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
-        assert any(c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.cdn.enabled" for c in changes)
+        assert any(c.old_path == "nginx.cspPolicy.cdnEnabled" and c.new_path == "nginx.cspPolicy.enabled" for c in changes)
+
+    def test_migrates_cdn_nested_enabled_to_flat(self) -> None:
+        """PLX-300 intermediate shape cdn.enabled is flattened to cspPolicy.enabled."""
+        data = _load_rt(
+            dedent("""\
+                nginx:
+                  cspPolicy:
+                    cdn:
+                      enabled: false
+                    connectsrc: "cdn.example.com"
+            """)
+        )
+        changes = migrate_values(data)
+        result = _to_plain(data)
+        assert result["nginx"]["cspPolicy"]["enabled"] is False
+        assert "cdn" not in result["nginx"]["cspPolicy"]
+        assert result["nginx"]["cspPolicy"]["connectsrc"] == "cdn.example.com"
+        assert any(c.old_path == "nginx.cspPolicy.cdn.enabled" and c.new_path == "nginx.cspPolicy.enabled" for c in changes)
 
     def test_no_op_when_csp_policy_missing(self) -> None:
         """No nginx.cspPolicy section produces no nginx CSP migration changes."""
@@ -263,14 +282,13 @@ class TestNginxCspPolicyMigration:
         assert _to_plain(data)["nginx"]["replicas"] == 2
         assert not any("nginx.cspPolicy" in c.old_path for c in changes)
 
-    def test_idempotent_when_already_nested(self) -> None:
-        """Second migration pass does not alter already-nested cdn.enabled."""
+    def test_idempotent_when_already_flat_enabled(self) -> None:
+        """Second migration pass does not alter already-flat cspPolicy.enabled."""
         data = _load_rt(
             dedent("""\
                 nginx:
                   cspPolicy:
-                    cdn:
-                      enabled: true
+                    enabled: true
                     connectsrc: "x"
             """)
         )
@@ -279,7 +297,7 @@ class TestNginxCspPolicyMigration:
         data2 = _load_rt(_dump_rt(data))
         changes2 = migrate_values(data2)
         assert _to_plain(data2) == plain_after_first
-        assert not any("nginx.cspPolicy.cdnEnabled" in c.old_path for c in changes2)
+        assert not any("nginx.cspPolicy" in c.old_path for c in changes2)
 
 
 class TestSubtreeMove:


### PR DESCRIPTION
## Description

Simplifies the nginx Content-Security-Policy toggle by flattening `cspPolicy.cdn.enabled` to `cspPolicy.enabled`. The `cdn` nesting was misleading — this flag controls the entire CSP block, not anything CDN-specific.

**Changes:**
- `charts/nginx/values.yaml`: flatten `cdn: {enabled: true}` → `enabled: true`
- Both nginx headers configmaps: simplify to read `.Values.cspPolicy.enabled` directly (same pattern as the original `cdnEnabled`)
- Migration script (`helm_chart_values_migration_shared.py`): extend `apply_nginx_csp_policy_migrations` to rewrite both legacy shapes — `cdnEnabled` (original) and `cdn.enabled` (PLX-300 intermediate) — to the new `cspPolicy.enabled`
- Tests and docs updated accordingly

## Related Issues

Related https://linear.app/astronomer/issue/PLX-300/cdnenabled-feature-flag-is-not-as-per-unified-schema

## Testing

- Migration logic verified manually against all cases:
  - `cdnEnabled: false` → `enabled: false`
  - `cdn: {enabled: false}` → `enabled: false`
  - Already on `enabled: true` → no-op
  - No `cspPolicy` section → no-op
- Unit tests updated in `tests/migration/test_migrate_helm_chart_values.py` covering all four cases above

## Merging

- master
- 2.0.0