### PR TITLE
PINF-746 -  fix certgenerator image location

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -259,6 +259,12 @@ data:
         networkNSLabels: true
       {{- end }}
 
+        astronomer:
+          images:
+            certgenerator:
+              repository: "{{ include "certgenerator.repository" . }}"
+              tag: "{{ .Values.global.certgenerator.images.tag }}"
+
         gitSyncRelay:
           metrics:
             enabled: {{ .Values.global.gitSyncRelay.metrics.enabled }}
@@ -285,9 +291,6 @@ data:
 
         airflow:
           images:
-            certgenerator:
-              repository: "{{ include "certgenerator.repository" . }}"
-              tag: "{{ .Values.global.certgenerator.images.tag }}"
             statsd:
               repository: "{{ .Values.global.airflow.images.statsd.repository }}"
               tag: "{{ .Values.global.airflow.images.statsd.tag }}"

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1103,19 +1103,6 @@ def test_houston_configmap_certgenerator_in_astronomer_images():
     prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     certgen = prod["deployments"]["helm"]["astronomer"]["images"]["certgenerator"]
     assert certgen["repository"] == "quay.io/astronomer/ap-certgenerator"
-    assert certgen["tag"] == "0.1.8"
-
-
-def test_houston_configmap_certgenerator_not_in_airflow_images():
-    """certgenerator must NOT appear under airflow.images — regression guard for PR-3284.
-
-    Before the fix, certgenerator was erroneously placed under the airflow.images block.
-    This test ensures it is never re-introduced there.
-    """
-    docs = render_chart(
-        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
-    )
-    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
     af_images = prod["deployments"]["helm"]["airflow"]["images"]
     assert "certgenerator" not in af_images, "certgenerator must not appear under airflow.images; it belongs in astronomer.images"
 

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -76,6 +76,12 @@ def test_houston_configmap_defaults():
     assert git_sync_images["gitSync"]["repository"] == "quay.io/astronomer/ap-git-sync-relay"
     assert prod["deployments"]["helm"]["sccEnabled"] is False
 
+    # certgenerator belongs in astronomer.images, not airflow.images (PR-3284)
+    certgen = prod["deployments"]["helm"]["astronomer"]["images"]["certgenerator"]
+    assert certgen["repository"] == "quay.io/astronomer/ap-certgenerator"
+    assert certgen["tag"]
+    assert "certgenerator" not in af_images
+
 
 def test_houston_configmap_ldap_disabled_by_default():
     """auth.ldap.enabled should be False in the baseline production.yaml, parallel to auth.local."""
@@ -1083,3 +1089,45 @@ def test_houston_configmap_no_vector_enabled_key():
     assert find_key_paths(prod, "vectorEnabled") == [], (
         "Legacy vectorEnabled key reappeared in rendered ConfigMap. Use loggingSidecar.enabled instead."
     )
+
+
+def test_houston_configmap_certgenerator_in_astronomer_images():
+    """certgenerator image must appear under astronomer.images in the houston configmap (PR-3284).
+
+    certgenerator is an Astronomer platform component, so Houston should resolve
+    its image from the astronomer.images block, not the airflow.images block.
+    """
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    certgen = prod["deployments"]["helm"]["astronomer"]["images"]["certgenerator"]
+    assert certgen["repository"] == "quay.io/astronomer/ap-certgenerator"
+    assert certgen["tag"] == "0.1.8"
+
+
+def test_houston_configmap_certgenerator_not_in_airflow_images():
+    """certgenerator must NOT appear under airflow.images — regression guard for PR-3284.
+
+    Before the fix, certgenerator was erroneously placed under the airflow.images block.
+    This test ensures it is never re-introduced there.
+    """
+    docs = render_chart(
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    af_images = prod["deployments"]["helm"]["airflow"]["images"]
+    assert "certgenerator" not in af_images, "certgenerator must not appear under airflow.images; it belongs in astronomer.images"
+
+
+def test_houston_configmap_certgenerator_custom_tag():
+    """Custom global.certgenerator.images.tag is reflected in astronomer.images.certgenerator."""
+    docs = render_chart(
+        values={"global": {"certgenerator": {"images": {"tag": "custom-999"}}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+    prod = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    certgen = prod["deployments"]["helm"]["astronomer"]["images"]["certgenerator"]
+    assert certgen["tag"] == "custom-999"
+    # Must remain absent from airflow images even when a custom tag is set
+    assert "certgenerator" not in prod["deployments"]["helm"]["airflow"]["images"]


### PR DESCRIPTION
## Description

Corrects the incorrect certgenerator  image refrence . The certgenerator repository and tag were declared under the `airflow.images` block of the Houston config, but certgenerator is under Astronomer subsection  component, not an Airflow one. This moves the entry to a dedicated `astronomer.images` block so Houston resolves the image from the correct location.


### Improvements

- Houston now reads the certgenerator image from `astronomer.images.certgenerator`, matching the component's actual ownership instead of being misfiled under Airflow images.
- No change to the resolved values — both `repository` (via the `certgenerator.repository` helper) and `tag` (`global.certgenerator.images.tag`) are preserved; only their location in the config tree changes.

## Related Issues

None

## Testing

Render the chart and confirm the certgenerator image now appears under the `astronomer.images` block of the Houston configmap and is gone from `airflow.images`:

\`\`\`bash
helm template . --show-only charts/astronomer/templates/houston/houston-configmap.yaml \
  | grep -A4 'astronomer:' | grep -A3 certgenerator
\`\`\`

Expected: `astronomer.images.certgenerator.repository` and `.tag` are populated, and no `certgenerator` entry remains under `airflow.images`.

## Merging

Merge to `master`. Cherry-pick to active release branches if certgenerator image resolution is broken there as well.