### PR TITLE
PINF-602: Remove unsupported api from vector configmap

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -36,7 +36,7 @@ images:
     pullPolicy: IfNotPresent
   vector:
     repository: quay.io/astronomer/ap-vector
-    tag: "0.54.0-1"
+    tag: "0.55.0-1"
     pullPolicy: IfNotPresent
 
 

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -19,8 +19,6 @@ data:
     api:
       enabled: true
       address: "0.0.0.0:8686"
-      graphql: false
-      playground: false
     log_schema:
       timestamp_key: "@timestamp"
 

--- a/charts/vector/values.yaml
+++ b/charts/vector/values.yaml
@@ -16,7 +16,7 @@ vector:
     runAsUser: 0
   image:
     repository: quay.io/astronomer/ap-vector
-    tag: 0.54.0-1
+    tag: 0.55.0-1
     pullPolicy: IfNotPresent
   resources: ~
   livenessProbe: ~

--- a/values.yaml
+++ b/values.yaml
@@ -253,7 +253,7 @@ global:
       enabled: false
       name: sidecar-log-consumer
       repository: quay.io/astronomer/ap-vector
-      tag: 0.54.0-1
+      tag: 0.55.0-1
       customConfig: false
       indexPattern: ~
       extraEnv: []


### PR DESCRIPTION
## Description

Remove unsupported api properties from vector configmap

## Related Issues

https://linear.app/astronomer/issue/PINF-602/vector-daemonset-crashloop-on-cpdp-cluster-install-release-113

## Testing

- Before we were seeing crashloop of vector with 0.55 version:
<img width="569" height="276" alt="Screenshot 2026-05-21 at 2 09 01 PM" src="https://github.com/user-attachments/assets/120dd1ad-7ba0-4fc6-a69d-c99f7ebc3c3b" />

- After removal of the graphql component:
<img width="800" height="389" alt="Screenshot 2026-05-21 at 2 10 45 PM" src="https://github.com/user-attachments/assets/877b31e0-d3d3-4a4a-995c-222cabd5e57c" />

- Pods were stable:
<img width="495" height="320" alt="Screenshot 2026-05-21 at 2 13 18 PM" src="https://github.com/user-attachments/assets/bfb7deb0-b303-413c-b65f-d994e0463ab5" />


## Merging

Master, 2.0, 1.1