### PR TITLE
PINF-513 Fix label mismatch. Add test to ensure this doesn't happen again.

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -28,7 +28,7 @@ images:
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 2.0.6
+    tag: 2.0.5
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         version: {{ .Chart.Version }}
         release: {{ .Release.Name }}
         component: {{ template "prometheus-postgres-exporter.name" . }}
+        app: {{ template "prometheus-postgres-exporter.name" . }}
         {{- include "global.podLabels" . | nindent 8 }}
 {{- if .Values.podLabels }}
 {{ toYaml .Values.podLabels | trim | indent 8 }}

--- a/configs/failover-eks-dev.yaml
+++ b/configs/failover-eks-dev.yaml
@@ -1,26 +1,26 @@
-# astronomer:
-#   dpLink:
-#     enabled: true
-#   flightDeck:
-#     enabled: true
-#   houston:
-#     worker:
-#       dispatcher:
-#         enabled: true
-#   images:
-#     astroUI:
-#       pullPolicy: Always
-#     commander:
-#       pullPolicy: Always
-#     houston:
-#       pullPolicy: Always
-#   navigator:
-#     enabled: true
-#     env:
-#       - name: DEBUG
-#         value: "true"
-#   pilot:
-#     enabled: true
+astronomer:
+  dpLink:
+    enabled: true
+  flightDeck:
+    enabled: true
+  houston:
+    worker:
+      dispatcher:
+        enabled: true
+  images:
+    astroUI:
+      pullPolicy: Always
+    commander:
+      pullPolicy: Always
+    houston:
+      pullPolicy: Always
+  navigator:
+    enabled: true
+    env:
+      - name: DEBUG
+        value: "true"
+  pilot:
+    enabled: true
 external-secrets:
   enabled: true
 global:

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -1,30 +1,29 @@
-# astronomer:
-#   airflowChartVersion: 1.17.28-build40412
-#   dpLink:
-#     enabled: true
-#   flightDeck:
-#     enabled: true
-#   houston:
-#     worker:
-#       dispatcher:
-#         enabled: true
-#   images:
-#     astroUI:
-#       pullPolicy: Always
-#     commander:
-#       pullPolicy: Always
-#       tag: master
-#     houston:
-#       pullPolicy: Always
-#       tag: main
-#   navigator:
-#     enabled: true
-#     env:
-#       - name: DEBUG
-#         value: "true"
-#   pilot:
-#     enabled: true
-
+astronomer:
+  airflowChartVersion: 1.17.28-build40412
+  dpLink:
+    enabled: true
+  flightDeck:
+    enabled: true
+  houston:
+    worker:
+      dispatcher:
+        enabled: true
+  images:
+    astroUI:
+      pullPolicy: Always
+    commander:
+      pullPolicy: Always
+      tag: master
+    houston:
+      pullPolicy: Always
+      tag: main
+  navigator:
+    enabled: true
+    env:
+      - name: DEBUG
+        value: "true"
+  pilot:
+    enabled: true
 # Toggle external-secret chart rendering on
 external-secrets:
   enabled: true

--- a/tests/chart_tests/test_default_chart.py
+++ b/tests/chart_tests/test_default_chart.py
@@ -79,6 +79,29 @@ class TestAllPodSpecContainers:
         pod_manager_docs,
         ids=[f"{x['kind']}/{x['metadata']['name']}" for x in pod_manager_docs],
     )
+    def test_selector_matches_pod_template_labels(self, doc):
+        """Test that spec.selector.matchLabels is a subset of spec.template.metadata.labels.
+
+        Kubernetes requires that the selector matches the pod template labels, otherwise
+        the Deployment/StatefulSet/DaemonSet will be rejected by the API server.
+        """
+        match_labels = doc["spec"]["selector"]["matchLabels"]
+        template_labels = doc["spec"]["template"]["metadata"]["labels"]
+        for key, value in match_labels.items():
+            assert key in template_labels, (
+                f"{doc['kind']}/{doc['metadata']['name']}: selector.matchLabels key '{key}' "
+                f"is missing from spec.template.metadata.labels"
+            )
+            assert template_labels[key] == value, (
+                f"{doc['kind']}/{doc['metadata']['name']}: selector.matchLabels['{key}']={value!r} "
+                f"does not match template label value {template_labels[key]!r}"
+            )
+
+    @pytest.mark.parametrize(
+        "doc",
+        pod_manager_docs,
+        ids=[f"{x['kind']}/{x['metadata']['name']}" for x in pod_manager_docs],
+    )
     def test_default_chart_with_basedomain(self, doc):
         """Test that each container in each pod spec renders and has some required fields."""
         c_by_name = get_containers_by_name(doc, include_init_containers=True)


### PR DESCRIPTION
## Description

- Fix label mismatch in prometheus-postgres-exporter
- Write a unit test to ensure that all pod manager specs have labels that will not violate the k8s api requirement
- Revert astro-ui 2.0.6 because it broke some tests

## Related Issues

https://linear.app/astronomer/issue/PINF-513/fix-selector-mismatch-in-prometheus-postgres-exporter-labels

## Testing

Unit tests were added to ensure this failure scenario never happens to any pod manager again.

## Merging

master, release-2.0