### PR TITLE
PLX-342 Fix GCP audit logging sink resource wiring for Houston sidecars

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -83,6 +83,11 @@
 {{- if not (or $hasBuiltInSink $hasExtraSinks) -}}
 {{- fail "houston.logging.loggingSidecar.enabled requires at least one sink: enable cloudwatch, gcpCloudLogging, elasticsearch, or set extraSinks" -}}
 {{- end -}}
+{{- if .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.projectId must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.location must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -84,11 +84,43 @@
 {{- fail "houston.logging.loggingSidecar.enabled requires at least one sink: enable cloudwatch, gcpCloudLogging, elasticsearch, or set extraSinks" -}}
 {{- end -}}
 {{- if .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled -}}
-{{- required "houston.logging.loggingSidecar.gcpCloudLogging.projectId must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId -}}
-{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.location must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location -}}
-{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName must be set when gcpCloudLogging.enabled is true" .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.projectId must be set when gcpCloudLogging.enabled is true" (.Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | default "" | trim) -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.location must be set when gcpCloudLogging.enabled is true" (.Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location | default "" | trim) -}}
+{{- required "houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName must be set when gcpCloudLogging.enabled is true" (.Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName | default "" | trim) -}}
 {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{- define "houston.logging.loggingSidecar.gcpCloudLogging.sink" -}}
+{{- $root := .root -}}
+{{- $gcp := $root.Values.houston.logging.loggingSidecar.gcpCloudLogging -}}
+gcp_cloud_logging:
+  type: gcp_stackdriver_logs
+  inputs:
+    - normalize_levels
+  project_id: {{ $gcp.projectId | default "" | trim | quote }}
+  log_id: {{ $gcp.logId | quote }}
+  severity_key: {{ $gcp.severityKey | quote }}
+{{- if not $gcp.useWorkloadIdentity }}
+  credentials_path: "/etc/gcp-credentials/{{ $gcp.credentialsSecretKey }}"
+{{- end }}
+  resource:
+    type: {{ $gcp.resource.type | quote }}
+    project_id: {{ $gcp.projectId | default "" | trim | quote }}
+    location: {{ $gcp.resource.location | default "" | trim | quote }}
+    namespace_name: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
+    pod_name: "{{ "{{" }} kubernetes.pod_name {{ "}}" }}"
+    container_name: {{ .containerName | quote }}
+    cluster_name: {{ $gcp.resource.clusterName | default "" | trim | quote }}
+  labels:
+    component: {{ .componentName | quote }}
+  batch:
+    max_events: 100
+    timeout_secs: 5
+  buffer:
+    type: memory
+    max_events: 10000
+    when_full: block
 {{- end -}}
 
 {{ define "registry.docker.config" -}}

--- a/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
@@ -120,33 +120,7 @@ data:
           enabled: true
     {{- end }}
     {{- if .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled }}
-      gcp_cloud_logging:
-        type: gcp_stackdriver_logs
-        inputs:
-          - normalize_levels
-        project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-        log_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.logId | quote }}
-        severity_key: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.severityKey | quote }}
-    {{- if not .Values.houston.logging.loggingSidecar.gcpCloudLogging.useWorkloadIdentity }}
-        credentials_path: "/etc/gcp-credentials/{{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.credentialsSecretKey }}"
-    {{- end }}
-        resource:
-          type: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.type | quote }}
-          project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-          location: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location | quote }}
-          namespace_name: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
-          pod_name: "{{ "{{" }} kubernetes.pod_name {{ "}}" }}"
-          container_name: "houston"
-          cluster_name: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName | quote }}
-        labels:
-          component: "houston-api"
-        batch:
-          max_events: 100
-          timeout_secs: 5
-        buffer:
-          type: memory
-          max_events: 10000
-          when_full: block
+{{ include "houston.logging.loggingSidecar.gcpCloudLogging.sink" (dict "root" . "containerName" "houston" "componentName" "houston-api") | nindent 6 }}
     {{- end }}
     {{- if .Values.houston.logging.loggingSidecar.elasticsearch.enabled }}
       elasticsearch:

--- a/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
@@ -133,11 +133,11 @@ data:
         resource:
           type: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.type | quote }}
           project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-          location: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
+          location: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location | quote }}
           namespace_name: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
           pod_name: "{{ "{{" }} kubernetes.pod_name {{ "}}" }}"
           container_name: "houston"
-          cluster_name: {{ .Values.global.clusterName | default "unknown" | quote }}
+          cluster_name: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName | quote }}
         labels:
           component: "houston-api"
         batch:

--- a/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
@@ -120,33 +120,7 @@ data:
           enabled: true
     {{- end }}
     {{- if .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled }}
