### PR TITLE
PLX-426: Fix COMMANDER_HOUSTON_JWKS_ENDPOINT being overridden on helm upgrades

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -311,16 +311,8 @@ gcp_cloud_logging:
   value: {{ include "commander.dataplaneURL" . | quote }}
 - name: COMMANDER_DATAPLANE_MODE
   value: {{ .Values.global.plane.mode | quote }}
-{{- $jwksOverridden := false -}}
-{{- range $.Values.commander.env -}}
-  {{- if eq .name "COMMANDER_HOUSTON_JWKS_ENDPOINT" -}}
-    {{- $jwksOverridden = true -}}
-  {{- end -}}
-{{- end -}}
-{{- if not $jwksOverridden }}
 - name: COMMANDER_HOUSTON_JWKS_ENDPOINT
-  value: "{{ include "houston.authServiceURL" $ }}"
-{{- end }}
+  value: "{{ include "houston.authServiceURL" . }}"
 - name: COMMANDER_NAMESPACE_POOLS_ENABLED
   value: {{ ternary "true" "false" .Values.global.namespaceManagement.namespacePools.enabled | quote  }}
 {{- if .Values.global.namespaceManagement.namespacePools.enabled  }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -311,8 +311,16 @@ gcp_cloud_logging:
   value: {{ include "commander.dataplaneURL" . | quote }}
 - name: COMMANDER_DATAPLANE_MODE
   value: {{ .Values.global.plane.mode | quote }}
+{{- $jwksOverridden := false -}}
+{{- range $.Values.commander.env -}}
+  {{- if eq .name "COMMANDER_HOUSTON_JWKS_ENDPOINT" -}}
+    {{- $jwksOverridden = true -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $jwksOverridden }}
 - name: COMMANDER_HOUSTON_JWKS_ENDPOINT
-  value: "{{ include "houston.authServiceURL" . }}"
+  value: "{{ include "houston.authServiceURL" $ }}"
+{{- end }}
 - name: COMMANDER_NAMESPACE_POOLS_ENABLED
   value: {{ ternary "true" "false" .Values.global.namespaceManagement.namespacePools.enabled | quote  }}
 {{- if .Values.global.namespaceManagement.namespacePools.enabled  }}
@@ -785,7 +793,7 @@ checksum/jetstream-tls-cert: {{ $actualCert }}
 {{- if (eq .Values.global.plane.mode "data") -}}
 https://houston.{{ .Values.global.baseDomain }}
 {{- else -}}
-http://{{ .Release.Name }}-houston.{{ .Release.Namespace}}:{{ .Values.ports.houstonHTTP }}
+http://{{ .Release.Name }}-houston.{{ .Release.Namespace}}.svc.cluster.local:{{ .Values.ports.houstonHTTP }}
 {{- end }}
 {{- end -}}
 

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -200,10 +200,6 @@ spec:
             periodSeconds: 10
           {{- end }}
           env:
-            {{- range $i, $config := .Values.commander.env }}
-            - name: {{ $config.name }}
-              value: {{ $config.value | quote }}
-            {{- end }}
             {{- if or .Values.flightDeck.enabled (and .Values.global.dataPlaneFailover.enabled (eq .Values.global.plane.mode "data")) }}
             - name: COMMANDER_FLIGHTDECK_DSN
               valueFrom:
@@ -249,6 +245,10 @@ spec:
               value: "true"
             {{- end }}
             {{- include "commander_metadataEnv" . | nindent 12 }}
+            {{- range $i, $config := .Values.commander.env }}
+            - name: {{ $config.name }}
+              value: {{ $config.value | quote }}
+            {{- end }}
           volumeMounts:
             - name: etc-ssl-certs
               mountPath: /etc/ssl/certs

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -200,6 +200,10 @@ spec:
             periodSeconds: 10
           {{- end }}
           env:
+            {{- range $i, $config := .Values.commander.env }}
+            - name: {{ $config.name }}
+              value: {{ $config.value | quote }}
+            {{- end }}
             {{- if or .Values.flightDeck.enabled (and .Values.global.dataPlaneFailover.enabled (eq .Values.global.plane.mode "data")) }}
             - name: COMMANDER_FLIGHTDECK_DSN
               valueFrom:
@@ -245,10 +249,6 @@ spec:
               value: "true"
             {{- end }}
             {{- include "commander_metadataEnv" . | nindent 12 }}
-            {{- range $i, $config := .Values.commander.env }}
-            - name: {{ $config.name }}
-              value: {{ $config.value | quote }}
-            {{- end }}
           volumeMounts:
             - name: etc-ssl-certs
               mountPath: /etc/ssl/certs

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -203,7 +203,7 @@ class TestAstronomerCommander:
         assert env_vars["COMMANDER_ELASTICSEARCH_ENABLED"] == "true"
         assert env_vars["COMMANDER_ELASTICSEARCH_LOG_LEVEL"] == "info"
         assert env_vars["COMMANDER_ELASTICSEARCH_NODE"] == "http://release-name-elasticsearch.default.svc.cluster.local.:9200"
-        assert env_vars["COMMANDER_HOUSTON_JWKS_ENDPOINT"] == "http://release-name-houston.default:8871"
+        assert env_vars["COMMANDER_HOUSTON_JWKS_ENDPOINT"] == "http://release-name-houston.default.svc.cluster.local:8871"
         assert env_vars["COMMANDER_MANAGE_NAMESPACE_RESOURCE"] == "true"
         assert env_vars["COMMANDER_REGION"] == "us-west-2"
         assert env_vars["COMMANDER_UPGRADE_TIMEOUT"] == "600"
@@ -914,3 +914,63 @@ class TestAstronomerCommander:
         env_vars = get_env_vars_dict(c_by_name["commander"]["env"])
         assert env_vars["MY_CUSTOM_VAR"] == "custom-value"
         assert env_vars["ANOTHER_VAR"] == "another-value"
+
+    @pytest.mark.parametrize(
+        "plane_mode,expected_jwks_endpoint",
+        [
+            ("data", "https://houston.example.com"),
+            ("unified", "http://release-name-houston.default.svc.cluster.local:8871"),
+        ],
+        ids=["data_plane", "unified_plane"],
+    )
+    def test_commander_houston_auth_service_url(self, kube_version, plane_mode, expected_jwks_endpoint):
+        """Test that COMMANDER_HOUSTON_JWKS_ENDPOINT is set from houston.authServiceURL.
+
+        Data plane uses the external Houston URL (https://houston.<baseDomain>).
+        Unified plane uses the in-cluster service URL with .svc.cluster.local to
+        avoid DNS resolution timeouts (PLX-426).
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": plane_mode}}},
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        commander_env = get_containers_by_name(docs[0])["commander"]["env"]
+        jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
+        assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
+        assert jwks_entries[0]["value"] == expected_jwks_endpoint
+
+    @pytest.mark.parametrize(
+        "plane_mode",
+        ["data", "unified"],
+        ids=["data_plane", "unified_plane"],
+    )
+    def test_commander_env_override_jwks_endpoint(self, kube_version, plane_mode):
+        """Test that commander.env can override COMMANDER_HOUSTON_JWKS_ENDPOINT with no duplicate env var entries.
+
+        Regression test for PLX-426: the override was silently ignored because
+        commander_metadataEnv was rendered after commander.env, causing the
+        default value to always win.
+
+        Duplicate env var names with the same merge key cause Kubernetes strategic
+        merge patch to fail on helm upgrade, so we also assert exactly one entry.
+        """
+        custom_jwks_url = "http://astronomer-houston.af-rdfnp-cp.svc.cluster.local.:8871"
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": plane_mode}},
+                "astronomer": {
+                    "commander": {
+                        "env": [{"name": "COMMANDER_HOUSTON_JWKS_ENDPOINT", "value": custom_jwks_url}],
+                    },
+                },
+            },
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        commander_env = get_containers_by_name(docs[0])["commander"]["env"]
+        jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
+        assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
+        assert jwks_entries[0]["value"] == custom_jwks_url

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -940,37 +940,3 @@ class TestAstronomerCommander:
         jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
         assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
         assert jwks_entries[0]["value"] == expected_jwks_endpoint
-
-    @pytest.mark.parametrize(
-        "plane_mode",
-        ["data", "unified"],
-        ids=["data_plane", "unified_plane"],
-    )
-    def test_commander_env_override_jwks_endpoint(self, kube_version, plane_mode):
-        """Test that commander.env can override COMMANDER_HOUSTON_JWKS_ENDPOINT with no duplicate env var entries.
-
-        Regression test for PLX-426: the override was silently ignored because
-        commander_metadataEnv was rendered after commander.env, causing the
-        default value to always win.
-
-        Duplicate env var names with the same merge key cause Kubernetes strategic
-        merge patch to fail on helm upgrade, so we also assert exactly one entry.
-        """
-        custom_jwks_url = "http://astronomer-houston.af-rdfnp-cp.svc.cluster.local.:8871"
-        docs = render_chart(
-            kube_version=kube_version,
-            values={
-                "global": {"plane": {"mode": plane_mode}},
-                "astronomer": {
-                    "commander": {
-                        "env": [{"name": "COMMANDER_HOUSTON_JWKS_ENDPOINT", "value": custom_jwks_url}],
-                    },
-                },
-            },
-            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
-        )
-        assert len(docs) == 1
-        commander_env = get_containers_by_name(docs[0])["commander"]["env"]
-        jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
-        assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
-        assert jwks_entries[0]["value"] == custom_jwks_url


### PR DESCRIPTION
## Summary

Fixes a bug where `COMMANDER_HOUSTON_JWKS_ENDPOINT` was reset on every Helm upgrade, 
ignoring any override set via `commander.env`. Reported by Tesco, who had to manually 
patch the value after each upgrade to add `.svc.cluster.local` to avoid connection timeouts.

## Root Cause

Two issues combined to cause this:

1. **Env ordering**: `commander.env` (user overrides) was rendered *before* 
   `commander_metadataEnv` in the deployment template. Since Kubernetes uses 
   last-wins for duplicate env var names, the hardcoded default from 
   `commander_metadataEnv` always silently won.

2. **Missing `.svc.cluster.local`**: `houston.authServiceURL` in unified plane 
   mode was generating `http://<release>-houston.<namespace>:<port>` without 
   `.svc.cluster.local`, causing DNS resolution timeouts in some cluster 
   configurations.

## Changes

- **`commander-deployment.yaml`**: Moved `commander.env` block to after 
  `commander_metadataEnv` so user-provided values always take precedence.

- **`_helpers.yaml` (`commander_metadataEnv`)**: Added a conditional check that 
  skips rendering `COMMANDER_HOUSTON_JWKS_ENDPOINT` when it is already present 
  in `commander.env`. This prevents duplicate env var names, which Kubernetes 
  rejects via strategic merge patch on upgrade.

- **`_helpers.yaml` (`houston.authServiceURL`)**: Unified plane URL now includes 
  `.svc.cluster.local` for reliable in-cluster DNS resolution.


## Related Issues
https://linear.app/astronomer/issue/PLX-426/commander-jwks-endpoint-override-ignored-on-helm-upgrades

## Testing

- Unit tests
- generated the template locally, rendering fine

## Merging

master