### PR TITLE
PINF-688 - Allow extraAnnotation metadata support commander

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -24,6 +24,14 @@
 {{- end }}
 {{- end }}
 
+{{ define "commander.metadata.extraAnnotations" }}
+{{- if not (empty .Values.global.extraAnnotations) -}}
+{{ .Values.global.extraAnnotations | toYaml | nindent 6 -}}
+{{- else -}}
+{}
+{{- end -}}
+{{- end }}
+
 {{ define "commander.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
 {{ .Values.global.privateRegistry.repository }}/ap-commander:{{ .Values.images.commander.tag }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -18,6 +18,7 @@ data:
     registry:
       version: {{ .Values.images.registry.tag | quote}}
     namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
+    extraAnnotations: {{ include "commander.metadata.extraAnnotations" . }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
 {{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -50,12 +50,14 @@ class TestAstronomerCommander:
         if namespace_labels and rbac_enabled:
             assert metadata_file_contents == {
                 "namespaceLabels": namespace_labels,
+                "extraAnnotations": {},
                 "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
             }
         else:
             assert metadata_file_contents == {
                 "namespaceLabels": {},
+                "extraAnnotations": {},
                 "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
             }
@@ -85,9 +87,34 @@ class TestAstronomerCommander:
         metadata_file_contents = yaml.safe_load(doc["data"]["metadata.yaml"])
         assert metadata_file_contents == {
             "namespaceLabels": {},
+            "extraAnnotations": {},
             "customLogging": {"enabled": enabled},
             "registry": {"version": "99.88.77"},
         }
+
+    def test_commander_metadata_extra_annotations(self, kube_version):
+        """Test that global.extraAnnotations are passed through to commander metadata.yaml."""
+        extra_annotations = {
+            "kubernetes.io/ingress.class": "default",
+            "route.openshift.io/termination": "passthrough",
+        }
+        values = {
+            "global": {
+                "extraAnnotations": extra_annotations,
+            },
+            "astronomer": {
+                "images": {"registry": {"tag": "99.88.77"}},
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/astronomer/templates/commander/commander-metadata.yaml"],
+        )
+
+        assert len(docs) == 1
+        metadata_file_contents = yaml.safe_load(docs[0]["data"]["metadata.yaml"])
+        assert metadata_file_contents["extraAnnotations"] == extra_annotations
 
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""


### PR DESCRIPTION
## Description

Surfaces `global.extraAnnotations` in the commander metadata ConfigMap so commander can read global annotation defaults at runtime.

```mermaid
sequenceDiagram
    actor User
    participant Helm as Helm
    participant K8s as Kubernetes API
    participant CM as ConfigMap<br/>(metadata.yaml)
    participant Deploy as Commander<br/>Deployment / Pod
    participant LC as LoadConfig (http.go)
    participant EP as /metadata endpoint

    Note over User,EP: 1. Configure & upgrade
    User->>Helm: update global.extraAnnotations in values.yaml
    User->>Helm: helm upgrade
    Helm->>Helm: render metadata.yaml (extraAnnotations: {...})
    Helm->>K8s: apply manifests
    K8s->>CM: update ConfigMap (metadata.yaml)

    Note over K8s,Deploy: 2. Roll out
    K8s->>Deploy: restart Commander deployment
    CM-->>Deploy: metadata.yaml mounted into new pod
    Deploy->>Deploy: pod becomes Ready

    Note over Helm,User: helm upgrade completes ✓

    Note over User,EP: 3. Read updated values
    User->>EP: GET http://localhost:8880/metadata
    EP->>LC: LoadConfig(metadata.yaml)
    LC->>Deploy: os.ReadFile(metadata.yaml)
    Deploy-->>LC: raw YAML
    LC->>LC: yaml.Unmarshal → MetadataConfig
    LC->>LC: env.Parse overrides + default nil maps → {}
    LC-->>EP: *MetadataConfig
    EP-->>User: 200 JSON { extraAnnotations: {...} }
```
### Changes

| File | What changed |
|------|-------------|
| `charts/astronomer/templates/_helpers.yaml` | New `commander.metadata.extraAnnotations` helper that emits `global.extraAnnotations` as YAML, falling back to `{}` when empty |
| `charts/astronomer/templates/commander/commander-metadata.yaml` | Adds `extraAnnotations:` to the ConfigMap, rendered via the new helper |
| `tests/chart_tests/test_astronomer_commander.py` | Updates existing tests to expect the new `extraAnnotations` field; adds `test_commander_metadata_extra_annotations` covering ingress-class and OpenShift route annotations |

### Improvements

- Commander can now read `global.extraAnnotations` from its metadata file and propagate them to managed resources (e.g. ingress class, OpenShift route termination)
- Empty annotation maps render as `{}` rather than producing malformed YAML
- Behaviour is unchanged when `global.extraAnnotations` is unset — new key just renders as `{}`

## Related Issues

https://linear.app/astronomer/issue/PINF-688/auto-sync-extraannotations-to-airflow-deployments-via-dataplane

## Testing

1. `pytest tests/chart_tests/test_astronomer_commander.py::test_commander_metadata_extra_annotations` passes
2. Existing `test_commander_metadata_yaml` and `test_commander_metadata_custom_logging` pass with the updated `extraAnnotations: {}` expectation
3. Render the chart with `global.extraAnnotations` set to a sample map — confirm the value appears verbatim in the commander metadata ConfigMap
4. Render with `global.extraAnnotations` unset — confirm `extraAnnotations: {}` in the ConfigMap

## Merging

Merge to master.