### PR TITLE
PINF-541: increase pilot max retry per flight to 15

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -796,7 +796,7 @@ pilot:
 
   # -- Maximum retry attempts per flight
   # @default -- 5
-  maxAttemptsPerFlight: 5
+  maxAttemptsPerFlight: 15
 
   # -- Retry base interval in milliseconds
   # @default -- 250

--- a/tests/chart_tests/test_astronomer_pilot.py
+++ b/tests/chart_tests/test_astronomer_pilot.py
@@ -92,7 +92,7 @@ class TestAstronomerPilot:
 
         # Retry knobs
         assert env_vars["PILOT_MAX_ATTEMPTS_PER_LEASE"] == "3"
-        assert env_vars["PILOT_MAX_ATTEMPTS_PER_FLIGHT"] == "5"
+        assert env_vars["PILOT_MAX_ATTEMPTS_PER_FLIGHT"] == "15"
         assert env_vars["PILOT_RETRY_BASE_INTERVAL_MS"] == "250"
         assert env_vars["PILOT_RETRY_MAX_INTERVAL_MS"] == "5000"
         assert env_vars["PILOT_RETRY_COOLOFF_SECONDS"] == "30"


### PR DESCRIPTION
## Description

Based on testing this will increase commander fault tolerance by increaseing per flight retries from 5 to 15

## Related Issues

[PINF-541: Update PIlot max retries per flight to 15](https://linear.app/astronomer/issue/PINF-541/update-pilot-max-retries-per-flight-to-15)

## Testing

Tested on AWS cp-dp setup

## Merging

Merge to master and 2.0.0
