### PR TITLE
PINF-505 - update commander version 1.1.9

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.1.8
+    tag: 1.1.9
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

currently we don't have proper way to detect incluster logging vs customLogging within product post 1.x and this is causing a new inconvenience for the customers and users as well to keep manually configuring the changes and update the settings.

by introducing a new configuration spec in metadata endpoint we will able to control the settings at control plane level by refreshing the setting to auto update from metadata and make users to triggerer the deployment updates for further updates to the airflow deployments

## Related Issues

https://linear.app/astronomer/issue/PINF-505/expose-customlogging-flag-in-commander-metadata

## Testing

check more details on linear ticket 

## Merging

merge to master and release-1.x
