### PR TITLE
pinf-580 fix test cases

### DIFF
--- a/tests/chart_tests/test_network_ns_labels.py
+++ b/tests/chart_tests/test_network_ns_labels.py
@@ -41,7 +41,7 @@ class TestNSSelectorNetworkPolicies:
         """Labeller hook Job and supporting RBAC must render when networkNSLabels is enabled."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"networkNSLabels": {"enabled": True}}},
+            values={"global": {"networkNSLabels": True}},
             show_only=["charts/astronomer/templates/add-labels-to-namespace.yaml"],
         )
 
@@ -59,7 +59,7 @@ class TestNSSelectorNetworkPolicies:
             kube_version=kube_version,
             values={
                 "global": {
-                    "networkNSLabels": {"enabled": True},
+                    "networkNSLabels": True,
                     "privateRegistry": {"enabled": True, "secretName": "private-registry-secret"},
                 }
             },


### PR DESCRIPTION
## Description

Cherry picking changes from `master` that was part of https://github.com/astronomer/astronomer/pull/3228, caused issues with the test cases because of schema diff between `1.x` and `2.x`.

This PR fixes it

## Related Issues

Related astronomer/issues#XXXX

## Testing

Do not merge this PR until this text is replaced with details about how these changes were tested.

## Merging

Do not merge this PR until it lists which release branches this PR should be merged / cherry-picked into.
