### PR TITLE
PINF-492: Add Exporter image and TLS syntax fixes

### DIFF
--- a/charts/elasticsearch/templates/es-ingress.yaml
+++ b/charts/elasticsearch/templates/es-ingress.yaml
@@ -35,9 +35,9 @@ spec:
   {{- if .Values.global.tlsSecret }}
   tls:
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "elasticsearch.ingressurl" . }}
+  {{- end }}
   rules:
     - host: {{ template "elasticsearch.ingressurl" . }}
       http:

--- a/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
@@ -33,9 +33,9 @@ spec:
   {{- if .Values.global.tlsSecret }}
   tls:
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "es-proxy.url" . }}
+  {{- end }}
   rules:
     - host: {{ template "es-proxy.url" . }}
       http:

--- a/charts/prometheus-node-exporter/values.yaml
+++ b/charts/prometheus-node-exporter/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: quay.io/astronomer/ap-node-exporter
-  tag: 1.10.2
+  tag: 1.11.0
   pullPolicy: IfNotPresent
 
 service:

--- a/tests/chart_tests/test_alertmanager.py
+++ b/tests/chart_tests/test_alertmanager.py
@@ -207,3 +207,29 @@ class TestAlertmanager:
 
         assert "persistentVolumeClaimRetentionPolicy" in doc["spec"]
         assert test_persistentVolumeClaimRetentionPolicy == doc["spec"]["persistentVolumeClaimRetentionPolicy"]
+
+    def test_alertmanager_ingress_with_tls_secret(self, kube_version):
+        """Test that alertmanager ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/alertmanager/templates/ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": "my-tls-secret"}},
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert len(tls[0]["hosts"]) == 1
+
+    def test_alertmanager_ingress_without_tls_secret(self, kube_version):
+        """Test that alertmanager ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/alertmanager/templates/ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": ""}},
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]

--- a/tests/chart_tests/test_astronomer_commander_ingress.py
+++ b/tests/chart_tests/test_astronomer_commander_ingress.py
@@ -119,3 +119,79 @@ class TestAstronomerCommanderIngress:
         annotations = doc["metadata"]["annotations"]
         assert annotations["nginx.ingress.kubernetes.io/rate-limit"] == "200"
         assert annotations["custom.metadata/test"] == "metadata-value"
+
+    def test_commander_grpc_ingress_with_tls_secret(self, kube_version):
+        """Test that commander grpc ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "baseDomain": "example.com",
+                    "tlsSecret": "my-tls-secret",
+                },
+            },
+            show_only=["charts/astronomer/templates/commander/commander-grpc-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert len(tls[0]["hosts"]) == 1
+
+    def test_commander_grpc_ingress_without_tls_secret(self, kube_version):
+        """Test that commander grpc ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "baseDomain": "example.com",
+                    "tlsSecret": "",
+                },
+            },
+            show_only=["charts/astronomer/templates/commander/commander-grpc-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]
+
+    def test_commander_metadata_ingress_with_tls_secret(self, kube_version):
+        """Test that commander metadata ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "baseDomain": "example.com",
+                    "tlsSecret": "my-tls-secret",
+                },
+            },
+            show_only=["charts/astronomer/templates/commander/commander-metadata-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert len(tls[0]["hosts"]) == 1
+
+    def test_commander_metadata_ingress_without_tls_secret(self, kube_version):
+        """Test that commander metadata ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "baseDomain": "example.com",
+                    "tlsSecret": "",
+                },
+            },
+            show_only=["charts/astronomer/templates/commander/commander-metadata-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -984,3 +984,29 @@ class TestElasticSearch:
         # Verify custom TTL settings
         assert "proxy_cache_valid 200 10m" in nginx_config
         assert "proxy_cache_valid 401 403 2m" in nginx_config
+
+    def test_elasticsearch_ingress_with_tls_secret(self, kube_version):
+        """Test that elasticsearch ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/elasticsearch/templates/es-ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": "my-tls-secret"}},
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert len(tls[0]["hosts"]) == 1
+
+    def test_elasticsearch_ingress_without_tls_secret(self, kube_version):
+        """Test that elasticsearch ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/elasticsearch/templates/es-ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": ""}},
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -968,3 +968,43 @@ class TestExternalElasticSearch:
         # Verify custom TTL settings
         assert "proxy_cache_valid 200 10m" in nginx_config
         assert "proxy_cache_valid 401 403 2m" in nginx_config
+
+    def test_external_elasticsearch_ingress_with_tls_secret(self, kube_version):
+        """Test that external-es-proxy ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/external-es-proxy/templates/external-es-proxy-ingress.yaml"],
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "my-tls-secret",
+                    "customLogging": {"enabled": True},
+                    "plane": {"mode": "data"},
+                },
+            },
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert len(tls[0]["hosts"]) == 1
+
+    def test_external_elasticsearch_ingress_without_tls_secret(self, kube_version):
+        """Test that external-es-proxy ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/external-es-proxy/templates/external-es-proxy-ingress.yaml"],
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "",
+                    "customLogging": {"enabled": True},
+                    "plane": {"mode": "data"},
+                },
+            },
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]

