### PR TITLE
PINF-659 - bump houston version 1.1.12

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.1.11
+    tag: 1.1.12
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

fixes issue on copy airflow files into emptyDir 

### Changes

| File | What changed |
|------|-------------|
| `charts/astronomer/values.yaml` | `images.houston.tag`: `1.1.11` → `1.1.12`. |

## Related Issues

https://linear.app/astronomer/issue/PINF-659

## Testing

- Chart renders cleanly with the new tag; no other values changed.
- Smoke-test by installing the chart and verifying the houston deployment pulls `quay.io/astronomer/ap-houston-api:1.1.12` and comes up healthy.

## Merging

release-1.1