### PR TITLE
PINF-844 fix missing scc privileges

### DIFF
--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -23,11 +23,10 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:default
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-commander
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-houston-bootstrapper
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-cp
-{{- end }}
-{{- if eq .Values.global.plane.mode "data" }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-dp
+{{- $mode := .Values.global.plane.mode }}
+{{- if has $mode (list "control" "unified" "data") }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-{{ ternary "dp" "cp" (eq $mode "data") }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-default-backend
 {{- end }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus
 volumes:

--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -23,11 +23,8 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:default
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-commander
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-houston-bootstrapper
-{{- $mode := .Values.global.plane.mode }}
-{{- if has $mode (list "control" "unified" "data") }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-{{ ternary "dp" "cp" (eq $mode "data") }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-{{ ternary "dp" "cp" (eq .Values.global.plane.mode "data") }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-default-backend
-{{- end }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus
 volumes:
 - configMap

--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -28,7 +28,7 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-cp
 {{- end }}
 {{- if eq .Values.global.plane.mode "data" }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-dp 
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-dp
 {{- end }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus
 volumes:

--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -23,7 +23,6 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:default
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-commander
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-houston-bootstrapper
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-cp
 {{- end }}

--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -24,6 +24,12 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-commander
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-houston-bootstrapper
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx
+{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-cp
+{{- end }}
+{{- if eq .Values.global.plane.mode "data" }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-dp 
+{{- end }}
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus
 volumes:
 - configMap

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -11,6 +11,7 @@ from tests.utils.chart import render_chart
 show_only = [
     "charts/astronomer/templates/commander/commander-role.yaml",
     "charts/astronomer/templates/houston/houston-configmap.yaml",
+    "templates/scc/astronomer-scc-anyuid.yaml",
 ]
 
 
@@ -60,6 +61,24 @@ class TestScc:
         )
         houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
 
-        assert len(docs) == 2
+        assert len(docs) == 3
         assert commander_expected_result in docs[0]["rules"]
         assert houston_values["deployments"]["helm"]["sccEnabled"] is True
+
+    def test_scc_privilges(self, kube_version):
+        """Test scc privileges when scc is enabled."""
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "clusterRoles": True,
+                    "scc": {"enabled": True},
+                }
+            },
+            show_only=["templates/scc/astronomer-scc-anyuid.yaml"],
+            # SecurityContextConstraints is not part of the k8s schema we validate against.
+            validate_objects=False,
+        )
+        assert len(docs) == 1
+        assert len(docs[0]["users"]) == 5

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -81,4 +81,4 @@ class TestScc:
             validate_objects=False,
         )
         assert len(docs) == 1
-        assert len(docs[0]["users"]) == 5
+        assert len(docs[0]["users"]) == 6

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -65,7 +65,7 @@ class TestScc:
         assert commander_expected_result in docs[0]["rules"]
         assert houston_values["deployments"]["helm"]["sccEnabled"] is True
 
-    def test_scc_privilges(self, kube_version):
+    def test_scc_privileges(self, kube_version):
         """Test scc privileges when scc is enabled."""
 
         docs = render_chart(


### PR DESCRIPTION
## Description

Adds missing nginx cp and dp ingress controller service account to scc privileges

## Related Issues

https://linear.app/astronomer/issue/PINF-844/sccenabled-prevents-nginx-pod-creation-due-to-incorrect-service

## Testing

QA should able to provision nginx ingress controller with sccEnabled flag

## Merging

merge to master and release-2.x and 1.x
