### PR TITLE
update images

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
     dagOnlyDeployment:
       enabled: false
       repository: quay.io/astronomer/ap-dag-deploy
-      tag: 0.9.5
+      tag: 0.9.6
       securityContexts:
         pod:
           fsGroup: 50000
@@ -346,7 +346,7 @@ global:
         tag: 1.24.1-9
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.20.0-5
+        tag: 0.20.0-6
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 2026.5.12
@@ -360,7 +360,7 @@ global:
         tag: 2026.5.12
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
-        tag: 0.2.7
+        tag: 0.2.9
     metrics:
       enabled: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -111,7 +111,7 @@ global:
     dagOnlyDeployment:
       enabled: false
       repository: quay.io/astronomer/ap-dag-deploy
-      tag: 0.9.6
+      tag: 0.9.5
       securityContexts:
         pod:
           fsGroup: 50000


### PR DESCRIPTION
## Description


| Image | From | To | Release notes |
|-------|------|-----|---------------|
| `ap-pgbouncer-exporter` | `0.20.0-5` | `0.20.0-6` | __NA__ |
| `ap-git-sync-relay` | `0.2.7` | `0.2.9` | https://github.com/astronomer/git-sync-relay/releases/tag/v0.2.9 |

## Related Issues

None

## Testing

1. Render the chart and confirm the three image tags resolve to the new versions
2. Deploy and verify the dataplane pods (`pgbouncer-exporter`, `git-sync-relay`) come up healthy on the bumped tags
3. No regression to other platform images — only the three above are touched

## Merging

Merge to master.