### PR TITLE
PINF-560 Add update-ca-certificates in houston wrapper configMap

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml
+++ b/charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml
@@ -21,6 +21,7 @@ data:
     #!/bin/sh
     # Wrapper script to redirect Houston logs to files for Vector sidecar
     # stdout/stderr are tee'd to log files so kubectl logs still works
+    echo "update ca certs on startup..."
     update-ca-certificates
     exec "$@" \
       1> >(tee -a /var/log/sidecar-log-consumer/out.log) \

--- a/charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml
+++ b/charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml
@@ -21,6 +21,7 @@ data:
     #!/bin/sh
     # Wrapper script to redirect Houston logs to files for Vector sidecar
     # stdout/stderr are tee'd to log files so kubectl logs still works
+    update-ca-certificates
     exec "$@" \
       1> >(tee -a /var/log/sidecar-log-consumer/out.log) \
       2> >(tee -a /var/log/sidecar-log-consumer/err.log)

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -307,6 +307,57 @@ class TestHoustonSidecarLogging:
             )
         assert "houston.logging.loggingSidecar.elasticsearch.endpoint must be set" in excinfo.value.stderr.decode("utf-8")
 
+    def test_houston_log_wrapper_refreshes_ca_certificates(self, kube_version):
+        """
+        The shared log-wrapper ConfigMap must run update-ca-certificates so
+        certs from global.privateCaCerts are trusted by Node
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml",
+            ],
+            values={
+                "astronomer": {
+                    "houston": {
+                        "logging": {
+                            "loggingSidecar": {
+                                "enabled": True,
+                                "cloudwatch": {"enabled": True, "region": "us-east-2"},
+                            },
+                        },
+                    }
+                }
+            },
+        )
+
+        assert len(docs) == 1
+        wrapper_sh = docs[0]["data"]["wrapper.sh"]
+
+        marker_idx = wrapper_sh.find('echo "update ca certs on startup..."')
+        update_idx = wrapper_sh.find("update-ca-certificates")
+        exec_idx = wrapper_sh.find('exec "$@"')
+
+        assert marker_idx != -1, "startup marker missing from wrapper.sh"
+        assert update_idx != -1, "update-ca-certificates missing from wrapper.sh"
+        assert exec_idx != -1, "exec line missing from wrapper.sh"
+        assert marker_idx < update_idx < exec_idx, (
+            "wrapper.sh must echo the marker and run update-ca-certificates before exec"
+        )
+
+    def test_houston_log_wrapper_not_rendered_when_sidecar_disabled(self, kube_version):
+        """
+        The log-wrapper ConfigMap should only render when the sidecar is enabled.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[
+                "charts/astronomer/templates/houston/api/houston-log-wrapper-configmap.yaml",
+            ],
+            values={},
+        )
+        assert len(docs) == 0
+
     def test_houston_sidecar_logging_elasticsearch_uses_explicit_endpoint(self, kube_version):
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_astronomer_houston_sidecar.py
+++ b/tests/chart_tests/test_astronomer_houston_sidecar.py
@@ -341,9 +341,7 @@ class TestHoustonSidecarLogging:
         assert marker_idx != -1, "startup marker missing from wrapper.sh"
         assert update_idx != -1, "update-ca-certificates missing from wrapper.sh"
         assert exec_idx != -1, "exec line missing from wrapper.sh"
-        assert marker_idx < update_idx < exec_idx, (
-            "wrapper.sh must echo the marker and run update-ca-certificates before exec"
-        )
+        assert marker_idx < update_idx < exec_idx, "wrapper.sh must echo the marker and run update-ca-certificates before exec"
 
     def test_houston_log_wrapper_not_rendered_when_sidecar_disabled(self, kube_version):
         """


### PR DESCRIPTION
## Description

- Houston API on the logging-sidecar path bypassed the image's entrypoint (bin/entrypoint), which is where `update-ca-certificates` runs. As a result, certs from `global.privateCaCerts` were mounted at `/usr/local/share/ca-certificates/` but never added to the trust bundle, so Node TLS calls (e.g. Houston → data-plane Commander) failed.
- Fix: invoke `update-ca-certificates` inside the shared log-wrapper script. Same ConfigMap is mounted by houston-api and houston-worker, so both stay covered uniformly.

## Related Issues

https://linear.app/astronomer/issue/PINF-560/houston-does-not-trust-private-ca-during-deployment-creation

Related astronomer/issues#XXXX

## Testing

https://astronomer.slack.com/archives/C0A8A36G7HT/p1777458575571209

## Merging

This needs to go in `2.0.1`
