### PR TITLE
APC-1256: Fix duplicate series crash in cadvisor recording rules by filtering unscheduled pods

### DIFF
--- a/charts/prometheus/templates/prometheus-alerts-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-alerts-configmap.yaml
@@ -209,23 +209,23 @@ data:
         - expr: |
             sum by (cluster, namespace, pod, container) (
               rate(container_cpu_usage_seconds_total{job="kubernetes-nodes-cadvisor", image!="", container!="POD"}[5m])
-            ) * on (cluster, namespace, pod) group_left(node) max by(cluster, namespace, pod, node) (kube_pod_info)
+            ) * on (cluster, namespace, pod) group_left(node) max by(cluster, namespace, pod, node) (kube_pod_info{node!=""})
           record: node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
         - expr: |
             container_memory_working_set_bytes{job="kubernetes-nodes-cadvisor", image!=""}
-            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info{node!=""})
           record: node_namespace_pod_container:container_memory_working_set_bytes
         - expr: |
             container_memory_rss{job="kubernetes-nodes-cadvisor", image!=""}
-            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info{node!=""})
           record: node_namespace_pod_container:container_memory_rss
         - expr: |
             container_memory_cache{job="kubernetes-nodes-cadvisor", image!=""}
-            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info{node!=""})
           record: node_namespace_pod_container:container_memory_cache
         - expr: |
             container_memory_swap{job="kubernetes-nodes-cadvisor", image!=""}
-            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info)
+            * on (namespace, pod) group_left(node) max by(namespace, pod, node) (kube_pod_info{node!=""})
           record: node_namespace_pod_container:container_memory_swap
         - expr: |
             sum(container_memory_usage_bytes{job="kubernetes-nodes-cadvisor", image!="", container!="POD"}) by (namespace)


### PR DESCRIPTION
## Description

Adds node!="" selector to kube_pod_info in all 5 cadvisor recording rules to prevent many-to-many join failures during pod scheduling transitions.

All 5 node_namespace_pod_container:* recording rules in prometheus-alerts-configmap.yaml silently fail whenever any pod in the cluster is in a Pending (unscheduled) state.
kube_pod_info emits two series for a pod during scheduling transitions.

## Related Issues

https://linear.app/astronomer/issue/APC-1256/bug-prometheus-label-conflict-kube-pod-info-duplicate-node-labels

## Testing

- Tested that after adding this config, I was able to see clean logs in prometheus and metrics on ui:
<img width="1707" height="645" alt="Screenshot 2026-04-23 at 8 08 28 PM" src="https://github.com/user-attachments/assets/5e1fce85-a458-459a-8aae-ad49305dff12" />

<img width="1621" height="502" alt="Screenshot 2026-04-23 at 8 09 03 PM" src="https://github.com/user-attachments/assets/b92a40b0-5f87-4149-8c06-4add92e3775c" />


## Merging

Master, 2.0