### PR TITLE
PINF-682 - rework openshift enabled to support podsecurity context

### DIFF
--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -84,6 +84,17 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser  fields on OpenShift Based Installation.
+*/}}
+{{- define "alertmanager.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "alertmanager.serviceAccountName" -}}
 {{- if and .Values.serviceAccount.create .Values.global.rbac.enabled -}}
 {{ default (printf "%s" (include "alertmanager.fullname" . )) .Values.serviceAccount.name }}

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -44,9 +44,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "alertmanager.serviceAccountName" . }}
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "alertmanager.podSecurityContext" . | nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -860,17 +860,6 @@ omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation
 {{- end }}
 
 {{/*
-Return commander podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
-*/}}
-{{- define "astronomer.commander.podSecurityContext" -}}
-{{- if .Values.global.openshift.enabled }}
-{{- omit .Values.commander.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
-{{- else }}
-{{- toYaml .Values.commander.podSecurityContext }}
-{{- end -}}
-{{- end }}
-
-{{/*
 Return registry podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
 */}}
 {{- define "astronomer.registry.podSecurityContext" -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -846,3 +846,37 @@ entropy of a Fernet key.
 {{- merge $required .Values.houston.logging.loggingSidecar.securityContext | toYaml }}
 {{- end -}}
 {{- end }}
+
+{{/*
+Return shared podSecurityContext (astro-ui, navigator, pilot, dp-link),
+omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "astronomer.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return commander podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "astronomer.commander.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.commander.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.commander.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return registry podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "astronomer.registry.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.registry.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.registry.podSecurityContext }}
+{{- end -}}
+{{- end }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "astroUI.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       tolerations:
         {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "commander.serviceAccountName" . }}
-      securityContext: {{- include "astronomer.commander.podSecurityContext" . | nindent 8 }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       restartPolicy: Always
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       {{- include "commander.hostAliases" . | nindent 6 }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -56,6 +56,7 @@ spec:
       tolerations:
         {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "commander.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.commander.podSecurityContext" . | nindent 8 }}
       restartPolicy: Always
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       {{- include "commander.hostAliases" . | nindent 6 }}

--- a/charts/astronomer/templates/dp-link/dp-link-deployment.yaml
+++ b/charts/astronomer/templates/dp-link/dp-link-deployment.yaml
@@ -44,6 +44,7 @@ spec:
       tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "dpLink.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-ssl-certs-copier

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -48,6 +48,7 @@ spec:
       {{- include "houston.hostAliases" . | nindent 6 }}
       restartPolicy: Always
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
       initContainers:
         - name: etc-ssl-certs-copier

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -48,6 +48,7 @@ spec:
       {{- include "houston.worker.hostAliases" . | nindent 6 }}
       restartPolicy: Always
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
 

--- a/charts/astronomer/templates/navigator/navigator-deployment.yaml
+++ b/charts/astronomer/templates/navigator/navigator-deployment.yaml
@@ -44,6 +44,7 @@ spec:
       tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "navigator.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-ssl-certs-copier

--- a/charts/astronomer/templates/pilot/pilot-deployment.yaml
+++ b/charts/astronomer/templates/pilot/pilot-deployment.yaml
@@ -45,6 +45,7 @@ spec:
       tolerations:
         {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "pilot.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       restartPolicy: Always
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       initContainers:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -64,9 +64,7 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{ toYaml .Values.registry.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "astronomer.registry.podSecurityContext" . | nindent 8 }}
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
       {{- if .Values.registry.hostAliases }}
       hostAliases: {{- toYaml .Values.registry.hostAliases | nindent 8 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -43,6 +43,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 astroUI:
   replicas: 2
   env: []

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -162,6 +162,28 @@ imagePullSecrets:
 {{- end -}}
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "elasticsearch.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return exporter podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "elasticsearch.exporter.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.exporter.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.exporter.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{- define "elasticsearch.ingressurl" -}}
 {{ if eq .Values.global.plane.mode "data" -}}
 elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -45,9 +45,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.client.antiAffinity "hard" }}

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -49,9 +49,7 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 3600
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.data.antiAffinity "hard" }}

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -55,7 +55,7 @@ spec:
       affinity: {{- toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: {{ .Values.exporter.restartPolicy }}
-      securityContext: {{- toYaml .Values.exporter.podSecurityContext | nindent 8 }}
+      securityContext: {{- include "elasticsearch.exporter.podSecurityContext" . | nindent 8 }}
       {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: metrics-exporter

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -48,9 +48,7 @@ spec:
         {{- toYaml .Values.master.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.master.antiAffinity "hard" }}

--- a/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
@@ -41,6 +41,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector: {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{- toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/grafana/templates/_helpers.yaml
+++ b/charts/grafana/templates/_helpers.yaml
@@ -79,3 +79,14 @@ imagePullSecrets:
   - name: {{ .Values.global.privateRegistry.secretName }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "grafana.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -43,6 +43,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "grafana.bootstrapper.serviceAccountName" . }}
+      securityContext: {{- include "grafana.podSecurityContext" . | nindent 8 }}
       {{- include "grafana.imagePullSecrets" . | nindent 6 }}
     {{- if and (not .Values.backendSecretName) (not .Values.backendConnection) }}
       initContainers:

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -21,6 +21,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 serviceAccount:
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   automountServiceAccountToken: true

--- a/charts/kube-state/templates/_helpers.yaml
+++ b/charts/kube-state/templates/_helpers.yaml
@@ -49,6 +49,17 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "kube-state.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "kube-state.serviceAccountName" -}}
 {{- if and .Values.serviceAccount.create .Values.global.rbac.enabled -}}
 {{ default (printf "%s" (include "kube-state.fullname" . )) .Values.serviceAccount.name }}

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "kube-state.serviceAccountName" . }}
+      securityContext: {{- include "kube-state.podSecurityContext" . | nindent 8 }}
       {{- include "kube-state.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: kube-state

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -15,6 +15,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 env: {}
 resources:
   limits:

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -77,6 +77,17 @@ imagePullSecrets:
 {{- end }}
 
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "nats.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "nats.serviceAccountName" -}}
 {{- if and .Values.nats.serviceAccount.create .Values.global.rbac.enabled -}}
 {{ default (printf "%s" (include "nats.name" . )) .Values.nats.serviceAccount.name }}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -54,9 +54,7 @@ spec:
     spec:
       serviceAccountName: {{ template "nats.serviceAccountName" . }}
     {{- include "nats.imagePullSecrets" . | nindent 6 }}
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "nats.podSecurityContext" . | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -77,6 +77,17 @@ imagePullSecrets:
 {{ printf "%s-default-backend" (include "nginx.fullname" .)}}
 {{- end -}}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "nginx.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "defaultBackend.serviceAccountName" -}}
 {{- if and .Values.defaultBackend.serviceAccount.create .Values.global.rbac.enabled -}}
 {{ default (printf "%s" (include "defaultBackend.fullname" . )) .Values.defaultBackend.serviceAccount.name }}

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -88,6 +88,19 @@ Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on O
 {{- end -}}
 {{- end }}
 
+{{/*
+Return container securityContext, always enforcing readOnlyRootFilesystem: true.
+Omits runAsUser on OpenShift (UIDs are assigned dynamically).
+*/}}
+{{- define "nginx.securityContext" -}}
+{{- $required := dict "readOnlyRootFilesystem" true }}
+{{- if .Values.global.openshift.enabled }}
+{{- merge $required (omit .Values.securityContext "runAsUser") | toYaml }}
+{{- else }}
+{{- merge $required .Values.securityContext | toYaml }}
+{{- end -}}
+{{- end }}
+
 {{ define "defaultBackend.serviceAccountName" -}}
 {{- if and .Values.defaultBackend.serviceAccount.create .Values.global.rbac.enabled -}}
 {{ default (printf "%s" (include "defaultBackend.fullname" . )) .Values.defaultBackend.serviceAccount.name }}

--- a/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
@@ -46,6 +46,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}-cp
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-nginx-copier

--- a/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
@@ -52,9 +52,7 @@ spec:
         - name: etc-nginx-copier
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/sh
@@ -72,9 +70,7 @@ spec:
               mountPath: /etc/ingress-controller
       containers:
         - name: nginx
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
@@ -50,9 +50,7 @@ spec:
         - name: etc-nginx-copier
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/sh
@@ -70,9 +68,7 @@ spec:
               mountPath: /etc/ingress-controller
       containers:
         - name: nginx
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
@@ -44,6 +44,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}-dp
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-nginx-copier

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -49,9 +49,7 @@ spec:
         - name: default-backend
           image: {{ template "nginx.defaultBackend.image" . }}
           imagePullPolicy: {{ .Values.images.defaultBackend.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           {{- if .Values.defaultBackend.readinessProbe }}
           readinessProbe: {{ toYaml .Values.defaultBackend.readinessProbe | nindent 12 }}
           {{- end }}

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "defaultBackend.serviceAccountName" . }}
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -26,6 +26,9 @@ securityContext:
       - NET_BIND_SERVICE
   allowPrivilegeEscalation: false
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/pgbouncer/templates/_helpers.yaml
+++ b/charts/pgbouncer/templates/_helpers.yaml
@@ -32,6 +32,17 @@
 {{ .Release.Name }}-pgbouncer-stats
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "pgbouncer.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "pgbouncer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{ default (printf "%s-pgbouncer" .Release.Name ) .Values.serviceAccount.name }}

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "pgbouncer.serviceAccountName" . }}
+      securityContext: {{- include "pgbouncer.podSecurityContext" . | nindent 8 }}
       volumes:
         - name: tmp-workspace
           emptyDir: {}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -9,6 +9,9 @@ image:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 internalPort: 6543
 servicePort: 6543
 