--- a/tests/chart_tests/test_houston_ingress.py
+++ b/tests/chart_tests/test_houston_ingress.py
@@ -75,3 +75,29 @@ class TestIngress:
         annotations = jmespath.search("metadata.annotations", doc)
         assert annotations["nginx.ingress.kubernetes.io/upstream-keepalive-connections"] == "9999"
         assert annotations["nginx.ingress.kubernetes.io/upstream-keepalive-timeout"] == "7777"
+
+    def test_houston_ingress_with_tls_secret(self, kube_version):
+        """Test that houston ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/astronomer/templates/houston/ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": "my-tls-secret"}},
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert "houston.example.com" in tls[0]["hosts"]
+
+    def test_houston_ingress_without_tls_secret(self, kube_version):
+        """Test that houston ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/astronomer/templates/houston/ingress.yaml"],
+            values={"global": {"baseDomain": "example.com", "tlsSecret": ""}},
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -210,3 +210,89 @@ class TestIngress:
         if expected_astro_ui:
             assert "nginx.ingress.kubernetes.io/configuration-snippet" in annotations
             assert "app.example.com" in annotations["nginx.ingress.kubernetes.io/configuration-snippet"]
+
+    def test_astro_ui_ingress_with_tls_secret(self, kube_version):
+        """Test that astro-ui per-host ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "my-tls-secret",
+                    "perHostIngress": {"enabled": True},
+                },
+            },
+            show_only=["charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml"],
+        )
+
+        assert len(docs) == 2
+
+        astroui_ingress = docs[0]
+        tls = astroui_ingress["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert "app.example.com" in tls[0]["hosts"]
+
+        common_ingress = docs[1]
+        tls = common_ingress["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert "example.com" in tls[0]["hosts"]
+
+    def test_astro_ui_ingress_without_tls_secret(self, kube_version):
+        """Test that astro-ui per-host ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "",
+                    "perHostIngress": {"enabled": True},
+                },
+            },
+            show_only=["charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml"],
+        )
+
+        assert len(docs) == 2
+        assert "tls" not in docs[0]["spec"]
+        assert "tls" not in docs[1]["spec"]
+
+    def test_registry_ingress_with_tls_secret(self, kube_version):
+        """Test that registry per-host ingress includes tls with hosts when tlsSecret is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "my-tls-secret",
+                    "perHostIngress": {"enabled": True},
+                },
+            },
+            show_only=["charts/astronomer/templates/registry/registry-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        tls = docs[0]["spec"]["tls"]
+        assert len(tls) == 1
+        assert tls[0]["secretName"] == "my-tls-secret"
+        assert "hosts" in tls[0]
+        assert "registry.example.com" in tls[0]["hosts"]
+
+    def test_registry_ingress_without_tls_secret(self, kube_version):
+        """Test that registry per-host ingress does not include tls when tlsSecret is empty."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "baseDomain": "example.com",
+                    "tlsSecret": "",
+                    "perHostIngress": {"enabled": True},
+                },
+            },
+            show_only=["charts/astronomer/templates/registry/registry-ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        assert "tls" not in docs[0]["spec"]


### PR DESCRIPTION
## Description

This PR adds exporter image and adds some if end fixes in chart.

## Related Issues

https://linear.app/astronomer/issue/PINF-492/conditionally-render-tls-block-in-ingress-templates-when-tlssecret-is


## Merging

Master, 2.0
