### PR TITLE
Bump ap-houston-api to 2.0.18

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.17
+    tag: 2.0.18
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Summary
- bump `charts/astronomer/values.yaml` default Houston API image tag from `2.0.17` to `2.0.18`
- keep all other chart image defaults unchanged

[PINF-527: Navigator failover_request reconciler bug](https://linear.app/astronomer/issue/PINF-527/navigator-failover-request-reconciler-bug)

## Test plan
- [x] `uv run pre-commit run --files charts/astronomer/values.yaml`

Made with [Cursor](https://cursor.com)