--- a/charts/prometheus-node-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-node-exporter/templates/_helpers.tpl
@@ -80,6 +80,18 @@ Docker repository name
 {{- end }}
 
 {{/*
+Return podSecurityContext, omitting UID/GID fields on OpenShift where the platform
+assigns them. OpenShift users can also override per-component via values.
+*/}}
+{{- define "prometheus-node-exporter.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "prometheus-node-exporter.imagePullSecrets" -}}

--- a/charts/prometheus-node-exporter/templates/daemonset.yaml
+++ b/charts/prometheus-node-exporter/templates/daemonset.yaml
@@ -33,9 +33,7 @@ spec:
       priorityClassName:  {{ .Values.priorityClassName  }}
 {{ end }}
       serviceAccountName: {{ template "prometheus-node-exporter.serviceAccountName" . }}
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext| nindent 8 }}
-{{- end }}
+      securityContext: {{- include "prometheus-node-exporter.podSecurityContext" . | nindent 8 }}
 {{- include "prometheus-node-exporter.imagePullSecrets" . | indent 6 }}
       containers:
         - name: node-exporter

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -59,6 +59,17 @@ Set DATA_SOURCE_URI environment variable
 {{- end }}
 
 {{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "prometheus-postgres-exporter.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "prometheus-postgres-exporter.imagePullSecrets" -}}

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -46,6 +46,7 @@ spec:
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
+      securityContext: {{- include "prometheus-postgres-exporter.podSecurityContext" . | nindent 8 }}
 {{- include "prometheus-postgres-exporter.imagePullSecrets" . | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}
@@ -126,20 +127,6 @@ spec:
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 8 }}
 {{- end }}
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
-     {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -106,6 +106,17 @@ imagePullSecrets:
 {{- end -}}
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "prometheus.podSecurityContext" -}}
+{{- if .Values.global.openshift.enabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{- define "prometheus.airflowMetricsActionDrop" }}
 - source_labels: [__name__]
   regex: 'airflow_task_instance_created_.*'

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -60,6 +60,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.serviceAccountName" . }}
+      securityContext: {{- include "prometheus.podSecurityContext" . | nindent 8 }}
       {{- include "prometheus.imagePullSecrets" . | nindent 6 }}
       {{- include "prometheus.hostAliases" . | nindent 6 }}
       initContainers:
@@ -263,9 +264,6 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 1
           {{- end }}
-{{- if eq .Values.global.openshift.enabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
       volumes:
         {{- if .Values.global.authSidecar.enabled }}
         - name: nginx-write-dir

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -51,7 +51,7 @@ class TestOpenshift:
 
         assert len(docs) == 6
         for doc in docs:
-            assert "securityContext" not in doc["spec"]["template"]["spec"]
+            assert "securityContext" in doc["spec"]["template"]["spec"]
 
     def test_openshift_flag_defaults_with_enabled_and_validate_container_securitycontext(self, kube_version):
         "Validate containerSecurityContext when openshiftEnabled is Enabled"


### PR DESCRIPTION
## Description

Replaces all hardcoded toYaml .Values.podSecurityContext calls with named Helm helpers that omit fsGroup, runAsGroup, runAsUser when global.openshift.enabled=true — OpenShift manages UID/GID assignment at the platform level.

## Related Issues

 https://linear.app/astronomer/issue/PINF-682/allow-podsecuritycontext-independent-of-openshift-flag

## Testing

NA

## Merging

merge to master
