### PR TITLE
PLX-350 - remove unused logging configs

### DIFF
--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -109,7 +109,7 @@ def get_images_from_houston_configmap(doc, args):
     auth_sidecar_tag = deployments["authSideCar"]["tag"]
     if auth_sidecar_repository and auth_sidecar_tag:
         images.append(f"{auth_sidecar_repository}:{auth_sidecar_tag}")
-    if logging_sidecar_image := deployments.get("logging", {}).get("loggingSidecar", {}).get("image"):
+    if logging_sidecar_image := (deployments.get("logging") or {}).get("loggingSidecar") or {}.get("image"):
         images.append(logging_sidecar_image)
     dag_server_repository = deployments.get("dagDeploy", {}).get("images", {}).get("dagServer", {}).get("repository")
     dag_server_tag = deployments.get("dagDeploy", {}).get("images", {}).get("dagServer", {}).get("tag")

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -109,7 +109,7 @@ def get_images_from_houston_configmap(doc, args):
     auth_sidecar_tag = deployments["authSideCar"]["tag"]
     if auth_sidecar_repository and auth_sidecar_tag:
         images.append(f"{auth_sidecar_repository}:{auth_sidecar_tag}")
-    if logging_sidecar_image := (deployments.get("logging") or {}).get("loggingSidecar") or {}.get("image"):
+    if logging_sidecar_image := (deployments.get("logging") or {}).get("loggingSidecar", {}).get("image"):
         images.append(logging_sidecar_image)
     dag_server_repository = deployments.get("dagDeploy", {}).get("images", {}).get("dagServer", {}).get("repository")
     dag_server_tag = deployments.get("dagDeploy", {}).get("images", {}).get("dagServer", {}).get("tag")

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -119,19 +119,6 @@ data:
           enabled: {{ .Values.houston.cleanupAirflowDb.enabled }}
 
       logging:
-        enabled: true
-        provider: {{ default "fluentd" .Values.global.logging.provider | quote }}
-        elasticsearch:
-          enabled: true
-        {{- if .Values.global.customLogging.enabled }}
-          connection:
-            host: {{ printf "%s-external-es-proxy.%s" .Release.Name .Release.Namespace }}
-            port: 9200
-        {{- else }}
-          connection:
-            host: {{ printf "%s-elasticsearch-nginx.%s" .Release.Name .Release.Namespace }}
-            port: 9200
-        {{- end }}
         {{- if .Values.global.logging.loggingSidecar.enabled }}
         loggingSidecar:
           enabled: true

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -232,7 +232,6 @@ def test_houston_configmap_with_config_syncer_disabled():
     prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
     assert "extraVolumeMounts" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
     assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
-    assert not prod_yaml["deployments"]["logging"].get("loggingSidecar")
 
 
 def test_houston_configmap_with_vector_index_prefix_defaults():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -992,7 +992,7 @@ def test_houston_configmap_features_elasticsearch_defaults():
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    es = prod["deployments"]["logging"]["elasticsearch"]
+    es = prod["deployments"]["helm"]["airflow"]["elasticsearch"]
     assert es["enabled"] is True
     assert es["connection"]["host"].endswith("-elasticsearch-nginx.default")
     assert es["connection"]["port"] == 9200
@@ -1005,7 +1005,7 @@ def test_houston_configmap_features_elasticsearch_custom_logging():
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
     )
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    es = prod["deployments"]["logging"]["elasticsearch"]
+    es = prod["deployments"]["helm"]["airflow"]["elasticsearch"]
     assert es["enabled"] is True
     assert es["connection"]["host"].endswith("-external-es-proxy.default")
     assert es["connection"]["port"] == 9200

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1019,18 +1019,6 @@ def test_houston_configmap_features_grafana_defaults():
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     assert prod["deployments"]["metricsReporting"]["grafana"]["enabled"] is True
 
-
-def test_houston_configmap_features_logging_defaults():
-    """Validate that logging is emitted with defaults."""
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    log = prod["deployments"]["logging"]
-    assert log["enabled"] is True
-    assert log["provider"] == "fluentd"
-
-
 def test_houston_configmap_no_flat_enabled_flags_under_deployments():
     """Guard the uniform flag pattern (PLX-254): no flat *Enabled keys may
     appear directly under deployments in the rendered production.yaml.

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -55,10 +55,6 @@ def test_houston_configmap_defaults():
     assert not prod["deployments"].get("authSideCar")
 
     # Verify new unified feature flags
-    assert prod["deployments"]["logging"]["enabled"] is True
-    assert prod["deployments"]["logging"]["provider"] == "fluentd"
-    assert prod["deployments"]["logging"]["elasticsearch"]["enabled"] is True
-    assert prod["deployments"]["logging"]["elasticsearch"]["connection"]["port"] == 9200
     assert prod["deployments"]["metricsReporting"]["grafana"]["enabled"] is True
     assert prod["strictSchemaCheck"]["enabled"] is True
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -53,7 +53,6 @@ def test_houston_configmap_defaults():
     assert prod["elasticsearch"]["client"]["node"].startswith("http://")
 
     assert not prod["deployments"].get("authSideCar")
-    assert not prod["deployments"]["logging"].get("loggingSidecar")
 
     # Verify new unified feature flags
     assert prod["deployments"]["logging"]["enabled"] is True
@@ -1017,6 +1016,7 @@ def test_houston_configmap_features_grafana_defaults():
     )
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     assert prod["deployments"]["metricsReporting"]["grafana"]["enabled"] is True
+
 
 def test_houston_configmap_no_flat_enabled_flags_under_deployments():
     """Guard the uniform flag pattern (PLX-254): no flat *Enabled keys may


### PR DESCRIPTION
## Description

This PR removes unused configs from the houston config map 

## Related Issues

https://linear.app/astronomer/issue/PLX-350/bug-airflowelasticsearch-config-takes-priority-over

## Testing

NA

## Merging

merge to master and release-2.0
