### PR TITLE
Refactor k3d cluster names

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,10 @@
         "ms-python.vscode-pylance",
         "ms-vscode-remote.remote-containers",
         "ms-vscode.makefile-tools"
-      ]
+      ],
+      "settings": {
+        "ruff.path": ["/root/.local/bin/ruff"]
+      }
     }
   }
 }

--- a/bin/reconcile-k3d-orbstack-network.py
+++ b/bin/reconcile-k3d-orbstack-network.py
@@ -188,12 +188,12 @@ class Settings:
 
 def _settings_from_env() -> Settings:
     return Settings(
-        cp_context=os.environ.get("CP_CONTEXT", "k3d-control"),
-        dp_context=os.environ.get("DP_CONTEXT", "k3d-data"),
+        cp_context=os.environ.get("CP_CONTEXT", "k3d-cp01"),
+        dp_context=os.environ.get("DP_CONTEXT", "k3d-dp01"),
         platform_namespace=os.environ.get("PLATFORM_NAMESPACE", "astronomer"),
         base_domain=os.environ.get("BASE_DOMAIN", "localtest.me"),
         dp_domain_prefix=os.environ.get("DP_DOMAIN_PREFIX", "dp01"),
-        dp_node_container=os.environ.get("DP_NODE_CONTAINER", "k3d-data-server-0"),
+        dp_node_container=os.environ.get("DP_NODE_CONTAINER", "k3d-dp01-server-0"),
         cp_ingress_service=os.environ.get("CP_INGRESS_SERVICE", "astronomer-cp-nginx"),
     )
 

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -1146,7 +1146,7 @@ def parse_args() -> argparse.Namespace:
         "--cp-count",
         type=int,
         default=1,
