### PR TITLE
PINF-407: Add nodeexporter and cadvisor job for prometheus in controlplane 

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -74,7 +74,7 @@ data:
         scrape_interval: 5s
         params:
           'match[]':
-            - '{job=~".*-kube-state$|airflow"}'
+            - '{job=~".*-kube-state$|airflow|kubernetes-nodes-cadvisor|node-exporter"}'
         file_sd_configs:
           - files:
             - /prometheusreloader/airflow/clusters.json


### PR DESCRIPTION
## Description

This PR adds nodeexporter and cadvisor job for prometheus in controlplane mode.

## Related Issues

https://linear.app/astronomer/issue/APC-1243/test-all-the-changes-for-node-exporter-pod-metrics-and-add-all-the

## Testing

- Added the configmap and was able to confirm that the label took effect:
<img width="827" height="334" alt="Screenshot 2026-04-22 at 3 52 58 PM" src="https://github.com/user-attachments/assets/5e0d32c7-207d-41be-b2f5-f0d63a1f28cb" />

- Confirmed the metrics:
<img width="1653" height="515" alt="Screenshot 2026-04-22 at 3 53 26 PM" src="https://github.com/user-attachments/assets/922b0dcc-84a0-4709-849c-d3830ac9bba1" />

## Merging

Master, 2.0