### PR TITLE
PINF-539 backport commander metadata changes

### DIFF
--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -15,5 +15,11 @@ metadata:
     plane: {{ .Values.global.plane.mode }}
 data:
   metadata.yaml: |-
+    registry:
+      version: {{ .Values.images.registry.tag | quote }}
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
+    customLogging:
+      enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
+    openshift:
+      enabled: {{ ternary "true" "false" .Values.global.openshiftEnabled }}
 {{- end }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 1.1.9
+    tag: 1.1.10
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -28,7 +28,10 @@ class TestAstronomerCommander:
             "global": {
                 "rbacEnabled": rbac_enabled,
                 "namespaceLabels": namespace_labels,
-            }
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "99.88.77"}},
+            },
         }
         docs = render_chart(
             kube_version=kube_version,
@@ -43,9 +46,49 @@ class TestAstronomerCommander:
 
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
         if namespace_labels and rbac_enabled:
-            assert metadata_file_contents == {"namespaceLabels": namespace_labels}
+            assert metadata_file_contents == {
+                "namespaceLabels": namespace_labels,
+                "registry": {"version": "99.88.77"},
+                "customLogging": {"enabled": False},
+                "openshift": {"enabled": False},
+            }
         else:
-            assert metadata_file_contents == {"namespaceLabels": {}}
+            assert metadata_file_contents == {
+                "namespaceLabels": {},
+                "registry": {"version": "99.88.77"},
+                "customLogging": {"enabled": False},
+                "openshift": {"enabled": False},
+            }
+
+    @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
+    def test_commander_metadata_custom_logging(self, kube_version, enabled):
+        """Test that helm renders custom logging in metadata.yaml template for astronomer/commander."""
+        values = {
+            "global": {
+                "customLogging": {"enabled": enabled},
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "99.88.77"}},
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/astronomer/templates/commander/commander-metadata.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+
+        metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
+        assert metadata_file_contents == {
+            "namespaceLabels": {},
+            "customLogging": {"enabled": enabled},
+            "registry": {"version": "99.88.77"},
+            "openshift": {"enabled": False},
+        }
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -90,6 +90,36 @@ class TestAstronomerCommander:
             "openshift": {"enabled": False},
         }
 
+    @pytest.mark.parametrize("enabled", [True, False], ids=["openshift_enabled", "openshift_disabled"])
+    def test_commander_metadata_openshift(self, kube_version, enabled):
+        """Test that helm renders openshift in metadata.yaml template for astronomer/commander."""
+        values = {
+            "global": {
+                "openshiftEnabled": enabled,
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "99.88.77"}},
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/astronomer/templates/commander/commander-metadata.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "ConfigMap"
+        assert doc["apiVersion"] == "v1"
+
+        metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
+        assert metadata_file_contents == {
+            "namespaceLabels": {},
+            "customLogging": {"enabled": False},
+            "registry": {"version": "99.88.77"},
+            "openshift": {"enabled": enabled},
+        }
+
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""
         values = {


### PR DESCRIPTION
## Description

adds openshift metadata support
adds customLogging metadata support
fixes registry version in the metadata endpoint

## Related Issues

https://linear.app/astronomer/issue/PINF-539/fix-registry-version-missing-from-dataplane-metadata-endpoint

## Testing

refer tagged issues

## Merging

merged to release-1.x
