### PR TITLE
PINF-468: Resolve duplicate task logs in Elasticsearch for AF2 deployments

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -145,34 +145,6 @@ data:
           }
           .log_source = "airflow_3_file"
 
-      enrich_k8s_logs:
-        type: remap
-        inputs:
-          - filter_by_component
-        source: |
-          # airflow_k8s_logs source automatically populates pod labels
-          if exists(.kubernetes.pod_labels.component) {
-            .component = .kubernetes.pod_labels.component
-          }
-          if exists(.kubernetes.pod_labels.release) {
-            .release = .kubernetes.pod_labels.release
-          }
-          if exists(.kubernetes.pod_labels.workspace) {
-            .workspace = .kubernetes.pod_labels.workspace
-          }
-          if exists(.kubernetes.pod_namespace) {
-            .namespace = .kubernetes.pod_namespace
-          }
-          # Parse JSON messages
-          if is_string(.message) {
-            parsed = parse_json(.message) ?? {}
-            if is_object(parsed) {
-              . = merge!(., parsed)
-            }
-          }
-          .log_source = "kubernetes_logs"
-
-
       parse_airflowV3_path:
         type: remap
         inputs:
@@ -223,7 +195,6 @@ data:
         type: remap
         inputs:
           - enrich_file_logs
-          - enrich_k8s_logs
         source: |
           # Component from k8s labels if we have it
           if !exists(.component) && exists(.kubernetes.pod_labels.component) {

--- a/tests/chart_tests/test_vector_cm.py
+++ b/tests/chart_tests/test_vector_cm.py
@@ -66,8 +66,8 @@ class TestVectorConfigmap:
 
         assert "parsed = parse_json(.message)" in config_yaml
 
-    def test_vector_configmap_merge_logs_receives_both_pipelines(self, kube_version):
-        """Test that merge_logs consolidates both AF2 and AF3 processed logs."""
+    def test_vector_configmap_merge_logs_receives_file_logs_pipeline(self, kube_version):
+        """Test that merge_logs receives enrich_file_logs and not enrich_k8s_logs."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/vector/templates/vector-configmap.yaml"],
@@ -77,16 +77,30 @@ class TestVectorConfigmap:
         doc = docs[0]
         config_yaml = doc["data"]["vector-config.yaml"]
 
-        # Verify merge_logs exists
         assert "merge_logs:" in config_yaml
         assert "type: remap" in config_yaml
 
-        # Verify it receives inputs from both pipelines
         config_dict = yaml.safe_load(config_yaml)
         merge_logs_inputs = config_dict["transforms"]["merge_logs"]["inputs"]
 
         assert "enrich_file_logs" in merge_logs_inputs, "AF3 file logs should feed into merge_logs"
-        assert "enrich_k8s_logs" in merge_logs_inputs, "AF2 processed logs should feed into merge_logs"
+        assert "enrich_k8s_logs" not in merge_logs_inputs, "enrich_k8s_logs should not be an input to merge_logs"
+
+    def test_vector_configmap_no_enrich_k8s_logs_transform(self, kube_version):
+        """Test that the enrich_k8s_logs transform is not present in the vector config."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        config_yaml = doc["data"]["vector-config.yaml"]
+
+        assert "enrich_k8s_logs:" not in config_yaml
+
+        config_dict = yaml.safe_load(config_yaml)
+        assert "enrich_k8s_logs" not in config_dict.get("transforms", {})
 
     def test_vector_configmap_filter_by_component_keeps_airflow_components(self, kube_version):
         """Test that filter_by_component keeps only Airflow components."""


### PR DESCRIPTION
## Description

After upgrading to APC 1.1.1, every Airflow task log line appeared twice in the UI for environments running Runtime 12.x with KubernetesExecutor and Elasticsearch via Vector. The duplication affected the entire log block — from Pre task execution logs through all task output to Post task execution logs.

## Root Cause

Chart 1.1.1 introduced a second Vector pipeline to handle Airflow 3 file-based logs alongside the existing Airflow 2 k8s stdout pipeline. The `merge_logs` transform was incorrectly wired with both `enrich_file_logs` and `enrich_k8s_logs` as inputs, causing every k8s stdout log event to flow through both pipelines simultaneously and be written to Elasticsearch twice under the same `log_id`.

With enrich_k8s_logs present in merge_logs inputs, k8s stdout logs were processed by both pipelines and written to ES twice.

## Related Issues

https://linear.app/astronomer/issue/PINF-468/duplicate-task-logs-in-apc-111-airflow-ui

## Testing

- Verified with a test DAG and confirmed zero duplicate lines after the fix:
<img width="872" height="142" alt="Screenshot 2026-04-14 at 6 33 07 PM" src="https://github.com/user-attachments/assets/81a6eab3-8f1e-4d71-9d0a-b1d88114bdf7" />

- Verified the AF3 logs are present as expected:
<img width="1621" height="863" alt="Screenshot 2026-04-14 at 6 56 02 PM" src="https://github.com/user-attachments/assets/08fdcf2d-8b7e-4dc1-bdb0-76b0e90ea1f1" />

## Merging

Master, 2.0, 1.x