-        choices=range(1, 5),
+        choices=range(1, 2),
         help="Number of control plane clusters to create. Clusters are named cp01, cp02, … Default: '%(default)s'",
     )
     parser.add_argument(

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-One-shot local CP/DP setup for Astronomer using two k3d clusters.
+One-shot local CP/DP setup for Astronomer using k3d clusters.
 
 This script automates the workflow documented in `docs/cp-dp-k3d-setup-guide.md`:
 - Generate TLS certs (mkcert) with the right SANs for CP + DP subdomains
@@ -174,9 +174,10 @@ mirrors:
 
 
 @dataclass(frozen=True)
-class Ports:
-    cp_https: int
-    cp_http: int
+class ControlPlane:
+    cluster_name: str
+    https_port: int
+    http_port: int
 
 
 @dataclass(frozen=True)
@@ -194,8 +195,7 @@ class Settings:
     release_name: str
     docker_network: str
     cp_mode: str
-    cp_cluster_name: str
-    ports: Ports
+    control_planes: tuple[ControlPlane, ...]
     data_planes: tuple[DataPlane, ...]
     tls_secret_name: str
     mkcert_root_ca_secret_name: str
@@ -1009,7 +1009,7 @@ def _helm_upgrade_install(
     _run(cmd, check=True, capture=False)
 
 
-def _run_dns_reconcile(settings: Settings, dp: DataPlane) -> None:
+def _run_dns_reconcile(settings: Settings, cp: ControlPlane, dp: DataPlane) -> None:
     """
     Run the existing reconcile helper to pin CoreDNS NodeHosts and the DP node's /etc/hosts.
     """
@@ -1017,7 +1017,7 @@ def _run_dns_reconcile(settings: Settings, dp: DataPlane) -> None:
     env = dict(os.environ)
     env.update(
         {
-            "CP_CONTEXT": f"k3d-{settings.cp_cluster_name}",
+            "CP_CONTEXT": f"k3d-{cp.cluster_name}",
             "DP_CONTEXT": f"k3d-{dp.cluster_name}",
             "PLATFORM_NAMESPACE": settings.namespace,
             "BASE_DOMAIN": settings.base_domain,
@@ -1091,7 +1091,8 @@ def _ensure_dp_node_houston_hosts_pin(settings: Settings, dp: DataPlane) -> None
     - Pods resolve via CoreDNS, but node-level operations (kubelet/containerd image pulls) use node DNS + /etc/hosts.
     - If `houston.<baseDomain>` resolves incorrectly at the node level, registry auth can break.
     """
-    cp_context = f"k3d-{settings.cp_cluster_name}"
+    primary_cp = settings.control_planes[0]
+    cp_context = f"k3d-{primary_cp.cluster_name}"
     dp_node_container = f"k3d-{dp.cluster_name}-server-0"
     cp_nginx_svc = f"{settings.release_name}-cp-nginx"
 
@@ -1107,12 +1108,9 @@ def _print_host_etc_hosts_instructions(settings: Settings) -> None:
     Print the recommended /etc/hosts entries for accessing CP/DP from the host machine.
 
     This uses the Docker IPs of the k3d `*-serverlb` containers:
-    - k3d-control-serverlb (CP ingress)
-    - k3d-<name>-serverlb (DP ingress, one per data plane)
+    - k3d-cp0X-serverlb (CP ingress, one per control plane)
+    - k3d-dp0X-serverlb (DP ingress, one per data plane)
     """
-    cp_serverlb = f"k3d-{settings.cp_cluster_name}-serverlb"
-    cp_nginx_lb_ip = _docker_inspect_ip(cp_serverlb)
-
     base = settings.base_domain
 
     _print("\nAdd the following entries to your host `/etc/hosts`:\n")
@@ -1123,9 +1121,12 @@ def _print_host_etc_hosts_instructions(settings: Settings) -> None:
         _print(
             f"{dp_nginx_lb_ip} {prefix}.{base} deployments.{prefix}.{base} registry.{prefix}.{base} commander.{prefix}.{base} prometheus.{prefix}.{base} prom-proxy.{prefix}.{base} elasticsearch.{prefix}.{base}"
         )
-    _print(
-        f"{cp_nginx_lb_ip} {base} app.{base} houston.{base} grafana.{base} prometheus.{base} elasticsearch.{base} alertmanager.{base} registry.{base}"
-    )
+    for cp in settings.control_planes:
+        cp_serverlb = f"k3d-{cp.cluster_name}-serverlb"
+        cp_nginx_lb_ip = _docker_inspect_ip(cp_serverlb)
+        _print(
+            f"{cp_nginx_lb_ip} {base} app.{base} houston.{base} grafana.{base} prometheus.{base} elasticsearch.{base} alertmanager.{base} registry.{base}"
+        )
 
 
 def _validate_prereqs() -> None:
@@ -1141,30 +1142,47 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--namespace", default="astronomer")
     parser.add_argument("--release-name", default="astronomer")
     parser.add_argument("--docker-network", default="astronomer-net")
-    parser.add_argument("--cp-cluster-name", default="control")
+    parser.add_argument(
+        "--cp-count",
+        type=int,
+        default=1,
+        choices=range(1, 5),
+        help="Number of control plane clusters to create. Clusters are named cp01, cp02, … Default: '%(default)s'",
+    )
     parser.add_argument(
         "--dp-count",
         type=int,
         default=1,
-        help="Number of data plane clusters to create. Clusters are named data-1, data-2, … Default: '%(default)s'",
+        choices=range(1, 5),
+        help="Number of data plane clusters to create. Clusters are named dp01, dp02, … Default: '%(default)s'",
     )
 
     parser.add_argument(
         "--cp-mode", type=str, default="unified", help="Control plane mode to install (unified, control) Default: '%(default)s'"
     )
-    parser.add_argument("--cp-https-port", type=int, default=8443, help="Control plane HTTPS port. Default: '%(default)s'")
-    parser.add_argument("--cp-http-port", type=int, default=8080, help="Control plane HTTP port. Default: '%(default)s'")
+    parser.add_argument(
+        "--cp-base-https-port",
+        type=int,
+        default=8443,
+        help="Base HTTPS port for the first control plane; subsequent control planes increment by 1. Default: '%(default)s'",
+    )
+    parser.add_argument(
+        "--cp-base-http-port",
+        type=int,
+        default=8080,
+        help="Base HTTP port for the first control plane; subsequent control planes increment by 1. Default: '%(default)s'",
+    )
     parser.add_argument(
         "--dp-base-https-port",
         type=int,
-        default=8444,
-        help="Base HTTPS port for the first data plane; subsequent data planes increment by 1. Default: '%(default)s'",
+        default=None,
+        help="Base HTTPS port for the first data plane; subsequent data planes increment by 1. Defaults to --cp-base-https-port + cp-count.",
     )
     parser.add_argument(
         "--dp-base-http-port",
         type=int,
-        default=8081,
-        help="Base HTTP port for the first data plane; subsequent data planes increment by 1. Default: '%(default)s'",
+        default=None,
+        help="Base HTTP port for the first data plane; subsequent data planes increment by 1. Defaults to --cp-base-http-port + cp-count.",
     )
 
     parser.add_argument("--tls-secret-name", default="astronomer-tls")
@@ -1234,12 +1252,24 @@ def main() -> int:  # noqa: C901
 
     ms = Milestones()
 
+    dp_base_https = args.dp_base_https_port if args.dp_base_https_port is not None else (args.cp_base_https_port + args.cp_count)
+    dp_base_http = args.dp_base_http_port if args.dp_base_http_port is not None else (args.cp_base_http_port + args.cp_count)
+
+    control_planes = tuple(
+        ControlPlane(
+            cluster_name=f"cp{i:02d}",
+            https_port=args.cp_base_https_port + (i - 1),
+            http_port=args.cp_base_http_port + (i - 1),
+        )
+        for i in range(1, args.cp_count + 1)
+    )
+
     data_planes = tuple(
         DataPlane(
-            cluster_name=f"data-{i}",
+            cluster_name=f"dp{i:02d}",
             domain_prefix=f"dp{i:02d}",
-            https_port=args.dp_base_https_port + (i - 1),
-            http_port=args.dp_base_http_port + (i - 1),
+            https_port=dp_base_https + (i - 1),
+            http_port=dp_base_http + (i - 1),
         )
         for i in range(1, args.dp_count + 1)
     )
@@ -1250,8 +1280,7 @@ def main() -> int:  # noqa: C901
         release_name=args.release_name,
         docker_network=args.docker_network,
         cp_mode=args.cp_mode,
-        cp_cluster_name=args.cp_cluster_name,
-        ports=Ports(cp_https=args.cp_https_port, cp_http=args.cp_http_port),
+        control_planes=control_planes,
         data_planes=data_planes,
         tls_secret_name=args.tls_secret_name,
         mkcert_root_ca_secret_name=args.mkcert_root_ca_secret_name,
@@ -1301,29 +1330,32 @@ def main() -> int:  # noqa: C901
             raise RuntimeError("mkcert root CA path not available")
 
         # Step: clusters
+        cp_names = ", ".join(cp.cluster_name for cp in settings.control_planes)
         dp_names = ", ".join(dp.cluster_name for dp in settings.data_planes)
         if not args.skip_clusters:
-            h = ms.start(f"Ensure k3d clusters exist (CP={settings.cp_cluster_name}, DP={dp_names})")
+            h = ms.start(f"Ensure k3d clusters exist (CP={cp_names}, DP={dp_names})")
             if args.recreate_clusters:
-                _delete_k3d_cluster(settings.cp_cluster_name)
+                for cp in settings.control_planes:
+                    _delete_k3d_cluster(cp.cluster_name)
                 for dp in settings.data_planes:
                     _delete_k3d_cluster(dp.cluster_name)
 
-            if not _k3d_cluster_exists(settings.cp_cluster_name):
-                _k3d_create_cluster(
-                    name=settings.cp_cluster_name,
-                    docker_network=settings.docker_network,
-                    ports=[
-                        f"{settings.ports.cp_https}:443@loadbalancer",
-                        f"{settings.ports.cp_http}:80@loadbalancer",
-                    ],
-                    mkcert_root_ca=mkcert_root_ca,
-                    # Expand NodePort range so postgres can be exposed as NodePort 5432.
-                    extra_k3s_args=["--kube-apiserver-arg=--service-node-port-range=1024-65535@server:0"],
-                    registry_config=registry_config,
-                )
-            else:
-                _debug(f"Cluster already exists, skipping: {settings.cp_cluster_name}")
+            for cp in settings.control_planes:
+                if not _k3d_cluster_exists(cp.cluster_name):
+                    _k3d_create_cluster(
+                        name=cp.cluster_name,
+                        docker_network=settings.docker_network,
+                        ports=[
+                            f"{cp.https_port}:443@loadbalancer",
+                            f"{cp.http_port}:80@loadbalancer",
+                        ],
+                        mkcert_root_ca=mkcert_root_ca,
+                        # Expand NodePort range so postgres can be exposed as NodePort 5432.
+                        extra_k3s_args=["--kube-apiserver-arg=--service-node-port-range=1024-65535@server:0"],
+                        registry_config=registry_config,
+                    )
+                else:
+                    _debug(f"Cluster already exists, skipping: {cp.cluster_name}")
 
             for dp in settings.data_planes:
                 if not _k3d_cluster_exists(dp.cluster_name):
@@ -1342,19 +1374,19 @@ def main() -> int:  # noqa: C901
             ms.done(h)
         else:
             ms.skip(
-                f"Ensure k3d clusters exist (CP={settings.cp_cluster_name}, DP={dp_names})",
+                f"Ensure k3d clusters exist (CP={cp_names}, DP={dp_names})",
                 reason="--skip-clusters set",
             )
 
-        cp_context = f"k3d-{settings.cp_cluster_name}"
-
         # Step: namespace + secrets
         if not args.skip_secrets:
-            h = ms.start(f"Apply namespace + secrets in both clusters (ns={settings.namespace})")
+            h = ms.start(f"Apply namespace + secrets in all clusters (ns={settings.namespace})")
             if cert_path is None or key_path is None:
                 raise RuntimeError("TLS cert/key paths not available; cannot create secrets")
 
-            for ctx in [cp_context] + [f"k3d-{dp.cluster_name}" for dp in settings.data_planes]:
+            for ctx in [f"k3d-{cp.cluster_name}" for cp in settings.control_planes] + [
+                f"k3d-{dp.cluster_name}" for dp in settings.data_planes
+            ]:
                 _kubectl_create_namespace(ctx, settings.namespace)
                 _kubectl_apply_tls_secret(
                     context=ctx,
@@ -1372,7 +1404,7 @@ def main() -> int:  # noqa: C901
                 )
             ms.done(h, detail=f"tlsSecret={settings.tls_secret_name} caSecret={settings.mkcert_root_ca_secret_name}")
         else:
-            ms.skip("Apply namespace + secrets in both clusters", reason="--skip-secrets set")
+            ms.skip("Apply namespace + secrets in all clusters", reason="--skip-secrets set")
 
         # Step: deploy MySQL in DP clusters (when --dp-airflow-db=mysql)
         # Bootstrap secrets (postgres or mysql) are created later in a dedicated step after CP helm install.
@@ -1392,8 +1424,11 @@ def main() -> int:  # noqa: C901
         else:
             values_dir = Path(tempfile.mkdtemp(prefix="astro-k3d-"))
 
-        cp_values = values_dir / "cp-values.yaml"
-        _write_values_file(cp_values, _cp_values_yaml(settings))
+        cp_values_files: dict[str, Path] = {}
+        for cp in settings.control_planes:
+            cp_values_path = values_dir / f"cp-{cp.cluster_name}-values.yaml"
+            _write_values_file(cp_values_path, _cp_values_yaml(settings))
+            cp_values_files[cp.cluster_name] = cp_values_path
         dp_values_files: dict[str, Path] = {}
         for dp in settings.data_planes:
             dp_values_path = values_dir / f"dp-{dp.cluster_name}-values.yaml"
@@ -1410,21 +1445,22 @@ def main() -> int:  # noqa: C901
             else:
                 ms.skip("Helm dependency update", reason="Disabled by default (vendored local charts)")
 
-            h = ms.start(f"Helm install/upgrade Control Plane (context={cp_context})")
-            _helm_upgrade_install(
-                context=cp_context,
-                chart_dir=GIT_ROOT_DIR,
-                release_name=settings.release_name,
-                namespace=settings.namespace,
-                values_file=cp_values,
-                extra_values_files=[Path(f) for f in args.helm_values],
-                timeout=settings.helm_timeout,
-                debug=settings.helm_debug,
-            )
-            ms.done(h)
+            for cp in settings.control_planes:
+                h = ms.start(f"Helm install/upgrade Control Plane (context=k3d-{cp.cluster_name})")
+                _helm_upgrade_install(
+                    context=f"k3d-{cp.cluster_name}",
+                    chart_dir=GIT_ROOT_DIR,
+                    release_name=settings.release_name,
+                    namespace=settings.namespace,
+                    values_file=cp_values_files[cp.cluster_name],
+                    extra_values_files=[Path(f) for f in args.helm_values],
+                    timeout=settings.helm_timeout,
+                    debug=settings.helm_debug,
+                )
+                ms.done(h)
 
             # Step: create astronomer-bootstrap secrets in all DP clusters.
-            # Postgres mode: point to the CP's shared postgres NodePort on the CP node Docker IP.
+            # Postgres mode: point to the primary CP's (cp01) shared postgres NodePort on the CP node Docker IP.
             # MySQL mode: point to each DP's own MySQL service.
             h = ms.start("Create DP astronomer-bootstrap secrets")
             if settings.dp_airflow_db == "mysql":
@@ -1435,7 +1471,8 @@ def main() -> int:  # noqa: C901
                         release_name=settings.release_name,
                     )
             else:
-                cp_node_ip = _docker_inspect_ip(f"k3d-{settings.cp_cluster_name}-server-0")
+                primary_cp = settings.control_planes[0]
+                cp_node_ip = _docker_inspect_ip(f"k3d-{primary_cp.cluster_name}-server-0")
                 for dp in settings.data_planes:
                     _create_astronomer_bootstrap_secret_postgres(
                         context=f"k3d-{dp.cluster_name}",
@@ -1450,7 +1487,7 @@ def main() -> int:  # noqa: C901
                 dp_ctx = f"k3d-{dp.cluster_name}"
                 if not args.skip_dns_reconcile:
                     h = ms.start(f"Pre-DP: update {dp.cluster_name} CoreDNS NodeHosts for CP ingress")
-                    _run_dns_reconcile(settings, dp)
+                    _run_dns_reconcile(settings, settings.control_planes[0], dp)
                     ms.done(h)
                 else:
                     ms.skip(f"Pre-DP: update {dp.cluster_name} CoreDNS NodeHosts for CP ingress", reason="--skip-dns-reconcile set")
@@ -1470,11 +1507,11 @@ def main() -> int:  # noqa: C901
         else:
             ms.skip("Helm dependency update + CP/DP install", reason="--skip-helm set")
 
-        # Step: DNS reconcile (final, once per DP)
+        # Step: DNS reconcile (final, once per DP against the primary CP)
         for dp in settings.data_planes:
             if not args.skip_dns_reconcile:
                 h = ms.start(f"Reconcile cross-cluster DNS + node-level hosts pins ({dp.cluster_name})")
-                _run_dns_reconcile(settings, dp)
+                _run_dns_reconcile(settings, settings.control_planes[0], dp)
                 ms.done(h)
             else:
                 ms.skip(

--- a/configs/failover-local-dev.yaml
+++ b/configs/failover-local-dev.yaml
@@ -49,3 +49,11 @@ global:
 tags:
   logging: false
   monitoring: true
+prometheus:
+  resources:
+    limits:
+      cpu: 2000m
+      memory: 4Gi
+    requests:
+      cpu: 1000m
+      memory: 1Gi

--- a/docs/cp-dp-k3d-setup-guide.md
+++ b/docs/cp-dp-k3d-setup-guide.md
@@ -129,7 +129,7 @@ ls -la "${MKCERT_ROOT_CA}"
 If you regenerated the TLS cert/key (for `dp01.localtest.me` + `*.dp01.localtest.me`), update the `astronomer-tls` secret in both clusters:
 
 ```bash
-for CTX in k3d-control k3d-data; do
+for CTX in k3d-cp01 k3d-dp01; do
   kubectl --context "$CTX" -n astronomer create secret tls astronomer-tls \
     --cert="$HOME/.local/share/astronomer-software/certs/astronomer-tls.pem" \
     --key="$HOME/.local/share/astronomer-software/certs/astronomer-tls.key" \
@@ -137,8 +137,8 @@ for CTX in k3d-control k3d-data; do
 done
 
 # Restart nginx in both clusters to reload the updated certificate
-kubectl --context k3d-control -n astronomer rollout restart deployment -l tier=nginx
-kubectl --context k3d-data -n astronomer rollout restart deployment -l tier=nginx
+kubectl --context k3d-cp01 -n astronomer rollout restart deployment -l tier=nginx
+kubectl --context k3d-dp01 -n astronomer rollout restart deployment -l tier=nginx
 ```
 
 ---
@@ -154,8 +154,8 @@ k3d uses Flannel by default, which properly routes traffic to external networks.
 
 ```bash
 # Delete any existing clusters with these names
-k3d cluster delete control 2>/dev/null || true
-k3d cluster delete data 2>/dev/null || true
+k3d cluster delete cp01 2>/dev/null || true
+k3d cluster delete dp01 2>/dev/null || true
 
 # mkcert root CA path (generated in Step 2)
 MKCERT_CAROOT="$($HOME/.local/share/astronomer-software/bin/mkcert -CAROOT)"
@@ -164,7 +164,7 @@ MKCERT_ROOT_CA="${MKCERT_CAROOT}/rootCA.pem"
 # Create Control Plane cluster
 # --network: puts both clusters on the same Docker network
 # --port: maps container ports to host for external access
-k3d cluster create control \
+k3d cluster create cp01 \
   --network astronomer-net \
   --port "8443:443@loadbalancer" \
   --port "8080:80@loadbalancer" \
@@ -172,7 +172,7 @@ k3d cluster create control \
   --k3s-arg "--disable=traefik@server:0"
 
 # Create Data Plane cluster on the same network
-k3d cluster create data \
+k3d cluster create dp01 \
   --network astronomer-net \
   --port "8444:443@loadbalancer" \
   --port "8081:80@loadbalancer" \
@@ -194,17 +194,17 @@ If you need the node itself to trust mkcert (for example, debugging from inside 
 
 ```bash
 # Append mkcert root CA into the node CA bundle (Control Plane + Data Plane nodes)
-docker exec k3d-control-server-0 sh -c 'cat /etc/ssl/certs/mkcert-rootCA.pem >> /etc/ssl/certs/ca-certificates.crt'
-docker exec k3d-data-server-0 sh -c 'cat /etc/ssl/certs/mkcert-rootCA.pem >> /etc/ssl/certs/ca-certificates.crt'
+docker exec k3d-cp01-server-0 sh -c 'cat /etc/ssl/certs/mkcert-rootCA.pem >> /etc/ssl/certs/ca-certificates.crt'
+docker exec k3d-dp01-server-0 sh -c 'cat /etc/ssl/certs/mkcert-rootCA.pem >> /etc/ssl/certs/ca-certificates.crt'
 
 # Verify the file exists
-docker exec k3d-control-server-0 ls -la /etc/ssl/certs/mkcert-rootCA.pem
-docker exec k3d-data-server-0 ls -la /etc/ssl/certs/mkcert-rootCA.pem
+docker exec k3d-cp01-server-0 ls -la /etc/ssl/certs/mkcert-rootCA.pem
+docker exec k3d-dp01-server-0 ls -la /etc/ssl/certs/mkcert-rootCA.pem
 ```
 
 > **Note:** This optional node-level trust does **not** replace Step 5. Pods trust Houston’s TLS via `global.privateCaCerts` and the chart’s `update-ca-certificates` step.
 
-The clusters will have contexts named `k3d-control` and `k3d-data`.
+The clusters will have contexts named `k3d-cp01` and `k3d-dp01`.
 
 ---
 
@@ -212,11 +212,11 @@ The clusters will have contexts named `k3d-control` and `k3d-data`.
 
 ```bash
 # Get Control Plane node IP
-CP_NODE_IP=$(docker inspect k3d-control-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+CP_NODE_IP=$(docker inspect k3d-cp01-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 echo "Control Plane Node IP: $CP_NODE_IP"
 
 # Get Data Plane node IP
-DP_NODE_IP=$(docker inspect k3d-data-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+DP_NODE_IP=$(docker inspect k3d-dp01-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 echo "Data Plane Node IP: $DP_NODE_IP"
 
 # Get Docker network subnet
@@ -231,42 +231,42 @@ docker network inspect astronomer-net -f '{{range .IPAM.Config}}{{.Subnet}} {{en
 
 ```bash
 # Create namespace
-kubectl --context k3d-control create namespace astronomer
+kubectl --context k3d-cp01 create namespace astronomer
 
 # Create TLS secret
-kubectl --context k3d-control -n astronomer create secret tls astronomer-tls \
+kubectl --context k3d-cp01 -n astronomer create secret tls astronomer-tls \
   --cert=$HOME/.local/share/astronomer-software/certs/astronomer-tls.pem \
   --key=$HOME/.local/share/astronomer-software/certs/astronomer-tls.key
 
 # Create mkcert root CA secret (CRITICAL: enables pods to trust the self-signed TLS chain)
 MKCERT_CAROOT="$($HOME/.local/share/astronomer-software/bin/mkcert -CAROOT)"
 MKCERT_ROOT_CA="${MKCERT_CAROOT}/rootCA.pem"
-kubectl --context k3d-control -n astronomer create secret generic mkcert-root-ca \
+kubectl --context k3d-cp01 -n astronomer create secret generic mkcert-root-ca \
   --from-file=cert.pem="${MKCERT_ROOT_CA}"
 
 # Verify secrets
-kubectl --context k3d-control -n astronomer get secrets
+kubectl --context k3d-cp01 -n astronomer get secrets
 ```
 
 ### Data Plane Cluster
 
 ```bash
 # Create namespace
-kubectl --context k3d-data create namespace astronomer
+kubectl --context k3d-dp01 create namespace astronomer
 
 # Create TLS secret
-kubectl --context k3d-data -n astronomer create secret tls astronomer-tls \
+kubectl --context k3d-dp01 -n astronomer create secret tls astronomer-tls \
   --cert=$HOME/.local/share/astronomer-software/certs/astronomer-tls.pem \
   --key=$HOME/.local/share/astronomer-software/certs/astronomer-tls.key
 
 # Create mkcert root CA secret (CRITICAL: enables pods to trust the self-signed TLS chain)
 MKCERT_CAROOT="$($HOME/.local/share/astronomer-software/bin/mkcert -CAROOT)"
 MKCERT_ROOT_CA="${MKCERT_CAROOT}/rootCA.pem"
-kubectl --context k3d-data -n astronomer create secret generic mkcert-root-ca \
+kubectl --context k3d-dp01 -n astronomer create secret generic mkcert-root-ca \
   --from-file=cert.pem="${MKCERT_ROOT_CA}"
 
 # Verify secrets
-kubectl --context k3d-data -n astronomer get secrets
+kubectl --context k3d-dp01 -n astronomer get secrets
 ```
 
 ---
@@ -550,7 +550,7 @@ helm dependency update .
 echo "Installing Astronomer Control Plane..."
 helm install astronomer . \
   --namespace astronomer \
-  --kube-context k3d-control \
+  --kube-context k3d-cp01 \
   --values /tmp/cp-values.yaml \
   --timeout 60m \
   --wait --debug
@@ -560,10 +560,10 @@ helm install astronomer . \
 
 ```bash
 # Check all CP pods are running
-kubectl --context k3d-control -n astronomer get pods
+kubectl --context k3d-cp01 -n astronomer get pods
 
 # Get CP nginx service
-kubectl --context k3d-control -n astronomer get svc astronomer-cp-nginx
+kubectl --context k3d-cp01 -n astronomer get svc astronomer-cp-nginx
 ```
 
 Wait until all pods show `Running` or `Completed` status before proceeding.
@@ -579,7 +579,7 @@ With k3d/Flannel, pods CAN reach external IPs. We just need to configure DNS.
 ```bash
 # IMPORTANT: Use the Control Plane nginx LoadBalancer IP for inter-cluster calls.
 # Do NOT use the node container IP, otherwise you may hit the wrong ingress and get 404s for Houston endpoints.
-CP_NGINX_LB_IP=$(kubectl --context k3d-control -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+CP_NGINX_LB_IP=$(kubectl --context k3d-cp01 -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 echo "CP nginx LoadBalancer IP: $CP_NGINX_LB_IP"
 ```
 
@@ -591,13 +591,13 @@ echo "CP nginx LoadBalancer IP: $CP_NGINX_LB_IP"
 
 ```bash
 # Backup CoreDNS ConfigMap
-kubectl --context k3d-data -n kube-system get configmap coredns -o yaml > /tmp/coredns-dp-backup.yaml
+kubectl --context k3d-dp01 -n kube-system get configmap coredns -o yaml > /tmp/coredns-dp-backup.yaml
 
 # Create the coredns-custom ConfigMap if it doesn't exist (required by k3d)
-kubectl --context k3d-data -n kube-system create configmap coredns-custom 2>/dev/null || true
+kubectl --context k3d-dp01 -n kube-system create configmap coredns-custom 2>/dev/null || true
 
 # Edit CoreDNS ConfigMap
-kubectl --context k3d-data -n kube-system edit configmap coredns
+kubectl --context k3d-dp01 -n kube-system edit configmap coredns
 ```
 
 Add your custom DNS entries to the `NodeHosts` section (at the end of the data section):
@@ -629,10 +629,10 @@ data:
     import /etc/coredns/custom/*.server
   NodeHosts: |
     192.168.147.1 host.k3d.internal
-    192.168.147.4 k3d-data-serverlb
-    192.168.147.5 k3d-control-serverlb
-    192.168.147.2 k3d-data-server-0
-    192.168.147.3 k3d-control-server-0
+    192.168.147.4 k3d-dp01-serverlb
+    192.168.147.5 k3d-cp01-serverlb
+    192.168.147.2 k3d-dp01-server-0
+    192.168.147.3 k3d-cp01-server-0
     <CP_NGINX_LB_IP> localtest.me houston.localtest.me app.localtest.me grafana.localtest.me
 ```
 
@@ -642,23 +642,23 @@ Replace `<CP_NGINX_LB_IP>` with the actual CP nginx LoadBalancer IP (e.g., `192.
 
 ```bash
 # Restart CoreDNS to pick up changes
-kubectl --context k3d-data -n kube-system delete pod -l k8s-app=kube-dns
-kubectl --context k3d-data -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=60s
+kubectl --context k3d-dp01 -n kube-system delete pod -l k8s-app=kube-dns
+kubectl --context k3d-dp01 -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=60s
 ```
 
 ### Verify DNS and Connectivity from DP
 
 ```bash
 # Test DNS resolution
-kubectl --context k3d-data run test-dns --rm -it --restart=Never --image=busybox -- nslookup houston.localtest.me
+kubectl --context k3d-dp01 run test-dns --rm -it --restart=Never --image=busybox -- nslookup houston.localtest.me
 
 # Test actual connectivity (this should work with k3d!)
-kubectl --context k3d-data run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
+kubectl --context k3d-dp01 run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
   curl -v -k --connect-timeout 10 https://houston.localtest.me/v1/healthz
 
 # IMPORTANT: The registry uses https://houston.<baseDomain>/v1/registry/authorization for OAuth tokens (no port),
 # so this must NOT be a 404 from the DP cluster:
-kubectl --context k3d-data run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
+kubectl --context k3d-dp01 run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
   curl -v -k --connect-timeout 10 "https://houston.localtest.me/v1/registry/authorization"
 ```
 
@@ -675,7 +675,7 @@ kubectl --context k3d-data run test-curl --rm -it --restart=Never --image=curlim
 echo "Installing Astronomer Data Plane..."
 helm install astronomer . \
   --namespace astronomer \
-  --kube-context k3d-data \
+  --kube-context k3d-dp01 \
   --values /tmp/dp-values.yaml \
   --timeout 60m \
   --wait --debug
@@ -687,14 +687,14 @@ helm install astronomer . \
 
 ```bash
 # Get DP node IP
-DP_NODE_IP=$(docker inspect k3d-data-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+DP_NODE_IP=$(docker inspect k3d-dp01-server-0 -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
 echo "DP Node IP: $DP_NODE_IP"
 
 # Create the coredns-custom ConfigMap if it doesn't exist (required by k3d)
-kubectl --context k3d-control -n kube-system create configmap coredns-custom 2>/dev/null || true
+kubectl --context k3d-cp01 -n kube-system create configmap coredns-custom 2>/dev/null || true
 
 # Edit CoreDNS in CP cluster
-kubectl --context k3d-control -n kube-system edit configmap coredns
+kubectl --context k3d-cp01 -n kube-system edit configmap coredns
 ```
 
 Add DP entries to the `NodeHosts` section (same approach as DP cluster):
@@ -709,8 +709,8 @@ Replace `<DP_NODE_IP>` with the actual DP node IP (e.g., `192.168.147.2`).
 
 ```bash
 # Restart CoreDNS
-kubectl --context k3d-control -n kube-system delete pod -l k8s-app=kube-dns
-kubectl --context k3d-control -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=60s
+kubectl --context k3d-cp01 -n kube-system delete pod -l k8s-app=kube-dns
+kubectl --context k3d-cp01 -n kube-system wait --for=condition=ready pod -l k8s-app=kube-dns --timeout=60s
 ```
 
 ---
@@ -748,7 +748,7 @@ sudo bash -c 'echo "127.0.0.1 dp01.localtest.me deployments.dp01.localtest.me re
 # Option B (only if your host can route to the LB IPs): map hostnames to the k3d LoadBalancer IPs
 # You can test routability from your macOS host:
 #
-#   CP_LB_IP=$(kubectl --context k3d-control -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+#   CP_LB_IP=$(kubectl --context k3d-cp01 -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 #   curl -vk --connect-timeout 3 "https://${CP_LB_IP}/healthz"
 #
 # If this succeeds, you can map /etc/hosts to the LB IPs and use 443 with no port.
@@ -762,22 +762,22 @@ sudo bash -c 'echo "127.0.0.1 dp01.localtest.me deployments.dp01.localtest.me re
 
 ```bash
 echo "=== Control Plane Pods ==="
-kubectl --context k3d-control -n astronomer get pods
+kubectl --context k3d-cp01 -n astronomer get pods
 
 echo ""
 echo "=== Data Plane Pods ==="
-kubectl --context k3d-data -n astronomer get pods
+kubectl --context k3d-dp01 -n astronomer get pods
 ```
 
 ### Test Cross-Cluster Communication
 
 ```bash
 # From DP pod, test connectivity to CP
-kubectl --context k3d-data run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
+kubectl --context k3d-dp01 run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
   curl -k https://houston.localtest.me/v1/healthz
 
 # From CP pod, test connectivity to DP
-kubectl --context k3d-control run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
+kubectl --context k3d-cp01 run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
   curl -k https://dp01.localtest.me/healthz
 ```
 
@@ -817,8 +817,8 @@ python3 bin/reconcile-k3d-orbstack-network.py
 ```
 
 Defaults assumed by the script:
-- CP context: `k3d-control`
-- DP context: `k3d-data`
+- CP context: `k3d-cp01`
+- DP context: `k3d-dp01`
 - Namespace: `astronomer`
 - Base domain: `localtest.me`
 - DP domain prefix: `dp01`
@@ -826,8 +826,8 @@ Defaults assumed by the script:
 Override via env vars (example):
 
 ```bash
-CP_CONTEXT=k3d-control \
-DP_CONTEXT=k3d-data \
+CP_CONTEXT=k3d-cp01 \
+DP_CONTEXT=k3d-dp01 \
 BASE_DOMAIN=localtest.me \
 DP_DOMAIN_PREFIX=dp01 \
 python3 bin/reconcile-k3d-orbstack-network.py
@@ -837,14 +837,14 @@ python3 bin/reconcile-k3d-orbstack-network.py
 
 ```bash
 # Has the CP ingress LB IP changed?
-kubectl --context k3d-control -n astronomer get svc astronomer-cp-nginx
+kubectl --context k3d-cp01 -n astronomer get svc astronomer-cp-nginx
 
 # Can a DP pod still reach Houston?
-kubectl --context k3d-data run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
+kubectl --context k3d-dp01 run test-curl --rm -it --restart=Never --image=curlimages/curl -- \
   curl -vk -k --connect-timeout 5 https://houston.localtest.me/v1/healthz
 
 # Does the DP node container resolve Houston correctly (node-level DNS)?
-docker exec k3d-data-server-0 sh -c 'grep -n "houston.localtest.me" /etc/hosts || true'
+docker exec k3d-dp01-server-0 sh -c 'grep -n "houston.localtest.me" /etc/hosts || true'
 ```
 
 ### Browser works but CLI (`astro`, `curl`) fails
@@ -901,17 +901,17 @@ If a **pod** in the Data Plane can reach Houston, the problem is usually **node-
 **Check from the DP node container**:
 
 ```bash
-docker exec k3d-data-server-0 sh -c 'nslookup houston.localtest.me || true'
+docker exec k3d-dp01-server-0 sh -c 'nslookup houston.localtest.me || true'
 ```
 
 If it resolves to `127.0.0.1` / `::1`, fix it by pinning `houston.localtest.me` to the **CP nginx LoadBalancer IP** in the node’s `/etc/hosts`:
 
 ```bash
-CP_NGINX_LB_IP=$(kubectl --context k3d-control -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-docker exec k3d-data-server-0 sh -c "echo \"$CP_NGINX_LB_IP houston.localtest.me\" >> /etc/hosts"
+CP_NGINX_LB_IP=$(kubectl --context k3d-cp01 -n astronomer get svc astronomer-cp-nginx -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+docker exec k3d-dp01-server-0 sh -c "echo \"$CP_NGINX_LB_IP houston.localtest.me\" >> /etc/hosts"
 
 # Verify: should be 401 (or 403), but NOT 404
-docker exec k3d-data-server-0 sh -c 'apk add --no-cache curl >/dev/null 2>&1 || true; curl -4sk --connect-timeout 3 -o /dev/null -w "%{http_code}\n" "https://houston.localtest.me/v1/registry/authorization?service=docker-registry&scope=repository:test/test:pull"'
+docker exec k3d-dp01-server-0 sh -c 'apk add --no-cache curl >/dev/null 2>&1 || true; curl -4sk --connect-timeout 3 -o /dev/null -w "%{http_code}\n" "https://houston.localtest.me/v1/registry/authorization?service=docker-registry&scope=repository:test/test:pull"'
 ```
 
 For a permanent solution, recreate k3d clusters using k3d’s host-alias support so these `/etc/hosts` entries are injected at cluster creation time.
@@ -920,22 +920,22 @@ For a permanent solution, recreate k3d clusters using k3d’s host-alias support
 
 ```bash
 # Control Plane Houston logs
-kubectl --context k3d-control -n astronomer logs -l component=houston -f
+kubectl --context k3d-cp01 -n astronomer logs -l component=houston -f
 
 # Data Plane Commander logs
-kubectl --context k3d-data -n astronomer logs -l component=commander -f
+kubectl --context k3d-dp01 -n astronomer logs -l component=commander -f
 ```
 
 ### Delete and Recreate
 
 ```bash
 # Delete helm releases
-helm --kube-context k3d-control uninstall astronomer -n astronomer
-helm --kube-context k3d-data uninstall astronomer -n astronomer
+helm --kube-context k3d-cp01 uninstall astronomer -n astronomer
+helm --kube-context k3d-dp01 uninstall astronomer -n astronomer
 
 # Delete clusters entirely
-k3d cluster delete control
-k3d cluster delete data
+k3d cluster delete cp01
+k3d cluster delete dp01
 ```
 
 ---

--- a/docs/local-registry.md
+++ b/docs/local-registry.md
@@ -25,9 +25,9 @@ Four **Docker Registry v2 pull-through caching containers** run as persistent Do
 
 ```
 Docker network: astronomer-net
-├── k3d-control-server-0 \
-├── k3d-data-1-server-0   }── k3d cluster nodes (destroyed/recreated)
-├── ...                  /
+├── k3d-cp01-server-0 \
+├── k3d-dp01-server-0  }── k3d cluster nodes (destroyed/recreated)
+├── ...                /
 │
 ├── astronomer-registry-proxy-quay     → caches quay.io          (host: localhost:15001)
 ├── astronomer-registry-proxy-docker   → caches docker.io         (host: localhost:15002)


### PR DESCRIPTION
## Description

- Refactor k3d setup to not map `data-N` cluster to `dp0N`, and to use `cp0N` instead of `control` for the cp cluster.
- Fix devcontainer ruff complaint
- Reduce prometheus resources in local dev config

## Related Issues

This was prerequisite work for https://linear.app/astronomer/issue/PLA-211/dr-test-dp-link-crash-recovery

## Testing

I've tested this locally and it works as expected. It does change the command line arguments though, which is a breaking change, so devs will need to account for that in their scripts.

None of these changes are shipped to the customer, they are all docs and dev related changes, so no QA work is needed.

## Merging

master, release-2.0