### PR TITLE
Security: Potential Command Injection via shell=True in subprocess.check_output

### DIFF
--- a/bin/repo-state-report.py
+++ b/bin/repo-state-report.py
@@ -21,10 +21,10 @@ def get_repo_state() -> dict:
         if os.getenv(var):
             repo_state[var] = os.getenv(var)
 
-    helm_path = subprocess.check_output(["which helm"], shell=True).decode("utf-8").strip()
+    helm_path = subprocess.check_output(["which", "helm"]).decode("utf-8").strip()
     repo_state["helm_path"] = helm_path
 
-    helm_version = subprocess.check_output(["helm version --short"], shell=True).decode("utf-8").strip()
+    helm_version = subprocess.check_output(["helm", "version", "--short"]).decode("utf-8").strip()
     repo_state["helm_version"] = helm_version
 
     return repo_state


### PR DESCRIPTION
## Summary

Security: Potential Command Injection via shell=True in subprocess.check_output

## Problem

**Severity**: `Medium` | **File**: `bin/repo-state-report.py:L30`

The `repo-state-report.py` script uses `subprocess.check_output` with `shell=True` and unsanitized string input. While the commands themselves are hardcoded, the use of `shell=True` with string commands is a dangerous pattern that can lead to command injection if any part of the command becomes dynamic in the future. Additionally, `which helm` is passed as a single string to `subprocess.check_output` with `shell=True`, which is unnecessary and risky.

## Solution

Avoid `shell=True` and pass commands as lists instead. For example: `subprocess.check_output(['which', 'helm'])` and `subprocess.check_output(['helm', 'version', '--short'])`.

## Changes

- `bin/repo-state-report.py` (modified)