### PR TITLE
PLX-358 restrict houston audit logging to validated sink configurations

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -78,10 +78,12 @@
 
 {{- define "houston.logging.loggingSidecar.validate" -}}
 {{- if .Values.houston.logging.loggingSidecar.enabled -}}
-{{- $hasBuiltInSink := or .Values.houston.logging.loggingSidecar.cloudwatch.enabled .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled .Values.houston.logging.loggingSidecar.elasticsearch.enabled -}}
-{{- $hasExtraSinks := ne (trim (.Values.houston.logging.loggingSidecar.extraSinks | default "")) "" -}}
-{{- if not (or $hasBuiltInSink $hasExtraSinks) -}}
-{{- fail "houston.logging.loggingSidecar.enabled requires at least one sink: enable cloudwatch, gcpCloudLogging, elasticsearch, or set extraSinks" -}}
+{{- $enabledSinkCount := add (ternary 1 0 .Values.houston.logging.loggingSidecar.cloudwatch.enabled) (ternary 1 0 .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled) (ternary 1 0 .Values.houston.logging.loggingSidecar.elasticsearch.enabled) -}}
+{{- if eq $enabledSinkCount 0 -}}
+{{- fail "houston.logging.loggingSidecar.enabled requires at least one supported sink: enable cloudwatch, gcpCloudLogging, or elasticsearch" -}}
+{{- end -}}
+{{- if gt $enabledSinkCount 1 -}}
+{{- fail "houston.logging.loggingSidecar supports exactly one sink at a time: choose cloudwatch, gcpCloudLogging, or elasticsearch" -}}
 {{- end -}}
 {{- if .Values.houston.logging.loggingSidecar.gcpCloudLogging.enabled -}}
 {{- required "houston.logging.loggingSidecar.gcpCloudLogging.projectId must be set when gcpCloudLogging.enabled is true" (.Values.houston.logging.loggingSidecar.gcpCloudLogging.projectId | default "" | trim) -}}

--- a/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/api/houston-vector-configmap.yaml
@@ -159,8 +159,5 @@ data:
           verify_certificate: true
     {{- end }}
     {{- end }}
-    {{- if .Values.houston.logging.loggingSidecar.extraSinks }}
-{{ tpl .Values.houston.logging.loggingSidecar.extraSinks $ | nindent 6 }}
-    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml
@@ -159,8 +159,5 @@ data:
           verify_certificate: true
     {{- end }}
     {{- end }}
-    {{- if .Values.houston.logging.loggingSidecar.extraSinks }}
-{{ tpl .Values.houston.logging.loggingSidecar.extraSinks $ | nindent 6 }}
-    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -219,9 +219,11 @@ houston:
     # Vector sidecar for audit log shipping from Houston API and worker.
     # When enabled, a Vector sidecar container is added to both Houston API
     # and Houston Worker pods, along with a log wrapper script that redirects
-    # stdout/stderr to files which Vector reads and ships to the configured sink(s).
-    # CloudWatch, GCP Cloud Logging, Elasticsearch, and extra sinks can be enabled
-    # together when desired.
+    # stdout/stderr to files which Vector reads and ships to the configured sink.
+    # Choose exactly one supported sink for Houston audit logging:
+    # - CloudWatch on EKS
+    # - GCP Cloud Logging on GKE
+    # - Elasticsearch to an external ES cluster
     loggingSidecar:
       enabled: false
 
@@ -237,25 +239,25 @@ houston:
           memory: "256Mi"
           cpu: "200m"
 
-      # AWS CloudWatch Logs configuration
+      # AWS CloudWatch Logs configuration for Houston audit logging on EKS.
       cloudwatch:
         enabled: false
         region: ""
         logGroupName: "/astronomer/houston/audit"
-        # Use IRSA (IAM Roles for Service Accounts) for authentication.
+        # Use IRSA (IAM Roles for Service Accounts) for authentication on EKS.
         # When true, no access keys are needed; the service account must be
         # annotated with eks.amazonaws.com/role-arn via houston.serviceAccount.annotations.
         useIRSA: true
         # Secret containing aws_access_key_id and aws_secret_access_key keys.
-        # Only used when useIRSA is false.
+        # Use this fallback when IRSA is unavailable for the EKS deployment.
         secretName: "houston-cloudwatch-creds"
 
-      # GCP Cloud Logging (formerly Stackdriver) configuration
+      # GCP Cloud Logging configuration for Houston audit logging on GKE.
       gcpCloudLogging:
         enabled: false
         # GCP project ID to which logs are published (required).
         projectId: ""
-        # Custom log ID that identifies this log stream in Cloud Logging.
+        # Custom log ID that identifies this Houston audit stream in Cloud Logging.
         logId: "houston-audit"
         # Monitored resource type. "k8s_container" is the standard for GKE pods.
         resource:
@@ -274,11 +276,11 @@ houston:
         # houston.serviceAccount.annotations.
         useWorkloadIdentity: true
         # Name of the K8s Secret containing a GCP service account JSON key file.
