### PR TITLE
PLX-294: Add more tests in houston configmap

### DIFF
--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -2,7 +2,7 @@ import ast
 
 import yaml
 
-from tests.utils.chart import render_chart
+from tests.utils.chart import find_key_paths, render_chart
 
 
 def common_test_cases(docs):
@@ -1017,19 +1017,6 @@ def test_houston_configmap_no_vector_enabled_key():
     )
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
 
-    def _find_key(obj, needle, path=""):
-        hits = []
-        if isinstance(obj, dict):
-            for k, v in obj.items():
-                p = f"{path}.{k}" if path else k
-                if k == needle:
-                    hits.append(p)
-                hits.extend(_find_key(v, needle, p))
-        elif isinstance(obj, list):
-            for i, item in enumerate(obj):
-                hits.extend(_find_key(item, needle, f"{path}[{i}]"))
-        return hits
-
-    assert _find_key(prod, "vectorEnabled") == [], (
+    assert find_key_paths(prod, "vectorEnabled") == [], (
         "Legacy vectorEnabled key reappeared in rendered ConfigMap. Use loggingSidecar.enabled instead."
     )

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -990,3 +990,51 @@ def test_houston_configmap_features_logging_defaults():
     log = prod["deployments"]["logging"]
     assert log["enabled"] is True
     assert log["provider"] == "fluentd"
+
+
+def test_houston_configmap_no_flat_enabled_flags_under_deployments():
+    """Guard the uniform flag pattern (PLX-254): no flat *Enabled keys may
+    appear directly under deployments in the rendered production.yaml.
+    New feature flags must be nested as <feature>.enabled."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    deployments = prod["deployments"]
+
+    violations = [
+        key
+        for key, value in deployments.items()
+        if key.endswith("Enabled") and isinstance(value, bool)
+    ]
+    assert violations == [], (
+        f"Flat *Enabled keys found under deployments: {violations}. "
+        "Wrap each in a named object: deployments.<feature>.enabled: true"
+    )
+
+
+def test_houston_configmap_no_vector_enabled_key():
+    """Guard PLX-287: global.vectorEnabled must not reappear in the rendered
+    ConfigMap. The sidecar logging toggle lives at loggingSidecar.enabled."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+
+    def _find_key(obj, needle, path=""):
+        hits = []
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                p = f"{path}.{k}" if path else k
+                if k == needle:
+                    hits.append(p)
+                hits.extend(_find_key(v, needle, p))
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                hits.extend(_find_key(item, needle, f"{path}[{i}]"))
+        return hits
+
+    assert _find_key(prod, "vectorEnabled") == [], (
+        "Legacy vectorEnabled key reappeared in rendered ConfigMap. "
+        "Use loggingSidecar.enabled instead."
+    )

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1002,11 +1002,7 @@ def test_houston_configmap_no_flat_enabled_flags_under_deployments():
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     deployments = prod["deployments"]
 
-    violations = [
-        key
-        for key, value in deployments.items()
-        if key.endswith("Enabled") and isinstance(value, bool)
-    ]
+    violations = [key for key, value in deployments.items() if key.endswith("Enabled") and isinstance(value, bool)]
     assert violations == [], (
         f"Flat *Enabled keys found under deployments: {violations}. "
         "Wrap each in a named object: deployments.<feature>.enabled: true"
@@ -1035,6 +1031,5 @@ def test_houston_configmap_no_vector_enabled_key():
         return hits
 
     assert _find_key(prod, "vectorEnabled") == [], (
-        "Legacy vectorEnabled key reappeared in rendered ConfigMap. "
-        "Use loggingSidecar.enabled instead."
+        "Legacy vectorEnabled key reappeared in rendered ConfigMap. Use loggingSidecar.enabled instead."
     )

--- a/tests/utils/chart.py
+++ b/tests/utils/chart.py
@@ -203,3 +203,18 @@ def prepare_k8s_lookup_dict(k8s_objects) -> dict[tuple[str, str], dict[str, Any]
     The keys of the dict are the k8s object's kind and name
     """
     return {(k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object for k8s_object in k8s_objects}
+
+
+def find_key_paths(obj: Any, needle: str, path: str = "") -> list[str]:
+    """Return dotted paths of every occurrence of `needle` as a key in a nested dict/list."""
+    hits: list[str] = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            p = f"{path}.{k}" if path else k
+            if k == needle:
+                hits.append(p)
+            hits.extend(find_key_paths(v, needle, p))
+    elif isinstance(obj, list):
+        for i, item in enumerate(obj):
+            hits.extend(find_key_paths(item, needle, f"{path}[{i}]"))
+    return hits


### PR DESCRIPTION
## Description

Adds regression guards for PLX-294 in the rendered Houston ConfigMap.
- `test_houston_configmap_no_flat_enabled_flags_under_deployments`: fails if any flat `*Enabled` boolean reappears directly under `deployments`.
- `test_houston_configmap_no_vector_enabled_key`: fails if `vectorEnabled` reappears anywhere in `production.yaml`.
Refs: PLX-254, PLX-287.


## Related Issues

https://linear.app/astronomer/issue/PLX-294/phase-1-uniform-flag-pattern-automation-tests

## Testing

- unit tests

## Merging

2.0, main