### PR TITLE
PINF-872: Exclude filesd-reloader sidecar from data plane Prometheus deployments

### DIFF
--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -150,6 +150,7 @@ spec:
               mountPath: /etc/prometheus/alerts.d
             - name: prometheus-config-volume
               mountPath: /etc/prometheus/config
+        {{- if $planeCPMode }}
         - name: filesd-reloader
           image: {{ include "filesdReloader.image" . }}
           imagePullPolicy: {{ .Values.images.filesdReloader.pullPolicy }}
@@ -189,6 +190,7 @@ spec:
           volumeMounts:
           - mountPath: /prometheusreloader/airflow
             name: filesd
+        {{- end }}
         - name: prometheus
           image: {{ include "prometheus.image" . }}
           env:

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -239,6 +239,32 @@ class TestPrometheusStatefulset:
         c_by_name = get_containers_by_name(docs[0])
         assert {"name": "CUSTOM_DATABASE_NAME", "values": "astrohouston"} in c_by_name["filesd-reloader"]["env"]
 
+    @pytest.mark.parametrize(
+        "plane_mode,expected_present,expected_container_count",
+        [
+            ("unified", True, 3),
+            ("control", True, 3),
+            ("data", False, 2),
+        ],
+    )
+    def test_prometheus_filesd_reloader_by_plane_mode(self, kube_version, plane_mode, expected_present, expected_container_count):
+        """Test filesd-reloader presence varies by plane mode.
+
+        filesd-reloader connects to astronomer_houston which only exists in the
+        control plane. It must be excluded from data plane deployments to avoid
+        a fatal DB connection error on startup.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": plane_mode}}},
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert ("filesd-reloader" in c_by_name) == expected_present
+        assert len(docs[0]["spec"]["template"]["spec"]["containers"]) == expected_container_count
+
     def test_prometheus_cluster_role_defaults(self, kube_version):
         """Test Prometheus with cluster role defaults."""
         values = {}


### PR DESCRIPTION
## Description

In data plane clusters, the astronomer-prometheus StatefulSet was always injecting the filesd-reloader (ap-kuiper-reloader) sidecar regardless of plane mode. On startup, the sidecar unconditionally attempts to connect to astronomer_houston — the Houston database — which does not exist in the data plane. This caused the container to crash-loop immediately with:
```
FATAL: database "astronomer_houston" does not exist
```
## Related Issues

https://linear.app/astronomer/issue/PINF-872/astronomer-prometheus-0-pod-is-in-crashloopbackoff-after-upgrading-to

## Testing

- Removed it from a DP cluster and confirmed that this did not affect the working of prometheus.
<img width="777" height="303" alt="Screenshot 2026-06-23 at 4 49 56 PM" src="https://github.com/user-attachments/assets/b18fa051-9b67-423f-949a-e35715b6bc11" />


- Added unittests.
## Merging

Master, 2.0, 1.1