### PR TITLE
PINF-413  ESO fixes 3

### DIFF
--- a/.agents/skills/chart-tests/SKILL.md
+++ b/.agents/skills/chart-tests/SKILL.md
@@ -220,6 +220,8 @@ from tests.utils import get_all_features
 
 ## Running Tests
 
+### Correct examples
+
 ```bash
 # Full suite in parallel (fastest — use for full runs)
 uv run pytest tests/chart_tests/ -n auto --quiet
@@ -244,6 +246,16 @@ uv run pytest tests/chart_tests/ --maxfail=1 --lf
 ```
 
 > **Tip**: `-n auto` uses all CPU cores. Omit it when running a single file to avoid subprocess overhead.
+
+### Incorrect examples
+
+```bash
+# ❌ WRONG — we do not need to activate the venv manually, and we do not run pytest without `uv run`
+.venv/bin/activate && pytest tests/chart_tests/
+
+# ❌ WRONG — do not create virtual environment with python, do not use pip install. Use `uv run` to run all python files in the repo.
+python3 -m venv .venv && .venv/bin/pip install -r requirements-dev.txt && .venv/bin/python3 -m pytest tests/chart_tests/
+```
 
 ---
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -34,4 +34,4 @@ RUN uv python install 3.14 --default && \
 RUN npm install --ignore-scripts --min-release-age=7 -g @anthropic-ai/claude-code
 
 # TODO: make this use the helm version from metadata.yaml
-RUN curl -fsSL https://get.helm.sh/helm-v3.20.1-linux-amd64.tar.gz | tar --directory=/usr/local/bin/ --strip-components=1 -xzf - linux-amd64/helm
+RUN curl -fsSL https://get.helm.sh/helm-v3.20.2-linux-amd64.tar.gz | tar --directory=/usr/local/bin/ --strip-components=1 -xzf - linux-amd64/helm

--- a/bin/get-secret-info.py
+++ b/bin/get-secret-info.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+Fetch and display Kubernetes secret data in a compact columnar format.
+
+For each secret, prints a comma-separated line of:
+  name=<name>,resourceVersion=<resourceVersion>,data.<key>=<decoded value>,...
+
+All values under `data` are base64-decoded before printing.
+
+Supports optional watch mode (-w) which streams updates as secrets change,
+and label selectors (-l) to filter secrets. When no secret name is given,
+all secrets in the namespace are printed.
+"""
+
+import argparse
+import base64
+import json
+import subprocess
+import sys
+
+
+def print_secret(secret):
+    name = secret.get("metadata", {}).get("name", "<not found>")
+    resource_version = secret.get("metadata", {}).get("resourceVersion", "<not found>")
+
+    parts = [f"name={name}", f"resourceVersion={resource_version}"]
+    for key, value in (secret.get("data") or {}).items():
+        decoded = base64.b64decode(value).decode()
+        parts.append(f"data.{key}={decoded}")
+
+    print(",".join(parts), flush=True)
+
+
+def main():  # noqa: C901
+    parser = argparse.ArgumentParser(description="Print resourceVersion and data.connection from a Kubernetes secret")
+    parser.add_argument("name", nargs="?", default=None, help="Secret name (omit to list all secrets)")
+    parser.add_argument("-n", "--namespace", help="Namespace")
+    parser.add_argument("--context", help="Kubernetes context")
+    parser.add_argument("--kubeconfig", help="Path to kubeconfig file")
+    parser.add_argument("-l", "--selector", help="Label selector (e.g. app=foo)")
+    parser.add_argument("-w", "--watch", action="store_true", help="Watch for changes (streams output)")
+    parser.add_argument("--debug", action="store_true", help="Print the kubectl command before running it")
+    args = parser.parse_args()
+
+    cmd = ["kubectl", "get", "secret"] + ([args.name] if args.name else []) + ["-o", "json"]
+    if args.namespace:
+        cmd.extend(["-n", args.namespace])
+    if args.context:
+        cmd.extend(["--context", args.context])
+    if args.kubeconfig:
+        cmd.extend(["--kubeconfig", args.kubeconfig])
+    if args.selector:
+        cmd.extend(["-l", args.selector])
+    if args.watch:
+        cmd.append("--watch")
+
+    if args.debug:
+        print(f"+ {' '.join(cmd)}", file=sys.stderr, flush=True)
+
+    if not args.watch:
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(result.stderr, file=sys.stderr)
+            sys.exit(result.returncode)
+
+        payload = json.loads(result.stdout)
+        if payload.get("kind") == "SecretList":
+            for secret in payload.get("items", []):
+                print_secret(secret)
+        else:
+            print_secret(payload)
+    else:
+        # kubectl -o json --watch emits pretty-printed JSON objects concatenated together.
+        # Parse by tracking brace depth to detect document boundaries.
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+        try:
+            buf = []
+            depth = 0
+            in_string = False
+            escape_next = False
+            for line in iter(proc.stdout.readline, ""):
+                for ch in line:
+                    if escape_next:
+                        escape_next = False
+                    elif ch == "\\" and in_string:
+                        escape_next = True
+                    elif ch == '"':
+                        in_string = not in_string
+                    elif not in_string:
+                        if ch == "{":
+                            depth += 1
+                        elif ch == "}":
+                            depth -= 1
+                    buf.append(ch)
+                    if depth == 0 and buf:
+                        text = "".join(buf).strip()
+                        if text:
+                            doc = json.loads(text)
+                            print_secret(doc)
+                        buf = []
+        except KeyboardInterrupt:
+            proc.terminate()
+        finally:
+            proc.wait()
+            if proc.returncode and proc.returncode != 0:
+                err = proc.stderr.read()
+                if err:
+                    print(err, file=sys.stderr)
+                sys.exit(proc.returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/get-secret-info.py
+++ b/bin/get-secret-info.py
@@ -10,6 +10,8 @@ All values under `data` are base64-decoded before printing.
 Supports optional watch mode (-w) which streams updates as secrets change,
 and label selectors (-l) to filter secrets. When no secret name is given,
 all secrets in the namespace are printed.
+
+Example usage: bin/get-secret-info.py -n astronomer -w -l 'owner!=helm'
 """
 
 import argparse
