### PR TITLE
PINF-504 - rework postgres exporter component label

### DIFF
--- a/charts/prometheus-postgres-exporter/templates/configmap.yaml
+++ b/charts/prometheus-postgres-exporter/templates/configmap.yaml
@@ -6,7 +6,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -10,7 +10,7 @@ kind: Deployment
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -18,13 +18,12 @@ spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ template "prometheus-postgres-exporter.name" . }}
+      component: {{ template "prometheus-postgres-exporter.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         tier: monitoring
-        app: {{ template "prometheus-postgres-exporter.name" . }}
         version: {{ .Chart.Version }}
         release: {{ .Release.Name }}
         component: prometheus-postgres-exporter

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         tier: monitoring
         version: {{ .Chart.Version }}
         release: {{ .Release.Name }}
-        component: prometheus-postgres-exporter
+        component: {{ template "prometheus-postgres-exporter.name" . }}
         {{- include "global.podLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | trim | indent 8 }}

--- a/charts/prometheus-postgres-exporter/templates/networkpolicy.yaml
+++ b/charts/prometheus-postgres-exporter/templates/networkpolicy.yaml
@@ -17,7 +17,7 @@ spec:
   podSelector:
     matchLabels:
       tier: monitoring
-      app: {{ template "prometheus-postgres-exporter.name" . }}
+      component: {{ template "prometheus-postgres-exporter.name" . }}
       release: {{ .Release.Name }}
   policyTypes:
   - Ingress

--- a/charts/prometheus-postgres-exporter/templates/pod-disruption-budget.yaml
+++ b/charts/prometheus-postgres-exporter/templates/pod-disruption-budget.yaml
@@ -10,6 +10,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      app: {{ template "prometheus-postgres-exporter.name" . }}
+      component: {{ template "prometheus-postgres-exporter.name" . }}
       release: {{ .Release.Name }}
 {{- end }}

--- a/charts/prometheus-postgres-exporter/templates/role.yaml
+++ b/charts/prometheus-postgres-exporter/templates/role.yaml
@@ -7,7 +7,7 @@ kind: Role
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
+++ b/charts/prometheus-postgres-exporter/templates/rolebinding.yaml
@@ -7,7 +7,7 @@ kind: RoleBinding
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/prometheus-postgres-exporter/templates/secret.yaml
+++ b/charts/prometheus-postgres-exporter/templates/secret.yaml
@@ -7,7 +7,7 @@ kind: Secret
 metadata:
   name: {{ template "prometheus-postgres-exporter.fullname" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}

--- a/charts/prometheus-postgres-exporter/templates/service.yaml
+++ b/charts/prometheus-postgres-exporter/templates/service.yaml
@@ -28,5 +28,5 @@ spec:
       name: {{ .Values.service.name }}
       appProtocol: tcp
   selector:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     release: {{ .Release.Name }}

--- a/charts/prometheus-postgres-exporter/templates/service.yaml
+++ b/charts/prometheus-postgres-exporter/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
+++ b/charts/prometheus-postgres-exporter/templates/serviceaccount.yaml
@@ -7,7 +7,7 @@ kind: ServiceAccount
 metadata:
   name: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
   labels:
-    app: {{ template "prometheus-postgres-exporter.name" . }}
+    component: {{ template "prometheus-postgres-exporter.name" . }}
     chart: {{ template "prometheus-postgres-exporter.chart" . }}
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/tests/chart_tests/test_prometheus_postgres_exporter.py
+++ b/tests/chart_tests/test_prometheus_postgres_exporter.py
@@ -29,7 +29,7 @@ class TestPrometheusPostgresExporter:
         doc = docs[0]
         assert doc["kind"] == "Service"
         assert doc["metadata"]["name"] == "release-name-postgresql-exporter"
-        assert doc["spec"]["selector"]["app"] == "prometheus-postgres-exporter"
+        assert doc["spec"]["selector"]["component"] == "prometheus-postgres-exporter"
         assert doc["spec"]["type"] == "ClusterIP"
         assert doc["spec"]["ports"] == [
             {


### PR DESCRIPTION
## Description

fix postgres component label to match all other subchart convention

moved from app -> component

## Related Issues

https://linear.app/astronomer/issue/PINF-504/fix-postgres-exporter-exporter-component-label

## Testing

QA should able to verify postgres exporters works as expected

## Merging

merge to master and release-2.0
