### PR TITLE
pinf-580 Add imagePullSecrets to platform-labeller Job

### DIFF
--- a/charts/astronomer/templates/add-labels-to-namespace.yaml
+++ b/charts/astronomer/templates/add-labels-to-namespace.yaml
@@ -68,6 +68,7 @@ spec:
     spec:
       restartPolicy: Never
       serviceAccountName: {{ .Release.Name }}-labeller
+      {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: label-platform-namespace
         image: {{ template "dbBootstrapper.image" . }}

--- a/tests/chart_tests/test_network_ns_labels.py
+++ b/tests/chart_tests/test_network_ns_labels.py
@@ -28,6 +28,50 @@ class TestNSSelectorNetworkPolicies:
         assert doc["metadata"]["name"] == "release-name-houston-config"
         assert prod["deployments"]["helm"]["networkNSLabels"] is True
 
+    def test_platform_labeller_job_not_rendered_by_default(self, kube_version):
+        """Labeller hook resources must not render when networkNSLabels is disabled (default)."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/astronomer/templates/add-labels-to-namespace.yaml"],
+        )
+
+        assert docs == []
+
+    def test_platform_labeller_job_rendered_when_enabled(self, kube_version):
+        """Labeller hook Job and supporting RBAC must render when networkNSLabels is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"networkNSLabels": {"enabled": True}}},
+            show_only=["charts/astronomer/templates/add-labels-to-namespace.yaml"],
+        )
+
+        kinds = sorted(doc["kind"] for doc in docs)
+        assert kinds == ["Job", "Role", "RoleBinding", "ServiceAccount"]
+
+        job = next(doc for doc in docs if doc["kind"] == "Job")
+        assert job["metadata"]["name"] == "release-name-platform-labeller"
+        assert job["spec"]["template"]["spec"]["serviceAccountName"] == "release-name-labeller"
+        assert "imagePullSecrets" not in job["spec"]["template"]["spec"]
+
+    def test_platform_labeller_job_image_pull_secrets(self, kube_version):
+        """Labeller hook Job must include imagePullSecrets when privateRegistry is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "networkNSLabels": {"enabled": True},
+                    "privateRegistry": {"enabled": True, "secretName": "private-registry-secret"},
+                }
+            },
+            show_only=["charts/astronomer/templates/add-labels-to-namespace.yaml"],
+        )
+
+        jobs = [doc for doc in docs if doc["kind"] == "Job"]
+        assert len(jobs) == 1
+        job = jobs[0]
+        assert job["metadata"]["name"] == "release-name-platform-labeller"
+        assert job["spec"]["template"]["spec"]["imagePullSecrets"] == [{"name": "private-registry-secret"}]
+
     def test_networknsselector_with_postgresql(self, kube_version):
         """Test postgresql Service with namespace selector labels."""
         docs = render_chart(


### PR DESCRIPTION
## Description

Add imagePullSecrets to `platform-labeller` Job

The pre-install/pre-upgrade `platform-labeller` Job was missing `imagePullSecrets`, causing ErrImagePull on installs that use a private registry together with networkNSLabels.enabled.

## Related Issues

https://linear.app/astronomer/issue/PINF-580/astronomer-chart-platform-labeller-job-missing-imagepullsecrets-when

## Testing

Added test cases to verify that imagePullSecrets are rendered correctly

## Merging

Merge this to 1.1.3 and 2.0.1
