### PR TITLE
PLX-351: Add strictSchemaCheck feature flag and set it to false

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -619,6 +619,37 @@ def apply_houston_config_flag_migrations(root: CommentedMap) -> list[MigrationCh
     return changes
 
 
+def apply_new_houston_defaults(root: CommentedMap) -> list[MigrationChange]:
+    """Inject new top-level houston keys introduced in 2.x with their default values.
+
+    Adds keys that are new in 2.x and must be present after migration.
+    Uses if-missing semantics — existing keys are never overwritten.
+
+    Parameters:
+        root: The parsed YAML document root.
+
+    Returns:
+        MigrationChange entries for every key that was injected.
+    """
+    changes: list[MigrationChange] = []
+
+    path = ["astronomer", "houston", "strictSchemaCheck"]
+    if not _path_exists(root, path):
+        parent = _ensure_nested_key(root, path[:-1])
+        cm = CommentedMap()
+        cm["enabled"] = False
+        parent[path[-1]] = cm
+        changes.append(
+            MigrationChange(
+                "(new)",
+                "astronomer.houston.strictSchemaCheck",
+                "Added astronomer.houston.strictSchemaCheck with default value",
+            )
+        )
+
+    return changes
+
+
 def load_yaml(input_path: Path) -> tuple[YAML, Any]:
     """Load a YAML file using round-trip mode.
 

--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -336,6 +336,44 @@ class SubtreeMove:
         return [MigrationChange(old_str, new_str, f"Moved subtree {old_str}.* -> {new_str}.*")]
 
 
+@dataclass
+class AddKeyIfMissing:
+    """Add a key with a default value only if it does not already exist.
+
+    Example: AddKeyIfMissing(["global", "plane"], {"mode": "unified", "domainPrefix": ""})
+    """
+
+    path: list[str] = field(default_factory=list)
+    value: Any = None
+
+    def apply(self, root: CommentedMap) -> list[MigrationChange]:
+        """Apply the add-key-if-missing rule."""
+        if _path_exists(root, self.path):
+            return []
+
+        parent_keys = self.path[:-1]
+        leaf = self.path[-1]
+
+        parent = _ensure_nested_key(root, parent_keys) if parent_keys else root
+
+        if isinstance(self.value, dict):
+            cm = CommentedMap()
+            for k, v in self.value.items():
+                if isinstance(v, dict):
+                    inner = CommentedMap()
+                    for ik, iv in v.items():
+                        inner[ik] = iv
+                    cm[k] = inner
+                else:
+                    cm[k] = v
+            parent[leaf] = cm
+        else:
+            parent[leaf] = self.value
+
+        path_str = ".".join(self.path)
+        return [MigrationChange("(new)", path_str, f"Added {path_str} with default value")]
+
+
 GLOBAL_FEATURE_FLAG_RULES: list[BoolToNested | InvertedBoolToNested | SubtreeMove] = [
     BoolToNested("rbacEnabled", ["rbac", "enabled"]),
     BoolToNested("sccEnabled", ["scc", "enabled"]),
@@ -615,37 +653,6 @@ def apply_houston_config_flag_migrations(root: CommentedMap) -> list[MigrationCh
             parent[new_path[-1]] = value
             _delete_key(section, old_key)
             changes.append(MigrationChange(old_str, new_str, f"Moved {old_str} -> {new_str}"))
-
-    return changes
-
-
-def apply_new_houston_defaults(root: CommentedMap) -> list[MigrationChange]:
-    """Inject new top-level houston keys introduced in 2.x with their default values.
-
-    Adds keys that are new in 2.x and must be present after migration.
-    Uses if-missing semantics — existing keys are never overwritten.
-
-    Parameters:
-        root: The parsed YAML document root.
-
-    Returns:
-        MigrationChange entries for every key that was injected.
-    """
-    changes: list[MigrationChange] = []
-
-    path = ["astronomer", "houston", "strictSchemaCheck"]
-    if not _path_exists(root, path):
-        parent = _ensure_nested_key(root, path[:-1])
-        cm = CommentedMap()
-        cm["enabled"] = False
-        parent[path[-1]] = cm
-        changes.append(
-            MigrationChange(
-                "(new)",
-                "astronomer.houston.strictSchemaCheck",
-                "Added astronomer.houston.strictSchemaCheck with default value",
-            )
-        )
 
     return changes
 

--- a/bin/migrate-helm-chart-values-037x-to-2x.py
+++ b/bin/migrate-helm-chart-values-037x-to-2x.py
@@ -38,6 +38,7 @@ from helm_chart_values_migration_shared import (  # noqa: E402
     apply_global_feature_flag_rules_to_all,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
+    apply_new_houston_defaults,
     apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
@@ -404,6 +405,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
     all_changes.extend(apply_nginx_csp_policy_migrations(data))
+    all_changes.extend(apply_new_houston_defaults(data))
 
     return all_changes
 

--- a/bin/migrate-helm-chart-values-037x-to-2x.py
+++ b/bin/migrate-helm-chart-values-037x-to-2x.py
@@ -288,7 +288,7 @@ MIGRATIONS: list[MigrationRule] = [
     AddKeyIfMissing(["global", "authHeaderSecretName"], value=None),
     AddKeyIfMissing(["global", "plane"], value={"mode": "unified", "domainPrefix": ""}),
     AddKeyIfMissing(["global", "podLabels"], value={}),
-    AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": False}),
+    AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": True}),
     AddKeyIfMissing(
         ["nats", "init"],
         value={

--- a/bin/migrate-helm-chart-values-037x-to-2x.py
+++ b/bin/migrate-helm-chart-values-037x-to-2x.py
@@ -34,11 +34,11 @@ if str(_BIN) not in sys.path:
 import helm_chart_values_migration_shared as _shared  # noqa: E402
 from helm_chart_values_migration_shared import (  # noqa: E402
     HOUSTON_DEPLOYMENTS_PREFIX,
+    AddKeyIfMissing,
     MigrationChange,
     apply_global_feature_flag_rules_to_all,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
-    apply_new_houston_defaults,
     apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
@@ -231,44 +231,6 @@ class SetValue(MigrationRule):
 
 
 @dataclass
-class AddKeyIfMissing(MigrationRule):
-    """Add a key with a default value only if it does not already exist.
-
-    Example: AddKeyIfMissing(["global", "plane"], {"mode": "unified", "domainPrefix": ""})
-    """
-
-    path: list[str] = field(default_factory=list)
-    value: Any = None
-
-    def apply(self, root: CommentedMap) -> list[MigrationChange]:
-        """Apply the add-key-if-missing rule."""
-        if _shared._path_exists(root, self.path):
-            return []
-
-        parent_keys = self.path[:-1]
-        leaf = self.path[-1]
-
-        parent = _shared._ensure_nested_key(root, parent_keys) if parent_keys else root
-
-        if isinstance(self.value, dict):
-            cm = CommentedMap()
-            for k, v in self.value.items():
-                if isinstance(v, dict):
-                    inner = CommentedMap()
-                    for ik, iv in v.items():
-                        inner[ik] = iv
-                    cm[k] = inner
-                else:
-                    cm[k] = v
-            parent[leaf] = cm
-        else:
-            parent[leaf] = self.value
-
-        path_str = ".".join(self.path)
-        return [MigrationChange("(new)", path_str, f"Added {path_str} with default value")]
-
-
-@dataclass
 class HoustonDeploymentBoolToNested(MigrationRule):
     """Migrate a flat boolean under ``astronomer.houston.config.deployments`` to nested ``.enabled``."""
 
@@ -326,6 +288,7 @@ MIGRATIONS: list[MigrationRule] = [
     AddKeyIfMissing(["global", "authHeaderSecretName"], value=None),
     AddKeyIfMissing(["global", "plane"], value={"mode": "unified", "domainPrefix": ""}),
     AddKeyIfMissing(["global", "podLabels"], value={}),
+    AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": False}),
     AddKeyIfMissing(
         ["nats", "init"],
         value={
@@ -405,7 +368,6 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
     all_changes.extend(apply_nginx_csp_policy_migrations(data))
-    all_changes.extend(apply_new_houston_defaults(data))
 
     return all_changes
 

--- a/bin/migrate-helm-chart-values-1x-to-2x.py
+++ b/bin/migrate-helm-chart-values-1x-to-2x.py
@@ -39,6 +39,7 @@ from helm_chart_values_migration_shared import (  # noqa: E402
     apply_global_feature_flag_rules_to_all,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
+    apply_new_houston_defaults,
     apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
@@ -66,6 +67,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
     all_changes.extend(apply_nginx_csp_policy_migrations(data))
+    all_changes.extend(apply_new_houston_defaults(data))
 
     return all_changes
 

--- a/bin/migrate-helm-chart-values-1x-to-2x.py
+++ b/bin/migrate-helm-chart-values-1x-to-2x.py
@@ -32,6 +32,7 @@ if str(_BIN) not in sys.path:
 from helm_chart_values_migration_shared import (  # noqa: E402
     GLOBAL_FEATURE_FLAG_RULES,
     HOUSTON_DEPLOYMENT_BOOL_RULES,
+    AddKeyIfMissing,
     BoolToNested,  # noqa: F401
     InvertedBoolToNested,  # noqa: F401
     MigrationChange,
@@ -39,7 +40,6 @@ from helm_chart_values_migration_shared import (  # noqa: E402
     apply_global_feature_flag_rules_to_all,
     apply_houston_config_flag_migrations,
     apply_houston_deployment_migrations,
-    apply_new_houston_defaults,
     apply_nginx_csp_policy_migrations,
     dump_yaml,
     load_yaml,
@@ -67,7 +67,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
     all_changes.extend(apply_nginx_csp_policy_migrations(data))
-    all_changes.extend(apply_new_houston_defaults(data))
+    all_changes.extend(AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": False}).apply(data))
 
     return all_changes
 

--- a/bin/migrate-helm-chart-values-1x-to-2x.py
+++ b/bin/migrate-helm-chart-values-1x-to-2x.py
@@ -67,7 +67,7 @@ def migrate_values(data: Any) -> list[MigrationChange]:
     all_changes.extend(apply_houston_config_flag_migrations(data))
     all_changes.extend(apply_houston_deployment_migrations(data))
     all_changes.extend(apply_nginx_csp_policy_migrations(data))
-    all_changes.extend(AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": False}).apply(data))
+    all_changes.extend(AddKeyIfMissing(["astronomer", "houston", "strictSchemaCheck"], value={"enabled": True}).apply(data))
 
     return all_changes
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -671,6 +671,8 @@ data:
       host: {{ printf "%s-prometheus" .Release.Name }}
     updateRuntimeCheck:
       enabled: {{ .Values.houston.updateRuntimeCheck.enabled }}
+    strictSchemaCheck:
+      enabled: {{ .Values.houston.strictSchemaCheck.enabled }}
 
   # These are any user-specified config overrides.
   local-production.yaml: |

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -444,6 +444,12 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
+  # Strict schema validation for deploymentsConfigOverride.
+  # When disabled, Houston skips AJV schema checks on config overrides, allowing
+  # unknown keys and type mismatches to pass through.
+  strictSchemaCheck:
+    enabled: false
+
   # Populate daily task usage data
   # This runs as a CronJob
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -444,6 +444,10 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
+  # When true, Houston rejects deployment config overrides that fail JSON-schema validation.
+  strictSchemaCheck:
+    enabled: true
+
   # Populate daily task usage data
   # This runs as a CronJob
 

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -444,12 +444,6 @@ houston:
     readinessProbe: {}
     livenessProbe: {}
 
-  # Strict schema validation for deploymentsConfigOverride.
-  # When disabled, Houston skips AJV schema checks on config overrides, allowing
-  # unknown keys and type mismatches to pass through.
-  strictSchemaCheck:
-    enabled: false
-
   # Populate daily task usage data
   # This runs as a CronJob
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -622,6 +622,44 @@ def test_houston_configmapwith_update_airflow_runtime_checks_disabled():
     assert prod["updateRuntimeCheck"]["enabled"] is False
 
 
+def test_houston_configmap_strict_schema_check_enabled():
+    """Validate the houston configmap renders strictSchemaCheck.enabled: true."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "strictSchemaCheck": {"enabled": True},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["strictSchemaCheck"]["enabled"] is True
+
+
+def test_houston_configmap_strict_schema_check_disabled():
+    """Validate the houston configmap renders strictSchemaCheck.enabled: false (default)."""
+    docs = render_chart(
+        values={
+            "astronomer": {
+                "houston": {
+                    "strictSchemaCheck": {"enabled": False},
+                }
+            }
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    doc = docs[0]
+
+    prod = yaml.safe_load(doc["data"]["production.yaml"])
+    assert prod["strictSchemaCheck"]["enabled"] is False
+
+
 def test_houston_configmap_with_cleanup_airflow_db_enabled():
     """Validate the houston configmap and its embedded data with
     cleanupAirflowDb."""

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -61,6 +61,7 @@ def test_houston_configmap_defaults():
     assert prod["deployments"]["logging"]["elasticsearch"]["enabled"] is True
     assert prod["deployments"]["logging"]["elasticsearch"]["connection"]["port"] == 9200
     assert prod["deployments"]["metricsReporting"]["grafana"]["enabled"] is True
+    assert prod["strictSchemaCheck"]["enabled"] is True
 
     af_images = prod["deployments"]["helm"]["airflow"]["images"]
     git_sync_images = prod["deployments"]["helm"]["gitSyncRelay"]["images"]
@@ -642,7 +643,7 @@ def test_houston_configmap_strict_schema_check_enabled():
 
 
 def test_houston_configmap_strict_schema_check_disabled():
-    """Validate the houston configmap renders strictSchemaCheck.enabled: false (default)."""
+    """Validate the houston configmap renders strictSchemaCheck.enabled: false when disabled in values."""
     docs = render_chart(
         values={
             "astronomer": {

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -210,7 +210,7 @@ def expected_new_partial_text() -> str:
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
             strictSchemaCheck:
-              enabled: false
+              enabled: true
     """)
 
 
@@ -290,7 +290,7 @@ def new_schema_partial_text() -> str:
                 logHelmValues:
                   enabled: true
             strictSchemaCheck:
-              enabled: false
+              enabled: true
     """)
 
 
@@ -561,7 +561,7 @@ def expected_037x_new_partial_text() -> str:
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
             strictSchemaCheck:
-              enabled: false
+              enabled: true
 
         vector:
           resources:
@@ -660,7 +660,7 @@ def new_037x_schema_partial_text() -> str:
                   triggerer:
                     enabled: true
             strictSchemaCheck:
-              enabled: false
+              enabled: true
 
         tags:
           platform: true

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -209,6 +209,8 @@ def expected_new_partial_text() -> str:
                     enabled: false
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
+            strictSchemaCheck:
+              enabled: false
     """)
 
 
@@ -287,6 +289,8 @@ def new_schema_partial_text() -> str:
                     enabled: true
                 logHelmValues:
                   enabled: true
+            strictSchemaCheck:
+              enabled: false
     """)
 
 
@@ -556,6 +560,8 @@ def expected_037x_new_partial_text() -> str:
                     enabled: false
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
+            strictSchemaCheck:
+              enabled: false
 
         vector:
           resources:
@@ -653,6 +659,8 @@ def new_037x_schema_partial_text() -> str:
                     enabled: true
                   triggerer:
                     enabled: true
+            strictSchemaCheck:
+              enabled: false
 
         tags:
           platform: true

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -583,7 +583,7 @@ class TestEdgeCases:
 
         result = _to_plain(data)
         assert result["astronomer"]["houston"]["replicas"] == 3
-        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
         assert len(changes) == 1
 
     def test_mixed_old_and_new_keys(self):
@@ -634,7 +634,7 @@ class TestEdgeCases:
         result = _to_plain(data)
 
         assert result["global"]["baseDomain"] == "example.com"
-        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
         assert len(changes) == 1
 
     def test_features_with_extra_keys_not_deleted(self):
@@ -692,12 +692,12 @@ class TestAddKeyIfMissingHouston:
     """Tests for AddKeyIfMissing rules applied to houston keys."""
 
     def test_adds_strict_schema_check_when_missing(self):
-        """Injects astronomer.houston.strictSchemaCheck: {enabled: false} when absent."""
+        """Injects astronomer.houston.strictSchemaCheck: {enabled: true} when absent."""
         data = _load_rt("global:\n  baseDomain: x.com\n")
         changes = migrate_values(data)
 
         result = _to_plain(data)
-        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
         assert any(c.new_path == "astronomer.houston.strictSchemaCheck" for c in changes)
         assert len([c for c in changes if c.new_path == "astronomer.houston.strictSchemaCheck"]) == 1
 
@@ -710,13 +710,22 @@ class TestAddKeyIfMissingHouston:
         assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
         assert not any(c.new_path == "astronomer.houston.strictSchemaCheck" for c in changes)
 
+    def test_does_not_overwrite_existing_strict_schema_check_when_disabled(self):
+        """Preserves astronomer.houston.strictSchemaCheck when the customer set enabled: false."""
+        data = _load_rt("astronomer:\n  houston:\n    strictSchemaCheck:\n      enabled: false\n")
+        changes = migrate_values(data)
+
+        result = _to_plain(data)
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert not any(c.new_path == "astronomer.houston.strictSchemaCheck" for c in changes)
+
     def test_creates_astronomer_houston_subtree_when_absent(self):
         """Creates astronomer.houston path if neither key exists in the document."""
         data = _load_rt("global:\n  baseDomain: x.com\n")
         migrate_values(data)
 
         result = _to_plain(data)
-        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -70,7 +70,7 @@ class TestPartialOverrideMigration:
         expected = _to_plain(_load_rt(expected_new_partial_text))
 
         assert result == expected
-        assert len(changes) == 36
+        assert len(changes) == 37
 
     def test_non_global_sections_preserved(self, old_partial_override_text: str):
         """Sections outside global (astronomer, nginx, etc.) are not modified."""
@@ -118,7 +118,7 @@ class TestFullValuesMigration:
         assert g["perHostIngress"]["enabled"] is False
         assert g["argoCD"]["annotation"]["enabled"] is False
         assert g["manageClusterScopedResources"]["enabled"] is True
-        assert len(changes) == 36
+        assert len(changes) == 37
 
     def test_houston_config_migrated(self, old_full_values_text: str):
         """Houston config deployment flags are restructured and obsolete keys deleted."""
@@ -576,14 +576,15 @@ class TestEdgeCases:
         assert len(changes) == 0
 
     def test_no_global_section(self):
-        """YAML without a global key passes through unchanged."""
+        """YAML without a global key still gets new houston defaults injected."""
         text = "astronomer:\n  houston:\n    replicas: 3\n"
         data = _load_rt(text)
         changes = migrate_values(data)
 
         result = _to_plain(data)
         assert result["astronomer"]["houston"]["replicas"] == 3
-        assert len(changes) == 0
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert len(changes) == 1
 
     def test_mixed_old_and_new_keys(self):
         """File with some old keys and some new keys migrates only the old ones."""
@@ -606,22 +607,22 @@ class TestEdgeCases:
         assert result["global"]["networkNSLabels"]["enabled"] is True
         assert "rbacEnabled" not in result["global"]
         assert "openshiftEnabled" not in result["global"]
-        assert len(changes) == 2
+        assert len(changes) == 3
 
     def test_global_section_empty(self):
-        """global section that is empty does not crash."""
+        """global section that is empty does not crash; new houston defaults are still injected."""
         data = _load_rt("global: {}\n")
         changes = migrate_values(data)
-        assert len(changes) == 0
+        assert len(changes) == 1
 
     def test_global_section_null(self):
-        """global section set to null does not crash."""
+        """global section set to null does not crash; new houston defaults are still injected."""
         data = _load_rt("global:\n")
         changes = migrate_values(data)
-        assert len(changes) == 0
+        assert len(changes) == 1
 
     def test_only_unrelated_global_keys(self):
-        """global section with only unrelated keys is not modified."""
+        """global section with only unrelated keys is not modified; new houston defaults are injected."""
         text = dedent("""\
             global:
               baseDomain: example.com
@@ -629,12 +630,12 @@ class TestEdgeCases:
               privateCaCerts: []
         """)
         data = _load_rt(text)
-        original = _dump_rt(data)
         changes = migrate_values(data)
-        after = _dump_rt(data)
+        result = _to_plain(data)
 
-        assert original == after
-        assert len(changes) == 0
+        assert result["global"]["baseDomain"] == "example.com"
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert len(changes) == 1
 
     def test_features_with_extra_keys_not_deleted(self):
         """If features has keys besides namespacePools, features is kept."""
@@ -680,6 +681,42 @@ class TestEdgeCases:
         assert "deployRollbackEnabled" not in nested_global
         assert "loggingSidecar" not in nested_global
         assert any(c.old_path == "astronomer.global.networkNSLabels" for c in changes)
+
+
+# ---------------------------------------------------------------------------
+# apply_new_houston_defaults tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyNewHoustonDefaults:
+    """Tests for the apply_new_houston_defaults shared function."""
+
+    def test_adds_strict_schema_check_when_missing(self):
+        """Injects astronomer.houston.strictSchemaCheck: {enabled: false} when absent."""
+        data = _load_rt("global:\n  baseDomain: x.com\n")
+        changes = migrate_values(data)
+
+        result = _to_plain(data)
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
+        assert any(c.new_path == "astronomer.houston.strictSchemaCheck" for c in changes)
+        assert len([c for c in changes if c.new_path == "astronomer.houston.strictSchemaCheck"]) == 1
+
+    def test_does_not_overwrite_existing_strict_schema_check(self):
+        """Does not overwrite astronomer.houston.strictSchemaCheck if already present."""
+        data = _load_rt("astronomer:\n  houston:\n    strictSchemaCheck:\n      enabled: true\n")
+        changes = migrate_values(data)
+
+        result = _to_plain(data)
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True
+        assert not any(c.new_path == "astronomer.houston.strictSchemaCheck" for c in changes)
+
+    def test_creates_astronomer_houston_subtree_when_absent(self):
+        """Creates astronomer.houston path if neither key exists in the document."""
+        data = _load_rt("global:\n  baseDomain: x.com\n")
+        migrate_values(data)
+
+        result = _to_plain(data)
+        assert result["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -684,12 +684,12 @@ class TestEdgeCases:
 
 
 # ---------------------------------------------------------------------------
-# apply_new_houston_defaults tests
+# AddKeyIfMissing (houston) tests
 # ---------------------------------------------------------------------------
 
 
-class TestApplyNewHoustonDefaults:
-    """Tests for the apply_new_houston_defaults shared function."""
+class TestAddKeyIfMissingHouston:
+    """Tests for AddKeyIfMissing rules applied to houston keys."""
 
     def test_adds_strict_schema_check_when_missing(self):
         """Injects astronomer.houston.strictSchemaCheck: {enabled: false} when absent."""

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -964,7 +964,7 @@ RULE_TEST_CASES = [
     (
         "add_houston_strictSchemaCheck",
         "global:\n  baseDomain: x.com\n",
-        lambda d: d["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False,
+        lambda d: d["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is True,
     ),
     # HoustonDeploymentBoolToNested
     (

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -30,7 +30,7 @@ HoustonDeploymentDeleteKey = migrate_mod.HoustonDeploymentDeleteKey
 MIGRATIONS = migrate_mod.MIGRATIONS
 main = migrate_mod.main
 
-TOTAL_RULES_ON_FULL_037X = 53
+TOTAL_RULES_ON_FULL_037X = 54
 
 
 def _load_rt(text: str):
@@ -961,6 +961,11 @@ RULE_TEST_CASES = [
     ("add_plane", "global:\n  baseDomain: x.com\n", lambda d: d["global"]["plane"]["mode"] == "unified"),
     ("add_podLabels", "global:\n  baseDomain: x.com\n", lambda d: "podLabels" in d["global"]),
     ("add_nats_init", "nats:\n  nats:\n    resources: {}\n", lambda d: d["nats"]["init"]["resources"]["requests"]["cpu"] == "75m"),
+    (
+        "add_houston_strictSchemaCheck",
+        "global:\n  baseDomain: x.com\n",
+        lambda d: d["astronomer"]["houston"]["strictSchemaCheck"]["enabled"] is False,
+    ),
     # HoustonDeploymentBoolToNested
     (
         "houston_dagProcessorEnabled",

--- a/values.yaml
+++ b/values.yaml
@@ -470,6 +470,9 @@ astronomer:
         cpu: "1000m"
         memory: "2048Mi"
 
+    strictSchemaCheck:
+      enabled: false
+
   commander:
     resources:
       requests:

--- a/values.yaml
+++ b/values.yaml
@@ -471,7 +471,7 @@ astronomer:
         memory: "2048Mi"
 
     strictSchemaCheck:
-      enabled: false
+      enabled: true
 
   commander:
     resources:


### PR DESCRIPTION
## Description

Add strictSchemaCheck feature flag and set it to false

## Related Issues

https://linear.app/astronomer/issue/PLX-351/could-not-override-some-of-the-feature-flags

## Testing

- Unit tests
- Tested by generating the helm template

```
 helm template astronomer . \
  --values values.yaml \
  --show-only charts/astronomer/templates/houston/houston-configmap.yaml

    prometheus:
      enabled: true
      host: astronomer-prometheus
    updateRuntimeCheck:
      enabled: true
    strictSchemaCheck:
      enabled: false
```
## Merging

2.0, main