### PR TITLE
fix incorrect indent

### DIFF
--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -102,7 +102,7 @@ spec:
             mountPath: /var/run
 
 {{- if .Values.astroUI.volumeMounts }}
-{{- tpl (toYaml .Values.astroUI.volumeMounts) $ | nindent 12 }}
+{{- tpl (toYaml .Values.astroUI.volumeMounts) $ | nindent 10 }}
 {{- end }}
 {{- if .Values.astroUI.extraContainers }}
 {{- tpl (toYaml .Values.astroUI.extraContainers) $ | nindent 8 }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -96,13 +96,12 @@ spec:
               value: "wss://houston.{{ .Values.global.baseDomain }}/ws"
             {{- end }}
           volumeMounts:
-          - name: tmp
-            mountPath: /tmp
-          - name: var-cache-nginx
-            mountPath: /var/run
-
+            - name: tmp
+              mountPath: /tmp
+            - name: var-cache-nginx
+              mountPath: /var/run
 {{- if .Values.astroUI.volumeMounts }}
-{{- tpl (toYaml .Values.astroUI.volumeMounts) $ | nindent 10 }}
+{{- tpl (toYaml .Values.astroUI.volumeMounts) $ | nindent 12 }}
 {{- end }}
 {{- if .Values.astroUI.extraContainers }}
 {{- tpl (toYaml .Values.astroUI.extraContainers) $ | nindent 8 }}

--- a/tests/chart_tests/test_astro_ui_deployment.py
+++ b/tests/chart_tests/test_astro_ui_deployment.py
@@ -75,6 +75,57 @@ class TestAstroUIDeployment:
         assert "var-cache-nginx" in volumes
         assert "emptyDir" in volumes["var-cache-nginx"]
 
+    def test_astro_ui_extra_volume_mounts(self, kube_version):
+        """Test that user-provided volumeMounts and extraVolumes are rendered with correct indentation."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {
+                    "astroUI": {
+                        "env": [
+                            {
+                                "name": "NODE_EXTRA_CA_CERTS",
+                                "value": "/usr/local/share/ca-certificates/ldap-ca.crt",
+                            }
+                        ],
+                        "volumeMounts": [
+                            {
+                                "name": "ldap-ca",
+                                "mountPath": "/usr/local/share/ca-certificates/ldap-ca.crt",
+                                "subPath": "ldap-ca.crt",
+                                "readOnly": True,
+                            }
+                        ],
+                        "extraVolumes": [
+                            {
+                                "name": "ldap-ca",
+                                "secret": {
+                                    "secretName": "houston-ldap-tls",
+                                    "items": [{"key": "ca.crt", "path": "ldap-ca.crt"}],
+                                },
+                            }
+                        ],
+                    }
+                }
+            },
+            show_only=["charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+
+        astro_ui_container = get_containers_by_name(doc)["astro-ui"]
+
+        volume_mounts = {mount["name"]: mount for mount in astro_ui_container["volumeMounts"]}
+        assert "ldap-ca" in volume_mounts
+        assert volume_mounts["ldap-ca"]["mountPath"] == "/usr/local/share/ca-certificates/ldap-ca.crt"
+        assert volume_mounts["ldap-ca"]["subPath"] == "ldap-ca.crt"
+        assert volume_mounts["ldap-ca"]["readOnly"] is True
+
+        volumes = {vol["name"]: vol for vol in doc["spec"]["template"]["spec"]["volumes"]}
+        assert "ldap-ca" in volumes
+        assert volumes["ldap-ca"]["secret"]["secretName"] == "houston-ldap-tls"
+
     def test_astro_ui_user_provided_env_vars(self, kube_version):
         """Test that user-provided env vars are injected into the astro-ui container."""
         docs = render_chart(


### PR DESCRIPTION
## Description

Fix incorrect indent in `astro-ui` template for `volumeMounts`.

## Related Issues

https://linear.app/astronomer/issue/PM-3649/astroui-volumemounts-templating-produces-invalid-yaml

## Testing

Use something like

```yaml
astronomer:
  astroUI:
    volumeMounts:
      - name: ldap-ca
        mountPath: /usr/local/share/ca-certificates/ldap-ca.crt
        subPath: ldap-ca.crt
        readOnly: true
```

## Merging

AFAIK this should be merged into `1.x` and `2.x`.