### PR TITLE
update version public release 1.1.3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 1.1.3-beta5
-appVersion: 1.1.3-beta5
+version: 1.1.3
+appVersion: 1.1.3
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 1.1.3-beta5
+version: 1.1.3
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer


### PR DESCRIPTION
## Description

Promotes the astronomer chart to GA `1.1.3` on `release-1.1`.

### Changes

| File | What changed |
|------|-------------|
| `Chart.yaml` | `version` and `appVersion`: `1.1.3-beta5` → `1.1.3`. |
| `charts/astronomer/Chart.yaml` | Subchart `version`: `1.1.3-beta5` → `1.1.3`. |

## Related Issues

None

## Testing

- `helm lint .` succeeds against the updated chart.
- `helm template . | head` renders cleanly with no manifest diff vs `1.1.3-beta5` other than chart metadata.
- Smoke-test by installing the chart and confirming `helm list` reports `astronomer-1.1.3`.

## Merging

release-1.1