### PR TITLE
PINF-809 Dual-host ingress & TLS SAN templating (astronomer umbrella chart)

### DIFF
--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -46,6 +46,11 @@ Image name.
 alertmanager.{{ .Values.global.baseDomain }}
 {{- end }}
 
+{{/* Global customer-facing host, templated from controlPlaneHA.globalBaseDomain (CP HA only). */}}
+{{ define "alertmanager.globalUrl" -}}
+alertmanager.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- end }}
+
 {{/*
 Return  the proper Storage Class
 */}}

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -32,6 +32,9 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
         - {{ template "alertmanager.url" . }}
+        {{- if .Values.global.controlPlaneHA.enabled }}
+        - {{ template "alertmanager.globalUrl" . }}
+        {{- end }}
   {{- end }}
   rules:
     - host: {{ template "alertmanager.url" . }}
@@ -48,5 +51,21 @@ spec:
                   {{- else }}
                   name: http
                   {{- end }}
+    {{- if .Values.global.controlPlaneHA.enabled }}
+    - host: {{ template "alertmanager.globalUrl" . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "alertmanager.fullname" . }}
+                port:
+                  {{- if .Values.global.authSidecar.enabled  }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: http
+                  {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/ingress.yaml
+++ b/charts/astronomer/templates/houston/ingress.yaml
@@ -40,6 +40,9 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
         - houston.{{ .Values.global.baseDomain }}
+        {{- if .Values.global.controlPlaneHA.enabled }}
+        - houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+        {{- end }}
   {{- end }}
   rules:
   - host: houston.{{ .Values.global.baseDomain }}
@@ -52,5 +55,17 @@ spec:
               name: {{ .Release.Name }}-houston
               port:
                 name: houston-http
+  {{- if .Values.global.controlPlaneHA.enabled }}
+  - host: houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-houston
+              port:
+                name: houston-http
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -27,6 +27,11 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
+      {{- if .Values.global.controlPlaneHA.enabled }}
+      if ($host = '{{ .Values.global.controlPlaneHA.globalBaseDomain }}' ) {
+        rewrite ^ https://app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}$request_uri permanent;
+      }
+      {{- end }}
     {{- end }}
 spec:
   {{- if .Values.global.tlsSecret }}
@@ -36,6 +41,10 @@ spec:
       {{- if $planeControlMode }}
         - {{ .Values.global.baseDomain }}
         - app.{{ .Values.global.baseDomain }}
+        {{- if .Values.global.controlPlaneHA.enabled }}
+        - {{ .Values.global.controlPlaneHA.globalBaseDomain }}
+        - app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+        {{- end }}
       {{- end }}
       {{- if $planeDataMode }}
         - {{ include "registry.ingressURL" . }}
@@ -63,6 +72,28 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
+{{- if .Values.global.controlPlaneHA.enabled }}
+  - host: {{ .Values.global.controlPlaneHA.globalBaseDomain }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-astro-ui
+              port:
+                name: astro-ui-http
+  - host: app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ .Release.Name }}-astro-ui
+              port:
+                name: astro-ui-http
+{{- end }}
 {{- end }}
 {{- if $planeDataMode }}
   - host: {{ include "registry.ingressURL" . }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -4,6 +4,8 @@
 {{- if and .Values.global.baseDomain ( not .Values.global.perHostIngress.enabled ) }}
 {{- $planeDataMode := or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- $planeControlMode := or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- /* Global customer-facing host is control-plane-only (globalBaseDomain is unset on data planes). */}}
+{{- $emitGlobalHost := and .Values.global.controlPlaneHA.enabled $planeControlMode }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -27,7 +29,7 @@ metadata:
       if ($host = '{{ .Values.global.baseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.baseDomain }}$request_uri permanent;
       }
-      {{- if .Values.global.controlPlaneHA.enabled }}
+      {{- if $emitGlobalHost }}
       if ($host = '{{ .Values.global.controlPlaneHA.globalBaseDomain }}' ) {
         rewrite ^ https://app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}$request_uri permanent;
       }
@@ -41,7 +43,7 @@ spec:
       {{- if $planeControlMode }}
         - {{ .Values.global.baseDomain }}
         - app.{{ .Values.global.baseDomain }}
-        {{- if .Values.global.controlPlaneHA.enabled }}
+        {{- if $emitGlobalHost }}
         - {{ .Values.global.controlPlaneHA.globalBaseDomain }}
         - app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
         {{- end }}
@@ -72,7 +74,7 @@ spec:
               name: {{ .Release.Name }}-astro-ui
               port:
                 name: astro-ui-http
-{{- if .Values.global.controlPlaneHA.enabled }}
+{{- if $emitGlobalHost }}
   - host: {{ .Values.global.controlPlaneHA.globalBaseDomain }}
     http:
       paths:

--- a/charts/grafana/templates/_helpers.yaml
+++ b/charts/grafana/templates/_helpers.yaml
@@ -42,6 +42,11 @@ Create chart name and version as used by the chart label.
 grafana.{{ .Values.global.baseDomain }}
 {{- end }}
 
+{{/* Global customer-facing host, templated from controlPlaneHA.globalBaseDomain (CP HA only). */}}
+{{ define "grafana.globalUrl" -}}
+grafana.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- end }}
+
 {{ define "grafana.backend.secret" -}}
 {{ default (printf "%s-grafana-backend" .Release.Name) .Values.backendSecretName }}
 {{- end }}

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -31,6 +31,9 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
         - {{ template "grafana.url" . }}
+        {{- if .Values.global.controlPlaneHA.enabled }}
+        - {{ template "grafana.globalUrl" . }}
+        {{- end }}
   {{- end }}
   rules:
     - host: {{ template "grafana.url" . }}
@@ -47,5 +50,21 @@ spec:
                   {{- else }}
                   name: grafana-ui
                   {{- end }}
+    {{- if .Values.global.controlPlaneHA.enabled }}
+    - host: {{ template "grafana.globalUrl" . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "grafana.fullname" . }}
+                port:
+                  {{- if .Values.global.authSidecar.enabled }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: grafana-ui
+                  {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -75,6 +75,11 @@ prometheus.{{ .Values.global.baseDomain }}
 {{- end -}}
 {{- end -}}
 
+{{/* Global customer-facing host, templated from controlPlaneHA.globalBaseDomain (CP HA only). */}}
+{{- define "prometheus.globalUrl" -}}
+prometheus.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- end -}}
+
 {{- define "prom-proxy.url" -}}
 {{- if eq .Values.global.plane.mode "data" -}}
 prom-proxy.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -2,6 +2,8 @@
 ## Prometheus Ingress ##
 ########################
 {{- if .Values.global.baseDomain }}
+{{- /* Global customer-facing host is control-plane-only (globalBaseDomain is unset on data planes). */}}
+{{- $emitGlobalHost := and .Values.global.controlPlaneHA.enabled (or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified")) }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -30,6 +32,9 @@ spec:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
         - {{ template "prometheus.url" . }}
+        {{- if $emitGlobalHost }}
+        - {{ template "prometheus.globalUrl" . }}
+        {{- end }}
   {{- end }}
   rules:
     - host: {{ template "prometheus.url" . }}
@@ -46,4 +51,20 @@ spec:
                   {{- else }}
                   name: prometheus-data
                   {{- end }}
+    {{- if $emitGlobalHost }}
+    - host: {{ template "prometheus.globalUrl" . }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "prometheus.fullname" . }}
+                port:
+                  {{- if .Values.global.authSidecar.enabled }}
+                  name: auth-proxy
+                  {{- else }}
+                  name: prometheus-data
+                  {{- end }}
+    {{- end }}
 {{- end }}

--- a/tests/chart_tests/test_dual_host_ingress.py
+++ b/tests/chart_tests/test_dual_host_ingress.py
@@ -1,0 +1,125 @@
+"""Tests for dual-host ingress & TLS SAN templating (PINF-809).
+
+When `global.controlPlaneHA.enabled` is set, each customer-facing ingress (public,
+houston, grafana, alertmanager, prometheus) emits two host families:
+  * per-CP admin     — templated from `global.baseDomain` (unchanged)
+  * customer-facing  — templated from `global.controlPlaneHA.globalBaseDomain`
+Both the `rules[].host` list and the mirrored `spec.tls[].hosts` list (TLS SAN
+expansion) cover both families. With HA off, only the per-CP family is rendered
+(single-CP installs are unchanged).
+"""
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+PUBLIC_INGRESS = "charts/astronomer/templates/ingress.yaml"
+HOUSTON_INGRESS = "charts/astronomer/templates/houston/ingress.yaml"
+GRAFANA_INGRESS = "charts/grafana/templates/grafana-ingress.yaml"
+ALERTMANAGER_INGRESS = "charts/alertmanager/templates/ingress.yaml"
+PROMETHEUS_INGRESS = "charts/prometheus/templates/ingress.yaml"
+
+BASE_DOMAIN = "example.com"
+GLOBAL_BASE_DOMAIN = "astro.example.com"
+
+# Per ingress: the host(s) expected from baseDomain (per-CP admin family) and from
+# globalBaseDomain (customer-facing family). The public ingress emits two hosts per
+# family (bare + app); the rest emit one.
+INGRESS_HOSTS = {
+    PUBLIC_INGRESS: (
+        [BASE_DOMAIN, f"app.{BASE_DOMAIN}"],
+        [GLOBAL_BASE_DOMAIN, f"app.{GLOBAL_BASE_DOMAIN}"],
+    ),
+    HOUSTON_INGRESS: ([f"houston.{BASE_DOMAIN}"], [f"houston.{GLOBAL_BASE_DOMAIN}"]),
+    GRAFANA_INGRESS: ([f"grafana.{BASE_DOMAIN}"], [f"grafana.{GLOBAL_BASE_DOMAIN}"]),
+    ALERTMANAGER_INGRESS: ([f"alertmanager.{BASE_DOMAIN}"], [f"alertmanager.{GLOBAL_BASE_DOMAIN}"]),
+    PROMETHEUS_INGRESS: ([f"prometheus.{BASE_DOMAIN}"], [f"prometheus.{GLOBAL_BASE_DOMAIN}"]),
+}
+
+
+def _ha_values(**overrides):
+    """global.controlPlaneHA enabled with a valid globalBaseDomain, control plane."""
+    cpha = {"enabled": True, "globalBaseDomain": GLOBAL_BASE_DOMAIN}
+    cpha.update(overrides)
+    return {"global": {"plane": {"mode": "control"}, "baseDomain": BASE_DOMAIN, "controlPlaneHA": cpha}}
+
+
+def _no_ha_values():
+    return {"global": {"plane": {"mode": "control"}, "baseDomain": BASE_DOMAIN}}
+
+
+def _find_ingress(docs):
+    """Return the single Ingress doc from a rendered template (ignores any extra docs)."""
+    ingresses = [d for d in docs if d and d.get("kind") == "Ingress"]
+    assert len(ingresses) == 1
+    return ingresses[0]
+
+
+def _rule_hosts(ingress):
+    return [rule["host"] for rule in ingress["spec"]["rules"]]
+
+
+def _tls_hosts(ingress):
+    hosts = []
+    for entry in ingress["spec"].get("tls", []):
+        hosts.extend(entry.get("hosts", []))
+    return hosts
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+@pytest.mark.parametrize("ingress_file", list(INGRESS_HOSTS))
+class TestDualHostIngress:
+    def test_ha_off_single_host_family(self, kube_version, ingress_file):
+        """HA off: only the per-CP (baseDomain) host family renders — no global hosts."""
+        per_cp_hosts, global_hosts = INGRESS_HOSTS[ingress_file]
+        ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[ingress_file], values=_no_ha_values()))
+        rule_hosts = _rule_hosts(ingress)
+        for host in per_cp_hosts:
+            assert host in rule_hosts
+        for host in global_hosts:
+            assert host not in rule_hosts
+        # TLS SAN list must not leak global hosts when HA is off.
+        for host in global_hosts:
+            assert host not in _tls_hosts(ingress)
+
+    def test_ha_on_both_host_families(self, kube_version, ingress_file):
+        """HA on: both per-CP and global host families render in rules and TLS hosts."""
+        per_cp_hosts, global_hosts = INGRESS_HOSTS[ingress_file]
+        ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[ingress_file], values=_ha_values()))
+        rule_hosts = _rule_hosts(ingress)
+        for host in per_cp_hosts + global_hosts:
+            assert host in rule_hosts, f"{host} missing from rules of {ingress_file}"
+        # TLS SAN expansion mirrors the rule hosts (both families).
+        tls_hosts = _tls_hosts(ingress)
+        for host in per_cp_hosts + global_hosts:
+            assert host in tls_hosts, f"{host} missing from tls.hosts of {ingress_file}"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_prometheus_data_plane_ha_no_global_host(kube_version):
+    """Prometheus ingress renders on data planes; globalBaseDomain is control-plane-only.
+
+    A data-plane render with HA enabled (e.g. shared values) and no globalBaseDomain must
+    render cleanly and emit no global host (mirrors PINF-768's data-plane guard).
+    """
+    values = {
+        "global": {
+            "plane": {"mode": "data", "domainPrefix": "dp"},
+            "baseDomain": BASE_DOMAIN,
+            "controlPlaneHA": {"enabled": True},
+        }
+    }
+    ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[PROMETHEUS_INGRESS], values=values))
+    rule_hosts = _rule_hosts(ingress)
+    assert rule_hosts == [f"prometheus.dp.{BASE_DOMAIN}"]
+    assert GLOBAL_BASE_DOMAIN not in " ".join(_tls_hosts(ingress))
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_public_ingress_global_bare_domain_redirect(kube_version):
+    """Public ingress redirects the bare global host to app.<globalBaseDomain> (parity with baseDomain)."""
+    ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[PUBLIC_INGRESS], values=_ha_values()))
+    snippet = ingress["metadata"]["annotations"]["nginx.ingress.kubernetes.io/configuration-snippet"]
+    assert f"if ($host = '{GLOBAL_BASE_DOMAIN}' )" in snippet
+    assert f"https://app.{GLOBAL_BASE_DOMAIN}$request_uri" in snippet

