### PR TITLE
PINF-413 add pilot networkpolicy

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -47,6 +47,13 @@ spec:
           component: dp-ingress-controller
           release: {{ .Release.Name }}
     {{- end }}
+    {{- if .Values.global.dataPlaneFailover.enabled }}
+    - podSelector:
+        matchLabels:
+          component: pilot
+          release: astronomer
+          tier: astronomer
+    {{- end }}
     {{- end }}
     {{- if (eq .Values.global.plane.mode "unified") }}
     - podSelector:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.5
+    tag: 2.0.6
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.8
+    tag: 2.0.9
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.6
+    tag: 2.0.7
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.7
+    tag: 2.0.8
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/tests/chart_tests/test_astronomer_commander_networkpolicy.py
+++ b/tests/chart_tests/test_astronomer_commander_networkpolicy.py
@@ -1,0 +1,82 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+NP_FILE = "charts/astronomer/templates/commander/commander-networkpolicy.yaml"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestCommanderNetworkPolicyDataplaneFailover:
+    def test_dataplane_failover_enabled_adds_pilot_ingress_rule(self, kube_version):
+        """Pilot podSelector is added to ingress when dataPlaneFailover is enabled in data plane mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "data"},
+                    "dataPlaneFailover": {"enabled": True},
+                }
+            },
+        )
+        assert len(docs) == 1
+        ingress_from = docs[0]["spec"]["ingress"][0]["from"]
+        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "astronomer", "tier": "astronomer"}}}
+        assert pilot_selector in ingress_from
+
+    def test_dataplane_failover_disabled_omits_pilot_ingress_rule(self, kube_version):
+        """Pilot podSelector is absent when dataPlaneFailover is disabled in data plane mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "data"},
+                    "dataPlaneFailover": {"enabled": False},
+                }
+            },
+        )
+        assert len(docs) == 1
+        ingress_from = docs[0]["spec"]["ingress"][0]["from"]
+        components = [r.get("podSelector", {}).get("matchLabels", {}).get("component") for r in ingress_from]
+        assert "pilot" not in components
+
+    def test_dataplane_failover_enabled_unified_mode_omits_pilot_ingress_rule(self, kube_version):
+        """Pilot podSelector is not added in unified mode even when dataPlaneFailover is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "unified"},
+                    "dataPlaneFailover": {"enabled": True},
+                }
+            },
+        )
+        assert len(docs) == 1
+        all_from_rules = [rule for ingress in docs[0]["spec"]["ingress"] for rule in ingress.get("from", [])]
+        components = [r.get("podSelector", {}).get("matchLabels", {}).get("component") for r in all_from_rules]
+        assert "pilot" not in components
+
+    def test_dataplane_failover_enabled_with_auth_sidecar_adds_pilot_ingress_rule(self, kube_version):
+        """Pilot podSelector is added even when authSidecar is enabled, as long as dataPlaneFailover is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "data"},
+                    "dataPlaneFailover": {"enabled": True},
+                    "authSidecar": {"enabled": True},
+                }
+            },
+        )
+        assert len(docs) == 1
+        ingress_from = docs[0]["spec"]["ingress"][0]["from"]
+        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "astronomer", "tier": "astronomer"}}}
+        assert pilot_selector in ingress_from

--- a/tests/chart_tests/test_dr_failover.py
+++ b/tests/chart_tests/test_dr_failover.py
@@ -19,8 +19,6 @@ def failover_values(plane_mode):
 class TestDataPlaneFailoverFlag:
     """Tests for the global.dataPlaneFailover.enabled feature flag."""
 
-    # --- Data-plane components (mode=data) ---
-
     def test_flag_data_mode_enables_pilot(self, kube_version):
         """Flag in data mode renders pilot deployment without pilot.enabled."""
         docs = render_chart(
@@ -144,8 +142,6 @@ class TestDataPlaneFailoverFlag:
         env_vars = get_env_vars_dict(c_by_name["pilot"]["env"])
         assert "COMMANDER_FLIGHTDECK_DSN" in env_vars
 
-    # --- Control-plane components (mode=control) ---
-
     def test_flag_control_mode_enables_navigator(self, kube_version):
         """Flag in control mode renders navigator deployment without navigator.enabled."""
         docs = render_chart(
@@ -220,8 +216,6 @@ class TestDataPlaneFailoverFlag:
         env_vars = get_env_vars_dict(c_by_name["houston"]["env"])
         assert env_vars["DISPATCHER_ENABLED"] == "true"
 
-    # --- Cross-mode isolation ---
-
     def test_flag_data_mode_does_not_enable_navigator(self, kube_version):
         """Flag in data mode does NOT render navigator."""
         docs = render_chart(
@@ -255,8 +249,6 @@ class TestDataPlaneFailoverFlag:
         )
         assert len(docs) == 0
 
-    # --- Unified mode: flag has no effect ---
-
     def test_flag_unified_mode_does_not_enable_pilot(self, kube_version):
         """Flag in unified mode does NOT auto-enable pilot."""
         docs = render_chart(
@@ -274,8 +266,6 @@ class TestDataPlaneFailoverFlag:
             show_only=["charts/astronomer/templates/navigator/navigator-deployment.yaml"],
         )
         assert len(docs) == 0
-
-    # --- Flag disabled: no effect ---
 
     def test_flag_disabled_no_pilot(self, kube_version):
         """With flag disabled, pilot is not rendered (pilot.enabled defaults to false)."""


### PR DESCRIPTION
## Description

- houston-api 2.0.9
- Modify commander networkPolicy to allow pilot to hit commander 

## Related Issues

These image changes were built as part of PINF-413

## Testing

These changes have been tested quite a bit in local dev

## Merging

master, release-2.0