### PR TITLE
PINF-680 - remove deprecated acme flag

### DIFF
--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -21,20 +21,14 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     {{- include "houston.internalauthurl" . | indent 4}}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
-  tls:
-  {{- if .Values.global.acme }}
-    - secretName: grafana-tls
-  {{- end }}
   {{- if .Values.global.tlsSecret }}
+  tls:
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "grafana.url" . }}
   {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -199,8 +199,6 @@ global:
   namespaceLabels: {}
     # To enforce PSA baseline policy, use the following values:
     # pod-security.kubernetes.io/enforce: baseline
-  # Use kube-lego
-  acme: false
 
   # whether to create pod disruption budgets by default for platform components
   podDisruptionBudgets:


### PR DESCRIPTION
## Description

Removes the dead `global.acme` flag — a kube-lego leftover that no longer wired into any working flow.

### Changes

| File | What changed |
|------|-------------|
| `values.yaml` | Drops the `global.acme: false` default and its `# Use kube-lego` comment |
| `charts/grafana/templates/grafana-ingress.yaml` | Removes the `kubernetes.io/tls-acme` annotation and the `global.acme`-gated `grafana-tls` secret block; the `tls:` block is now driven solely by `global.tlsSecret` |

### Improvements

- Grafana ingress TLS is controlled by a single setting (`global.tlsSecret`) — no more dual `acme` + `tlsSecret` branching
- One less dead config to maintain or accidentally document

## Related Issues

https://linear.app/astronomer/issue/PINF-680/remove-deprecated-globalacme-flag-from-astronomer-chart

## Testing

1. Render the grafana chart with `global.tlsSecret` set — `tls:` block emits the same secret and host as before
2. Render with `global.tlsSecret` unset — no `tls:` block, as before
3. `git grep global.acme` returns nothing across the repo post-merge

## Merging

Merge to master.