### PR TITLE
PINF-784: support dots in dag_id and task_id for Vector log path parsing 

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -155,7 +155,7 @@ data:
           file_str = to_string!(.file)
 
           # Try task execution logs: /dag_id=xxx/run_id=yyy/task_id=zzz/attempt=n.log
-          task_parsed, task_err = parse_regex(file_str, r'/dag_id=(?P<dag_id>[a-zA-Z0-9_-]+)/run_id=(?P<run_id>[^/]+)/task_id=(?P<task_id>[a-zA-Z0-9_-]+)/(?:map_index=(?P<map_index>-?[0-9]+)/)?attempt=(?P<attempt>[0-9]+)\.log$')
+          task_parsed, task_err = parse_regex(file_str, r'/dag_id=(?P<dag_id>[a-zA-Z0-9_.-]+)/run_id=(?P<run_id>[^/]+)/task_id=(?P<task_id>[a-zA-Z0-9_.-]+)/(?:map_index=(?P<map_index>-?[0-9]+)/)?attempt=(?P<attempt>[0-9]+)\.log$')
 
           # Try DAG parse logs: /component/YYYY-MM-DD/dag_file_path.log
           dag_parsed, dag_err = parse_regex(file_str, r'/(?:scheduler|dag_processor|dag_processor_manager)/(?P<date>\d{4}-\d{2}-\d{2})/(?P<dag_file>.+)\.log$')


### PR DESCRIPTION
## Description

Task logs from TaskGroup tasks were silently dropped by Vector when using the Kubernetes executor with DS logging. This happened as the regex in the `parse_airflowV3_path` transform used `[a-zA-Z0-9_-]` for `dag_id `and `task_id` path segments. Airflow natively permits dots in these identifiers, and TaskGroup task IDs use dot notation by default `(prefix_group_id=True)`, e.g. `my_group.my_task`. Vector failed to match these paths and dropped the logs entirely.

## Related Issues

https://linear.app/astronomer/issue/PINF-784/task-logs-from-taskgroup-tasks-with-prefix-group-idtrue-the-default

## Merging
Master