### PR TITLE
PINF-505 - Add custom logging commander metadata

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -326,6 +326,7 @@ gcp_cloud_logging:
 - name: COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME
   value: {{ .Values.global.dataPlaneFailover.externalSecretManagerSecretName | quote }}
 {{- end }}
+{{- end }}
 - name: COMMANDER_CUSTOM_LOGGING_ENABLED
   value: {{ ternary "true" "false" .Values.global.customLogging.enabled | quote }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -326,7 +326,8 @@ gcp_cloud_logging:
 - name: COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME
   value: {{ .Values.global.dataPlaneFailover.externalSecretManagerSecretName | quote }}
 {{- end }}
-{{- end }}
+- name: COMMANDER_CUSTOM_LOGGING_ENABLED
+  value: {{ ternary "true" "false" .Values.global.customLogging.enabled | quote }}
 {{- end }}
 
 {{- define "registry.gcsVolume" }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -327,8 +327,6 @@ gcp_cloud_logging:
   value: {{ .Values.global.dataPlaneFailover.externalSecretManagerSecretName | quote }}
 {{- end }}
 {{- end }}
-- name: COMMANDER_CUSTOM_LOGGING_ENABLED
-  value: {{ ternary "true" "false" .Values.global.customLogging.enabled | quote }}
 {{- end }}
 
 {{- define "registry.gcsVolume" }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -16,4 +16,6 @@ metadata:
 data:
   metadata.yaml: |-
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
+    customLogging:
+      enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled | quote }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -17,5 +17,5 @@ data:
   metadata.yaml: |-
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
     customLogging:
-      enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled | quote }}
+      enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
 {{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.0.9
+    tag: 2.0.10
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.0.8
+    tag: 2.0.9
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -45,7 +45,10 @@ class TestAstronomerCommander:
 
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
         if namespace_labels and rbac_enabled:
-            assert metadata_file_contents == {"namespaceLabels": namespace_labels}
+            assert metadata_file_contents == {
+                "namespaceLabels": namespace_labels,
+                "customLogging": {"enabled": False},
+            }
         else:
             assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": False}}
 

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -47,7 +47,29 @@ class TestAstronomerCommander:
         if namespace_labels and rbac_enabled:
             assert metadata_file_contents == {"namespaceLabels": namespace_labels}
         else:
-            assert metadata_file_contents == {"namespaceLabels": {}}
+            assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": "false"}}
+
+    @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
+    def test_commander_metadata_custom_logging(self, kube_version, enabled):
+        """Test that helm renders custom logging in metadata.yaml template for astronomer/commander."""
+        values = {
+            "global": {
+                "customLogging": {"enabled": enabled},
+            }
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/astronomer/templates/commander/commander-metadata.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+
+        metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
+        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": str(enabled).lower()}}
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -47,7 +47,7 @@ class TestAstronomerCommander:
         if namespace_labels and rbac_enabled:
             assert metadata_file_contents == {"namespaceLabels": namespace_labels}
         else:
-            assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": "false"}}
+            assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": False}}
 
     @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
     def test_commander_metadata_custom_logging(self, kube_version, enabled):
@@ -69,7 +69,7 @@ class TestAstronomerCommander:
         assert doc["apiVersion"] == "v1"
 
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
-        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": str(enabled).lower()}}
+        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": enabled}}
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""


### PR DESCRIPTION
## Description

This PR adds new commander metadata structure for customLogging spec for api to consume the information to generate elasticsearch endpoints dynamically without the interference of users .

## Related Issues

https://linear.app/astronomer/issue/PINF-505/expose-customlogging-flag-in-commander-metadata

## Testing

QA should now not require to update the values manually and it should happen automatically

## Merging

merge to master and release-2.0