--- a/tests/chart_tests/test_dual_host_ingress.py
+++ b/tests/chart_tests/test_dual_host_ingress.py
@@ -123,3 +123,25 @@ def test_public_ingress_global_bare_domain_redirect(kube_version):
     snippet = ingress["metadata"]["annotations"]["nginx.ingress.kubernetes.io/configuration-snippet"]
     assert f"if ($host = '{GLOBAL_BASE_DOMAIN}' )" in snippet
     assert f"https://app.{GLOBAL_BASE_DOMAIN}$request_uri" in snippet
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+def test_public_ingress_data_plane_ha_no_global_redirect(kube_version):
+    """Public ingress renders on data planes; the global bare-domain redirect is control-plane-only.
+
+    A data-plane render with HA enabled and no globalBaseDomain must not emit the global
+    redirect (which would otherwise template `<no value>` into the nginx snippet).
+    """
+    values = {
+        "global": {
+            "plane": {"mode": "data"},
+            "baseDomain": BASE_DOMAIN,
+            "controlPlaneHA": {"enabled": True},
+        }
+    }
+    ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[PUBLIC_INGRESS], values=values))
+    snippet = ingress["metadata"]["annotations"]["nginx.ingress.kubernetes.io/configuration-snippet"]
+    assert "<no value>" not in snippet
+    assert GLOBAL_BASE_DOMAIN not in snippet
+    # Only the per-CP baseDomain redirect should be present.
+    assert f"if ($host = '{BASE_DOMAIN}' )" in snippet

