### PR TITLE
PLX-548 rename rejectUnauthorized → verifyServerCert in LDAP chart test fixture

### DIFF
--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -97,7 +97,7 @@ def test_houston_configmap_ldap_customer_override():
     ldap_config = {
         "enabled": True,
         "host": "ldap.example.com",
-        "tls": {"mode": "starttls", "rejectUnauthorized": True},
+        "tls": {"mode": "starttls", "verifyServerCert": True},
         "bindDn": "cn=admin,dc=example,dc=com",
         "searchBase": "ou=people,dc=example,dc=com",
         "groups": {


### PR DESCRIPTION
## Description

One-line fixture rename in `tests/chart_tests/test_houston_configmap.py` to align the LDAP override example with the field rename shipping in [astronomer/houston-api#2586](https://github.com/astronomer/houston-api/pull/2586) (PLX-545).

The chart itself doesn't validate or enumerate `auth.ldap.*` sub-keys — `houston-configmap.yaml` just pass-through-splats `astronomer.houston.config` into the rendered configmap — so the test was passing functionally either way. The fix is purely about not documenting a stale field name in the example fixture that future readers might copy.

Diff:

```python
# tests/chart_tests/test_houston_configmap.py:100
-        "tls": {"mode": "starttls", "rejectUnauthorized": True},
+        "tls": {"mode": "starttls", "verifyServerCert": True},
```

Background on the rename: `rejectUnauthorized` was inherited from Node's `tls` module API. Ian flagged it on the design doc — "the 'unauthorized' is inaccurate; nothing is being authorised here, we're just saying whether we are validating the remote server's TLS certificate." Houston now exposes it as `verifyServerCert` (with the corresponding `AUTH__LDAP__TLS__VERIFY_SERVER_CERT` env var). Internally, Houston still passes `rejectUnauthorized` to ldapts/Node's TLS layer — that's the upstream library's option name and isn't ours to rename.

## Related Issues

- [PLX-548](https://linear.app/astronomer/issue/PLX-548) — this PR
- [PLX-545](https://linear.app/astronomer/issue/PLX-545) — Houston field rename ([astronomer/houston-api#2586](https://github.com/astronomer/houston-api/pull/2586))
- [PLX-489](https://linear.app/astronomer/issue/PLX-489) — original chart-wiring PR ([astronomer/astronomer#3272](https://github.com/astronomer/astronomer/pull/3272), merged) that introduced the fixture
- [PLX-283](https://linear.app/astronomer/issue/PLX-283) — Add LDAP Authentication Support for Astronomer Private Cloud (parent feature)

## Testing

**Chart unit tests** — both LDAP-specific tests pass with the renamed fixture:

```
.venv/bin/python -m pytest tests/chart_tests/test_houston_configmap.py -k "ldap" -v
```

Result:
```
tests/chart_tests/test_houston_configmap.py::test_houston_configmap_ldap_disabled_by_default PASSED
tests/chart_tests/test_houston_configmap.py::test_houston_configmap_ldap_customer_override PASSED
2 passed
```

No `helm template` or end-to-end verification needed — the rename only touches a test fixture (no chart template or values change).

## Sequencing

Best landed **after** [astronomer/houston-api#2586](https://github.com/astronomer/houston-api/pull/2586) merges, so the fixture matches the Houston field that actually ships. No functional impact either way (chart doesn't validate Houston config field names).

## Merging

- Merge into master
- Target release: APC 2.1.0
