### PR TITLE
PINF-495: add emptyDir mount for Prisma client path in db-migration job

### DIFF
--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -160,6 +160,8 @@ spec:
               mountPath: /tmp
             - name: tmp
               mountPath: /houston/node_modules/.cache
+            - name: tmp
+              mountPath: /houston/node_modules/.prisma
           {{- include "houston_volume_mounts" . | indent 12 }}
           {{- include "custom_ca_volume_mounts" . | indent 12 }}
       volumes:

--- a/tests/chart_tests/test_astronomer_houston_hook_job.py
+++ b/tests/chart_tests/test_astronomer_houston_hook_job.py
@@ -46,6 +46,10 @@ class TestHoustonHookJob:
             "mountPath": "/houston/config/local-production.yaml",
             "subPath": "local-production.yaml",
         } in c_by_name["post-upgrade-job"]["volumeMounts"]
+        assert {
+            "name": "tmp",
+            "mountPath": "/houston/node_modules/.prisma",
+        } in c_by_name["houston-db-migrations-job"]["volumeMounts"]
 
     def test_upgrade_deployments_job_disabled(self, kube_version):
         """Test Upgrade Deployments Job when disabled."""


### PR DESCRIPTION
## Description

Upgrading from `0.37.x` to `2.0.x` fails during the houston-db-migrations job with:
`Error: EROFS: read-only file system`, unlink '/houston/node_modules/.prisma/client/index.js'
Houston 2.x enforces `readOnlyRootFilesystem: true`, but Prisma needs to write/unlink files under node_modules/.prisma/client/ at migration time.

## Related Issues

https://linear.app/astronomer/issue/PINF-495/upgrade-from-0374-to-200-beta2-is-failed

## Testing

- Added unittest

## Merging

Master, 2.0