-      gcp_cloud_logging:
-        type: gcp_stackdriver_logs
-        inputs:
-          - normalize_levels
-        project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-        log_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.logId | quote }}
-        severity_key: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.severityKey | quote }}
-    {{- if not .Values.houston.logging.loggingSidecar.gcpCloudLogging.useWorkloadIdentity }}
-        credentials_path: "/etc/gcp-credentials/{{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.credentialsSecretKey }}"
-    {{- end }}
-        resource:
-          type: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.type | quote }}
-          project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-          location: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location | quote }}
-          namespace_name: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
-          pod_name: "{{ "{{" }} kubernetes.pod_name {{ "}}" }}"
-          container_name: "houston-worker"
-          cluster_name: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName | quote }}
-        labels:
-          component: "houston-worker"
-        batch:
-          max_events: 100
-          timeout_secs: 5
-        buffer:
-          type: memory
-          max_events: 10000
-          when_full: block
+{{ include "houston.logging.loggingSidecar.gcpCloudLogging.sink" (dict "root" . "containerName" "houston-worker" "componentName" "houston-worker") | nindent 6 }}
     {{- end }}
     {{- if .Values.houston.logging.loggingSidecar.elasticsearch.enabled }}
       elasticsearch:

--- a/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
@@ -133,11 +133,11 @@ data:
         resource:
           type: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.type | quote }}
           project_id: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | quote }}
-          location: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
+          location: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.location | quote }}
           namespace_name: "{{ "{{" }} kubernetes.pod_namespace {{ "}}" }}"
           pod_name: "{{ "{{" }} kubernetes.pod_name {{ "}}" }}"
           container_name: "houston-worker"
-          cluster_name: {{ .Values.global.clusterName | default "unknown" | quote }}
+          cluster_name: {{ .Values.houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName | quote }}
         labels:
           component: "houston-worker"
         batch:

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -260,6 +260,12 @@ houston:
         # Monitored resource type. "k8s_container" is the standard for GKE pods.
         resource:
           type: "k8s_container"
+          # Required for k8s_container resources. This should be the GKE
+          # cluster location, for example "us-east4" or "us-east4-b".
+          location: ""
+          # Required for k8s_container resources. This should match the GKE
+          # cluster name as it appears in Cloud Logging.
+          clusterName: ""
         # Map the "level" field in log entries to GCP severity levels.
         severityKey: "level"
         # Use GKE Workload Identity for authentication (recommended).

--- a/values.yaml
+++ b/values.yaml
@@ -439,6 +439,8 @@ astronomer:
           logId: "houston-audit"
           resource:
             type: "k8s_container"
+            location: ""
+            clusterName: ""
           severityKey: "level"
           useWorkloadIdentity: true
           credentialsSecretName: "houston-gcp-logging-creds"


### PR DESCRIPTION
## Description

This fixes the Houston Vector sidecar wiring for the GCP Cloud Logging sink.

The chart was rendering invalid `k8s_container` monitored resource metadata for the `gcp_stackdriver_logs` sink:
- `location` was incorrectly derived from the pod namespace
- `cluster_name` could silently fall back to `"unknown"`

In practice, this caused Vector to send requests that GCP rejected with `400 Bad Request`, so Houston audit logs were dropped instead of reaching Cloud Logging.

This change:
- wires `location` from `houston.logging.loggingSidecar.gcpCloudLogging.resource.location`
- wires `cluster_name` from `houston.logging.loggingSidecar.gcpCloudLogging.resource.clusterName`
- adds validation so `projectId`, `resource.location`, and `resource.clusterName` are required when `gcpCloudLogging.enabled=true`
- adds the new GCP resource fields to both chart values files

This keeps the configuration under the `houston.logging.loggingSidecar.gcpCloudLogging.*` schema and does not change CloudWatch or Elasticsearch sink behavior.

## Related Issues

https://linear.app/astronomer/issue/PLX-342/vector-in-gcp-sink-is-giving-400-error-due-to-bad-config-map

## Testing

- Debugged the issue on a live GKE cluster where Houston audit logs were not reaching Cloud Logging
- Confirmed Vector sidecars were attempting writes and receiving `400 Bad Request`
- Patched the live Houston Vector configmaps with the same `project_id`, `location`, and `cluster_name` wiring implemented in this PR
- Restarted Houston and Houston Worker
- Triggered fresh audit events through Houston API
- Verified the events landed successfully in GCP Cloud Logging with:
  - `resource.type = k8s_container`
  - correct `project_id`
  - correct `location`
  - correct `cluster_name`
- Verified the fix path is isolated to the GCP sink and does not change CloudWatch or Elasticsearch templates

## Merging

Merge into master