-        # Only used when useWorkloadIdentity is false.
+        # Use this fallback when Workload Identity is unavailable for the GKE deployment.
         credentialsSecretName: "houston-gcp-logging-creds"
         credentialsSecretKey: "key.json"
 
-      # Elasticsearch configuration
+      # Elasticsearch configuration for Houston audit logging to an external cluster.
       elasticsearch:
         enabled: false
         # External endpoint URL for the Elasticsearch cluster.
@@ -294,11 +296,6 @@ houston:
         tls:
           enabled: false
           caSecretName: ""
-
-      # Additional Vector sinks to append under the `sinks:` section.
-      # Provide as a YAML snippet with sink keys at the same indentation level
-      # as other sinks (e.g., `my_sink:`). Supports templating via `tpl`.
-      extraSinks: ""
 
   # Automatically upgrade Airflow deployments to the latest
   # version specified by Houston configuration.

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -230,39 +230,35 @@ class TestHoustonSidecarLogging:
         assert c_by_name["vector"]["image"].startswith("quay.io/astronomer/ap-vector:")
         assert c_by_name["vector"]["resources"] == resource_defaults
 
-    def test_houston_sidecar_logging_supports_multiple_sinks(self, kube_version):
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=[
-                "charts/astronomer/templates/houston/api/houston-vector-configmap.yaml",
-                "charts/astronomer/templates/houston/worker/houston-worker-vector-configmap.yaml",
-            ],
-            values={
-                "astronomer": {
-                    "houston": {
-                        "logging": {
-                            "loggingSidecar": {
-                                "enabled": True,
-                                "cloudwatch": {
+    def test_houston_sidecar_logging_rejects_multiple_sinks(self, kube_version):
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                kube_version=kube_version,
+                show_only=[
+                    "charts/astronomer/templates/houston/api/houston-vector-configmap.yaml",
+                ],
+                values={
+                    "astronomer": {
+                        "houston": {
+                            "logging": {
+                                "loggingSidecar": {
                                     "enabled": True,
-                                    "region": "us-east-2",
-                                },
-                                "elasticsearch": {
-                                    "enabled": True,
-                                    "endpoint": "https://es.example.com:9200",
+                                    "cloudwatch": {
+                                        "enabled": True,
+                                        "region": "us-east-2",
+                                    },
+                                    "elasticsearch": {
+                                        "enabled": True,
+                                        "endpoint": "https://es.example.com:9200",
+                                    },
                                 },
                             },
-                        },
+                        }
                     }
-                }
-            },
-        )
-
-        assert len(docs) == 2
-        for doc in docs:
-            vector_config = doc["data"]["vector.yaml"]
-            assert "cloudwatch:" in vector_config
-            assert "elasticsearch:" in vector_config
+                },
+            )
+        stderr = excinfo.value.stderr.decode("utf-8")
+        assert "houston.logging.loggingSidecar supports exactly one sink at a time" in stderr
 
     def test_houston_sidecar_logging_requires_at_least_one_sink(self, kube_version):
         with pytest.raises(CalledProcessError) as excinfo:
@@ -283,7 +279,9 @@ class TestHoustonSidecarLogging:
                     }
                 },
             )
-        assert "houston.logging.loggingSidecar.enabled requires at least one sink" in excinfo.value.stderr.decode("utf-8")
+        stderr = excinfo.value.stderr.decode("utf-8")
+        assert "houston.logging.loggingSidecar.enabled requires at least one supported sink" in stderr
+        assert "extraSinks" not in stderr
 
     def test_houston_sidecar_logging_elasticsearch_requires_endpoint(self, kube_version):
         with pytest.raises(CalledProcessError) as excinfo:

--- a/values.yaml
+++ b/values.yaml
@@ -460,8 +460,6 @@ astronomer:
             enabled: false
             caSecretName: ""
 
-        extraSinks: ""
-
     resources:
       requests:
         cpu: "500m"


### PR DESCRIPTION
## Description

This PR narrows the Houston audit logging sidecar surface to the sink configurations we want to support for this release.

Changes in this PR:
- remove `extraSinks` from the Houston audit logging sidecar chart surface
- require exactly one Houston audit sink at a time
- keep the supported sink set limited to:
  - CloudWatch
  - GCP Cloud Logging
  - Elasticsearch to an external cluster
- update chart values comments so they no longer imply multi-sink, cross-sink, or `extraSinks` support for Houston audit logging
- update chart tests to reject multiple sinks and to ensure the validation path no longer references `extraSinks`

This keeps the standalone `charts/vector` behavior unchanged. The restriction here is specifically for the Houston audit logging sidecar feature.

## Related Issues

https://linear.app/astronomer/issue/PLX-358/restrict-houston-audit-logging-to-validated-sink-configurations

## Testing

- Manually validated supported sink configurations on dev clusters:
  - no sink
  - CloudWatch on EKS
  - GCP Cloud Logging on GKE
  - external Elasticsearch
- Confirmed Houston audit logs landed successfully in the configured sink for the supported validation paths

## Merging

- merge into master
- merge into 2.0
