### PR TITLE
PLX-370: wire dagTarballVersionValidation.enabled and migrate old key

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -406,7 +406,8 @@ GLOBAL_FEATURE_FLAG_RULES: list[BoolToNested | InvertedBoolToNested | SubtreeMov
 
 HOUSTON_DEPLOYMENTS_PREFIX = "astronomer.houston.config.deployments"
 
-# Renders houston-api ``DEPLOYMENTS_PATH_MIGRATIONS`` for Helm
+# Renders houston-api ``DEPLOYMENTS_PATH_MIGRATIONS`` and
+# ``HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS`` for Helm
 # (``src/lib/deployments-config-path-migration/index.js``). Order is significant.
 HOUSTON_DEPLOYMENT_PATH_MIGRATIONS: list[tuple[str, str | None, str]] = [
     ("performanceOptimizationModeEnabled", "performanceOptimization.enabled", "boolean-to-enabled"),
@@ -567,6 +568,17 @@ HOUSTON_DEPLOYMENT_PATH_MIGRATIONS: list[tuple[str, str | None, str]] = [
     ("defaultDistribution", None, "deprecated-unset"),
 ]
 
+# Nested renames under ``deployments`` (old path → new path). Kept in sync with
+# ``DEPLOYMENTS_NESTED_PATH_MIGRATIONS`` in houston-api
+# ``src/lib/deployments-config-path-migration/index.js``.
+HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS: list[tuple[str, str, str]] = [
+    (
+        "deploymentLifecycle.deployRollback.enableDagTarballVersionValidation",
+        "deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled",
+        "boolean-to-enabled",
+    ),
+]
+
 HOUSTON_DEPLOYMENT_CHART_ONLY_DELETE_KEYS: Final[frozenset[str]] = frozenset(
     {
         "astroUnitsEnabled",
@@ -581,6 +593,32 @@ def _cfg_get(obj: Any, key: str) -> Any:
     if isinstance(obj, (dict, CommentedMap)) and key in obj:
         return obj[key]
     return None
+
+
+def _get_dotted_value(mapping: CommentedMap, dotted: str) -> Any:
+    """Return the value at a dotted path, or None if any segment is missing."""
+    parts = dotted.split(".")
+    current: Any = mapping
+    for part in parts:
+        if not isinstance(current, CommentedMap) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _unset_dotted_path(mapping: CommentedMap, dotted: str) -> None:
+    """Delete the leaf key at a dotted path; no-op if the path is invalid."""
+    parts = dotted.split(".")
+    if not parts:
+        return
+    *parents, last = parts
+    current: Any = mapping
+    for p in parents:
+        if not isinstance(current, CommentedMap) or p not in current:
+            return
+        current = current[p]
+    if isinstance(current, CommentedMap) and last in current:
+        del current[last]
 
 
 def _set_dotted_path_in_mapping(root: CommentedMap, dotted: str, value: Any) -> None:
@@ -728,6 +766,30 @@ def _apply_houston_deployments_path_migrations(
         p_new = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{new_dotted}"
         if not new_dotted.startswith(f"{old_key}."):
             _delete_key(deployments, old_key)
+        changes.append(MigrationChange(p_old, p_new, f"Migrated {p_old} -> {p_new}"))
+    for old_dotted, new_dotted, transform in HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS:
+        old_keys = old_dotted.split(".")
+        if not _path_exists(deployments, old_keys):
+            continue
+        new_keys = new_dotted.split(".")
+        if _path_exists(deployments, new_keys):
+            _unset_dotted_path(deployments, old_dotted)
+            p_old = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{old_dotted}"
+            p_new = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{new_dotted}"
+            changes.append(
+                MigrationChange(
+                    p_old,
+                    p_new,
+                    f"Removed stale {p_old} (kept existing {p_new})",
+                )
+            )
+            continue
+        old_value = _get_dotted_value(deployments, old_dotted)
+        new_value = _transform_houston_deployment_value(old_value, transform)
+        _set_dotted_path_in_mapping(deployments, new_dotted, new_value)
+        _unset_dotted_path(deployments, old_dotted)
+        p_old = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{old_dotted}"
+        p_new = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{new_dotted}"
         changes.append(MigrationChange(p_old, p_new, f"Migrated {p_old} -> {p_new}"))
     return changes
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -115,6 +115,8 @@ data:
         deployRollback:
           enabled: {{ .Values.global.deploymentLifecycle.deployRollback.enabled }}
           deployRevisionReportNumberOfDays: {{ .Values.houston.cleanupDeployRevisions.olderThan}}
+          dagTarballVersionValidation:
+            enabled: {{ .Values.global.deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled }}
         cleanupAirflowDb:
           enabled: {{ .Values.houston.cleanupAirflowDb.enabled }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pytest-xdist>=3.8.0",
     "pyyaml>=6.0.3",
     "requests>=2.32.5",
+    "ruamel.yaml>=0.19.1",
     "semver>=3.0.4",
     "yamllint>=1.37.1",
 ]

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -56,6 +56,8 @@ global:
   deploymentLifecycle:
     deployRollback:
       enabled: true
+      dagTarballVersionValidation:
+        enabled: true
   deployMechanisms:
     dagOnlyDeployment:
       enabled: true

--- a/tests/migration/test_migrate_helm_chart_values.py
+++ b/tests/migration/test_migrate_helm_chart_values.py
@@ -143,6 +143,25 @@ class TestFullValuesMigration:
         assert deployments["upsertDeployment"]["allowFromUi"]["enabled"] is True
         assert "enableSystemAdminCanCreateDeprecatedAirflows" not in deployments
 
+    def test_houston_deployments_migrates_enableDagTarballVersionValidation(self) -> None:
+        """Nested ``enableDagTarballVersionValidation`` becomes ``dagTarballVersionValidation.enabled``."""
+        text = """
+astronomer:
+  houston:
+    config:
+      deployments:
+        deploymentLifecycle:
+          deployRollback:
+            enabled: true
+            enableDagTarballVersionValidation: false
+"""
+        data = _load_rt(text)
+        migrate_values(data)
+        d = _to_plain(data)["astronomer"]["houston"]["config"]["deployments"]
+        dr = d["deploymentLifecycle"]["deployRollback"]
+        assert dr["dagTarballVersionValidation"]["enabled"] is False
+        assert "enableDagTarballVersionValidation" not in dr
+
     def test_old_keys_removed_after_migration(self, old_full_values_text: str):
         """Old flat keys no longer exist at the global root after migration."""
         data = _load_rt(old_full_values_text)

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
+
+[options]
+exclude-newer = "2026-04-17T18:40:03.730066Z"
+exclude-newer-span = "P7D"
 
 [[package]]
 name = "apc-dev-env"
@@ -24,6 +28,7 @@ dependencies = [
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "requests" },
+    { name = "ruamel-yaml" },
     { name = "semver" },
     { name = "yamllint" },
 ]
@@ -47,6 +52,7 @@ requires-dist = [
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "ruamel-yaml", specifier = ">=0.19.1" },
     { name = "semver", specifier = ">=3.0.4" },
     { name = "yamllint", specifier = ">=1.37.1" },
 ]
@@ -276,11 +282,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.2"
+version = "3.28.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
 ]
 
 [[package]]
@@ -462,11 +468,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
 ]
 
 [[package]]
@@ -787,6 +793,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,8 @@ global:
   deploymentLifecycle:
     deployRollback:
       enabled: false
+      dagTarballVersionValidation:
+        enabled: true
 
   # Deploy mechanisms
   deployMechanisms:


### PR DESCRIPTION
## Description

This is the chart-side follow-up to `enabledagtarballversionvalidation` and the coordinated **houston-api** change: the DAG tarball presence check for deploy rollback is controlled by **`deployments.deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled`**, not a flat `enableDagTarballVersionValidation` on `deployRollback`.

This PR:

- **Values:** `global.deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled` in `values.yaml` (default aligned with Houston).
- **Houston ConfigMap:** render that path under `astronomer.houston.config.deployments.deploymentLifecycle.deployRollback` so new installs and upgrades get the right shape in Houston’s config.
- **Helm values migration:** `HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS` in `bin/helm_chart_values_migration_shared.py` mirrors Houston’s `DEPLOYMENTS_NESTED_PATH_MIGRATIONS` — renames `deploymentLifecycle.deployRollback.enableDagTarballVersionValidation` → `...dagTarballVersionValidation.enabled` when present in `astronomer.houston.config.deployments`.

## Related Issues

- https://linear.app/astronomer/issue/PLX-370/update-missed-enabledagtarballversionvalidation-flag-in-houston-and

## Testing

- **Helm template sanity:** e.g. `helm template` (or your chart CI) to confirm `global.deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled` flows into the Houston configmap under `deployments.deploymentLifecycle.deployRollback` without template errors.
- **Migration dry-run:** sample `astronomer.houston.config.deployments` YAML that still has `enableDagTarballVersionValidation` under `deploymentLifecycle.deployRollback` should produce `dagTarballVersionValidation.enabled` after `migrate-helm-chart-values` (1.x/0.37.x → 2.x) per your script entrypoint.

## Merging

- main
- 2.0.0