--- a/values.yaml
+++ b/values.yaml
@@ -26,6 +26,18 @@ global:
     enabled: false
     # Parent domain of the global customer-facing hostname. REQUIRED when enabled.
     # E.g. set to "astro.example.com" when the global URL is "app.astro.example.com".
+    #
+    # TLS cert SANs (customer prerequisite: when
+    # enabled, each CP's ingresses serve two host families, so the per-CP TLS cert
+    # (global.tlsSecret) on EVERY CP must include SANs for both:
+    #   per-CP admin (under baseDomain):  <baseDomain>, app.<baseDomain>,
+    #     houston.<baseDomain>, grafana.<baseDomain>, alertmanager.<baseDomain>,
+    #     prometheus.<baseDomain>
+    #   global customer-facing (under globalBaseDomain): the same subdomains under
+    #     <globalBaseDomain> (app./houston./grafana./alertmanager./prometheus.) plus the
+    #     bare <globalBaseDomain>
+    # One physical cert per CP serves both families. Issue via DNS-01 ACME — HTTP-01 will
+    # not work because the global host only routes to active-region CPs.
     globalBaseDomain: ~
     # Stable per-CP identity (UUID), exposed to pods as the CP_ID env var.
     # When unset, the chart looks up the existing cp-identity Secret and reuses its value,


