### PR TITLE
PLX-368 Houston audit logging comment and vector default fix

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -68,7 +68,7 @@
 {{- $images := .Values.images | default dict -}}
 {{- $vector := $images.vector | default dict -}}
 {{- $repo := default "quay.io/astronomer/ap-vector" $vector.repository -}}
-{{- $tag := default "0.52.0" $vector.tag -}}
+{{- $tag := default "0.54.0" $vector.tag -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-vector:{{ $tag }}
 {{- else -}}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -223,7 +223,7 @@ houston:
     # Choose exactly one supported sink for Houston audit logging:
     # - CloudWatch on EKS
     # - GCP Cloud Logging on GKE
-    # - Elasticsearch to an external ES cluster
+    # - External Elasticsearch from EKS or GKE
     loggingSidecar:
       enabled: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -409,7 +409,10 @@ astronomer:
     # Vector sidecar for audit log shipping from Houston API and worker.
     # This mirrors charts/astronomer/values.yaml for customers who install
     # or upgrade the umbrella chart from the repo root or packaged release.
-    # When enabled, Vector can ship to one or more sinks at the same time.
+    # Choose exactly one supported sink for Houston audit logging:
+    # - CloudWatch on EKS
+    # - GCP Cloud Logging on GKE
+    # - External Elasticsearch from EKS or GKE
     logging:
       loggingSidecar:
         enabled: false


### PR DESCRIPTION
## Description

This PR cleans up two stale pieces of Houston audit logging chart metadata:

- updates the Houston audit logging comments in both values files to reflect the intended support matrix:
  - CloudWatch on EKS
  - GCP Cloud Logging on GKE
  - external Elasticsearch from EKS or GKE
- updates the Houston audit logging Vector sidecar image helper fallback tag from `0.52.0` to `0.54.0` so it matches the current chart defaults

The comments previously implied either multi-sink support or ambiguous Elasticsearch platform support, and the helper fallback tag had drifted behind the declared Vector image defaults.

## Related Issues

https://linear.app/astronomer/issue/PLX-368/clarify-houston-audit-logging-sink-comments-and-vector-fallback

## Testing

- Verified the affected chart values and helper paths locally:
  - `charts/astronomer/values.yaml`
  - `values.yaml`
  - `charts/astronomer/templates/_helpers.yaml`
- Confirmed the helper fallback now matches the current Vector image defaults used by the chart

## Merging

- Merge into `master`
- Merge into `2.0`
