### PR TITLE
PLX-344 : nest canUpsertDeploymentFromUI for 2.x values

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -398,6 +398,11 @@ HOUSTON_DEPLOYMENT_BOOL_RULES: list[BoolToNested] = [
     BoolToNested(
         "manualReleaseNames", ["namespaceManagement", "manualReleaseNames", "enabled"], path_prefix=HOUSTON_DEPLOYMENTS_PREFIX
     ),
+    BoolToNested(
+        "canUpsertDeploymentFromUI",
+        ["upsertDeployment", "allowFromUi", "enabled"],
+        path_prefix=HOUSTON_DEPLOYMENTS_PREFIX,
+    ),
 ]
 
 HOUSTON_DEPLOYMENT_MOVE_KEYS: list[tuple[str, list[str]]] = [
@@ -410,7 +415,6 @@ HOUSTON_DEPLOYMENT_DELETE_KEYS: list[str] = [
     "resourceProvisioningStrategy",
     "maxPodAu",
     "upsertDeploymentEnabled",
-    "canUpsertDeploymentFromUI",
     "enableSystemAdminCanCreateDeprecatedAirflows",
 ]
 

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -209,6 +209,11 @@ def expected_new_partial_text() -> str:
                     enabled: false
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
+                upsertDeployment:
+                  allowFromUi:
+                    enabled: true
+            strictSchemaCheck:
+              enabled: true
     """)
 
 
@@ -556,6 +561,11 @@ def expected_037x_new_partial_text() -> str:
                     enabled: false
                 databaseManagement:
                   pgBouncerResourceCalculationStrategy: airflowStratV2
+                upsertDeployment:
+                  allowFromUi:
+                    enabled: true
+            strictSchemaCheck:
+              enabled: true
 
         vector:
           resources:

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -140,6 +140,7 @@ class TestFullValuesMigration:
         assert "maxPodAu" not in deployments
         assert "upsertDeploymentEnabled" not in deployments
         assert "canUpsertDeploymentFromUI" not in deployments
+        assert deployments["upsertDeployment"]["allowFromUi"]["enabled"] is True
         assert "enableSystemAdminCanCreateDeprecatedAirflows" not in deployments
 
     def test_old_keys_removed_after_migration(self, old_full_values_text: str):
@@ -1056,6 +1057,7 @@ class TestHoustonDeploymentMigration:
         assert "canUpsertDeploymentFromUI" not in deployments
         assert "enableSystemAdminCanCreateDeprecatedAirflows" not in deployments
         assert deployments["otherKey"] is True
+        assert deployments["upsertDeployment"]["allowFromUi"]["enabled"] is True
         assert len(changes) == 6
 
     def test_houston_config_absent(self):

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -996,10 +996,7 @@ RULE_TEST_CASES = [
         "astronomer:\n  houston:\n    config:\n      deployments:\n        canUpsertDeploymentFromUI: true\n        otherKey: true\n",
         lambda d: (
             "canUpsertDeploymentFromUI" not in d["astronomer"]["houston"]["config"]["deployments"]
-            and d["astronomer"]["houston"]["config"]["deployments"]["upsertDeployment"]["allowFromUi"][
-                "enabled"
-            ]
-            is True
+            and d["astronomer"]["houston"]["config"]["deployments"]["upsertDeployment"]["allowFromUi"]["enabled"] is True
         ),
     ),
     (

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -197,10 +197,11 @@ class TestPartialOverrideMigration:
             "resourceProvisioningStrategy",
             "maxPodAu",
             "upsertDeploymentEnabled",
-            "canUpsertDeploymentFromUI",
             "enableSystemAdminCanCreateDeprecatedAirflows",
         ]:
             assert old_key not in deployments, f"Old key '{old_key}' should have been removed"
+        assert "canUpsertDeploymentFromUI" not in deployments
+        assert deployments["upsertDeployment"]["allowFromUi"]["enabled"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +260,7 @@ class TestFullValuesMigration:
         assert "maxPodAu" not in deployments
         assert "upsertDeploymentEnabled" not in deployments
         assert "canUpsertDeploymentFromUI" not in deployments
+        assert deployments["upsertDeployment"]["allowFromUi"]["enabled"] is True
         assert "enableSystemAdminCanCreateDeprecatedAirflows" not in deployments
 
     def test_old_keys_removed_after_migration(self, old_037x_full_values_text: str):
@@ -990,9 +992,15 @@ RULE_TEST_CASES = [
         lambda d: "upsertDeploymentEnabled" not in d["astronomer"]["houston"]["config"]["deployments"],
     ),
     (
-        "houston_delete_canUpsertDeploymentFromUI",
+        "houston_migrate_canUpsertDeploymentFromUI",
         "astronomer:\n  houston:\n    config:\n      deployments:\n        canUpsertDeploymentFromUI: true\n        otherKey: true\n",
-        lambda d: "canUpsertDeploymentFromUI" not in d["astronomer"]["houston"]["config"]["deployments"],
+        lambda d: (
+            "canUpsertDeploymentFromUI" not in d["astronomer"]["houston"]["config"]["deployments"]
+            and d["astronomer"]["houston"]["config"]["deployments"]["upsertDeployment"]["allowFromUi"][
+                "enabled"
+            ]
+            is True
+        ),
     ),
     (
         "houston_delete_enableSystemAdminCanCreateDeprecatedAirflows",


### PR DESCRIPTION
## Description

Updates the **1.x / 0.37.x → 2.x Helm values migration** so flat Houston deployments config `canUpsertDeploymentFromUI` is **preserved** by restructuring it instead of being dropped.

- **`bin/helm_chart_values_migration_shared.py`:** add a `BoolToNested` rule mapping `canUpsertDeploymentFromUI` → `deployments.upsertDeployment.allowFromUi.enabled` (under `astronomer.houston.config.deployments`).
- **Remove** `canUpsertDeploymentFromUI` from `HOUSTON_DEPLOYMENT_DELETE_KEYS` so the migrator no longer deletes the key after other rules run.

This aligns chart-side migration with Houston’s nested config and `appConfig.featureFlags.canUpsertDeploymentFromUI` behavior restored in the companion houston-api PR.

## Related Issues

- https://linear.app/astronomer/issue/PLX-344/restore-canupsertdeploymentfromui-flag-in-2x-releases

## Testing

- Tested migration paths
```
 ./bin/migrate-helm-chart-values-1x-to-2x.py --dry-run  values.yaml
Found 1 migration(s) to apply:
  astronomer.houston.config.deployments.canUpsertDeploymentFromUI -> astronomer.houston.config.deployments.upsertDeployment.allowFromUi.enabled
```
- Unit tests

## Merging

- master
- 2.0.0