### PR TITLE
PINF-882 Surface controlPlaneHA.enabled to Houston (astronomer chart)

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -69,7 +69,7 @@ data:
       baseDomain: {{ .Values.global.baseDomain }}
       {{- if .Values.global.controlPlaneHA.enabled }}
       controlPlaneHA:
-        enabled: true
+        enabled: {{ .Values.global.controlPlaneHA.enabled }}
       globalBaseDomain: {{ .Values.global.controlPlaneHA.globalBaseDomain }}
       {{- with .Values.global.controlPlaneHA.cookieDomain }}
       cookieDomain: {{ . }}

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -68,6 +68,8 @@ data:
     helm:
       baseDomain: {{ .Values.global.baseDomain }}
       {{- if .Values.global.controlPlaneHA.enabled }}
+      controlPlaneHA:
+        enabled: true
       globalBaseDomain: {{ .Values.global.controlPlaneHA.globalBaseDomain }}
       {{- with .Values.global.controlPlaneHA.cookieDomain }}
       cookieDomain: {{ . }}

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -185,15 +185,17 @@ class TestHoustonConfigHelmValues:
                 values={"global": {"plane": {"mode": "control"}, "baseDomain": "example.com"}},
             )
         )
+        assert "controlPlaneHA" not in helm
         assert "globalBaseDomain" not in helm
         assert "cookieDomain" not in helm
         assert "cookieName" not in helm
 
     def test_global_base_domain_emitted_in_ha(self, kube_version):
-        """HA-on configmap emits globalBaseDomain; cookie keys omitted unless overridden."""
+        """HA-on configmap emits the HA-enabled signal + globalBaseDomain; cookie keys omitted unless overridden."""
         values = _ha_values()
         values["global"]["baseDomain"] = "example.com"
         helm = self.production_yaml_prod_helm(render_chart(kube_version=kube_version, show_only=[CONFIGMAP_FILE], values=values))
+        assert helm["controlPlaneHA"]["enabled"] is True
         assert helm["globalBaseDomain"] == "astro.example.com"
         assert "cookieDomain" not in helm
         assert "cookieName" not in helm


### PR DESCRIPTION
## Description

Surfaces the Control Plane HA **enabled** signal to Houston via the chart, closing the last wiring gap in the HA config chain.

`global.controlPlaneHA.enabled` now renders `controlPlaneHA.enabled: true` into the `helm:` block of the Houston configmap (`production.yaml`). This populates the `helm.controlPlaneHA.enabled` config key that houston-api's `isControlPlaneHaEnabled()` accessor reads.

The configmap mechanism was chosen over a pod env var (`HELM__CONTROL_PLANE_HA_ENABLED`) for consistency with how `globalBaseDomain`/cookie values are already surfaced. it also covers both the Houston API and worker pods automatically (they mount the same config).

HA-off renders are unchanged. The key is simply absent and Houston falls back to the `false` default in `config/default.yaml`, so single-CP installs are unaffected.

## Related Issues

Related astronomer/issues#PINF-882
- PINF-768 (predecessor chart work, astronomer#3302)
- PINF-881 (houston-api consumer / accessor)

## Testing

- `uv run pytest tests/chart_tests/test_control_plane_ha.py` — 95 passed. Extended `TestHoustonConfigHelmValues`:
  - HA-off asserts `controlPlaneHA` absent from the rendered `helm:` block.
  - HA-on asserts `helm.controlPlaneHA.enabled is True`.
- Manual `helm template` of the Houston configmap:
  - HA on → `helm:` block contains `controlPlaneHA.enabled: true` and `globalBaseDomain`.
  - HA off → block contains only `baseDomain` (no `controlPlaneHA`, no `globalBaseDomain`).

## Merging

Merge to feature/cp-ha-dr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
