### PR TITLE
PINF-631: Fix ES master probe defaults — add liveness initialDelaySeconds, bump readiness delay

### DIFF
--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -161,7 +161,7 @@ spec:
             # Defaults to false, which means information is retrieved from the master node.
             path: /_cluster/health?local=true
             port: {{ .Values.common.ports.http }}
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
         {{- end }}
         {{- if .Values.master.livenessProbe }}
         livenessProbe: {{- tpl (toYaml .Values.master.livenessProbe) . | nindent 10 }}
@@ -169,6 +169,7 @@ spec:
         livenessProbe:
           tcpSocket:
             port: {{ .Values.common.ports.transport }}
+          initialDelaySeconds: 30
         {{- end }}
         volumeMounts:
         - name: tmp

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -86,7 +86,7 @@ class TestDefaultProbes:
             "initialDelaySeconds": 30,
             "timeoutSeconds": 10,
         },
-        "elasticsearch-master_es-master": {"tcpSocket": {"port": 9300}},
+        "elasticsearch-master_es-master": {"tcpSocket": {"port": 9300}, "initialDelaySeconds": 30},
         "grafana_auth-proxy": {
             "httpGet": {"path": "/healthz", "port": 8084, "scheme": "HTTP"},
             "initialDelaySeconds": 10,
@@ -189,7 +189,7 @@ class TestDefaultProbes:
         },
         "elasticsearch-master_es-master": {
             "httpGet": {"path": "/_cluster/health?local=true", "port": 9200},
-            "initialDelaySeconds": 5,
+            "initialDelaySeconds": 30,
         },
         "grafana_auth-proxy": {
             "httpGet": {"path": "/healthz", "port": 8084, "scheme": "HTTP"},


### PR DESCRIPTION
## Description

The Elasticsearch master StatefulSet's default liveness probe has no initialDelaySeconds, which means kubelet starts TCP-checking port 9300 immediately after the container starts. ES 8.x master nodes typically need 30-60s+ to open the transport port (especially the last replica joining an existing cluster), so the pod gets killed after ~30s (3 failures × 10s period) before it finishes bootstrapping. This causes a restart loop where the third master pod never stabilizes.

## Related Issues

https://linear.app/astronomer/issue/PINF-631/es-master-pods-restart-loop-due-to-missing-liveness-probe

## Testing

- No QA needed.
- Unittest added.

## Merging

Master, 1.1, 2.0