### PR TITLE
PINF-687 - allow extra ingress overrides precendence ordering

### DIFF
--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -18,13 +18,13 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     {{ include "houston.internalauthurl" . | indent 4 }}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -19,12 +19,12 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    {{ include "houston.internalauthurl" . | indent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
-    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    {{ include "houston.internalauthurl" . | indent 4 }}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -18,15 +18,15 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}
@@ -71,6 +71,9 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-ingress.yaml
@@ -19,14 +19,14 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}
@@ -66,14 +66,14 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -17,14 +17,14 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/enable-http2: "true"
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.commander.ingress.annotation  }}
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -20,11 +20,11 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/enable-http2: "true"
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    nginx.ingress.kubernetes.io/custom-http-errors: "404"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
     {{- if .Values.commander.ingress.annotation  }}
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -18,12 +18,12 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    nginx.ingress.kubernetes.io/custom-http-errors: "404"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-    nginx.ingress.kubernetes.io/rewrite-target: /metadata
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    nginx.ingress.kubernetes.io/rewrite-target: /metadata
     {{- end }}
     {{- if .Values.commander.ingress.annotation  }}
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -17,13 +17,13 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/rewrite-target: /metadata
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.commander.ingress.annotation  }}
     {{- toYaml .Values.commander.ingress.annotation  | nindent 4  }}

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       location ~ ^/v1/(alerts|metrics) {
@@ -26,9 +29,6 @@ metadata:
         return 403;
       }
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
 
     {{- if .Values.houston.ingress.annotation  }}

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -18,9 +18,6 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
@@ -29,6 +26,9 @@ metadata:
         return 403;
       }
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.houston.ingress.annotation  }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -18,15 +18,15 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -19,14 +19,14 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/custom-http-errors: "404"
     nginx.ingress.kubernetes.io/configuration-snippet: |
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -19,10 +19,10 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    nginx.ingress.kubernetes.io/custom-http-errors: "404"
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -18,11 +18,11 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
+    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    nginx.ingress.kubernetes.io/custom-http-errors: "404"
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
-    kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    nginx.ingress.kubernetes.io/custom-http-errors: "404"
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/elasticsearch/templates/es-ingress.yaml
+++ b/charts/elasticsearch/templates/es-ingress.yaml
@@ -18,9 +18,6 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
       {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-      {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
@@ -28,6 +25,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- if .Values.global.extraAnnotations }}
+      {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotation  }}
     {{- toYaml .Values.ingress.annotation  | nindent 4  }}

--- a/charts/elasticsearch/templates/es-ingress.yaml
+++ b/charts/elasticsearch/templates/es-ingress.yaml
@@ -19,15 +19,15 @@ metadata:
       {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+      {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- if .Values.global.extraAnnotations }}