### PR DESCRIPTION
## Description

Implements the **astronomer umbrella chart** half of dual-host ingress & TLS SAN templating for Control Plane HA (PINF-809).

When `global.controlPlaneHA.enabled` is set, each customer-facing ingress (public, houston, grafana, alertmanager, prometheus) emits **two host families**:

- **per-CP admin**: the existing host from `global.baseDomain` (unchanged)
- **global customer-facing**: a new host from `global.controlPlaneHA.globalBaseDomain`

The `spec.tls[].hosts` list mirrors both families on each ingress, so each per-CP cert's SAN expectation lines up with the hostnames it serves. With HA off, rendering is unchanged (single per-CP host family only).

Details:
- **public** (`charts/astronomer/templates/ingress.yaml`): emits `<globalBaseDomain>` + `app.<globalBaseDomain>` (both → astro-ui), extends the bare-domain→`app.` redirect snippet to the global host, mirrors the two global hosts into TLS hosts.
- **houston / grafana / alertmanager / prometheus**: add a second `host:` rule + TLS host; grafana/alertmanager/prometheus gain a `*.globalUrl` named helper next to the existing `*.url`.
- **prometheus**: the global host is gated by `$emitGlobalHost` (HA **and** control/unified plane) because `globalBaseDomain` is control-plane-only and unset on data planes with shared values.
- **docs**: abbreviated per-CP cert SAN directive added as comments in `values.yaml` under `global.controlPlaneHA.globalBaseDomain` (both host families, one physical cert per CP, DNS-01 ACME). Full customer-facing doc tracked in PINF-813.

Cert issuance itself (DNS-01 ACME) is a customer prerequisite. The chart only expands the ingress `tls.hosts` list.

> **Depends on PINF-768 (#3302)**, now merged into `feature/cp-ha-dr`, which introduces the `global.controlPlaneHA.*` values this consumes. This PR targets `feature/cp-ha-dr` and contains only the PINF-809 ingress/TLS changes.

## Related Issues

Related astronomer/issues#PINF-809
Consumes values from PINF-768 (#3302). Full SAN documentation tracked in PINF-813.

## Testing

- `uv run pytest tests/chart_tests/test_dual_host_ingress.py`: **60 passed** (HA-off single family, HA-on dual family + TLS SAN expansion across all 5 ingresses, prometheus data-plane regression guard, public bare-domain redirect).
- `uv run pytest tests/chart_tests/test_control_plane_ha.py`: 95 passed (no PINF-768 regressions).
- `uv run pytest tests/chart_tests/ -n auto`: **4667 passed, 72 skipped** (full suite, no regressions).
- Manual `helm template` renders verified for HA-on, HA-off, and the prometheus data-plane edge case.

## Merging

Target: `feature/cp-ha-dr` (CP-HA integration branch). Part of the 2.1.0 release line. No cherry-picks to older release branches.
