### PR TITLE
PINF-884 fix vector filtering regex

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -54,7 +54,7 @@ data:
             namespaces = [{{ range $i, $ns := .Values.global.namespaceManagement.namespacePools.namespaces.names }}{{ if $i }}, {{ end }}"{{ $ns }}"{{ end }}]
             includes(namespaces, .kubernetes.pod_namespace)
             {{- else if or .Values.global.namespaceManagement.manualNamespaceNames.enabled (not .Values.global.manageClusterScopedResources.enabled) }}
-            match(.kubernetes.pod_namespace, r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+            exists(.kubernetes.pod_namespace) && is_string(.kubernetes.pod_namespace) && .kubernetes.pod_namespace != ""
             {{- else }}
             .kubernetes.namespace_labels.platform == "{{ .Release.Name }}"
             {{- end }}

--- a/tests/chart_tests/test_vector.py
+++ b/tests/chart_tests/test_vector.py
@@ -157,7 +157,7 @@ class TestVector:
             show_only=["charts/vector/templates/vector-configmap.yaml"],
         )[0]
 
-        expected_rule = "exists(.kubernetes.pod_namespace) && is_string(.kubernetes.pod_namespace) && .kubernetes.pod_namespace != """
+        expected_rule = "exists(.kubernetes.pod_namespace) && is_string(.kubernetes.pod_namespace) && .kubernetes.pod_namespace != "
         assert expected_rule in doc["data"]["vector-config.yaml"]
 
     def test_vector_configmap_manual_namespaces_and_namespacepools_disabled(self, kube_version):

--- a/tests/chart_tests/test_vector.py
+++ b/tests/chart_tests/test_vector.py
@@ -157,7 +157,7 @@ class TestVector:
             show_only=["charts/vector/templates/vector-configmap.yaml"],
         )[0]
 
-        expected_rule = "match(.kubernetes.pod_namespace, r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')"
+        expected_rule = "exists(.kubernetes.pod_namespace) && is_string(.kubernetes.pod_namespace) && .kubernetes.pod_namespace != """
         assert expected_rule in doc["data"]["vector-config.yaml"]
 
     def test_vector_configmap_manual_namespaces_and_namespacepools_disabled(self, kube_version):


### PR DESCRIPTION
## Description

Fluentd regex ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$ was ported to Vector as a match() call on .kubernetes.pod_namespace, but this is unnecessary and unsafe. match() returns null on missing or non-string fields, risking unexpected event drops. Since Kubernetes already guarantees namespace name validity, and component-level filtering handles actual log selection, the namespace check only needs to confirm the field exists and is non-empty.

## Related Issues

https://linear.app/astronomer/issue/PINF-884/replace-kubernetes-namespace-regex-filter-with-existence-check-in

## Testing

QA should not see any error on vector daemon when manualNamespaceNames feature is enabled

## Merging

merge to master and release-2.0, release-1.0
