### PR TITLE
PINF-829 - fix values mangling in commander metadata config

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -16,21 +16,21 @@
 {{- end }}
 {{- end }}
 
-{{ define "commander.metadata.namespaceLabels" }}
+{{- define "commander.metadata.namespaceLabels" -}}
 {{- if .Values.global.rbac.enabled -}}
-{{ .Values.global.namespaceLabels | toYaml | nindent 6 -}}
-{{- else -}}
-{}
-{{- end }}
-{{- end }}
-
-{{ define "commander.metadata.extraAnnotations" }}
-{{- if not (empty .Values.global.extraAnnotations) -}}
-{{ .Values.global.extraAnnotations | toYaml | nindent 6 -}}
+{{ .Values.global.namespaceLabels | toYaml }}
 {{- else -}}
 {}
 {{- end -}}
-{{- end }}
+{{- end -}}
+
+{{- define "commander.metadata.extraAnnotations" -}}
+{{- if not (empty .Values.global.extraAnnotations) -}}
+{{ .Values.global.extraAnnotations | toYaml }}
+{{- else -}}
+{}
+{{- end -}}
+{{- end -}}
 
 {{ define "commander.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -17,8 +17,10 @@ data:
   metadata.yaml: |-
     registry:
       version: {{ .Values.images.registry.tag | quote}}
-    namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
-    extraAnnotations: {{ include "commander.metadata.extraAnnotations" . }}
+    namespaceLabels:
+      {{- include "commander.metadata.namespaceLabels" . | nindent 6 }}
+    extraAnnotations:
+      {{- include "commander.metadata.extraAnnotations" . | nindent 6 }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
 {{- end }}


### PR DESCRIPTION
## Description

metadata config values are mangled inside the configmap and makes the reading harder while editing this changes fixes the whitespace problems

before:

<img width="795" height="144" alt="image" src="https://github.com/user-attachments/assets/9f99b022-9280-4efe-b67c-2aa561e88218" />

after:

<img width="722" height="253" alt="image" src="https://github.com/user-attachments/assets/82b45fde-4cd5-45d8-bf48-4c334c140f6c" />


## Related Issues

https://linear.app/astronomer/issue/PINF-829/fix-commander-metadata-configmap-mangled-into-quoted-string-by

## Testing

when editing the commander metadata config they should not see mangled output

## Merging

merge to master and release-2.x
