### PR TITLE
PLX-167: Fix migration script for nodeExporter and daemonsetLogging

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -308,6 +308,7 @@ GLOBAL_FEATURE_FLAG_RULES: list[BoolToNested | InvertedBoolToNested | SubtreeMov
     BoolToNested("podDisruptionBudgetsEnabled", ["podDisruptionBudgets", "enabled"]),
     BoolToNested("postgresqlEnabled", ["postgresql", "enabled"]),
     BoolToNested("prometheusPostgresExporterEnabled", ["prometheusPostgresExporter", "enabled"]),
+    BoolToNested("nodeExporterEnabled", ["nodeExporter", "enabled"]),
     BoolToNested("manualNamespaceNamesEnabled", ["namespaceManagement", "manualNamespaceNames", "enabled"]),
     BoolToNested("enablePerHostIngress", ["perHostIngress", "enabled"]),
     BoolToNested("enableArgoCDAnnotation", ["argoCD", "annotation", "enabled"]),
@@ -320,6 +321,7 @@ GLOBAL_FEATURE_FLAG_RULES: list[BoolToNested | InvertedBoolToNested | SubtreeMov
     BoolToNested("prometheusEnabled", ["prometheus", "enabled"]),
     BoolToNested("elasticsearchEnabled", ["elasticsearch", "enabled"]),
     BoolToNested("vectorEnabled", ["daemonsetLogging", "enabled"]),
+    BoolToNested("fluentdEnabled", ["daemonsetLogging", "enabled"]),
 ]
 
 HOUSTON_DEPLOYMENTS_PREFIX = "astronomer.houston.config.deployments"

--- a/bin/migrate-helm-chart-values-037x-to-2x.py
+++ b/bin/migrate-helm-chart-values-037x-to-2x.py
@@ -148,7 +148,9 @@ class RenameKey(MigrationRule):
 
     The path identifies the parent + old key name; new_name is the replacement.
 
-    Example: RenameKey(["fluentd"], "vector") renames the top-level fluentd key.
+    Example: RenameKey(["fluentd"], "vector") renames the top-level Fluentd config subtree.
+    The logging feature flag migration is separate:
+    global.fluentdEnabled -> global.daemonsetLogging.enabled
     Example: RenameKey(["global", "pgbouncer", "krb5ConfSecretName"], "secretName")
     """
 
@@ -323,7 +325,6 @@ MIGRATIONS: list[MigrationRule] = [
     AddKeyIfMissing(["global", "authHeaderSecretName"], value=None),
     AddKeyIfMissing(["global", "plane"], value={"mode": "unified", "domainPrefix": ""}),
     AddKeyIfMissing(["global", "podLabels"], value={}),
-    AddKeyIfMissing(["global", "logging", "provider"], value=None),
     AddKeyIfMissing(
         ["nats", "init"],
         value={

--- a/docs/upgrade-values-migration-037x-to-2x.md
+++ b/docs/upgrade-values-migration-037x-to-2x.md
@@ -40,8 +40,12 @@ deletion. Ensure your platform is in a quiet state before upgrading.
 ### Fluentd replaced by Vector
 
 Chart 2.x replaces Fluentd with **Vector** for log collection. The migration
-script renames the top-level `fluentd` key to `vector`, preserving resource
-requests and limits.
+script performs two separate logging migrations:
+
+- It renames the top-level `fluentd` key to `vector`, preserving resource
+  requests and limits.
+- It renames `global.fluentdEnabled` to `global.daemonsetLogging.enabled`,
+  which matches the chart dependency condition in 2.x.
 
 **Impact**: Resource values (CPU, memory) carry over. However, **custom Fluentd
 configuration** — such as custom pipelines, filters, output plugins, or parser
@@ -148,6 +152,7 @@ Found 28 migration(s) to apply:
   global.singleNamespace -> (deleted): Deleted obsolete key global.singleNamespace
   global.veleroEnabled -> (deleted): Deleted obsolete key global.veleroEnabled
   ...
+  global.fluentdEnabled -> global.daemonsetLogging.enabled: Moved ...
   fluentd -> vector: Renamed fluentd -> vector
   global.pgbouncer.krb5ConfSecretName -> global.pgbouncer.secretName: Renamed ...
   global.pgbouncer.servicePort -> global.pgbouncer.servicePort: Updated ... "5432" -> "6543"
@@ -188,8 +193,8 @@ attention to:
 - **New default values** — review the [New Keys Added with
   Defaults](#new-keys-added-with-defaults) table below and override any
   defaults that do not match your environment.
-- **Fluentd-to-Vector rename** — if you had custom Fluentd configuration, only
-  the resource values carry over.
+- **Logging migration** — verify both `global.daemonsetLogging.enabled` and the
+  top-level `vector` subtree after migration.
 - **PGBouncer port** — confirm the new port (6543) works for your setup, or
   override it back to 5432.
 
@@ -221,6 +226,8 @@ structures:
 | `global.features.namespacePools.*` | `global.namespaceManagement.namespacePools.*` | subtree move |
 | `global.dagOnlyDeployment.*` | `global.deployMechanisms.dagOnlyDeployment.*` | subtree move |
 | `global.loggingSidecar.*` | `global.logging.loggingSidecar.*` | subtree move |
+| `global.nodeExporterEnabled` | `global.nodeExporter.enabled` | boolean → nested |
+| `global.fluentdEnabled` | `global.daemonsetLogging.enabled` | boolean → nested |
 
 ### Houston Config Passthrough Keys
 
@@ -365,6 +372,9 @@ keeps `global.rbac.enabled: false` and deletes `global.rbacEnabled`.
 
 The same precedence applies to renames: if both `fluentd` and `vector` exist
 at the top level, the `vector` subtree is preserved and `fluentd` is deleted.
+Likewise, if both `global.fluentdEnabled` and
+`global.daemonsetLogging.enabled` exist, the script preserves
+`global.daemonsetLogging.enabled` and deletes `global.fluentdEnabled`.
 
 ### What if I have a full copy of values.yaml instead of just overrides?
 
@@ -403,9 +413,11 @@ only transforms the specific keys it knows about.
 
 ### I have custom Fluentd configuration. What do I do?
 
-The migration script only renames the `fluentd` key to `vector` and preserves
-the subtree (including resource settings). Any Fluentd-specific configuration
-(custom pipelines, filters, output plugins) will not work with Vector.
+The migration script renames the `fluentd` key to `vector`, preserves the
+subtree (including resource settings), and separately migrates
+`global.fluentdEnabled` to `global.daemonsetLogging.enabled`. Any
+Fluentd-specific configuration (custom pipelines, filters, output plugins) will
+not work with Vector.
 
 Before upgrading:
 
@@ -430,8 +442,8 @@ This overrides the script's update to `6543`.
 ### How does this differ from the 1.x-to-2.x migration?
 
 The 0.37.x-to-2.x migration is a superset of the 1.x-to-2.x migration. It
-includes all 10 feature flag restructuring rules from the 1.x migration, plus
-18 additional rules for:
+includes the shared 1.x-to-2.x feature-flag restructuring rules, plus
+additional 0.37.x-specific rules for:
 
 - Deleting 9 obsolete keys
 - Renaming 2 keys (fluentd → vector, pgbouncer secret name)

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -495,7 +495,6 @@ def expected_037x_new_partial_text() -> str:
               name: my-sidecar
               repository: custom-registry/vector
               tag: 0.50.0
-            provider:
           nats:
             enabled: true
             replicas: 3
@@ -633,7 +632,6 @@ def new_037x_schema_partial_text() -> str:
             loggingSidecar:
               enabled: true
               name: sidecar-log-consumer
-            provider: elasticsearch
           nats:
             enabled: true
             replicas: 3

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -160,6 +160,8 @@ class TestFullValuesMigration:
             "podDisruptionBudgetsEnabled",
             "postgresqlEnabled",
             "prometheusPostgresExporterEnabled",
+            "nodeExporterEnabled",
+            "fluentdEnabled",
             "manualNamespaceNamesEnabled",
             "enablePerHostIngress",
             "enableArgoCDAnnotation",
@@ -469,6 +471,16 @@ RULE_TEST_CASES = [
         "prometheusPostgresExporterEnabled",
         "global:\n  prometheusPostgresExporterEnabled: false\n",
         lambda g: g["prometheusPostgresExporter"]["enabled"] is False,
+    ),
+    (
+        "nodeExporterEnabled",
+        "global:\n  nodeExporterEnabled: true\n",
+        lambda g: g["nodeExporter"]["enabled"] is True,
+    ),
+    (
+        "fluentdEnabled",
+        "global:\n  fluentdEnabled: false\n",
+        lambda g: g["daemonsetLogging"]["enabled"] is False and "fluentdEnabled" not in g,
     ),
     (
         "manualNamespaceNamesEnabled",
@@ -788,6 +800,22 @@ class TestConflictPrecedence:
 
         assert result["global"]["daemonsetLogging"]["enabled"] is False
         assert "vectorEnabled" not in result["global"]
+        assert len(changes) >= 1
+
+    def test_fluentd_enabled_conflict_keeps_new(self):
+        """fluentdEnabled conflict with daemonsetLogging.enabled preserves the new-schema value."""
+        text = dedent("""\
+            global:
+              fluentdEnabled: true
+              daemonsetLogging:
+                enabled: false
+        """)
+        data = _load_rt(text)
+        changes = migrate_values(data)
+        result = _to_plain(data)
+
+        assert result["global"]["daemonsetLogging"]["enabled"] is False
+        assert "fluentdEnabled" not in result["global"]
         assert len(changes) >= 1
 
 

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -30,7 +30,7 @@ HoustonDeploymentDeleteKey = migrate_mod.HoustonDeploymentDeleteKey
 MIGRATIONS = migrate_mod.MIGRATIONS
 main = migrate_mod.main
 
-TOTAL_RULES_ON_FULL_037X = 54
+TOTAL_RULES_ON_FULL_037X = 53
 
 
 def _load_rt(text: str):
@@ -280,6 +280,7 @@ class TestFullValuesMigration:
             "veleroEnabled",
             "enableHoustonInternalAuthorization",
             "nodeExporterSccEnabled",
+            "nodeExporterEnabled",
             "podDisruptionBudgetsEnabled",
             "postgresqlEnabled",
             "prometheusPostgresExporterEnabled",
@@ -353,7 +354,6 @@ class TestFullValuesMigration:
         assert g["plane"]["mode"] == "unified"
         assert g["plane"]["domainPrefix"] == ""
         assert "podLabels" in g
-        assert g["logging"]["provider"] is None
         assert result["nats"]["init"]["resources"]["requests"]["cpu"] == "75m"
 
     def test_unchanged_keys_preserved(self, old_037x_full_values_text: str):
@@ -623,22 +623,22 @@ class TestAddKeyIfMissing:
     def test_add_creates_parents(self):
         """AddKeyIfMissing creates parent keys if needed."""
         data = _load_rt("global:\n  baseDomain: x.com\n")
-        rule = AddKeyIfMissing(["global", "logging", "provider"], value=None)
+        rule = AddKeyIfMissing(["global", "logging", "indexNamePrefix"], value="platform")
         changes = rule.apply(data)
 
         result = _to_plain(data)
-        assert result["global"]["logging"]["provider"] is None
+        assert result["global"]["logging"]["indexNamePrefix"] == "platform"
         assert len(changes) == 1
 
     def test_add_to_existing_parent(self):
         """AddKeyIfMissing adds to an existing parent without overwriting siblings."""
         data = _load_rt("global:\n  logging:\n    indexNamePrefix: my-prefix\n")
-        rule = AddKeyIfMissing(["global", "logging", "provider"], value=None)
+        rule = AddKeyIfMissing(["global", "logging", "loggingSidecar"], value={"enabled": False})
         changes = rule.apply(data)
 
         result = _to_plain(data)
         assert result["global"]["logging"]["indexNamePrefix"] == "my-prefix"
-        assert result["global"]["logging"]["provider"] is None
+        assert result["global"]["logging"]["loggingSidecar"]["enabled"] is False
         assert len(changes) == 1
 
 
@@ -874,6 +874,11 @@ RULE_TEST_CASES = [
         lambda d: d["global"]["prometheusPostgresExporter"]["enabled"] is False,
     ),
     (
+        "nodeExporterEnabled",
+        "global:\n  nodeExporterEnabled: true\n",
+        lambda d: d["global"]["nodeExporter"]["enabled"] is True,
+    ),
+    (
         "manualNamespaceNamesEnabled",
         "global:\n  manualNamespaceNamesEnabled: false\n",
         lambda d: d["global"]["namespaceManagement"]["manualNamespaceNames"]["enabled"] is False,
@@ -892,6 +897,16 @@ RULE_TEST_CASES = [
         "disableManageClusterScopedResources",
         "global:\n  disableManageClusterScopedResources: false\n",
         lambda d: d["global"]["manageClusterScopedResources"]["enabled"] is True,
+    ),
+    (
+        "fluentdEnabled",
+        "global:\n  fluentdEnabled: true\n",
+        lambda d: d["global"]["daemonsetLogging"]["enabled"] is True,
+    ),
+    (
+        "vectorEnabled",
+        "global:\n  vectorEnabled: true\n",
+        lambda d: d["global"]["daemonsetLogging"]["enabled"] is True,
     ),
     # DeleteKey
     (
@@ -945,11 +960,6 @@ RULE_TEST_CASES = [
     ("add_authHeaderSecretName", "global:\n  baseDomain: x.com\n", lambda d: "authHeaderSecretName" in d["global"]),
     ("add_plane", "global:\n  baseDomain: x.com\n", lambda d: d["global"]["plane"]["mode"] == "unified"),
     ("add_podLabels", "global:\n  baseDomain: x.com\n", lambda d: "podLabels" in d["global"]),
-    (
-        "add_logging_provider",
-        "global:\n  baseDomain: x.com\n",
-        lambda d: "logging" in d["global"] and "provider" in d["global"]["logging"],
-    ),
     ("add_nats_init", "nats:\n  nats:\n    resources: {}\n", lambda d: d["nats"]["init"]["resources"]["requests"]["cpu"] == "75m"),
     # HoustonDeploymentBoolToNested
     (
@@ -1264,6 +1274,38 @@ class TestConflictPrecedence:
         assert result["global"]["pgbouncer"]["servicePort"] == "6543"
         assert len(changes) == 0
 
+    def test_vector_enabled_conflict_keeps_new(self):
+        """vectorEnabled preserves the existing global.daemonsetLogging.enabled value."""
+        text = dedent("""\
+            global:
+              vectorEnabled: true
+              daemonsetLogging:
+                enabled: false
+        """)
+        data = _load_rt(text)
+        changes = migrate_values(data)
+        result = _to_plain(data)
+
+        assert result["global"]["daemonsetLogging"]["enabled"] is False
+        assert "vectorEnabled" not in result["global"]
+        assert len(changes) >= 1
+
+    def test_fluentd_enabled_conflict_keeps_new(self):
+        """fluentdEnabled preserves the existing global.daemonsetLogging.enabled value."""
+        text = dedent("""\
+            global:
+              fluentdEnabled: true
+              daemonsetLogging:
+                enabled: false
+        """)
+        data = _load_rt(text)
+        changes = migrate_values(data)
+        result = _to_plain(data)
+
+        assert result["global"]["daemonsetLogging"]["enabled"] is False
+        assert "fluentdEnabled" not in result["global"]
+        assert len(changes) >= 1
+
 
 # ---------------------------------------------------------------------------
 # Comment preservation tests
@@ -1391,8 +1433,6 @@ class TestCLI:
               plane:
                 mode: unified
               podLabels: {}
-              logging:
-                provider: es
             nats:
               init:
                 resources:

--- a/values.yaml
+++ b/values.yaml
@@ -245,7 +245,6 @@ global:
 
   logging:
     indexNamePrefix: ~
-    provider: ~
     loggingSidecar:
       enabled: false
       name: sidecar-log-consumer
@@ -376,6 +375,9 @@ global:
       # another: thing
     extraLabels: []
       # do-funky-injection: maybe
+  daemonsetLogging:
+    enabled: true
+
 
 #################################
 ## Default tagged groups enabled


### PR DESCRIPTION
## Description

Fix migration script for nodeExporter and daemonsetLogging

## Related Issues

https://linear.app/astronomer/issue/PLX-167/cpdp-chart-migration-tooling-and-backwards-compatibility-for-the

## Testing

- Unit tests
- Tested locally by running the scripts

## Merging

2.0, main