### PR TITLE
PINF-533: Make federated-dataplanes scrape_interval configurable and add scrape_timeout

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -72,7 +72,7 @@ data:
         metrics_path: '/federate'
         scheme: https
         scrape_interval: {{ .Values.config.scrape_configs.federated_dataplanes.scrape_interval }}
-        scrape_timeout: 15s
+        scrape_timeout: {{ .Values.config.scrape_configs.federated_dataplanes.scrape_timeout }}
         params:
           'match[]':
             - '{job=~".*-kube-state$|airflow|kubernetes-nodes-cadvisor|node-exporter"}'

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -71,7 +71,8 @@ data:
         honor_labels: true
         metrics_path: '/federate'
         scheme: https
-        scrape_interval: 5s
+        scrape_interval: {{ .Values.config.scrape_configs.federated_dataplanes.scrape_interval }}
+        scrape_timeout: 15s
         params:
           'match[]':
             - '{job=~".*-kube-state$|airflow|kubernetes-nodes-cadvisor|node-exporter"}'

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -209,6 +209,7 @@ config:
         insecure_skip_verify: false
     federated_dataplanes:
       scrape_interval: 15s
+      scrape_timeout: 15s
 
 rbac:
   role:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -209,7 +209,7 @@ config:
         insecure_skip_verify: false
     federated_dataplanes:
       scrape_interval: 15s
-      scrape_timeout: 14s
+      scrape_timeout: 10s
 
 rbac:
   role:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -207,6 +207,8 @@ config:
     kubernetes_apiservers:
       tls_config:
         insecure_skip_verify: false
+    federated_dataplanes:
+      scrape_interval: 15s
 
 rbac:
   role:

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -209,7 +209,7 @@ config:
         insecure_skip_verify: false
     federated_dataplanes:
       scrape_interval: 15s
-      scrape_timeout: 15s
+      scrape_timeout: 14s
 
 rbac:
   role:

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -352,3 +352,61 @@ class TestPrometheusConfigConfigmap:
         assert len(airflow_operator_scrape_config) == 0
         airflow_scrape_config = [scrape for scrape in scrape_configs if scrape["job_name"] == "airflow"]
         assert len(airflow_scrape_config) == 1
+
+    def test_federated_dataplanes_default_scrape_settings(self, kube_version):
+        """Test that federated-dataplanes uses default scrape_interval and scrape_timeout."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            name="astronomer",
+        )[0]
+        scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
+        federated = [s for s in scrape_configs if s["job_name"] == "federated-dataplanes"]
+
+        assert len(federated) == 1
+        assert federated[0]["scrape_interval"] == "15s"
+        assert federated[0]["scrape_timeout"] == "10s"
+
+    def test_federated_dataplanes_custom_scrape_interval(self, kube_version):
+        """Test that federated-dataplanes scrape_interval is configurable."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            name="astronomer",
+            values={
+                "prometheus": {
+                    "config": {
+                        "scrape_configs": {
+                            "federated_dataplanes": {"scrape_interval": "30s"},
+                        },
+                    },
+                },
+            },
+        )[0]
+        scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
+        federated = [s for s in scrape_configs if s["job_name"] == "federated-dataplanes"]
+
+        assert len(federated) == 1
+        assert federated[0]["scrape_interval"] == "30s"
+
+    def test_federated_dataplanes_custom_scrape_timeout(self, kube_version):
+        """Test that federated-dataplanes scrape_timeout is configurable."""
+        doc = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+            name="astronomer",
+            values={
+                "prometheus": {
+                    "config": {
+                        "scrape_configs": {
+                            "federated_dataplanes": {"scrape_timeout": "5s"},
+                        },
+                    },
+                },
+            },
+        )[0]
+        scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
+        federated = [s for s in scrape_configs if s["job_name"] == "federated-dataplanes"]
+
+        assert len(federated) == 1
+        assert federated[0]["scrape_timeout"] == "5s"

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -367,8 +367,8 @@ class TestPrometheusConfigConfigmap:
         assert federated[0]["scrape_interval"] == "15s"
         assert federated[0]["scrape_timeout"] == "10s"
 
-    def test_federated_dataplanes_custom_scrape_interval(self, kube_version):
-        """Test that federated-dataplanes scrape_interval is configurable."""
+    def test_federated_dataplanes_custom_scrape_settings(self, kube_version):
+        """Test that federated-dataplanes scrape_interval and scrape_timeout are configurable."""
         doc = render_chart(
             kube_version=kube_version,
             show_only=self.show_only,
@@ -377,7 +377,10 @@ class TestPrometheusConfigConfigmap:
                 "prometheus": {
                     "config": {
                         "scrape_configs": {
-                            "federated_dataplanes": {"scrape_interval": "30s"},
+                            "federated_dataplanes": {
+                                "scrape_interval": "30s",
+                                "scrape_timeout": "5s",
+                            },
                         },
                     },
                 },
@@ -388,25 +391,4 @@ class TestPrometheusConfigConfigmap:
 
         assert len(federated) == 1
         assert federated[0]["scrape_interval"] == "30s"
-
-    def test_federated_dataplanes_custom_scrape_timeout(self, kube_version):
-        """Test that federated-dataplanes scrape_timeout is configurable."""
-        doc = render_chart(
-            kube_version=kube_version,
-            show_only=self.show_only,
-            name="astronomer",
-            values={
-                "prometheus": {
-                    "config": {
-                        "scrape_configs": {
-                            "federated_dataplanes": {"scrape_timeout": "5s"},
-                        },
-                    },
-                },
-            },
-        )[0]
-        scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
-        federated = [s for s in scrape_configs if s["job_name"] == "federated-dataplanes"]
-
-        assert len(federated) == 1
         assert federated[0]["scrape_timeout"] == "5s"


### PR DESCRIPTION
## Summary
- Make the `federated-dataplanes` scrape job's `scrape_interval` configurable via `prometheus.config.scrape_configs.federated_dataplanes.scrape_interval`, defaulting to `15s` (previously hardcoded to `5s`)
- Add `scrape_timeout: 15s` to the `federated-dataplanes` scrape job

## Related Issues
https://linear.app/astronomer/issue/PINF-533

## Testing

- We are just increasing the scrape_interval of prometheus, no logic changes. 

