### PR TITLE
PLX-489 surface auth.ldap as a known provider in houston-configmap

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -51,6 +51,9 @@ data:
           enabled: true
           clientId: ~
 
+      ldap:
+        enabled: false
+
       github:
         enabled: true
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -77,6 +77,47 @@ def test_houston_configmap_defaults():
     assert prod["deployments"]["helm"]["sccEnabled"] is False
 
 
+def test_houston_configmap_ldap_disabled_by_default():
+    """auth.ldap.enabled should be False in the baseline production.yaml, parallel to auth.local."""
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    common_test_cases(docs)
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+
+    assert prod["auth"]["ldap"]["enabled"] is False
+    # Sibling auth providers must remain untouched.
+    assert prod["auth"]["local"]["enabled"] is False
+    assert prod["auth"]["openidConnect"]["auth0"]["enabled"] is False
+    assert prod["auth"]["github"]["enabled"] is True
+
+
+def test_houston_configmap_ldap_customer_override():
+    """Customer-supplied auth.ldap.* under houston.config must reach local-production.yaml."""
+    ldap_config = {
+        "enabled": True,
+        "host": "ldap.example.com",
+        "tls": {"mode": "starttls", "rejectUnauthorized": True},
+        "bindDn": "cn=admin,dc=example,dc=com",
+        "searchBase": "ou=people,dc=example,dc=com",
+        "groups": {
+            "enabled": True,
+            "reconcileTeams": True,
+            "manageSystemPermissions": {
+                "enabled": True,
+                "systemAdmin": ["cn=admins,ou=groups,dc=example,dc=com"],
+            },
+        },
+    }
+    docs = render_chart(
+        values={"astronomer": {"houston": {"config": {"auth": {"ldap": ldap_config}}}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    local_prod = yaml.safe_load(docs[0]["data"]["local-production.yaml"])
+    assert local_prod["auth"]["ldap"] == ldap_config
+
+
 def test_houston_configmap_has_hook_annotations():
     """ConfigMap must be a pre-install/pre-upgrade hook with weight -1, and keep policy."""
     docs = render_chart(


### PR DESCRIPTION
## Description

Adds an `auth.ldap.enabled: false` block to the houston configmap's `production.yaml`, parallel to the existing `auth.local` / `auth.openidConnect` / `auth.github` entries. Makes LDAP discoverable in the rendered configmap as a known auth provider, matching the precedent for every other provider the chart surfaces.

Houston's LDAP feature ([houston-api#2396](https://github.com/astronomer/houston-api/pull/2396)) ships the full `auth.ldap.*` config tree in Houston's own `config/default.yaml`. The chart doesn't need to re-enumerate the fields — customers override via the existing generic `houston.config.auth.ldap.*` mechanism, same as how OIDC's `clientSecret` and any other provider-specific config is set today. The single `enabled: false` line here is purely the visibility/parity surface.

Two unit tests assert the wiring:

- `test_houston_configmap_ldap_disabled_by_default` — confirms `auth.ldap.enabled` is `false` in the baseline rendered `production.yaml` and that sibling auth providers are untouched.
- `test_houston_configmap_ldap_customer_override` — passes a representative customer override under `astronomer.houston.config.auth.ldap.*` (with `tls.mode`, `bindDn`, `groups.manageSystemPermissions`, etc.) and confirms it lands in `local-production.yaml`.

Scoped narrowly to chart-side wiring. No `_helpers.yaml` changes, no `values.yaml` changes (`houston.secret` / `houston.env` / `houston.config` already work for any auth provider's customer overrides — no need to demonstrate them inline; OIDC doesn't either).

## Related Issues

- [PLX-489](https://linear.app/astronomer/issue/PLX-489) — Helm chart: document LDAP enablement pattern in `values.yaml`
- [PLX-283](https://linear.app/astronomer/issue/PLX-283) — Add LDAP Authentication Support for Astronomer Private Cloud (parent feature)
- [houston-api#2396](https://github.com/astronomer/houston-api/pull/2396) — Houston LDAP feature (defines the `auth.ldap.*` config tree this surfaces)
- [astronomer/apc-ui#378](https://github.com/astronomer/apc-ui/pull/378) — apc-ui LDAP login form

## Testing

**Chart unit tests** — 44/44 pass in `tests/chart_tests/test_houston_configmap.py`, including the two new LDAP-specific tests:

```
uv run pytest tests/chart_tests/test_houston_configmap.py -n auto
```

**End-to-end on k3d** (CP cluster, helm rev 3, chart 2.0.0):

1. **Baseline path** — fresh `helm upgrade --install` via `bin/setup-cp-dp-k3d.py`; verified the rendered configmap contains the new block, positioned between `openidConnect` and `github`:

   ```yaml
   auth:
     local: { enabled: false }
     openidConnect: { auth0: {...}, google: {...} }
     ldap: { enabled: false }      ← new
     github: { enabled: true }
   ```

2. **Customer-override path** — applied a representative override via `helm upgrade --reuse-values -f ldap-override.yaml`; verified the full LDAP config (`enabled`, `host`, `tls.mode`, `tls.rejectUnauthorized`, `bindDn`, `searchBase`, `searchFilter`, `groups.enabled`, `groups.reconcileTeams`) flowed through to `local-production.yaml`:

   ```yaml
   auth:
     ldap:
       bindDn: cn=admin,dc=myorg,dc=com
       enabled: true
       groups: { enabled: true, reconcileTeams: true }
       host: ldap.myorg.local
       searchBase: ou=people,dc=myorg,dc=com
       searchFilter: (uid={{username}})
       tls: { mode: starttls, rejectUnauthorized: true }
     local: { enabled: true }
   ```

## Merging

- Merge into master
- Target release: APC 2.1.0