### PR TITLE
PINF-621 fix external es-proxy internal url

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -756,7 +756,7 @@ http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/e
 {{- if eq .Values.global.plane.mode "data" -}}
 es-proxy.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else if eq .Values.global.plane.mode "unified" -}}
-{{ .Release.Name }}-es-proxy.{{ .Release.Namespace }}.svc.cluster.local:9201
+{{ .Release.Name }}-external-es-proxy.{{ .Release.Namespace }}.svc.cluster.local:9201
 {{- end -}}
 {{- end -}}
 

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -753,11 +753,7 @@ http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/e
 {{- end -}}
 
 {{- define "esproxy.url" -}}
-{{- if eq .Values.global.plane.mode "data" -}}
-es-proxy.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
-{{- else if eq .Values.global.plane.mode "unified" -}}
 {{ .Release.Name }}-external-es-proxy.{{ .Release.Namespace }}.svc.cluster.local:9201
-{{- end -}}
 {{- end -}}
 
 {{- define "elasticsearch.url" -}}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -605,7 +605,7 @@ class TestAstronomerCommander:
             (
                 "unified",
                 True,
-                "http://release-name-es-proxy.default.svc.cluster.local:9201",
+                "http://release-name-external-es-proxy.default.svc.cluster.local:9201",
             ),
             (
                 "unified",


### PR DESCRIPTION
## Description

In `unified` plane mode, the ES proxy URL template in `_helpers.yaml` was pointing to `<release>-es-proxy` (the in-cluster ES proxy) instead of `<release>-external-es-proxy`. This caused commander to route external-ES traffic to the wrong service, while the equivalent `data` plane mode was correctly using the external proxy.

This PR fixes the service name and updates the affected unit test expectation.

## Improvements

- Unified plane deployments now route external ES traffic to the correct `external-es-proxy` service, matching the data plane mode behaviour
- Eliminates a divergence between unified and data plane mode that could cause silent routing failures or 5xx errors when commander tried to reach the wrong service

## Related Issues

https://linear.app/astronomer/issue/PINF-621

## Testing

1. Render the chart with `global.plane.mode=unified` and confirm the ES proxy URL helper resolves to `<release>-external-es-proxy.<namespace>.svc.cluster.local:9201`
2. Render with `global.plane.mode=data` and confirm the existing `es-proxy.<domainPrefix>.<baseDomain>` URL is unchanged
3. Run `tests/chart_tests/test_astronomer_commander.py::test_commander_data_plane_failover_permissions_disabled` — should pass with the updated expected URL

## Merging

Merge to master.