### PR TITLE
PINF-871 - add shared elasticsearch support control plane

### DIFF
--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -23,7 +23,7 @@ data:
       {{- include "commander.metadata.extraAnnotations" . | nindent 6 }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
-    {{- if .Values.global.sharedElasticsearch.enabled }}
+    {{- if and (eq .Values.global.plane.mode "data") .Values.global.sharedElasticsearch.enabled }}
     elasticsearch:
       sharedElasticsearchEnabled: true
     {{- end }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -23,4 +23,8 @@ data:
       {{- include "commander.metadata.extraAnnotations" . | nindent 6 }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
+    {{- if .Values.global.sharedElasticsearch.enabled }}
+    elasticsearch:
+      sharedElasticsearchEnabled: true
+    {{- end }}
 {{- end }}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -1,7 +1,7 @@
 #####################################
 ## Elasticsearch Client Deployment ##
 #####################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/elasticsearch/templates/client/es-client-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/client/es-client-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Client NetworkPolicy
 #####################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/client/es-client-pod-disruption-budget.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Elasticsearch Client Pod Disruption Budget ##
 ###########################################################
 {{- if .Values.global.podDisruptionBudgets.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/elasticsearch/templates/client/es-client-service.yaml
+++ b/charts/elasticsearch/templates/client/es-client-service.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## Elasticsearch Client Service ##
 ##################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-configmap.yaml
@@ -2,7 +2,7 @@
 ## Curator ConfigMap ##
 #######################
 {{- if .Values.curator.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -2,7 +2,7 @@
 ## Curator CronJob ##
 #####################
 {{- if .Values.curator.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: {{ include "apiVersion.batch.cronjob" . }}
 kind: CronJob
 metadata:

--- a/charts/elasticsearch/templates/data/es-data-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/data/es-data-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Data NetworkPolicy
 ###################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/elasticsearch/templates/data/es-data-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/data/es-data-pod-disruption-budget.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Elasticsearch Data Pod Disruption Budget
 ######################################################
 {{- if .Values.global.podDisruptionBudgets.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/elasticsearch/templates/data/es-data-service.yaml
+++ b/charts/elasticsearch/templates/data/es-data-service.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Data Service ##
 ################################
 {{- if .Values.data.persistence.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -1,7 +1,7 @@
 ####################################
 ## Elasticsearch Data StatefulSet ##
 ####################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/charts/elasticsearch/templates/es-configmap.yaml
+++ b/charts/elasticsearch/templates/es-configmap.yaml
@@ -1,6 +1,7 @@
 #############################
 ## Elasticsearch ConfigMap ##
 #############################
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -61,3 +62,4 @@ data:
     # We force the index pattern at the NGINX layer, and this prevents anybody
     # from overriding it.
     # rest.action.multi.allow_explicit_index: false
+{{- end }}

--- a/charts/elasticsearch/templates/es-ingress.yaml
+++ b/charts/elasticsearch/templates/es-ingress.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Logging Ingress ##
 ########################################
 {{- if not .Values.global.customLogging.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:

--- a/charts/elasticsearch/templates/es-serviceaccount.yaml
+++ b/charts/elasticsearch/templates/es-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## elasticsearch ServiceAccount ##
 ##################################
-{{- if and .Values.common.serviceAccount.create .Values.global.rbac.enabled }}
+{{- if and (eq (include "logging.enabled" .) "true") .Values.common.serviceAccount.create .Values.global.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.common.serviceAccount.automountServiceAccountToken }}

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -1,7 +1,7 @@
 #######################################
 ## Elasticsearch Exporter Deployment ##
 #######################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/elasticsearch/templates/exporter/es-exporter-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Exporter NetworkPolicy
 #######################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/elasticsearch/templates/exporter/es-exporter-service.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-service.yaml
@@ -1,7 +1,7 @@
 ####################################
 ## Elasticsearch Exporter Service ##
 ####################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/elasticsearch/templates/master/es-master-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/master/es-master-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Master NetworkPolicy
 #####################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/elasticsearch/templates/master/es-master-pod-disruption-budget.yaml
+++ b/charts/elasticsearch/templates/master/es-master-pod-disruption-budget.yaml
@@ -2,7 +2,7 @@
 ## Astronomer Elasticsearch Master Pod Disruption Budget
 ########################################################
 {{- if .Values.global.podDisruptionBudgets.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:

--- a/charts/elasticsearch/templates/master/es-master-service.yaml
+++ b/charts/elasticsearch/templates/master/es-master-service.yaml
@@ -1,7 +1,7 @@
 ##################################
 ## Elasticsearch Master Service ##
 ##################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -1,7 +1,7 @@
 ######################################
 ## Elasticsearch Master StatefulSet ##
 ######################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml
@@ -1,7 +1,7 @@
 ###################################
 ## NGINX Elasticsearch ConfigMap ##
 ###################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- $authCacheEnabled := .Values.nginx.authCache.enabled }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
@@ -1,7 +1,7 @@
 ####################################
 ## NGINX Elasticsearch Deployment ##
 ####################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:

--- a/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch NGiNX NetworkPolicy
 ####################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/elasticsearch/templates/nginx/nginx-es-service.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-service.yaml
@@ -1,7 +1,7 @@
 #################################
 ## NGINX Elasticsearch Service ##
 #################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-configmap.yaml
@@ -1,7 +1,7 @@
 ###################################
 ## Elasticsearch Proxy ConfigMap ##
 ###################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- $authCacheEnabled := .Values.authCache.enabled }}
 kind: ConfigMap
 apiVersion: v1

--- a/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-deployment.yaml
@@ -1,7 +1,7 @@
 ####################################
 ## Elasticsearch Proxy Deployment ##
 ####################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml
@@ -1,7 +1,7 @@
 ###################################
 ## Elasticsearch Proxy ConfigMap ##
 ###################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-networkpolicy.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Proxy NetworkPolicy ##
 #######################################
 {{- if .Values.global.networkPolicy.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-service.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-service.yaml
@@ -1,7 +1,7 @@
 #################################
 ## Elasticsearch Proxy Service ##
 #################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/external-es-proxy/templates/external-es-proxy-serviceaccount.yaml
+++ b/charts/external-es-proxy/templates/external-es-proxy-serviceaccount.yaml
@@ -2,7 +2,7 @@
 ## Elasticsearch Proxy ServiceAccount ##
 ########################################
 {{- if and .Values.serviceAccount.create .Values.global.rbac.enabled }}
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}

--- a/charts/vector/templates/vector-clusterrole.yaml
+++ b/charts/vector/templates/vector-clusterrole.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector ClusterRole
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- if .Values.global.rbac.enabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/vector/templates/vector-clusterrolebinding.yaml
+++ b/charts/vector/templates/vector-clusterrolebinding.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector ClusterRoleBinding
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- if .Values.global.rbac.enabled }}
 kind: ClusterRoleBinding
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -50,10 +50,10 @@ data:
         condition:
           type: "vrl"
           source: |
-            {{- if and .Values.global.namespaceManagement.namespacePools.enabled (gt (len .Values.global.namespaceManagement.namespacePools.namespaces.names) 0) }}
+            {{- if and .Values.global.namespaceManagement.namespacePools.enabled (gt (len .Values.global.namespaceManagement.namespacePools.namespaces.names) 0) (not .Values.global.sharedElasticsearch.enabled) }}
             namespaces = [{{ range $i, $ns := .Values.global.namespaceManagement.namespacePools.namespaces.names }}{{ if $i }}, {{ end }}"{{ $ns }}"{{ end }}]
             includes(namespaces, .kubernetes.pod_namespace)
-            {{- else if or .Values.global.namespaceManagement.manualNamespaceNames.enabled (not .Values.global.manageClusterScopedResources.enabled) }}
+            {{- else if or .Values.global.sharedElasticsearch.enabled .Values.global.namespaceManagement.manualNamespaceNames.enabled (not .Values.global.manageClusterScopedResources.enabled) }}
             exists(.kubernetes.pod_namespace) && is_string(.kubernetes.pod_namespace) && .kubernetes.pod_namespace != ""
             {{- else }}
             .kubernetes.namespace_labels.platform == "{{ .Release.Name }}"

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector ConfigMap
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/charts/vector/templates/vector-daemonset.yaml
+++ b/charts/vector/templates/vector-daemonset.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector DaemonSet
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/charts/vector/templates/vector-networkpolicy.yaml
+++ b/charts/vector/templates/vector-networkpolicy.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector NetworkPolicy
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- if .Values.global.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/vector/templates/vector-serviceaccount.yaml
+++ b/charts/vector/templates/vector-serviceaccount.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Vector ServiceAccount
 ###########################################################################
-{{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
+{{- if eq (include "logging.enabled" .) "true" }}
 {{- if and .Values.serviceAccount.create .Values.global.rbac.enabled }}
 apiVersion: v1
 kind: ServiceAccount

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -102,3 +102,15 @@ proxy_pass https://houston.{{ .Values.global.baseDomain }}/v1/elasticsearch;
 {{ define "registry.authHeaderSecret" -}}
 {{ default (printf "%s-registry-auth-key" .Release.Name) .Values.global.authHeaderSecretName }}
 {{- end }}
+
+{{/*
+Whether the logging stack (Elasticsearch, external-es-proxy, Vector) should be rendered
+for the current plane. Always on for unified. When global.sharedElasticsearch.enabled,
+the control plane hosts shared logging and the data plane runs none; when disabled, the
+data plane runs its own and the control plane runs none.
+Defined in the parent chart so all logging sub-charts can include it.
+Returns the string "true" or "false" — compare with eq.
+*/}}
+{{- define "logging.enabled" -}}
+{{- or (eq .Values.global.plane.mode "unified") (and (eq .Values.global.plane.mode "control") .Values.global.sharedElasticsearch.enabled) (and (eq .Values.global.plane.mode "data") (not .Values.global.sharedElasticsearch.enabled)) -}}
+{{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -123,7 +123,7 @@ class TestAstronomerCommander:
                 "sharedElasticsearch": {
                     "enabled": True,
                 },
-                "plane" : {
+                "plane": {
                     "mode": "data",
                 },
             },

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -116,6 +116,28 @@ class TestAstronomerCommander:
         metadata_file_contents = yaml.safe_load(docs[0]["data"]["metadata.yaml"])
         assert metadata_file_contents["extraAnnotations"] == extra_annotations
 
+    def test_commander_metadata_shared_elasticsearch_overrides(self, kube_version):
+        """Test that global.sharedElasticsearch are passed through to commander metadata.yaml."""
+        values = {
+            "global": {
+                "sharedElasticsearch": {
+                    "enabled": True,
+                },
+                "plane" : {
+                    "mode": "data",
+                },
+            },
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/astronomer/templates/commander/commander-metadata.yaml"],
+        )
+
+        assert len(docs) == 1
+        metadata_file_contents = yaml.safe_load(docs[0]["data"]["metadata.yaml"])
+        assert metadata_file_contents["elasticsearch"] == {"sharedElasticsearchEnabled": True}
+
     def test_commander_deployment_default(self, kube_version):
         """Test that helm renders a good deployment template for astronomer/commander."""
         values = {

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -831,6 +831,45 @@ class TestElasticSearch:
         else:
             assert len(docs) == 0, f"Document {doc} should not render in {plane_mode} mode"
 
+    @pytest.mark.parametrize("doc", es_component_templates)
+    @pytest.mark.parametrize(
+        "plane_mode,shared_elasticsearch,should_render",
+        [
+            # unified: logging is always enabled regardless of sharedElasticsearch
+            ("unified", False, True),
+            ("unified", True, True),
+            # control: logging is enabled only when sharedElasticsearch is enabled
+            ("control", False, False),
+            ("control", True, True),
+            # data: logging is enabled only when sharedElasticsearch is disabled
+            ("data", False, True),
+            ("data", True, False),
+        ],
+    )
+    def test_elasticsearch_logging_enabled_by_mode_and_shared_elasticsearch(
+        self, kube_version, doc, plane_mode, shared_elasticsearch, should_render
+    ):
+        """Test that elasticsearch templates render according to the logging.enabled helper across plane mode and sharedElasticsearch."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": plane_mode},
+                    "sharedElasticsearch": {"enabled": shared_elasticsearch},
+                },
+                "elasticsearch": {"data": {"persistence": {"enabled": True}}},
+            },
+            show_only=[doc],
+        )
+        if should_render:
+            assert len(docs) == 1, (
+                f"Document {doc} should render in {plane_mode} mode with sharedElasticsearch={shared_elasticsearch}"
+            )
+        else:
+            assert len(docs) == 0, (
+                f"Document {doc} should not render in {plane_mode} mode with sharedElasticsearch={shared_elasticsearch}"
+            )
+
     def test_elasticsearch_ingress_control_mode_default(self, kube_version):
         """Test that helm renders a correct Elasticsearch ingress template in data plane mode"""
         docs = render_chart(

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -1008,13 +1008,6 @@ class TestExternalElasticSearch:
         assert len(docs) == 1
         assert "tls" not in docs[0]["spec"]
 
-    # external-es-proxy templates gated purely by the logging.enabled helper.
-    logging_gated_templates = [
-        "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
-        "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
-        "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
-    ]
-
     @pytest.mark.parametrize(
         "mode,shared_elasticsearch,should_render",
         [
@@ -1035,7 +1028,7 @@ class TestExternalElasticSearch:
         """Test that external-es-proxy renders according to the logging.enabled helper across plane mode and sharedElasticsearch."""
         docs = render_chart(
             kube_version=kube_version,
-            show_only=self.logging_gated_templates,
+            show_only=self.es_proxy_templates,
             values={
                 "global": {
                     "customLogging": {"enabled": True},
@@ -1046,7 +1039,7 @@ class TestExternalElasticSearch:
         )
 
         if should_render:
-            assert len(docs) == len(self.logging_gated_templates)
+            assert len(docs) == len(self.es_proxy_templates)
             assert all(doc.get("apiVersion") for doc in docs)
             assert all(doc.get("kind") for doc in docs)
         else:

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -15,18 +15,20 @@ secret = base64.b64encode(b"sample-secret").decode()
     supported_k8s_versions,
 )
 class TestExternalElasticSearch:
+     # external-es-proxy templates gated purely by the logging.enabled helper.
+    es_proxy_templates = [
+        "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
+        "charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml",
+        "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
+        "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
+    ]
     def test_externalelasticsearch_with_secret(self, kube_version):
         """Test External ElasticSearch with secret passed from
         config/values.yaml."""
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"customLogging": {"enabled": True, "secret": secret}}},
-            show_only=[
-                "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
-            ],
+            show_only=self.es_proxy_templates,
         )
 
         expected_nginx_mounts = [
@@ -84,12 +86,7 @@ class TestExternalElasticSearch:
         docs = render_chart(
             kube_version=kube_version,
             values={"global": {"customLogging": {"enabled": True, "secretName": "essecret"}}},
-            show_only=[
-                "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
-                "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
-            ],
+            show_only=self.es_proxy_templates,
         )
 
         assert len(docs) == 4
@@ -1009,3 +1006,47 @@ class TestExternalElasticSearch:
 
         assert len(docs) == 1
         assert "tls" not in docs[0]["spec"]
+
+    # external-es-proxy templates gated purely by the logging.enabled helper.
+    logging_gated_templates = [
+        "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
+        "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
+        "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
+    ]
+
+    @pytest.mark.parametrize(
+        "mode,shared_elasticsearch,should_render",
+        [
+            # unified: logging is always enabled regardless of sharedElasticsearch
+            ("unified", False, True),
+            ("unified", True, True),
+            # control: logging is enabled only when sharedElasticsearch is enabled
+            ("control", False, False),
+            ("control", True, True),
+            # data: logging is enabled only when sharedElasticsearch is disabled
+            ("data", False, True),
+            ("data", True, False),
+        ],
+    )
+    def test_external_es_proxy_logging_enabled_by_mode_and_shared_elasticsearch(
+        self, kube_version, mode, shared_elasticsearch, should_render
+    ):
+        """Test that external-es-proxy renders according to the logging.enabled helper across plane mode and sharedElasticsearch."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.logging_gated_templates,
+            values={
+                "global": {
+                    "customLogging": {"enabled": True},
+                    "plane": {"mode": mode},
+                    "sharedElasticsearch": {"enabled": shared_elasticsearch},
+                },
+            },
+        )
+
+        if should_render:
+            assert len(docs) == len(self.logging_gated_templates)
+            assert all(doc.get("apiVersion") for doc in docs)
+            assert all(doc.get("kind") for doc in docs)
+        else:
+            assert len(docs) == 0

--- a/tests/chart_tests/test_external_elasticsearch.py
+++ b/tests/chart_tests/test_external_elasticsearch.py
@@ -15,13 +15,14 @@ secret = base64.b64encode(b"sample-secret").decode()
     supported_k8s_versions,
 )
 class TestExternalElasticSearch:
-     # external-es-proxy templates gated purely by the logging.enabled helper.
+    # external-es-proxy templates gated purely by the logging.enabled helper.
     es_proxy_templates = [
         "charts/external-es-proxy/templates/external-es-proxy-deployment.yaml",
         "charts/external-es-proxy/templates/external-es-proxy-env-configmap.yaml",
         "charts/external-es-proxy/templates/external-es-proxy-configmap.yaml",
         "charts/external-es-proxy/templates/external-es-proxy-service.yaml",
     ]
+
     def test_externalelasticsearch_with_secret(self, kube_version):
         """Test External ElasticSearch with secret passed from
         config/values.yaml."""

--- a/tests/chart_tests/test_vector.py
+++ b/tests/chart_tests/test_vector.py
@@ -417,7 +417,9 @@ class TestVector:
             ("data", True, 0),
         ],
     )
-    def test_vector_logging_enabled_by_mode_and_shared_elasticsearch_feature(self, kube_version, mode, shared_elasticsearch, expected_count):
+    def test_vector_logging_enabled_by_mode_and_shared_elasticsearch_feature(
+        self, kube_version, mode, shared_elasticsearch, expected_count
+    ):
         """Test that Vector renders according to the logging.enabled helper across plane mode and sharedElasticsearch."""
         values = {
             "global": {

--- a/tests/chart_tests/test_vector.py
+++ b/tests/chart_tests/test_vector.py
@@ -402,3 +402,38 @@ class TestVector:
         if expected_count > 0:
             assert all(doc.get("apiVersion") for doc in docs)
             assert all(doc.get("kind") for doc in docs)
+
+    @pytest.mark.parametrize(
+        "mode,shared_elasticsearch,expected_count",
+        [
+            # unified: logging is always enabled regardless of sharedElasticsearch
+            ("unified", False, 6),
+            ("unified", True, 6),
+            # control: logging is enabled only when sharedElasticsearch is enabled
+            ("control", False, 0),
+            ("control", True, 6),
+            # data: logging is enabled only when sharedElasticsearch is disabled
+            ("data", False, 6),
+            ("data", True, 0),
+        ],
+    )
+    def test_vector_logging_enabled_by_mode_and_shared_elasticsearch_feature(self, kube_version, mode, shared_elasticsearch, expected_count):
+        """Test that Vector renders according to the logging.enabled helper across plane mode and sharedElasticsearch."""
+        values = {
+            "global": {
+                "plane": {"mode": mode},
+                "sharedElasticsearch": {"enabled": shared_elasticsearch},
+            }
+        }
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=all_templates,
+        )
+
+        assert len(docs) == expected_count
+
+        if expected_count > 0:
+            assert all(doc.get("apiVersion") for doc in docs)
+            assert all(doc.get("kind") for doc in docs)

--- a/values.yaml
+++ b/values.yaml
@@ -94,6 +94,11 @@ global:
     # The name of a manually created ClusterSecretStore
     # externalSecretManagerName: your-css-name
 
+  # sharedElasticsearch: Allows sharing logging components with control plane.
+  # Built specially for cp dp split mode
+  sharedElasticsearch:
+    enabled: false
+
   # Metrics and reporting features
   metricsReporting:
     taskUsageMetrics:


### PR DESCRIPTION
## Description

Introduces shared Elasticsearch support on the control plane to preserve Airflow task log and component log continuity during the unified → CP/DP split migration.

## Related Issues

https://linear.app/astronomer/issue/PINF-871/add-shared-elasticsearch-support-on-control-plane-for-cpdp-split  

## Testing

QA should able to utilize control plane elasticsearch for  cp dp split mode setup

## Merging

merge to master and release-2.0
