### PR TITLE
PINF-515 fix helm value key

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -326,7 +326,7 @@ gcp_cloud_logging:
   value: {{ ternary "true" "false" .Values.global.dataPlaneFailover.enabled | quote }}
 {{- if .Values.global.dataPlaneFailover.enabled }}
 - name: COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME
-  value: {{ .Values.global.dataPlaneFailover.externalSecretManagerSecretName | quote }}
+  value: {{ .Values.global.dataPlaneFailover.externalSecretManagerName | quote }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/configs/failover-eks-dev.yaml
+++ b/configs/failover-eks-dev.yaml
@@ -1,4 +1,7 @@
-# astronomer:
+astronomer:
+  houston:
+    strictSchemaCheck:
+      enabled: true
 #   dpLink:
 #     enabled: true
 #   flightDeck:
@@ -12,8 +15,10 @@
 #       pullPolicy: Always
 #     commander:
 #       pullPolicy: Always
+#       tag: master
 #     houston:
 #       pullPolicy: Always
+#       tag: main
 #   navigator:
 #     enabled: true
 #     env:
@@ -28,12 +33,13 @@ global:
     enabled: true
     externalSecretManagerName: astronomer-cluster-secret-store
   helmRepo: https://internal-helm.astronomer.io
-  prometheusPostgresExporterEnabled: true
   rbac:
     enabled: true
   ssl:
     enabled: true
     mode: disable
+  prometheusPostgresExporter:
+    enabled: true
 tags:
   logging: true
   monitoring: true

--- a/configs/failover-eks-dev.yaml
+++ b/configs/failover-eks-dev.yaml
@@ -26,7 +26,7 @@ external-secrets:
 global:
   dataPlaneFailover:
     enabled: true
-    externalSecretManagerSecretName: astronomer-cluster-secret-store
+    externalSecretManagerName: astronomer-cluster-secret-store
   helmRepo: https://internal-helm.astronomer.io
   prometheusPostgresExporterEnabled: true
   rbac:

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -32,7 +32,7 @@ global:
   # Enable the dataPlaneFailover feature
   dataPlaneFailover:
     enabled: true
-    externalSecretManagerSecretName: astronomer-cluster-secret-store
+    externalSecretManagerName: astronomer-cluster-secret-store
   grafana:
     enabled: false
   helmRepo: https://internal-helm.astronomer.io

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -1,4 +1,7 @@
-# astronomer:
+astronomer:
+  houston:
+    strictSchemaCheck:
+      enabled: true
 #   airflowChartVersion: 1.17.28-build40412
 #   dpLink:
 #     enabled: true
@@ -36,12 +39,13 @@ global:
   grafana:
     enabled: false
   helmRepo: https://internal-helm.astronomer.io
-  prometheusPostgresExporterEnabled: false
   rbac:
     enabled: true
   ssl:
     enabled: true
     mode: disable
+  prometheusPostgresExporter:
+    enabled: false
 tags:
   logging: false
   monitoring: true

--- a/tests/chart_tests/test_dr_failover.py
+++ b/tests/chart_tests/test_dr_failover.py
@@ -94,7 +94,7 @@ class TestDataPlaneFailoverFlag:
                 "plane": {"mode": "data"},
                 "dataPlaneFailover": {
                     "enabled": True,
-                    "externalSecretManagerSecretName": "my-esm-secret",
+                    "externalSecretManagerName": "my-esm-name",
                 },
             },
         }
@@ -106,7 +106,7 @@ class TestDataPlaneFailoverFlag:
         assert len(docs) == 1
         containers = docs[0]["spec"]["template"]["spec"]["containers"]
         env_vars = get_env_vars_dict(containers[0]["env"])
-        assert env_vars["COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME"] == "my-esm-secret"
+        assert env_vars["COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME"] == "my-esm-name"
 
     def test_flag_data_mode_disabled_no_external_secret_manager_secret_name_env(self, kube_version):
         """When dataPlaneFailover is disabled, COMMANDER_EXTERNAL_SECRET_MANAGER_SECRET_NAME is not set."""

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -42,7 +42,7 @@ global:
     enabled: true
   dataPlaneFailover:
     enabled: true
-    externalSecretManagerSecretName: dummy-secret-name
+    externalSecretManagerName: dummy-esm-name
   networkPolicy:
     enabled: true
   rbac:

--- a/values.yaml
+++ b/values.yaml
@@ -91,6 +91,8 @@ global:
   # On unified (mode=unified): no effect — enable components individually
   dataPlaneFailover:
     enabled: false
+    # The name of a manually created ClusterSecretStore
+    # externalSecretManagerName: your-css-name
 
   # Metrics and reporting features
   metricsReporting:
@@ -771,4 +773,5 @@ kube-state:
 ## External Secrets configuration
 #################################
 external-secrets:
+  # Enable external-secrets to install ESO CRDs needed for dataPlaneFailover
   enabled: false


### PR DESCRIPTION
## Description

Fix helm value key. Ideally we should fix this before releasing 2.0.0, because otherwise we won't be able to fix it until 3.0.

This does not close PINF-515. It only fixes the customer-facing parts of this problem, the least amount of work we can do that will let us fix the full bug within the lifecycle of 2.0 instead of having to wait until 3.0.

## Related Issues

https://linear.app/astronomer/issue/PINF-515/correct-typo-in-external-secret-manager-failover-key

## Testing

I have tested this in a local cluster where dataPlaneFailover was enabled and I was able to create a deployment that came up healthy.

## Merging

This is for master, release-2.0