### PR TITLE
PINF-514 fix broken test container user is not root test

### DIFF
--- a/tests/functional/unified/test_container_user_is_not_root.py
+++ b/tests/functional/unified/test_container_user_is_not_root.py
@@ -5,20 +5,19 @@ from tests.utils.k8s import KUBECONFIG_UNIFIED, get_pod_running_containers
 
 container_ignore_list = ["kube-state", "houston", "astro-ui"]
 
+_all_containers = get_pod_running_containers(kubeconfig=KUBECONFIG_UNIFIED, namespace="astronomer")
+_test_containers = {k: v for k, v in _all_containers.items() if v["_name"] not in container_ignore_list}
 
-def test_container_user_is_not_root():
-    container_list = get_pod_running_containers(kubeconfig=KUBECONFIG_UNIFIED, namespace="astronomer")
-    for container in container_list.values():
-        if container["_name"] in container_ignore_list:
-            pytest.skip("Info: Unsupported container: " + container["_name"])
 
-        pod_client = testinfra.get_host(
-            f"kubectl://{container['pod_name']}?container={container['_name']}&namespace={container['namespace']}",
-            kubeconfig=KUBECONFIG_UNIFIED,
-        )
+@pytest.mark.parametrize("container", _test_containers.values(), ids=_test_containers.keys())
+def test_container_user_is_not_root(container):
+    pod_client = testinfra.get_host(
+        f"kubectl://{container['pod_name']}?container={container['_name']}&namespace={container['namespace']}",
+        kubeconfig=KUBECONFIG_UNIFIED,
+    )
 
-        user_info = pod_client.user()
-        assert user_info.name != "root"
-        assert user_info.group != "root"
-        assert user_info.gid != 0
-        assert user_info.uid != 0
+    user_info = pod_client.user()
+    assert user_info.name != "root"
+    assert user_info.group != "root"
+    assert user_info.gid != 0
+    assert user_info.uid != 0

--- a/tests/functional/unified/test_container_user_is_not_root.py
+++ b/tests/functional/unified/test_container_user_is_not_root.py
@@ -3,7 +3,16 @@ import testinfra
 
 from tests.utils.k8s import KUBECONFIG_UNIFIED, get_pod_running_containers
 
-container_ignore_list = ["kube-state", "houston", "astro-ui"]
+container_ignore_list = [
+    "astro-ui",
+    "configmap-reloader",
+    "default-backend",
+    "houston",
+    "kube-state",
+    "nginx",
+    "postgresql",
+    "vector",
+]
 
 _all_containers = get_pod_running_containers(kubeconfig=KUBECONFIG_UNIFIED, namespace="astronomer")
 _test_containers = {k: v for k, v in _all_containers.items() if v["_name"] not in container_ignore_list}

--- a/tests/functional/unified/test_container_user_is_not_root.py
+++ b/tests/functional/unified/test_container_user_is_not_root.py
@@ -5,12 +5,12 @@ from tests.utils.k8s import KUBECONFIG_UNIFIED, get_pod_running_containers
 
 container_ignore_list = [
     "astro-ui",
+    "astronomer-postgresql",
     "configmap-reloader",
     "default-backend",
     "houston",
     "kube-state",
     "nginx",
-    "postgresql",
     "vector",
 ]
 


### PR DESCRIPTION
## Description

- Fix a logic error that was exposed in <https://linear.app/astronomer/issue/PLX-364/fix-failing-apc-ui-test-capabilities-test> and caused confusion.
- Exclude all chainguard distroless containers from the root user test, since it requires a shell and there is no shell available in the container.

## Related Issues

https://linear.app/astronomer/issue/PINF-514/fix-broken-test-container-user-is-not-root-test-in

## Testing

CI tests passing is fine. These are only test changes.

## Merging

master, all supported >= 1.x branches