### PR TITLE
update kuiper reloader version 0.2.0

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.1.29
+    tag: 0.2.0
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

Improve DB connection error logging (PINF-785) + release automation & tooling updates.

Fixes [PINF-785](https://linear.app/astronomer/issue/PINF-785). The headline change is
clearer startup errors when the database is misconfigured or unreachable; the branch also
bundles release-workflow automation and routine tooling bumps.

Bumps version to v0.2.0.

## Related Issues

https://linear.app/astronomer/issue/PINF-785/improve-filesd-reloader-database-connection-error-logging

## Testing

refer issue ticket 

## Merging

merge to master