### PR TITLE
Disable kernel_hung collector on node-exporter to reduce log noise

### DIFF
--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -48,6 +48,7 @@ spec:
             - --path.procfs=/host/proc
             - --path.sysfs=/host/sys
             - --web.listen-address=$(HOST_IP):{{ .Values.service.port }}
+            - --no-collector.kernel_hung
 {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
 {{- end }}

--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -161,3 +161,50 @@ class TestPrometheusNodeExporterDaemonset:
         assert len(spec["tolerations"]) > 0
         assert spec["nodeSelector"] == values["prometheus-node-exporter"]["nodeSelector"]
         assert spec["tolerations"] == values["prometheus-node-exporter"]["tolerations"]
+
+    def test_prometheus_node_exporter_daemonset_extra_args(self, kube_version):
+        """Test to validate node exporter with extraArgs configured."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                **enable_node_exporter,
+                "prometheus-node-exporter": {
+                    "extraArgs": [
+                        "--something-to-test",
+                    ],
+                },
+            },
+            show_only=["charts/prometheus-node-exporter/templates/daemonset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        self.node_exporter_common_tests(doc)
+
+        c_by_name = get_containers_by_name(doc)
+        args = c_by_name["node-exporter"]["args"]
+        assert "--path.procfs=/host/proc" in args
+        assert "--path.sysfs=/host/sys" in args
+        assert "--web.listen-address=$(HOST_IP):9100" in args
+        assert "--no-collector.kernel_hung" in args
+        assert "--something-to-test" in args
+
+    def test_prometheus_node_exporter_daemonset_no_extra_args(self, kube_version):
+        """Test to validate node exporter without extraArgs has only default args."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=enable_node_exporter,
+            show_only=["charts/prometheus-node-exporter/templates/daemonset.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        self.node_exporter_common_tests(doc)
+
+        c_by_name = get_containers_by_name(doc)
+        args = c_by_name["node-exporter"]["args"]
+        assert len(args) == 4
+        assert "--path.procfs=/host/proc" in args
+        assert "--path.sysfs=/host/sys" in args
+        assert "--web.listen-address=$(HOST_IP):9100" in args
+        assert "--no-collector.kernel_hung" in args


### PR DESCRIPTION
## Description

The node-exporter DaemonSet on EKS clusters running Amazon Linux 2023 (`6.12.73-95.123.amzn2023.x86_64`) logs repeated collector failed errors for the `kernel_hung` collector on every scrape interval across all nodes.

The kernel on these nodes is compiled without `CONFIG_DETECT_HUNG_TASK`, so `/host/proc/sys/kernel/hung_task_detect_count` is absent. The collector fails every time it tries to read this file, generating significant log noise that makes it harder to spot real issues.

This does not cause metric loss — but the volume of error logs is operationally disruptive.


## Related Issues

https://linear.app/astronomer/issue/PINF-528/disable-kernel-hung-collector-on-amazon-linux-2023-nodes ﻿

## Testing

- Just addition of an args, the lognoise should be reduced with change.
- Unittests added
 
## Merging

Master, 2.0