### PR TITLE
PINF-864 - allows registry disable support

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -911,3 +911,12 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Whether the registry should be rendered.
+Master switch registry.enabled (default true) AND the registry plane modes (data/unified).
+Returns the string "true" or "false" — compare with eq.
+*/}}
+{{- define "registry.enabled" -}}
+{{- and .Values.registry.enabled (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) -}}
+{{- end }}

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -2,8 +2,9 @@
 ## Astronomer Ingress ##
 ########################
 {{- if and .Values.global.baseDomain ( not .Values.global.perHostIngress.enabled ) }}
-{{- $planeDataMode := or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 {{- $planeControlMode := or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- $registryEnabled := eq (include "registry.enabled" .) "true" }}
+{{- if or $planeControlMode $registryEnabled }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -37,7 +38,7 @@ spec:
         - {{ .Values.global.baseDomain }}
         - app.{{ .Values.global.baseDomain }}
       {{- end }}
-      {{- if $planeDataMode }}
+      {{- if $registryEnabled }}
         - {{ include "registry.ingressURL" . }}
       {{- end }}
   {{- end }}
@@ -64,7 +65,7 @@ spec:
               port:
                 name: astro-ui-http
 {{- end }}
-{{- if $planeDataMode }}
+{{- if $registryEnabled }}
   - host: {{ include "registry.ingressURL" . }}
     http:
       paths:
@@ -75,5 +76,6 @@ spec:
               name: {{ .Release.Name }}-registry
               port:
                 name: registry-http
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry ConfigMap ##
 ###################################
 {{ if and .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Ingress ##
 #################################
 {{- if and .Values.global.baseDomain .Values.global.perHostIngress.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Registry NetworkPolicy
 ################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/astronomer/templates/registry/registry-scc.yaml
+++ b/charts/astronomer/templates/registry/registry-scc.yaml
@@ -2,7 +2,7 @@
 ### Astronomer Registry Scc   ###
 #################################
 {{- if and .Values.registry.serviceAccount.create .Values.registry.serviceAccount.sccEnabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/astronomer/templates/registry/registry-secret.yaml
+++ b/charts/astronomer/templates/registry/registry-secret.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Secrets ##
 #################################
 {{ if and .Values.global.baseDomain (not .Values.registry.auth.secretName) }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-service.yaml
+++ b/charts/astronomer/templates/registry/registry-service.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry Service ##
 #################################
 {{- if .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/astronomer/templates/registry/registry-serviceaccount.yaml
+++ b/charts/astronomer/templates/registry/registry-serviceaccount.yaml
@@ -2,7 +2,7 @@
 ## Registry ServiceAccount ##
 #############################
 {{- if .Values.registry.serviceAccount.create }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.registry.serviceAccount.automountServiceAccountToken }}

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Registry StatefulSet ##
 #####################################
 {{- if .Values.global.baseDomain }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "registry.enabled" .) "true" }}
 {{- if or .Values.registry.gcs.enabled .Values.registry.azure.enabled .Values.registry.s3.enabled }}
 kind: Deployment
 apiVersion: apps/v1

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -951,6 +951,7 @@ navigator:
   flightCleanupTtl: 604800
 
 registry:
+  enabled: true
   # flag to bypass secure (tls) authentication to astronomer registry
   enableInsecureAuth: False
   replicas: 1

--- a/tests/chart_tests/test_astronomer_registry.py
+++ b/tests/chart_tests/test_astronomer_registry.py
@@ -230,3 +230,23 @@ class TestRegistryStatefulset:
         )
 
         assert len(docs) == 0
+
+    @pytest.mark.parametrize("mode", ["data", "unified", "control"])
+    def test_astronomer_registry_all_files_disabled_when_registry_enabled_false(self, kube_version, mode):
+        """registry.enabled=false removes the entire registry stack in every plane mode."""
+        registry_files = [
+            str(x.relative_to(git_root_dir))
+            for x in Path(f"{git_root_dir}/charts/astronomer/templates/registry").glob("*")
+            if x.is_file()
+        ]
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": mode}},
+                "astronomer": {"registry": {"enabled": False}},
+            },
+            show_only=sorted(registry_files),
+        )
+
+        assert len(docs) == 0

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -169,6 +169,36 @@ class TestIngress:
         assert "example.com" in tls_hosts
         assert "app.example.com" in tls_hosts
 
+    def test_public_registry_ingress_not_rendered_when_registry_disabled_in_data(self, kube_version):
+        """disables registry when flag is disabled when on data mode."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": "data"}},
+                "astronomer": {"registry": {"enabled": False}},
+            },
+            show_only=["charts/astronomer/templates/ingress.yaml"],
+        )
+
+        assert len(docs) == 0
+
+    def test_public_registry_ingress_renders_in_control_when_registry_disabled(self, kube_version):
+        """disables registry when flag is disabled when on control mode.."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": "control"}},
+                "astronomer": {"registry": {"enabled": False}},
+            },
+            show_only=["charts/astronomer/templates/ingress.yaml"],
+        )
+
+        assert len(docs) == 1
+        hosts = [rule["host"] for rule in docs[0]["spec"]["rules"]]
+        assert "registry.example.com" not in hosts
+        assert "example.com" in hosts
+        assert "app.example.com" in hosts
+
     @pytest.mark.parametrize(
         ("mode", "expected_astro_ui", "expected_registry", "expected_rule_count", "expected_hosts"),
         [


### PR DESCRIPTION
## Description

Introduces opt-out support for in-cluster registry provisioning in unified and data plane modes when customers have configured protectedCustomRegistry.

## Related Issues
https://linear.app/astronomer/issue/PINF-864/make-registry-provisioning-optional-for-unified-and-dataplane-mode
https://linear.app/astronomer/project/optionally-disable-internal-registry-when-an-external-registry-is-in-c475ad36cb2e

## Testing

QA should able to disable incluster registry on dataplane mode

## Merging

merge to master and release-2.x
