### PR TITLE
PINF-663: Add pgbouncer_exporter chainguard based image

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -344,7 +344,7 @@ global:
         tag: 1.24.1-9
       pgbouncerExporter:
         repository: quay.io/astronomer/ap-pgbouncer-exporter
-        tag: 0.20.0-6
+        tag: 0.12.0
       gitSync:
         repository: quay.io/astronomer/ap-git-sync
         tag: 2026.5.12


### PR DESCRIPTION
## Description

This PR adds pgbouncer_exporter chainguard images that were not released in first security run of 1.1.4 

## Related Issues

https://linear.app/astronomer/issue/PINF-614/try-prometheus-community-postgres-exporter-instead-of-jbub-that-we

## Testing

N/A

## Merging

Master, 1.1, 2.0