### PR TITLE
PINF-539 fix incorrect version for registry in meta endpoint

### DIFF
--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -15,6 +15,8 @@ metadata:
     plane: {{ .Values.global.plane.mode }}
 data:
   metadata.yaml: |-
+    registry:
+      version: {{ .Values.images.registry.tag }}
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -16,7 +16,7 @@ metadata:
 data:
   metadata.yaml: |-
     registry:
-      version: {{ .Values.images.registry.tag }}
+      version: {{ .Values.images.registry.tag | quote}}
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -32,7 +32,7 @@ class TestAstronomerCommander:
                 "namespaceLabels": namespace_labels,
             },
             "astronomer": {
-                "images": {"registry": {"tag": "3.0.1-9"}},
+                "images": {"registry": {"tag": "99.88.77"}},
             },
         }
         docs = render_chart(
@@ -50,13 +50,13 @@ class TestAstronomerCommander:
         if namespace_labels and rbac_enabled:
             assert metadata_file_contents == {
                 "namespaceLabels": namespace_labels,
-                "registry": {"version": "3.0.1-9"},
+                "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
             }
         else:
             assert metadata_file_contents == {
                 "namespaceLabels": {},
-                "registry": {"version": "3.0.1-9"},
+                "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
             }
 
@@ -68,7 +68,7 @@ class TestAstronomerCommander:
                 "customLogging": {"enabled": enabled},
             },
             "astronomer": {
-                "images": {"registry": {"tag": "3.0.1-10"}},
+                "images": {"registry": {"tag": "99.88.77"}},
             },
         }
         docs = render_chart(
@@ -86,7 +86,7 @@ class TestAstronomerCommander:
         assert metadata_file_contents == {
             "namespaceLabels": {},
             "customLogging": {"enabled": enabled},
-            "registry": {"version": "3.0.1-10"},
+            "registry": {"version": "99.88.77"},
         }
 
     def test_commander_deployment_default(self, kube_version):

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -1,3 +1,5 @@
+from ensurepip import version
+
 import jmespath
 import pytest
 import yaml
@@ -30,7 +32,10 @@ class TestAstronomerCommander:
             "global": {
                 "rbac": {"enabled": rbac_enabled},
                 "namespaceLabels": namespace_labels,
-            }
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "3.0.1-9"}},
+            },
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -47,10 +52,11 @@ class TestAstronomerCommander:
         if namespace_labels and rbac_enabled:
             assert metadata_file_contents == {
                 "namespaceLabels": namespace_labels,
+                "registry": {"version": "3.0.1-9"},
                 "customLogging": {"enabled": False},
             }
         else:
-            assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": False}}
+            assert metadata_file_contents == {"namespaceLabels": {}, "registry": {"version": "3.0.1-9"}, "customLogging": {"enabled": False}}
 
     @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
     def test_commander_metadata_custom_logging(self, kube_version, enabled):
@@ -58,7 +64,10 @@ class TestAstronomerCommander:
         values = {
             "global": {
                 "customLogging": {"enabled": enabled},
-            }
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "3.0.1-10"}},
+                },
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -72,7 +81,7 @@ class TestAstronomerCommander:
         assert doc["apiVersion"] == "v1"
 
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
-        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": enabled}}
+        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": enabled}, "registry": {"version": "3.0.1-10"}}
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -1,5 +1,3 @@
-from ensurepip import version
-
 import jmespath
 import pytest
 import yaml
@@ -56,7 +54,11 @@ class TestAstronomerCommander:
                 "customLogging": {"enabled": False},
             }
         else:
-            assert metadata_file_contents == {"namespaceLabels": {}, "registry": {"version": "3.0.1-9"}, "customLogging": {"enabled": False}}
+            assert metadata_file_contents == {
+                "namespaceLabels": {},
+                "registry": {"version": "3.0.1-9"},
+                "customLogging": {"enabled": False},
+            }
 
     @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
     def test_commander_metadata_custom_logging(self, kube_version, enabled):
@@ -67,7 +69,7 @@ class TestAstronomerCommander:
             },
             "astronomer": {
                 "images": {"registry": {"tag": "3.0.1-10"}},
-                },
+            },
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -81,7 +83,11 @@ class TestAstronomerCommander:
         assert doc["apiVersion"] == "v1"
 
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
-        assert metadata_file_contents == {"namespaceLabels": {}, "customLogging": {"enabled": enabled}, "registry": {"version": "3.0.1-10"}}
+        assert metadata_file_contents == {
+            "namespaceLabels": {},
+            "customLogging": {"enabled": enabled},
+            "registry": {"version": "3.0.1-10"},
+        }
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""


### PR DESCRIPTION
## Description

The dataplane metadata endpoint returns an empty string for `registry.version`. This PR fixes it by populating the field from the Helm value `images.registry.tag` in the commander metadata ConfigMap template.

### Changes

| File | What changed |
|------|-------------|
| `charts/astronomer/templates/commander/commander-metadata.yaml` | Adds `registry.version: {{ .Values.images.registry.tag }}` to the metadata template so the registry image tag is surfaced in the metadata endpoint |

### Improvements

- `registry.version` in the metadata endpoint now reflects the actual registry image tag instead of an empty string
- Consumers of the metadata API (Houston-API, commander) can now identify which registry version is running on the dataplane

## Related Issues

https://linear.app/astronomer/issue/PINF-539/fix-registry-version-missing-from-dataplane-metadata-endpoint

## Testing

1. Deploy with the patched chart
2. Call the dataplane metadata endpoint and verify `registry.version` matches the value of `images.registry.tag` in the Helm release values
3. Confirm no other metadata fields are affected

## Merging

Merge to master.