### PR TITLE
chore: bump ci-helm-release image to 2026-05

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   release_bom:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-04
+      - image: quay.io/astronomer/ci-pre-commit:2026-05
     resource_class: small
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     # https://circleci.com/docs/using-docker/#x86
     resource_class: large
     parallelism: 4
@@ -128,7 +128,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     parameters:
       qa_release:
         type: boolean
@@ -147,7 +147,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -186,7 +186,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-04
+      - image: quay.io/astronomer/ci-helm-release:2026-05
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
## Description
Bumps the `ci-helm-release` Docker image tag from `2026-04` to `2026-05` across all jobs in `.circleci/config.yml` to align with the CI server's current month. This fixes a pre-commit failure where the date-based image tag validation was passing locally (April) but failing on CI (already May).

## Related Issues
N/A

## Testing
- Pre-commit ran locally with `pre-commit run --all-files --show-diff-on-failure` and passed after the update.
- CI pipeline should pass once the image tags match the May release.

## Merging
- master
- 2.0.0