### PR TITLE
pinf-724 update-container-ca-script-to-preserve-mirror-registry

### DIFF
--- a/files/update-containerd-certs.py
+++ b/files/update-containerd-certs.py
@@ -276,6 +276,102 @@ _LEGACY_MIRRORS_HEADER_RE = re.compile(
 )
 
 
+def _extract_legacy_mirrors(config: dict) -> dict[str, list[str]]:
+    """Pull inline `registry.mirrors.<host>` blocks out of a parsed config.toml.
+
+    Walks both the 1.x (`io.containerd.grpc.v1.cri`) and 2.x
+    (`io.containerd.cri.v1.images`) plugin namespaces — current cloud-provider
+    images (GKE 1.33 et al) still declare their default mirrors under the 1.x
+    namespace even on a containerd 2.x runtime, but a future image could move
+    them.
+
+    Returns {registry_host: [endpoint_url, ...]}. Endpoint order is preserved —
+    containerd tries them in the order listed, so the first endpoint is the
+    primary (e.g. a pull-through cache) and the rest are fallbacks.
+    """
+    out: dict[str, list[str]] = {}
+    for version in (1, 2):
+        subtree = _registry_subtree(config, version)
+        if not subtree:
+            continue
+        mirrors = subtree.get("mirrors")
+        if not isinstance(mirrors, dict):
+            continue
+        for host, block in mirrors.items():
+            if not isinstance(block, dict):
+                continue
+            endpoints = block.get("endpoint")
+            if not isinstance(endpoints, list) or not endpoints:
+                continue
+            # Last namespace wins if both 1.x and 2.x have an entry for the
+            # same host — 2.x is the runtime namespace, so it's the source of
+            # truth on a 2.x node.
+            out[host] = [str(e) for e in endpoints if isinstance(e, str)]
+    return out
+
+
+def _generate_passthrough_hosts_toml(registry: str, endpoints: list[str]) -> str:
+    """Translate an inline `mirrors.<registry>` endpoint list into a hosts.toml
+    body that preserves the same pull behavior under the hosts.d schema.
+
+    No `ca` key — these are passthrough mirrors using the OS trust store, not
+    private-CA-trusted endpoints (which are handled by generate_hosts_toml()).
+
+    Validates the generated body parses as TOML before returning — catches
+    cases like a stray quote in an endpoint URL breaking the `[host."..."]`
+    header. Fails loudly rather than writing a hosts.toml containerd would
+    silently ignore.
+    """
+    lines = [f'server = "https://{registry}"', ""]
+    for endpoint in endpoints:
+        lines.append(f'[host."{endpoint}"]')
+        lines.append('  capabilities = ["pull", "resolve"]')
+    content = "\n".join(lines) + "\n"
+
+    try:
+        tomllib.loads(content)
+    except tomllib.TOMLDecodeError as exc:
+        log.error("Generated hosts.toml for %s is invalid TOML. Content:\n%s", registry, content)
+        raise RuntimeError(f"generated hosts.toml for {registry} is invalid TOML") from exc
+    return content
+
+
+def _write_preserved_mirrors(mirrors: dict[str, list[str]]) -> None:
+    """For each inline `mirrors.<host>` block discovered in config.toml, write a
+    `certs.d/<host>/hosts.toml` that preserves the cloud-provider mirror
+    behavior (e.g. a pull-through cache the provider ships by default).
+
+    Skips:
+      * <host> == REGISTRY_HOST — the private-registry hosts.toml is written
+        by `_apply_v2_hosts_toml()` with the customer CA. Translating the
+        inline block here would clobber that file with a no-`ca` version.
+      * Hosts where certs.d/<host>/hosts.toml already exists — respect any
+        hand-authored or operator-supplied file.
+
+    The endpoint list is treated as opaque content — no registry-specific
+    knowledge is hard-coded. Whatever the cloud provider's default config
+    declared is what gets carried over.
+    """
+    for host, endpoints in mirrors.items():
+        if host == REGISTRY_HOST:
+            continue
+        host_dir = CONTAINERD_HOST_PATH / "certs.d" / host
+        hosts_toml = host_dir / "hosts.toml"
+        if hosts_toml.exists():
+            log.info("Skipping mirror passthrough for %s: hosts.toml already exists", host)
+            continue
+        host_dir.mkdir(parents=True, exist_ok=True)
+        content = _generate_passthrough_hosts_toml(host, endpoints)
+        hosts_toml.write_text(content)
+        log.info(
+            "Preserved inline mirror for %s -> %s as %s. Content:\n%s",
+            host,
+            list(endpoints),
+            hosts_toml,
+            content,
+        )
+
+
 def _strip_registry_mirrors_blocks(text: str) -> str:
     """Remove every `[plugins."...".registry.mirrors.<host>]` section (+ its body)
     from config.toml source text.
@@ -341,6 +437,8 @@ def inject_config_path(containerd_version: int) -> None:
             plugin["header"],
         )
         return
+
+    _write_preserved_mirrors(_extract_legacy_mirrors(parsed))
 
     source_text = CONFIG_TOML.read_text()
     stripped_text = _strip_registry_mirrors_blocks(source_text)

--- a/tests/chart_tests/test_update_containerd_certs.py
+++ b/tests/chart_tests/test_update_containerd_certs.py
@@ -317,6 +317,7 @@ class TestInjectConfigPath:
 
         script.CONFIG_TOML = config_toml
         script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
         script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
         return config_toml, config_toml_bak
 
@@ -392,6 +393,7 @@ class TestInjectConfigPath:
 
         script.CONFIG_TOML = config_toml
         script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
         script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
 
         with patch.object(script, "restart_containerd"):
@@ -452,6 +454,7 @@ class TestInjectConfigPath:
 
         script.CONFIG_TOML = config_toml
         script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
         script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
 
         with patch.object(script, "restart_containerd") as mock_restart:
@@ -619,6 +622,140 @@ class TestStripRegistryMirrorsBlocks:
         assert "mirrors" not in out
         assert "configs" in out
         assert "ca_file" in out
+
+
+class TestPreserveMirrorsAsHostsToml:
+    """Tests for translating inline `mirrors.<host>` blocks into per-host
+    `hosts.toml` files before stripping. This preserves cloud-provider
+    behavior (e.g. GKE's `mirror.gcr.io` pull-through cache for `docker.io`)
+    under the hosts.d schema that containerd 2.x reads via `config_path`."""
+
+    def test_translates_gke_133_docker_io_mirror_to_hosts_toml(self, script, containerd_env):
+        """End-to-end: the GKE 1.33 default config.toml has an inline
+        `mirrors."docker.io"` block. After inject_config_path runs, a
+        `certs.d/docker.io/hosts.toml` must exist with the same endpoints in
+        the same order (`mirror.gcr.io` first, `registry-1.docker.io` second),
+        so containerd keeps using the GKE pull-through cache."""
+        config_toml = containerd_env["containerd_dir"] / "config.toml"
+        config_toml_bak = containerd_env["containerd_dir"] / "config.toml.bak"
+        shutil.copy2(DATA_FILES_DIR / "gke_1_33_containerd_2x_config.toml", config_toml)
+        shutil.copy2(DATA_FILES_DIR / "gke_1_33_containerd_2x_config.toml", config_toml_bak)
+
+        script.CONFIG_TOML = config_toml
+        script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
+        script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
+
+        with patch.object(script, "restart_containerd"):
+            script.inject_config_path(containerd_version=2)
+
+        hosts_toml = containerd_env["containerd_dir"] / "certs.d" / "docker.io" / "hosts.toml"
+        assert hosts_toml.is_file()
+        content = hosts_toml.read_text()
+        assert 'server = "https://docker.io"' in content
+        assert '[host."https://mirror.gcr.io"]' in content
+        assert '[host."https://registry-1.docker.io"]' in content
+        # Endpoint order must be preserved: containerd tries hosts in the order
+        # they appear in the file, and the GKE cache must be tried first.
+        assert content.index('[host."https://mirror.gcr.io"]') < content.index('[host."https://registry-1.docker.io"]')
+
+    def test_skips_translation_when_hosts_toml_already_exists(self, script, containerd_env):
+        """If a hosts.toml already exists for the registry (e.g. hand-authored
+        or written by a previous run), do not overwrite it."""
+        config_toml = containerd_env["containerd_dir"] / "config.toml"
+        config_toml_bak = containerd_env["containerd_dir"] / "config.toml.bak"
+        config_toml.write_text(
+            textwrap.dedent("""\
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+                  endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]
+            """)
+        )
+        config_toml_bak.write_text(config_toml.read_text())
+
+        pre_existing = "# do not clobber me\n"
+        docker_io_dir = containerd_env["containerd_dir"] / "certs.d" / "docker.io"
+        docker_io_dir.mkdir(parents=True)
+        (docker_io_dir / "hosts.toml").write_text(pre_existing)
+
+        script.CONFIG_TOML = config_toml
+        script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
+        script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
+
+        with patch.object(script, "restart_containerd"):
+            script.inject_config_path(containerd_version=2)
+
+        assert (docker_io_dir / "hosts.toml").read_text() == pre_existing
+
+    def test_skips_translation_for_registry_host(self, script, containerd_env):
+        """The private-registry hosts.toml is written by _apply_v2_hosts_toml
+        with a `ca = [...]` key. The mirror translator must not write a
+        no-`ca` version that would clobber it."""
+        config_toml = containerd_env["containerd_dir"] / "config.toml"
+        config_toml_bak = containerd_env["containerd_dir"] / "config.toml.bak"
+        config_toml.write_text(
+            textwrap.dedent("""\
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.example.com"]
+                  endpoint = ["https://registry.example.com"]
+            """)
+        )
+        config_toml_bak.write_text(config_toml.read_text())
+
+        script.CONFIG_TOML = config_toml
+        script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
+        script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
+        script.REGISTRY_HOST = "registry.example.com"
+
+        with patch.object(script, "restart_containerd"):
+            script.inject_config_path(containerd_version=2)
+
+        # The translator must have skipped REGISTRY_HOST — no hosts.toml
+        # without a `ca` key should be sitting where _apply_v2_hosts_toml
+        # is going to write later.
+        registry_hosts_toml = containerd_env["containerd_dir"] / "certs.d" / "registry.example.com" / "hosts.toml"
+        assert not registry_hosts_toml.exists()
+
+    def test_translates_multiple_mirrors_independently(self, script, containerd_env):
+        """If config.toml has inline mirror blocks for multiple registries,
+        each gets its own hosts.toml — no hard-coded registry knowledge."""
+        config_toml = containerd_env["containerd_dir"] / "config.toml"
+        config_toml_bak = containerd_env["containerd_dir"] / "config.toml.bak"
+        config_toml.write_text(
+            textwrap.dedent("""\
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+                  endpoint = ["https://mirror.gcr.io", "https://registry-1.docker.io"]
+                [plugins."io.containerd.grpc.v1.cri".registry.mirrors."quay.io"]
+                  endpoint = ["https://quay-mirror.example.com"]
+            """)
+        )
+        config_toml_bak.write_text(config_toml.read_text())
+
+        script.CONFIG_TOML = config_toml
+        script.CONFIG_TOML_BAK = config_toml_bak
+        script.CONTAINERD_HOST_PATH = containerd_env["containerd_dir"]
+        script.CERT_CONFIG_PATH = "/etc/containerd/certs.d"
+
+        with patch.object(script, "restart_containerd"):
+            script.inject_config_path(containerd_version=2)
+
+        docker_io = containerd_env["containerd_dir"] / "certs.d" / "docker.io" / "hosts.toml"
+        quay_io = containerd_env["containerd_dir"] / "certs.d" / "quay.io" / "hosts.toml"
+        assert docker_io.is_file()
+        assert quay_io.is_file()
+        assert '[host."https://mirror.gcr.io"]' in docker_io.read_text()
+        assert '[host."https://quay-mirror.example.com"]' in quay_io.read_text()
+
+    def test_passthrough_hosts_toml_has_no_ca_key(self, script):
+        """The translated file must not include a `ca = [...]` key — these are
+        OS-trust-store mirrors, not private-CA-trusted endpoints. Adding a
+        bogus `ca` would break TLS verification for the upstream."""
+        content = script._generate_passthrough_hosts_toml(
+            "docker.io",
+            ["https://mirror.gcr.io", "https://registry-1.docker.io"],
+        )
+        assert "ca =" not in content
+        assert 'capabilities = ["pull", "resolve"]' in content
 
 
 class TestWriteCustomerConfigToml:


### PR DESCRIPTION
## Description

### Issue

GKE's default `/etc/containerd/config.toml` ships an inline mirror for Docker Hub:
```
[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
  endpoint = ["https://mirror.gcr.io/","https://registry-1.docker.io/"]
```

`mirror.gcr.io` is GKE's pull-through cache — Docker Hub images are served from Google's regional cache first, with `registry-1.docker.io` as the fallback.
Our private-CA script needs to enable containerd's `config_path` (the hosts.d / containerd v2 mechanism) so it can write `certs.d/<our-registry-url>/hosts.toml` with the CA trust:
```
[plugins."io.containerd.cri.v1.images".registry]
  config_path = "/etc/containerd/certs.d"
```

`mirrors.*` and `config_path` cannot coexist — this is a containerd 2.x constraint. When both are set under the registry plugin, containerd 2.x silently disables `config_path` and falls back to the inline schema. So we cannot leave the `docker.io` block in place and still get private-CA trust on a different registry. Previously the script removed the `registry.mirrors` block entirely, which restored private-CA trust but disabled the GKE cache.

Side note: GKE's defaults still use the legacy containerd 1.x inline schema even on 2.x runtimes. If GKE shipped `mirror.gcr.io` as a hosts.d file out of the box, there would be no conflict to resolve.

More info on this is in slack thread: https://astronomer.slack.com/archives/C08QKH6LX3R/p1776966109295129

### Solution

Instead of just stripping the `mirrors.*` block, the script now reads it first and translates each entry into a per-registry `hosts.toml` under `/etc/containerd/certs.d/<host>/`. For GKE's Docker Hub mirror, that produces `/etc/containerd/certs.d/docker.io/hosts.toml`:

```
server = "https://docker.io"

[host."https://mirror.gcr.io"]
  capabilities = ["pull", "resolve"]
[host."https://registry-1.docker.io"]
  capabilities = ["pull", "resolve"]
```
Same endpoints in the same order, expressed in the schema containerd 2.x reads via config_path. The translation is cloud-agnostic — no registry URLs are hard-coded, so any inline mirror the cloud provider ships (GKE, EKS, AKS, on-prem) gets carried over verbatim.

## Related Issues

https://linear.app/astronomer/issue/PINF-724/update-script-for-walmart-containerd-ca-patch

## Testing

Tested end-to-end on a fresh GKE 1.33 / containerd 2.0.7 cluster.
After the new script ran:
```
/etc/containerd/certs.d/
├── docker.io/
 │   └── hosts.toml          ← NEW: GKE mirror behavior preserved
└── registry.sud.astrodev.io/
    ├── hosts.toml          ← private-registry trust (unchanged)
    └── private-ca-root-cert.pem
```
certs.d/docker.io/hosts.toml contents matched the translated GKE mirror block (mirror.gcr.io listed first, registry-1.docker.io second).

Verified the cache is actually being used: ran crictl pull docker.io/library/alpine:3.20 on the node and sampled containerd's open TCP connections during the pull. Both established connections went to 173.194.45.82:443 (Google's 173.194.0.0/16 netblock, the same range mirror.gcr.io resolves into). Docker Hub's registry-1.docker.io resolves to AWS IPs (2600:1f18:...), which were never contacted. Confirms the pull went through the GKE cache.

## Merging

release-2.0