@@ -32,7 +34,7 @@ def print_secret(secret):
 
 
 def main():  # noqa: C901
-    parser = argparse.ArgumentParser(description="Print resourceVersion and data.connection from a Kubernetes secret")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("name", nargs="?", default=None, help="Secret name (omit to list all secrets)")
     parser.add_argument("-n", "--namespace", help="Namespace")
     parser.add_argument("--context", help="Kubernetes context")

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -106,7 +106,7 @@ rules:
   verbs: ["create", "delete", "get", "patch"]
 - apiGroups: ["apps"]
   resources: ["deployments"]
-  verbs: ["create", "delete", "get", "patch", "update"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["autoscaling"]
   resources: ["horizontalpodautoscalers"]
   verbs: ["list", "watch"]

--- a/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
@@ -3,6 +3,8 @@
 ###############################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 {{- if and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "houston.backendSecret" .)) | default dict }}
+{{- $existingConnection := dig "data" "connection" "" $existingSecret }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -22,6 +24,8 @@ data:
   {{- if .Values.houston.backendSecretConnection }}
   # in prisma1 has hardcoded schema, so for now to migrate to prisma2 we need to hardcode it too.
   connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=houston%24default" .Values.houston.backendConnection.user .Values.houston.backendConnection.pass .Values.houston.backendConnection.host (.Values.houston.backendConnection.port | toString) .Values.houston.backendConnection.db) | b64enc | quote }}
+  {{- else if $existingConnection }}
+  connection: {{ $existingConnection | quote }}
   {{- else }}
   connection: {{ randAlphaNum 5 | b64enc | quote }}
   {{- end }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -33,6 +33,7 @@ spec:
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
         checksum/houston-config: {{ include (print $.Template.BasePath "/houston/houston-configmap.yaml") . | sha256sum }}
+        checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
         {{- include "houston.jetStreamTLSChecksum" . | nindent 8 }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}

--- a/charts/astronomer/templates/navigator/navigator-deployment.yaml
+++ b/charts/astronomer/templates/navigator/navigator-deployment.yaml
@@ -31,6 +31,7 @@ spec:
         plane: {{ .Values.global.plane.mode }}
         {{- include "global.podLabels" . | nindent 8 }}
       annotations:
+        checksum/houston-backend-secret: {{ include (print $.Template.BasePath "/houston/api/houston-backend-secret.yaml") . | sha256sum }}
         {{- if .Values.global.podAnnotations }}
         {{- toYaml .Values.global.podAnnotations | nindent 8 }}
         {{- end }}

--- a/charts/external-secrets/values.schema.json
+++ b/charts/external-secrets/values.schema.json
@@ -1,758 +1,509 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "affinity": {
-            "type": "object"
-        },
-        "bitwarden-sdk-server": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "namespaceOverride": {
-                    "type": "string"
-                }
-            }
-        },
-        "certController": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": "object"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "deploymentAnnotations": {
-                    "type": "object"
-                },
-                "extraArgs": {
-                    "type": "object"
-                },
-                "extraEnv": {
-                    "type": "array"
-                },
-                "extraInitContainers": {
-                    "type": "array"
-                },
-                "extraVolumeMounts": {
-                    "type": "array"
-                },
-                "extraVolumes": {
-                    "type": "array"
-                },
-                "hostAliases": {
-                    "type": "array"
-                },
-                "hostNetwork": {
-                    "type": "boolean"
-                },
-                "hostUsers": {
-                    "type": [
-                        "boolean",
-                        "null"
-                    ]
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "flavour": {
-                            "type": "string"
-                        },
-                        "pullPolicy": {
-                            "type": "string"
-                        },
-                        "repository": {
-                            "type": "string"
-                        },
-                        "tag": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
-                "log": {
-                    "type": "object",
-                    "properties": {
-                        "level": {
-                            "type": "string"
-                        },
-                        "timeEncoding": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "metrics": {
-                    "type": "object",
-                    "properties": {
-                        "listen": {
-                            "type": "object",
-                            "properties": {
-                                "port": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "service": {
-                            "type": "object",
-                            "properties": {
-                                "annotations": {
-                                    "type": "object"
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "port": {
-                                    "type": "integer"
-                                }
-                            }
-                        }
-                    }
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podAnnotations": {
-                    "type": "object"
-                },
-                "podDisruptionBudget": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "minAvailable": {
-                            "type": [
-                                "integer",
-                                "string"
-                            ]
-                        },
-                        "nameOverride": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "podLabels": {
-                    "type": "object"
-                },
-                "podSecurityContext": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "priorityClassName": {
-                    "type": "string"
-                },
-                "rbac": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "readinessProbe": {
-                    "type": "object",
-                    "properties": {
-                        "address": {
-                            "type": "string"
-                        },
-                        "port": {
-                            "type": "integer"
-                        }
-                    }
-                },
-                "replicaCount": {
-                    "type": "integer"
-                },
-                "requeueInterval": {
-                    "type": "string"
-                },
-                "resources": {
-                    "type": "object"
-                },
-                "revisionHistoryLimit": {
-                    "type": "integer"
-                },
-                "securityContext": {
-                    "type": "object",
-                    "properties": {
-                        "allowPrivilegeEscalation": {
-                            "type": "boolean"
-                        },
-                        "capabilities": {
-                            "type": "object",
-                            "properties": {
-                                "drop": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "readOnlyRootFilesystem": {
-                            "type": "boolean"
-                        },
-                        "runAsNonRoot": {
-                            "type": "boolean"
-                        },
-                        "runAsUser": {
-                            "type": "integer"
-                        },
-                        "seccompProfile": {
-                            "type": "object",
-                            "properties": {
-                                "type": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "serviceAccount": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "automount": {
-                            "type": "boolean"
-                        },
-                        "create": {
-                            "type": "boolean"
-                        },
-                        "extraLabels": {
-                            "type": "object"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "startupProbe": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "port": {
-                            "type": "string"
-                        },
-                        "useReadinessProbePort": {
-                            "type": "boolean"
-                        }
-                    }
-                },
-                "strategy": {
-                    "type": "object"
-                },
-                "tolerations": {
-                    "type": "array"
-                },
-                "topologySpreadConstraints": {
-                    "type": "array"
-                }
-            }
-        },
-        "commonLabels": {
-            "type": "object"
-        },
-        "concurrent": {
-            "type": "integer"
-        },
-        "controllerClass": {
-            "type": "string"
-        },
-        "crds": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
-                },
-                "conversion": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "deploymentAnnotations": {
-            "type": "object"
-        },
-        "dnsConfig": {
-            "type": "object"
-        },
-        "dnsPolicy": {
-            "type": "string"
-        },
-        "enableHTTP2": {
-            "type": "boolean"
-        },
-        "extendedMetricLabels": {
-            "type": "boolean"
-        },
-        "extraArgs": {
-            "type": "object"
-        },
-        "extraContainers": {
-            "type": "array"
-        },
-        "extraEnv": {
-            "type": "array"
-        },
-        "extraInitContainers": {
-            "type": "array"
-        },
-        "extraObjects": {
-            "type": "array"
-        },
-        "extraVolumeMounts": {
-            "type": "array"
-        },
-        "extraVolumes": {
-            "type": "array"
-        },
-        "fullnameOverride": {
-            "type": "string"
-        },
-        "genericTargets": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "resources": {
-                    "type": "array"
-                }
-            }
-        },
-        "global": {
-            "type": "object",
-            "properties": {
-                "affinity": {
-                    "type": "object"
-                },
-                "compatibility": {
-                    "type": "object",
-                    "properties": {
-                        "openshift": {
-                            "type": "object",
-                            "properties": {
-                                "adaptSecurityContext": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "hostAliases": {
-                    "type": "array"
-                },
-                "imagePullSecrets": {
-                    "type": "array"
-                },
-                "nodeSelector": {
-                    "type": "object"
-                },
-                "podAnnotations": {
-                    "type": "object"
-                },
-                "podLabels": {
-                    "type": "object"
-                },
-                "repository": {
-                    "type": "string"
-                },
-                "tolerations": {
-                    "type": "array"
-                },
-                "topologySpreadConstraints": {
-                    "type": "array"
-                }
-            }
-        },
-        "hostAliases": {
-            "type": "array"
-        },
-        "hostNetwork": {
-            "type": "boolean"
-        },
-        "hostUsers": {
-            "type": [
-                "boolean",
-                "null"
-            ]
-        },
-        "image": {
-            "type": "object",
-            "properties": {
-                "flavour": {
-                    "type": "string"
-                },
-                "pullPolicy": {
-                    "type": "string"
-                },
-                "repository": {
-                    "type": "string"
-                },
-                "tag": {
-                    "type": "string"
-                }
-            }
-        },
-        "imagePullSecrets": {
-            "type": "array"
-        },
-        "installCRDs": {
-            "type": "boolean"
-        },
-        "leaderElect": {
-            "type": "boolean"
-        },
-        "livenessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "spec": {
-                    "type": "object",
-                    "properties": {
-                        "address": {
-                            "type": "string"
-                        },
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "httpGet": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "type": [
-                                        "string",
-                                        "integer"
-                                    ]
-                                }
-                            }
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "log": {
-            "type": "object",
-            "properties": {
-                "level": {
-                    "type": "string"
-                },
-                "timeEncoding": {
-                    "type": "string"
-                }
-            }
-        },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "listen": {
-                    "type": "object",
-                    "properties": {
-                        "port": {
-                            "type": "integer"
-                        },
-                        "secure": {
-                            "type": "object",
-                            "properties": {
-                                "certDir": {
-                                    "type": "string"
-                                },
-                                "certFile": {
-                                    "type": "string"
-                                },
-                                "enabled": {
-                                    "type": "boolean"
-                                },
-                                "keyFile": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                },
-                "service": {
-                    "type": "object",
-                    "properties": {
-                        "annotations": {
-                            "type": "object"
-                        },
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "port": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "nameOverride": {
-            "type": "string"
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "affinity": {
+      "type": "object"
+    },
+    "bitwarden-sdk-server": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
         },
         "namespaceOverride": {
-            "type": "string"
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "concurrent": {
+      "type": "integer"
+    },
+    "controllerClass": {
+      "type": "string"
+    },
+    "crds": {
+      "properties": {
+        "annotations": {
+          "type": "object"
         },
-        "nodeSelector": {
-            "type": "object"
-        },
-        "openshiftFinalizers": {
-            "type": "boolean"
-        },
-        "podAnnotations": {
-            "type": "object"
-        },
-        "podDisruptionBudget": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "minAvailable": {
-                    "type": [
-                        "integer",
-                        "string"
-                    ]
-                },
-                "nameOverride": {
-                    "type": "string"
-                }
+        "conversion": {
+          "properties": {
+            "enabled": {
+              "type": "boolean"
             }
-        },
-        "podLabels": {
-            "type": "object"
-        },
-        "podSecurityContext": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "podSpecExtra": {
-            "type": "object"
-        },
-        "priorityClassName": {
-            "type": "string"
-        },
-        "processClusterExternalSecret": {
-            "type": "boolean"
-        },
-        "processClusterGenerator": {
-            "type": "boolean"
-        },
-        "processClusterPushSecret": {
-            "type": "boolean"
-        },
-        "processClusterStore": {
-            "type": "boolean"
-        },
-        "processPushSecret": {
-            "type": "boolean"
-        },
-        "processSecretStore": {
-            "type": "boolean"
-        },
-        "rbac": {
-            "type": "object",
-            "properties": {
-                "aggregateToEdit": {
-                    "type": "boolean"
-                },
-                "aggregateToView": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "servicebindings": {
-                    "type": "object",
-                    "properties": {
-                        "create": {
-                            "type": "boolean"
-                        }
-                    }
-                }
-            }
-        },
-        "readinessProbe": {
-            "type": "object",
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "spec": {
-                    "type": "object",
-                    "properties": {
-                        "failureThreshold": {
-                            "type": "integer"
-                        },
-                        "httpGet": {
-                            "type": "object",
-                            "properties": {
-                                "path": {
-                                    "type": "string"
-                                },
-                                "port": {
-                                    "type": [
-                                        "string",
-                                        "integer"
-                                    ]
-                                }
-                            }
-                        },
-                        "initialDelaySeconds": {
-                            "type": "integer"
-                        },
-                        "periodSeconds": {
-                            "type": "integer"
-                        },
-                        "successThreshold": {
-                            "type": "integer"
-                        },
-                        "timeoutSeconds": {
-                            "type": "integer"
-                        }
-                    }
-                }
-            }
-        },
-        "replicaCount": {
-            "type": "integer"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "deploymentAnnotations": {
+      "type": "object"
+    },
+    "dnsConfig": {
+      "type": "object"
+    },
+    "dnsPolicy": {
+      "type": "string"
+    },
+    "enableHTTP2": {
+      "type": "boolean"
+    },
+    "extendedMetricLabels": {
+      "type": "boolean"
+    },
+    "extraArgs": {
+      "type": "object"
+    },
+    "extraContainers": {
+      "type": "array"
+    },
+    "extraEnv": {
+      "type": "array"
+    },
+    "extraInitContainers": {
+      "type": "array"
+    },
+    "extraObjects": {
+      "type": "array"
+    },
+    "extraVolumeMounts": {
+      "type": "array"
+    },
+    "extraVolumes": {
+      "type": "array"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "genericTargets": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
         },
         "resources": {
-            "type": "object"
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "global": {
+      "properties": {
+        "affinity": {
+          "type": "object"
         },
-        "revisionHistoryLimit": {
-            "type": "integer"
-        },
-        "scopedNamespace": {
-            "type": "string"
-        },
-        "scopedRBAC": {
-            "type": "boolean"
-        },
-        "securityContext": {
-            "type": "object",
-            "properties": {
-                "allowPrivilegeEscalation": {
-                    "type": "boolean"
-                },
-                "capabilities": {
-                    "type": "object",
-                    "properties": {
-                        "drop": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "enabled": {
-                    "type": "boolean"
-                },
-                "readOnlyRootFilesystem": {
-                    "type": "boolean"
-                },
-                "runAsNonRoot": {
-                    "type": "boolean"
-                },
-                "runAsUser": {
-                    "type": "integer"
-                },
-                "seccompProfile": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
+        "compatibility": {
+          "properties": {
+            "openshift": {
+              "properties": {
+                "adaptSecurityContext": {
+                  "type": "string"
                 }
+              },
+              "type": "object"
             }
+          },
+          "type": "object"
         },
-        "service": {
-            "type": "object",
-            "properties": {
-                "ipFamilies": {
-                    "type": "array"
-                },
-                "ipFamilyPolicy": {
-                    "type": "string"
-                }
-            }
+        "hostAliases": {
+          "type": "array"
         },
-        "serviceAccount": {
-            "type": "object",
-            "properties": {
-                "annotations": {
-                    "type": "object"
-                },
-                "automount": {
-                    "type": "boolean"
-                },
-                "create": {
-                    "type": "boolean"
-                },
-                "extraLabels": {
-                    "type": "object"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "imagePullSecrets": {
+          "type": "array"
         },
-        "strategy": {
-            "type": "object"
+        "nodeSelector": {
+          "type": "object"
         },
-        "systemAuthDelegator": {
-            "type": "boolean"
+        "podAnnotations": {
+          "type": "object"
+        },
+        "podLabels": {
+          "type": "object"
+        },
+        "repository": {
+          "type": "string"
         },
         "tolerations": {
-            "type": "array"
+          "type": "array"
         },
         "topologySpreadConstraints": {
-            "type": "array"
+          "type": "array"
         }
+      },
+      "type": "object"
+    },
+    "hostAliases": {
+      "type": "array"
+    },
+    "hostNetwork": {
+      "type": "boolean"
+    },
+    "hostUsers": {
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
+    "image": {
+      "properties": {
+        "flavour": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string"
+        },
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "imagePullSecrets": {
+      "type": "array"
+    },
+    "installCRDs": {
+      "type": "boolean"
+    },
+    "leaderElect": {
+      "type": "boolean"
+    },
+    "livenessProbe": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "spec": {
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "httpGet": {
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "initialDelaySeconds": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "successThreshold": {
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "log": {
+      "properties": {
+        "level": {
+          "type": "string"
+        },
+        "timeEncoding": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "metrics": {
+      "properties": {
+        "listen": {
+          "properties": {
+            "port": {
+              "type": "integer"
+            },
+            "secure": {
+              "properties": {
+                "certDir": {
+                  "type": "string"
+                },
+                "certFile": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "keyFile": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "service": {
+          "properties": {
+            "annotations": {
+              "type": "object"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "port": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "namespaceOverride": {
+      "type": "string"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "openshiftFinalizers": {
+      "type": "boolean"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podDisruptionBudget": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "minAvailable": {
+          "type": [
+            "integer",
+            "string"
+          ]
+        },
+        "nameOverride": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "podSecurityContext": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "podSpecExtra": {
+      "type": "object"
+    },
+    "priorityClassName": {
+      "type": "string"
+    },
+    "processClusterExternalSecret": {
+      "type": "boolean"
+    },
+    "processClusterGenerator": {
+      "type": "boolean"
+    },
+    "processClusterPushSecret": {
+      "type": "boolean"
+    },
+    "processClusterStore": {
+      "type": "boolean"
+    },
+    "processPushSecret": {
+      "type": "boolean"
+    },
+    "processSecretStore": {
+      "type": "boolean"
+    },
+    "rbac": {
+      "properties": {
+        "aggregateToEdit": {
+          "type": "boolean"
+        },
+        "aggregateToView": {
+          "type": "boolean"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "servicebindings": {
+          "properties": {
+            "create": {
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "readinessProbe": {
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "spec": {
+          "properties": {
+            "failureThreshold": {
+              "type": "integer"
+            },
+            "httpGet": {
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": [
+                    "string",
+                    "integer"
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "initialDelaySeconds": {
+              "type": "integer"
+            },
+            "periodSeconds": {
+              "type": "integer"
+            },
+            "successThreshold": {
+              "type": "integer"
+            },
+            "timeoutSeconds": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "replicaCount": {
+      "type": "integer"
+    },
+    "resources": {
+      "type": "object"
+    },
+    "revisionHistoryLimit": {
+      "type": "integer"
+    },
+    "scopedNamespace": {
+      "type": "string"
+    },
+    "scopedRBAC": {
+      "type": "boolean"
+    },
+    "securityContext": {
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "type": "boolean"
+        },
+        "capabilities": {
+          "properties": {
+            "drop": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "readOnlyRootFilesystem": {
+          "type": "boolean"
+        },
+        "runAsNonRoot": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "seccompProfile": {
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "service": {
+      "properties": {
+        "ipFamilies": {
+          "type": "array"
+        },
+        "ipFamilyPolicy": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "serviceAccount": {
+      "properties": {
+        "annotations": {
+          "type": "object"
+        },
+        "automount": {
+          "type": "boolean"
+        },
+        "create": {
+          "type": "boolean"
+        },
+        "extraLabels": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "strategy": {
+      "type": "object"
+    },
+    "systemAuthDelegator": {
+      "type": "boolean"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "topologySpreadConstraints": {
+      "type": "array"
     }
+  },
+  "type": "object"
 }

--- a/charts/external-secrets/values.yaml
+++ b/charts/external-secrets/values.yaml
@@ -109,10 +109,12 @@ enableHTTP2: false
 # -- Specifies the number of concurrent ExternalSecret Reconciles external-secret executes at
 # a time.
 concurrent: 1
+
 # -- Specifies Log Params to the External Secrets Operator
 log:
   level: info
   timeEncoding: epoch
+
 service:
   # -- Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
   ipFamilyPolicy: ""
@@ -352,144 +354,6 @@ hostNetwork: false
 # -- (bool) Specifies if controller pod should use hostUsers or not. If hostNetwork is true, hostUsers should be too. Only available in Kubernetes ≥ 1.33.
 # @schema type: [boolean, null]
 hostUsers:
-
-certController:
-  # -- Specifies whether a certificate controller deployment be created.
-  create: true
-  requeueInterval: "5m"
-  replicaCount: 1
-  # -- Specifies Log Params to the Certificate Controller
-  log:
-    level: info
-    timeEncoding: epoch
-  # -- Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)
-  revisionHistoryLimit: 10
-
-  image:
-    repository: quay.io/astronomer/ap-external-secrets
-    tag: 2.2.0
-    pullPolicy: IfNotPresent
-  imagePullSecrets: []
-  rbac:
-  # -- Specifies whether role and rolebinding resources should be created.
-    create: true
-  serviceAccount:
-    # -- Specifies whether a service account should be created.
-    create: true
-    # -- Automounts the service account token in all containers of the pod
-    automount: true
-    # -- Annotations to add to the service account.
-    annotations: {}
-    # -- Extra Labels to add to the service account.
-    extraLabels: {}
-    # -- The name of the service account to use.
-    # If not set and create is true, a name is generated using the fullname template.
-    name: ""
-  nodeSelector: {}
-
-  # -- Specifies `hostAliases` to cert-controller deployment
-  hostAliases: []
-
-  tolerations: []
-
-  topologySpreadConstraints: []
-
-  affinity: {}
-
-  # -- Set deployment strategy
-  strategy: {}
-
-  # -- Run the certController on the host network
-  hostNetwork: false
-  # -- (bool) Specifies if certController pod should use hostUsers or not. If hostNetwork is true, hostUsers should be too. Only available in Kubernetes ≥ 1.33.
-  # @schema type: [boolean, null]
-  hostUsers:
-
-    # -- Pod priority class name.
-  priorityClassName: ""
-
-  # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-  podDisruptionBudget:
-    enabled: false
-    minAvailable: 1    # @schema type:[integer, string]
-    nameOverride: ""
-    # maxUnavailable: "50%"
-
-  metrics:
-
-    listen:
-      port: 8080
-
-    service:
-      # -- Enable if you use another monitoring tool than Prometheus to scrape the metrics
-      enabled: false
-
-      # -- Metrics service port to scrape
-      port: 8080
-
-      # -- Additional service annotations
-      annotations: {}
-
-  readinessProbe:
-    # -- Address for readiness probe
-    address: ""
-    # -- ReadinessProbe port for kubelet
-    port: 8081
-
-  startupProbe:
-    # -- Enabled determines if the startup probe should be used or not. By default it's enabled
-    enabled: false
-    # -- whether to use the readiness probe port for startup probe.
-    useReadinessProbePort: true
-    # -- Port for startup probe.
-    port: ""
-
-    ## -- Extra environment variables to add to container.
-  extraEnv: []
-
-    ## -- Map of extra arguments to pass to container.
-  extraArgs: {}
-
-    ## -- Extra init containers to add to the pod.
-  extraInitContainers: []
-
-    ## -- Extra volumes to pass to pod.
-  extraVolumes: []
-
-    ## -- Extra volumes to mount to the container.
-  extraVolumeMounts: []
-
-    # -- Annotations to add to Deployment
-  deploymentAnnotations: {}
-
-    # -- Annotations to add to Pod
-  podAnnotations: {}
-
-  podLabels: {}
-
-  podSecurityContext:
-    enabled: true
-      # fsGroup: 2000
-
-  securityContext:
-    allowPrivilegeEscalation: false
-    capabilities:
-      drop:
-        - ALL
-    enabled: true
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 1000
-    seccompProfile:
-      type: RuntimeDefault
-
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 10m
-      memory: 32Mi
 
 # -- Specifies `dnsPolicy` to deployment
 dnsPolicy: ClusterFirst

--- a/charts/external-secrets/values.yaml
+++ b/charts/external-secrets/values.yaml
@@ -366,18 +366,3 @@ hostAliases: []
 
 # -- Any extra pod spec on the deployment
 podSpecExtra: {}
-
-# -- Configuration for the Secrets Manager backend integration
-secretsBackend:
-  clusterSecretStore:
-    # -- Name of the ClusterSecretStore resource
-    name: astronomer-cluster-secret-store
-    # -- Region for Secrets Manager
-    region: us-east-2
-  credentials:
-    # -- Name of the Secret containing credentials
-    name: secrets-backend-credentials
-    # -- access key ID (plaintext, will be base64 encoded)
-    accessKey: ""
-    # -- secret access key (plaintext, will be base64 encoded)
-    secretAccessKey: ""

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -12,8 +12,10 @@ astronomer:
       pullPolicy: Always
     commander:
       pullPolicy: Always
+      tag: PINF-457-secret-sync-check-updates
     houston:
       pullPolicy: Always
+      tag: main
   navigator:
     enabled: true
     env:

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -1,4 +1,5 @@
 astronomer:
+  airflowChartVersion: 1.17.28-build40412
   dpLink:
     enabled: true
   flightDeck:
@@ -12,7 +13,7 @@ astronomer:
       pullPolicy: Always
     commander:
       pullPolicy: Always
-      tag: PINF-457-secret-sync-check-updates
+      tag: master
     houston:
       pullPolicy: Always
       tag: main

--- a/configs/use-docker-io.yaml
+++ b/configs/use-docker-io.yaml
@@ -23,9 +23,6 @@ elasticsearch:
     nginx:
       repository: docker.io/astronomerinc/ap-nginx-es
 external-secrets:
-  certController:
-    image:
-      repository: docker.io/astronomerinc/ap-external-secrets
   image:
     repository: docker.io/astronomerinc/ap-external-secrets
 global:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,7 +8,7 @@ test_k8s_versions:
   - 1.35.1
 tools:
   helm:
-    version: 3.20.1
+    version: 3.20.2
     url: https://github.com/helm/helm
   kind:
     version: 0.31.0

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -130,7 +130,6 @@ class TestServiceAccounts:
                 "enabled": True,
                 "serviceAccount": {"create": False},
                 "webhook": {"serviceAccount": {"create": False}},
-                "certController": {"serviceAccount": {"create": False}},
             },
         }
         show_only = [
@@ -186,7 +185,6 @@ class TestServiceAccounts:
                 "enabled": True,
                 "serviceAccount": {"create": True, "annotations": annotations},
                 "webhook": {"serviceAccount": {"create": True, "annotations": annotations}},
-                "certController": {"serviceAccount": {"create": True, "annotations": annotations}},
             },
         }
         show_only = [

--- a/tests/chart_tests/test_dr_failover.py
+++ b/tests/chart_tests/test_dr_failover.py
@@ -157,6 +157,25 @@ class TestDataPlaneFailoverFlag:
         assert docs[0]["kind"] == "Deployment"
         assert docs[0]["metadata"]["name"] == "release-name-navigator"
 
+    def test_navigator_has_backend_secret_checksum_annotation(self, kube_version):
+        """Test that the navigator pod template has a checksum annotation for the houston backend secret.
+
+        Navigator has no bootstrapper init container, so it cannot self-heal a corrupted
+        DATABASE_URL. The checksum annotation ensures a rolling restart is triggered whenever
+        the backend secret template changes, so the pod picks up the correct secret value.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"navigator": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/navigator/navigator-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        annotations = docs[0]["spec"]["template"]["metadata"]["annotations"]
+        assert "checksum/houston-backend-secret" in annotations
+        checksum = annotations["checksum/houston-backend-secret"]
+        assert len(checksum) == 64
+        assert all(c in "0123456789abcdef" for c in checksum)
+
     def test_flag_control_mode_enables_navigator_serviceaccount(self, kube_version):
         """Flag in control mode renders navigator service account."""
         docs = render_chart(

--- a/tests/chart_tests/test_houston_backend_secret.py
+++ b/tests/chart_tests/test_houston_backend_secret.py
@@ -1,0 +1,66 @@
+import base64
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+BACKEND_SECRET_FILE = "charts/astronomer/templates/houston/api/houston-backend-secret.yaml"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestHoustonBackendSecret:
+    def test_houston_backend_secret_renders_with_connection_key(self, kube_version):
+        """Test that the backend secret renders and contains a connection key.
+
+        When no existing secret is found (the common case in helm template / CI),
+        the template should fall back to a random placeholder value so the chart
+        still renders correctly on first install.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 1
+        secret = docs[0]
+        assert secret["kind"] == "Secret"
+        assert secret["type"] == "Opaque"
+        assert secret["metadata"]["name"] == "release-name-houston-backend"
+        assert "connection" in secret["data"]
+        # The value must be non-empty and valid base64
+        connection_b64 = secret["data"]["connection"]
+        assert connection_b64
+        base64.b64decode(connection_b64)  # raises if not valid base64
+
+    def test_houston_backend_secret_not_rendered_in_data_plane(self, kube_version):
+        """Test that the backend secret is not rendered in data plane mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 0
+
+    def test_houston_backend_secret_not_rendered_when_custom_secret_name_set(self, kube_version):
+        """Test that the managed secret is suppressed when backendSecretName is provided."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": {"backendSecretName": "my-custom-secret"}}},
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 0
+
+    def test_houston_backend_secret_rendered_in_control_mode(self, kube_version):
+        """Test that the backend secret renders in control plane mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "control"}}},
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "Secret"
+        assert "connection" in docs[0]["data"]

--- a/tests/chart_tests/test_houston_worker_deployment.py
+++ b/tests/chart_tests/test_houston_worker_deployment.py
@@ -214,3 +214,64 @@ class TestHoustonWorkerDeployment:
         assert len(docs) == 1
         doc = docs[0]
         assert doc["spec"]["replicas"] == CUSTOM_REPLICAS
+
+    def test_houston_worker_deployment_has_backend_secret_checksum_annotation(self, kube_version):
+        """Test that the worker pod template includes a checksum annotation for the houston backend secret.
+
+        This ensures the worker deployment rolling-updates when the backend secret template
+        changes (e.g. on helm upgrade), mirroring the same annotation already present on the
+        API deployment.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        annotations = docs[0]["spec"]["template"]["metadata"]["annotations"]
+        assert "checksum/houston-backend-secret" in annotations
+        # Must be a non-empty sha256 hex string (64 chars)
+        checksum = annotations["checksum/houston-backend-secret"]
+        assert len(checksum) == 64
+        assert all(c in "0123456789abcdef" for c in checksum)
+
+    def test_houston_worker_backend_secret_checksum_matches_api_deployment(self, kube_version):
+        """Test that the worker and API deployments share the same backend secret checksum.
+
+        Both deployments reference the same secret template, so their checksums must be identical.
+        A mismatch would indicate that the worker and API are not restarted consistently.
+        A deterministic backendConnection is supplied so randAlphaNum is not called (each
+        include of the backend-secret template would otherwise re-evaluate randAlphaNum,
+        producing different random values per include call).
+        """
+        deterministic_values = {
+            "astronomer": {
+                "houston": {
+                    "backendSecretConnection": True,
+                    "backendConnection": {
+                        "user": "houston",
+                        "pass": "s3cr3t",
+                        "host": "pg.example.com",
+                        "port": 5432,
+                        "db": "houston",
+                    },
+                }
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=deterministic_values,
+            show_only=[
+                "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml",
+                "charts/astronomer/templates/houston/api/houston-deployment.yaml",
+            ],
+        )
+
+        by_name = {d["metadata"]["name"]: d for d in docs}
+        worker = by_name["release-name-houston-worker"]
+        api = by_name["release-name-houston"]
+
+        worker_checksum = worker["spec"]["template"]["metadata"]["annotations"]["checksum/houston-backend-secret"]
+        api_checksum = api["spec"]["template"]["metadata"]["annotations"]["checksum/houston-backend-secret"]
+
+        assert worker_checksum == api_checksum

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -34,12 +34,15 @@ astronomer:
 global:
   airflowOperator:
     enabled: true
+  authSidecar:
+    enabled: true
   baseDomain: foo.com
   customLogging:
     awsSecretName: dummy
     enabled: true
-  authSidecar:
+  dataPlaneFailover:
     enabled: true
+    externalSecretManagerSecretName: dummy-secret-name
   networkPolicy:
     enabled: true
   rbac:


### PR DESCRIPTION
## Description

- Improve chart test agent skill
- Bump helm to 3.20.2
- Add bin/get-secret-info.py which base64 mass decodes secrets to make debugging them easier
- Add required deployment permissions to commander role
- Improve DATABASE_URL configmap handling
- Remove unused ESO certController

## Related Issues

These changes were made while working on PINF-413

## Testing

I have manually tested these changes extensively in local dev.

## Merging

These are only for 2.0