### PR TITLE
PINF-663: 1.1.4 public release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 1.1.4-beta1
-appVersion: 1.1.4-beta1
+version: 1.1.4
+appVersion: 1.1.4
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 1.1.4-beta1
+version: 1.1.4
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer


### PR DESCRIPTION
## Description

Updates `1.1.4-beta1` → `1.1.4` for the public release. All security patches under PINF-663 already landed in the beta (#3261, #3264, #3266); this PR is the version bump only.

## Related Issues

https://linear.app/astronomer/issue/PINF-663/apc-114-security-patch

## Merging

1.1
