### PR TITLE
PINF-526: update per flight retries to 5

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -795,8 +795,8 @@ pilot:
   maxAttemptsPerLease: 3
 
   # -- Maximum retry attempts per flight
-  # @default -- 25
-  maxAttemptsPerFlight: 25
+  # @default -- 5
+  maxAttemptsPerFlight: 5
 
   # -- Retry base interval in milliseconds
   # @default -- 250

--- a/tests/chart_tests/test_astronomer_pilot.py
+++ b/tests/chart_tests/test_astronomer_pilot.py
@@ -92,7 +92,7 @@ class TestAstronomerPilot:
 
         # Retry knobs
         assert env_vars["PILOT_MAX_ATTEMPTS_PER_LEASE"] == "3"
-        assert env_vars["PILOT_MAX_ATTEMPTS_PER_FLIGHT"] == "25"
+        assert env_vars["PILOT_MAX_ATTEMPTS_PER_FLIGHT"] == "5"
         assert env_vars["PILOT_RETRY_BASE_INTERVAL_MS"] == "250"
         assert env_vars["PILOT_RETRY_MAX_INTERVAL_MS"] == "5000"
         assert env_vars["PILOT_RETRY_COOLOFF_SECONDS"] == "30"


### PR DESCRIPTION
## Description

Update retrues per flight to 5 from 25 to reduce wait for failed flights

## Related Issues

[PINF-526: Update Pilot retry attempts default in astronomer chart](https://linear.app/astronomer/issue/PINF-526/update-pilot-retry-attempts-default-in-astronomer-chart)

## Testing

Tested in AWS test cluster

## Merging

Merge to master and 2.0.0