### PR TITLE
PINF-765 Fix security context diverged config

### DIFF
--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -154,7 +154,7 @@ imagePullSecrets:
 
 {{- define "elasticsearch.securityContext" -}}
 {{- $required := dict "readOnlyRootFilesystem" true }}
-{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshift.enabled ) }}
+{{- if .Values.global.openshift.enabled }}
 {{- merge $required (omit .Values.securityContext "runAsUser") | toYaml }}
 {{- else }}
 {{- merge $required .Values.securityContext | toYaml }}

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -153,11 +153,10 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "elasticsearch.securityContext" -}}
-{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshift.enabled ) }}
 {{- $required := dict "readOnlyRootFilesystem" true }}
+{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshift.enabled ) }}
 {{- merge $required (omit .Values.securityContext "runAsUser") | toYaml }}
 {{- else }}
-{{- $required := dict "readOnlyRootFilesystem" true }}
 {{- merge $required .Values.securityContext | toYaml }}
 {{- end -}}
 {{- end }}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -86,7 +86,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.client.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+        {{- if .Values.client.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.client.securityContext | toYaml | nindent 10}}
+        {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -90,7 +90,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.data.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+          {{- if .Values.data.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.data.securityContext | toYaml | nindent 10 }}
+          {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+          {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -89,7 +89,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.master.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+          {{- if .Values.master.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.master.securityContext | toYaml | nindent 10 }}
+          {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+          {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -101,7 +101,7 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "prometheus.securityContext" -}}
-{{- if or (eq (toString (.Values.securityContext.runAsUser)) "auto") .Values.global.openshift.enabled }}
+{{- if .Values.global.openshift.enabled }}
 {{- omit  .Values.securityContext "runAsUser" | toYaml }}
 {{- else }}
 {{- toYaml .Values.securityContext }}
@@ -109,7 +109,7 @@ imagePullSecrets:
 {{- end }}
 
 {{- define "filesdreloader.securityContext" -}}
-{{- if or (eq (toString .Values.filesdReloader.securityContext.runAsUser) "auto") .Values.global.openshift.enabled }}
+{{- if .Values.global.openshift.enabled }}
 {{- omit .Values.filesdReloader.securityContext "runAsUser" | toYaml }}
 {{- else }}
 {{- toYaml .Values.filesdReloader.securityContext }}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -101,9 +101,19 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "prometheus.securityContext" -}}
-{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshift.enabled ) }}
+{{- if or (eq (toString (.Values.securityContext.runAsUser)) "auto") .Values.global.openshift.enabled }}
 {{- omit  .Values.securityContext "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.securityContext }}
 {{- end -}}
+{{- end }}
+
+{{- define "filesdreloader.securityContext" -}}
+{{- if or (eq (toString .Values.filesdReloader.securityContext.runAsUser) "auto") .Values.global.openshift.enabled }}
+{{- omit .Values.filesdReloader.securityContext "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.filesdReloader.securityContext }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -154,7 +154,8 @@ spec:
           image: {{ include "filesdReloader.image" . }}
           imagePullPolicy: {{ .Values.images.filesdReloader.pullPolicy }}
           securityContext:
-            readOnlyRootFilesystem: true
+            {{- $required := dict "readOnlyRootFilesystem" true }}
+            {{- merge $required (include "filesdreloader.securityContext" . | fromYaml) | toYaml | nindent 12 }}
           resources: {{ toYaml .Values.filesdReloader.resources | nindent 12 }}
           {{- if .Values.filesdReloader.livenessProbe }}
           livenessProbe: {{ tpl (toYaml .Values.filesdReloader.livenessProbe) . | nindent 12 }}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -100,6 +100,7 @@ filesdReloader:
     #   cpu: 100m
     #   memory: 25Mi
   extraEnv: []
+  securityContext: {}
 
 # Which directory prometheus data should be stored
 dataDir: "/prometheus"

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -256,6 +256,7 @@ class TestElasticSearch:
                     "securityContext": {
                         "denver": "colorado",
                         "detroit": "michigan",
+                        "allowPrivilegeEscalation": False,
                     }
                 }
             },
@@ -277,6 +278,7 @@ class TestElasticSearch:
                     "detroit": "michigan",
                     "runAsNonRoot": True,
                     "runAsUser": 1000,
+                    "allowPrivilegeEscalation": False,
                 }.items()
             )
 

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -90,3 +90,21 @@ external-secrets:
 postgresql:
   replication:
     enabled: true
+prometheus:
+  securityContext:
+      allowPrivilegeEscalation: false
+  filesdReloader: 
+    securityContext:
+      allowPrivilegeEscalation: false
+elasticsearch:
+  securityContext:
+    allowPrivilegeEscalation: false
+  nginx:
+    securityContext:
+      allowPrivilegeEscalation: false
+  exporter:
+    securityContext:
+      allowPrivilegeEscalation: false
+  curator:
+    securityContext:
+      allowPrivilegeEscalation: false

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -90,21 +90,3 @@ external-secrets:
 postgresql:
   replication:
     enabled: true
-prometheus:
-  securityContext:
-      allowPrivilegeEscalation: false
-  filesdReloader: 
-    securityContext:
-      allowPrivilegeEscalation: false
-elasticsearch:
-  securityContext:
-    allowPrivilegeEscalation: false
-  nginx:
-    securityContext:
-      allowPrivilegeEscalation: false
-  exporter:
-    securityContext:
-      allowPrivilegeEscalation: false
-  curator:
-    securityContext:
-      allowPrivilegeEscalation: false


### PR DESCRIPTION
## Description

Fixes init/sidecar containers that hardcoded `securityContext.readOnlyRootFilesystem: true` and ignored user-configured `securityContext` values. They now merge the configured security context while still enforcing `readOnlyRootFilesystem`, bringing init containers in line with the main containers.

### Changes

| File | What changed |
|------|-------------|
| `charts/elasticsearch/templates/_helpers.tpl` | Hoist `$required` dict so it is defined on both branches |
| `charts/elasticsearch/templates/{client,data,master}/*.yaml` | Init container security context now merges the per-role `securityContext` (falls back to the shared helper) |
| `charts/prometheus/templates/_helpers.yaml` | Add `filesdreloader.securityContext` helper; honor configured `securityContext` in the else branch |
| `charts/prometheus/templates/prometheus-statefulset.yaml` | filesd-reloader sidecar merges configured security context with enforced `readOnlyRootFilesystem` |
| `charts/prometheus/values.yaml` | Add `filesdReloader.securityContext` default (`{}`) |

## Related Issues

PINF-765 - Container security context not respecting passed values
https://linear.app/astronomer/issue/PINF-765/container-security-context-not-respecting-passed-values

## Testing

`helm template` the elasticsearch and prometheus charts with and without a custom `securityContext` and confirm init/sidecar containers render the configured fields while `readOnlyRootFilesystem: true` is always present.

## Merging

Merge to \`master\`; cherry-pick to active release branches as needed.