### PR TITLE
PLX-365: Remove component from match labels

### DIFF
--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -20,7 +20,6 @@ spec:
   selector:
     matchLabels:
       app: {{ template "prometheus-postgres-exporter.name" . }}
-      component: {{ template "prometheus-postgres-exporter.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:


### PR DESCRIPTION
## Description

This PR removes `component`  key from macthLabels spec because during upgrade it is causing failures, as kubernetes doesn't seem to allow this as a mutable object: 

```
cannot patch "astronomer-prometheus-postgres-exporter" with kind Deployment: Deployment.apps "astronomer-prometheus-postgres-exporter" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app":"prometheus-postgres-exporter", "component":"prometheus-postgres-exporter", "release":"astronomer"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable
```

## Related Issues

Related astronomer/issues#XXXX

## Testing

- This needs to be tested by QA using an upgrade from 0.x to 2.0

## Merging

Master, 2.0