-      {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
     {{- if .Values.ingress.annotation  }}
     {{- toYaml .Values.ingress.annotation  | nindent 4  }}

--- a/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
@@ -18,15 +18,15 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/use-regex: "true"
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     {{- end }}
 
 spec:

--- a/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-ingress.yaml
@@ -17,9 +17,6 @@ metadata:
     {{- if .Values.global.authSidecar.enabled  }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
@@ -27,6 +24,9 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/use-regex: "true"
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 
 spec:

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -17,13 +17,13 @@ metadata:
     {{- if .Values.global.authSidecar.enabled }}
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     {{- include "houston.internalauthurl" . | indent 4}}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+    {{- if .Values.global.extraAnnotations }}
+    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -18,12 +18,12 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    {{- include "houston.internalauthurl" . | indent 4}}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
-    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- if .Values.global.extraAnnotations }}
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    {{- include "houston.internalauthurl" . | indent 4}}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -16,13 +16,13 @@ metadata:
     {{- if .Values.global.authSidecar.enabled }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     {{- include "houston.internalauthurl" . | nindent 4 }}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -17,12 +17,12 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    {{- include "houston.internalauthurl" . | nindent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
-    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    {{- include "houston.internalauthurl" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}

--- a/charts/prometheus/templates/prometheus-federate-ingress.yaml
+++ b/charts/prometheus/templates/prometheus-federate-ingress.yaml
@@ -16,12 +16,12 @@ metadata:
     {{- if .Values.global.authSidecar.enabled }}
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
-    {{- if .Values.global.extraAnnotations }}
-    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    {{- if .Values.global.extraAnnotations }}
+    {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
     {{- end }}
     {{- if .Values.federation.ingress.annotations }}
     {{- toYaml .Values.federation.ingress.annotations | nindent 4 }}

--- a/charts/prometheus/templates/prometheus-federate-ingress.yaml
+++ b/charts/prometheus/templates/prometheus-federate-ingress.yaml
@@ -17,11 +17,11 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- if .Values.global.extraAnnotations }}
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     {{- end }}
     {{- if .Values.federation.ingress.annotations }}
     {{- toYaml .Values.federation.ingress.annotations | nindent 4 }}

--- a/tests/chart_tests/test_global_ingress_annotation.py
+++ b/tests/chart_tests/test_global_ingress_annotation.py
@@ -7,7 +7,7 @@ from tests.utils.chart import render_chart
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
-class TestGlobabIngressAnnotation:
+class TestGlobalIngressAnnotation:
     def test_global_ingress_with_astronomer_ingress(self, kube_version):
         """Test global ingress annotation for platform ingress."""
 
@@ -44,3 +44,55 @@ class TestGlobabIngressAnnotation:
         assert doc["apiVersion"] == "networking.k8s.io/v1"
         assert "passthrough" in doc["metadata"]["annotations"]["route.openshift.io/termination"]
         assert len(doc["metadata"]["annotations"]) >= 4
+
+    def test_global_extra_annotations_override_ingress_class(self, kube_version):
+        """Test global ingress annotation overrides for platform ingress."""
+
+        all_ingress_files = [str(x.relative_to(git_root_dir)) for x in Path(git_root_dir).rglob("*ingress*.yaml")]
+        always_rendered_ingress = [f for f in all_ingress_files if "external-es-proxy-ingress.yaml" not in f]
+
+        custom_class = "custom-ingress-class"
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"extraAnnotations": {"kubernetes.io/ingress.class": custom_class}}},
+            show_only=sorted(always_rendered_ingress),
+        )
+        assert len(docs) == 6
+        for doc in docs:
+            assert doc["kind"] == "Ingress"
+            annotations = doc["metadata"]["annotations"]
+            assert annotations["kubernetes.io/ingress.class"] == custom_class, (
+                f"Expected customer override {custom_class!r} to win over platform default "
+                f"in {doc['metadata']['name']}, got {annotations['kubernetes.io/ingress.class']!r}"
+            )
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "extraAnnotations": {"kubernetes.io/ingress.class": custom_class},
+                    "plane": {"mode": "data"},
+                    "customLogging": {"enabled": True},
+                },
+                "astronomer": {"ingress": {"enabled": True}},
+            },
+            show_only=["charts/external-es-proxy/templates/external-es-proxy-ingress.yaml"],
+        )
+        assert len(docs) == 1
+        annotations = docs[0]["metadata"]["annotations"]
+        assert annotations["kubernetes.io/ingress.class"] == custom_class
+
+    def test_global_ingress_class_default_when_no_override(self, kube_version):
+        """Without an override, kubernetes.io/ingress.class falls back to the platform default."""
+
+        all_ingress_files = [str(x.relative_to(git_root_dir)) for x in Path(git_root_dir).rglob("*ingress*.yaml")]
+        always_rendered_ingress = [f for f in all_ingress_files if "external-es-proxy-ingress.yaml" not in f]
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"extraAnnotations": {"route.openshift.io/termination": "passthrough"}}},
+            show_only=sorted(always_rendered_ingress),
+        )
+        assert len(docs) == 6
+        for doc in docs:
+            assert doc["metadata"]["annotations"]["kubernetes.io/ingress.class"].endswith("-nginx")


### PR DESCRIPTION
## Description

Reorders `global.extraAnnotations` so they render **after** each chart's built-in nginx ingress annotations. Because Kubernetes keeps the last value when an annotation key is repeated, user-supplied `extraAnnotations` now take precedence over the chart defaults instead of being silently overridden by them.


### Improvements

- Values set in `global.extraAnnotations` now override the chart's default ingress annotations (e.g. `kubernetes.io/ingress.class`, `nginx.ingress.kubernetes.io/*`) instead of being overridden by them.
- Consistent annotation ordering across all 12 ingress templates, so override behavior is predictable regardless of which component's ingress is being configured.
- No behavioral change when `extraAnnotations` does not collide with a default key — only the precedence on duplicate keys changes.

## Related Issues

https://linear.app/astronomer/issue/PINF-687/allow-extraannotations-to-take-precedence-over-injected-ingress

## Testing

Render the affected charts with an `extraAnnotations` value that collides with a default and confirm the override wins in the output:

```bash
helm template . 
  --set global.extraAnnotations.'kubernetes\.io/ingress\.class'=custom-class \\
  --show-only charts/astronomer/templates/ingress.yaml
```

Expected: the rendered ingress `metadata.annotations` shows `kubernetes.io/ingress.class: custom-class` rather than the default `{{ .Release.Name }}-nginx`. Repeat for any of the other ingress templates and for the `global.authSidecar.enabled` path (unchanged) to confirm no regression.

## Merging

Merge to \`master\`. Cherry-pick to active release branches if the override-precedence fix is needed in supported releases.