### PR TITLE
PINF-502: Normalize integer level field in Vector DaemonSet pipeline to prevent ES mapping conflict

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -92,6 +92,10 @@ data:
               . = merge!(., parsed)
             }
           }
+          # Normalize level to string for all events
+          if exists(.level) && is_integer(.level) {
+            .level = to_string!(.level)
+          }
 
       transform_task_logs:
         type: remap

--- a/tests/chart_tests/test_vector_cm.py
+++ b/tests/chart_tests/test_vector_cm.py
@@ -157,3 +157,20 @@ class TestVectorConfigmap:
         # Verify bulk settings
         assert "mode: bulk" in config_yaml
         assert "max_bytes: 10485760" in config_yaml
+
+    def test_vector_configmap_parse_json_messages_normalizes_level_to_string(self, kube_version):
+        """Test that parse_json_messages transform normalizes integer level to string."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        config_yaml = doc["data"]["vector-config.yaml"]
+
+        config_dict = yaml.safe_load(config_yaml)
+        source = config_dict["transforms"]["parse_json_messages"]["source"]
+
+        assert "is_integer(.level)" in source
+        assert ".level = to_string!(.level)" in source


### PR DESCRIPTION
## Description

This PR fixes the level column which comes as long instead of string which is expected by ES. On CP/DP 1.1.2, all Airflow 3 task logs are lost on git-sync-enabled deployments. The Airflow UI shows no logs, with two errors:

Write path (Vector → ES):
```
elasticsearch.BadRequestError: document_parsing_exception:
failed to parse field [level] of type [long]... Preview of field's value: 'warning'
```
Read path (Airflow UI → ES):

```
elasticsearch.BadRequestError: No mapping found for [offset] in order to sort on
Dag-deploy and image-deploy deployments are not affected.
```

## Related Issues

https://linear.app/astronomer/issue/PINF-502/git-sync-deployments-with-ds-logging-break-elasticsearch-logs

## Testing

- After the change git-sync logs are consistent:
<img width="1796" height="981" alt="Screenshot 2026-04-17 at 1 33 13 PM" src="https://github.com/user-attachments/assets/16f56558-c360-4b66-9e62-35d13dbf0892" />

- Tested DOD mechanism: 
<img width="1540" height="700" alt="Screenshot 2026-04-17 at 1 35 28 PM" src="https://github.com/user-attachments/assets/80ed4f36-08b8-4035-a475-0f12ad7ff9be" />

<img width="1735" height="709" alt="Screenshot 2026-04-17 at 2 35 42 PM" src="https://github.com/user-attachments/assets/d7e88eed-3012-4b18-9797-7063ed51467a" />


## Merging

Master, 2.x, 1.x