### PR TITLE
PINF-888 - add ingress config support cp -- dp split

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -753,15 +753,17 @@ http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/e
 {{- end -}}
 
 {{- define "commander.dataplaneURL" -}}
-{{- if (eq .Values.global.plane.mode "data") -}}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 {{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+{{- else if eq .Values.global.plane.mode "data" -}}
+http://{{ .Release.Name }}-commander.{{ .Release.Namespace}}.svc.cluster.local.:{{ .Values.ports.commanderHTTP }}
 {{- else -}}
 {{ .Release.Name }}-commander.{{ .Release.Namespace}}.svc.cluster.local.:{{ .Values.ports.commanderHTTP }}
 {{- end }}
 {{- end -}}
 
 {{- define "commander.baseDomain" -}}
-{{- if (eq .Values.global.plane.mode "data") -}}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 {{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else -}}
 {{ .Values.global.baseDomain }}
@@ -774,7 +776,11 @@ http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/e
 
 {{- define "elasticsearch.url" -}}
 {{- if eq .Values.global.plane.mode "data" -}}
+{{- if .Values.global.plane.domainPrefix -}}
 elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+{{- else -}}
+elasticsearch.{{ .Values.global.baseDomain }}
+{{- end -}}
 {{- else if eq .Values.global.plane.mode "unified" -}}
 {{ .Release.Name }}-elasticsearch.{{ .Release.Namespace }}.svc.cluster.local.:9200
 {{- end -}}
@@ -802,7 +808,7 @@ http://{{ .Release.Name }}-houston.{{ .Release.Namespace}}.svc.cluster.local:{{ 
 {{- end -}}
 
 {{- define "registry.ingressURL" -}}
-{{- if (eq .Values.global.plane.mode "data") -}}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 registry.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else -}}
 registry.{{ .Values.global.baseDomain }}

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -34,10 +34,10 @@ spec:
   tls:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
-        - commander.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+        - commander.{{ include "commander.baseDomain" . }}
   {{- end }}
   rules:
-  - host: commander.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+  - host: commander.{{ include "commander.baseDomain" . }}
     http:
       paths:
         - path: /

--- a/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata-ingress.yaml
@@ -1,7 +1,7 @@
 ################################
 ## Commander Metadata Ingress ##
 ################################
-{{- if eq .Values.global.plane.mode "data" }}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:
@@ -33,10 +33,10 @@ spec:
   tls:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
-        - {{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+        - {{ include "commander.baseDomain" . }}
   {{- end }}
   rules:
-  - host: {{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+  - host: {{ include "commander.baseDomain" . }}
     http:
       paths:
         - path: /metadata

--- a/charts/astronomer/templates/registry/registry-ingress.yaml
+++ b/charts/astronomer/templates/registry/registry-ingress.yaml
@@ -29,10 +29,10 @@ spec:
   tls:
     - secretName: {{ .Values.global.tlsSecret }}
       hosts:
-        - {{ if eq .Values.global.plane.mode "data" }}registry.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}{{ else }}registry.{{ .Values.global.baseDomain }}{{ end }}
+        - {{ include "registry.ingressURL" . }}
   {{- end }}
   rules:
-  - host: {{ if eq .Values.global.plane.mode "data" }}registry.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}{{ else }}registry.{{ .Values.global.baseDomain }}{{ end }}
+  - host: {{ include "registry.ingressURL" . }}
     http:
       paths:
         - path: /

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -166,7 +166,7 @@ spec:
           emptyDir: {}
         - name: config
           configMap:
-            name: {{ .Release.Name }}-registry
+            name: {{ template "registry.fullname" . }}
             items:
               - key: config.yml
                 path: config.yml

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -188,7 +188,7 @@ Return exporter podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fi
 {{- end }}
 
 {{- define "elasticsearch.ingressurl" -}}
-{{ if eq .Values.global.plane.mode "data" -}}
+{{ if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else -}}
 elasticsearch.{{ .Values.global.baseDomain }}

--- a/charts/external-es-proxy/templates/_helpers.tpl
+++ b/charts/external-es-proxy/templates/_helpers.tpl
@@ -126,5 +126,9 @@ proxy_pass {{.Values.global.customLogging.scheme}}://{{.Values.global.customLogg
 {{- end }}
 
 {{- define "es-proxy.url" -}}
+{{- if .Values.global.plane.domainPrefix -}}
 elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
+{{- else -}}
+elasticsearch.{{ .Values.global.baseDomain }}
+{{- end -}}
 {{- end -}}

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -68,7 +68,7 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{- define "prometheus.url" -}}
-{{- if eq .Values.global.plane.mode "data" -}}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 prometheus.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else -}}
 prometheus.{{ .Values.global.baseDomain }}
@@ -76,7 +76,7 @@ prometheus.{{ .Values.global.baseDomain }}
 {{- end -}}
 
 {{- define "prom-proxy.url" -}}
-{{- if eq .Values.global.plane.mode "data" -}}
+{{- if and (eq .Values.global.plane.mode "data") .Values.global.plane.domainPrefix -}}
 prom-proxy.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}
 {{- else -}}
 prom-proxy.{{ .Values.global.baseDomain }}

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -1,7 +1,7 @@
 ########################
 ## Prometheus Ingress ##
 ########################
-{{- if .Values.global.baseDomain }}
+{{- if and .Values.global.baseDomain (or (ne .Values.global.plane.mode "data") .Values.global.plane.domainPrefix) }}
 kind: Ingress
 apiVersion: {{ template "apiVersion.Ingress" . }}
 metadata:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -32,6 +32,9 @@ The control plane is responsible for platform management, orchestration, and use
 You can access the data plane at:
 - Astronomer dashboard:   {{ if and $astronomerEnabled $platformEnabled }}https://{{ $domainPrefix }}.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
 - Grafana dashboard:      {{ if and $grafanaEnabled $monitoringEnabled }}https://grafana.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
+{{ else }}
+- Commander API:   {{ if and $astronomerEnabled $platformEnabled }}commander.{{ .Values.global.baseDomain }}:443{{ else }}Disabled{{ end }}
+- Commander Metadata: {{ if and $astronomerEnabled $platformEnabled }}http://{{ .Release.Name}}-commander.{{ .Release.Namespace }}.svc.cluster.local.:8880{{ else }}Disabled{{ end }}
 {{- end }}
 
 The data plane is responsible for executing and monitoring Airflow workloads.

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -33,7 +33,7 @@ You can access the data plane at:
 - Astronomer dashboard:   {{ if and $astronomerEnabled $platformEnabled }}https://{{ $domainPrefix }}.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
 - Grafana dashboard:      {{ if and $grafanaEnabled $monitoringEnabled }}https://grafana.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
 {{ else }}
-- Commander API:   {{ if and $astronomerEnabled $platformEnabled }}commander.{{ .Values.global.baseDomain }}:443{{ else }}Disabled{{ end }}
+- Commander API:      {{ if and $astronomerEnabled $platformEnabled }}commander.{{ .Values.global.baseDomain }}:443{{ else }}Disabled{{ end }}
 - Commander Metadata: {{ if and $astronomerEnabled $platformEnabled }}http://{{ .Release.Name}}-commander.{{ .Release.Namespace }}.svc.cluster.local.:8880{{ else }}Disabled{{ end }}
 {{- end }}
 

--- a/tests/chart_tests/test_astronomer_commander_ingress.py
+++ b/tests/chart_tests/test_astronomer_commander_ingress.py
@@ -69,7 +69,7 @@ class TestAstronomerCommanderIngress:
         """Test that helm renders a good metadata ingress template for astronomer/commander in data plane mode."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "data"}}},
+            values={"global": {"plane": {"mode": "data", "domainPrefix": "dp01"}}},
             show_only=["charts/astronomer/templates/commander/commander-metadata-ingress.yaml"],
         )
         assert len(docs) == 1
@@ -78,6 +78,7 @@ class TestAstronomerCommanderIngress:
         assert doc["metadata"]["name"] == "release-name-commander-metadata-ingress"
         assert doc["metadata"]["labels"]["component"] == "metadata-ingress"
         assert doc["metadata"]["labels"]["plane"] == "dataplane"
+        assert doc["spec"]["rules"][0]["host"] == "dp01.example.com"
 
         annotations = doc["metadata"]["annotations"]
         assert annotations["kubernetes.io/ingress.class"] == "release-name-nginx"
@@ -109,7 +110,7 @@ class TestAstronomerCommanderIngress:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "global": {"plane": {"mode": "data"}},
+                "global": {"plane": {"mode": "data", "domainPrefix": "dp01"}},
                 "astronomer": {"commander": {"ingress": {"annotation": custom_annotations}}},
             },
             show_only=["charts/astronomer/templates/commander/commander-metadata-ingress.yaml"],
@@ -164,7 +165,7 @@ class TestAstronomerCommanderIngress:
             kube_version=kube_version,
             values={
                 "global": {
-                    "plane": {"mode": "data"},
+                    "plane": {"mode": "data", "domainPrefix": "dp01"},
                     "baseDomain": "example.com",
                     "tlsSecret": "my-tls-secret",
                 },
@@ -185,7 +186,7 @@ class TestAstronomerCommanderIngress:
             kube_version=kube_version,
             values={
                 "global": {
-                    "plane": {"mode": "data"},
+                    "plane": {"mode": "data", "domainPrefix": "dp01"},
                     "baseDomain": "example.com",
                     "tlsSecret": "",
                 },
@@ -195,3 +196,27 @@ class TestAstronomerCommanderIngress:
 
         assert len(docs) == 1
         assert "tls" not in docs[0]["spec"]
+
+    @pytest.mark.parametrize(
+        ("domain_prefix", "expected_host"),
+        [("dp01", "commander.dp01.example.com"), ("", "commander.example.com")],
+    )
+    def test_commander_grpc_ingress_host_domain_prefix(self, kube_version, domain_prefix, expected_host):
+        """commander gRPC ingress host falls back to the base domain when no domainPrefix is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data", "domainPrefix": domain_prefix}}},
+            show_only=["charts/astronomer/templates/commander/commander-grpc-ingress.yaml"],
+        )
+        assert len(docs) == 1
+        assert docs[0]["spec"]["rules"][0]["host"] == expected_host
+
+    @pytest.mark.parametrize(("domain_prefix", "expected_count"), [("dp01", 1), ("", 0)])
+    def test_commander_metadata_ingress_requires_domain_prefix(self, kube_version, domain_prefix, expected_count):
+        """commander metadata ingress only renders in data mode when a domainPrefix is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data", "domainPrefix": domain_prefix}}},
+            show_only=["charts/astronomer/templates/commander/commander-metadata-ingress.yaml"],
+        )
+        assert len(docs) == expected_count

--- a/tests/chart_tests/test_astronomer_houston_internal_authorization.py
+++ b/tests/chart_tests/test_astronomer_houston_internal_authorization.py
@@ -53,7 +53,7 @@ class TestHoustonInternalAuthorization:
         """Test Alertmanager Service with authSidecar."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "data"}}},
+            values={"global": {"plane": {"mode": "data", "domainPrefix": "dp01"}}},
             show_only=[
                 "charts/alertmanager/templates/ingress.yaml",
                 "charts/grafana/templates/grafana-ingress.yaml",

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -97,7 +97,7 @@ class TestIngress:
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/prometheus/templates/ingress.yaml", "charts/prometheus/templates/prometheus-federate-ingress.yaml"],
-            values={"global": {"baseDomain": "example.com", "plane": {"mode": "data"}}},
+            values={"global": {"baseDomain": "example.com", "plane": {"mode": "data", "domainPrefix": "dp01"}}},
         )
 
         assert len(docs) == 2

--- a/tests/chart_tests/test_prometheus_ingress.py
+++ b/tests/chart_tests/test_prometheus_ingress.py
@@ -44,3 +44,21 @@ class TestIngress:
             assert "prometheus-data" in [
                 port[0] for port in jmespath.search("spec.rules[*].http.paths[*].backend.servicePort", doc)
             ]
+
+    @pytest.mark.parametrize(
+        ("mode", "domain_prefix", "expected_count"),
+        [
+            ("control", "", 1),
+            ("unified", "", 1),
+            ("data", "dp01", 1),
+            ("data", "", 0),  # data plane without a domainPrefix: no prometheus ingress
+        ],
+    )
+    def test_prometheus_ingress_data_plane_domain_prefix_gate(self, kube_version, mode, domain_prefix, expected_count):
+        """Prometheus ingress is skipped in data mode unless a domainPrefix is set."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/prometheus/templates/ingress.yaml"],
+            values={"global": {"plane": {"mode": mode, "domainPrefix": domain_prefix}}},
+        )
+        assert len(docs) == expected_count


### PR DESCRIPTION
## Description

This PR extends ingress configuration to support CP–DP split deployments within the same cluster.
The core challenge was around how domain resolution behaves when global.plane.mode is set to data but no domainPrefix is defined. In this case, we now treat the installation as a same-cluster CP–DP split, where the data plane components communicate internally rather than over external ingress endpoints.
To support this, we restructured the domain helper templates across several charts so that domainPrefix is required for external ingress to be active in data plane mode. When it is absent, certain ingress resources are intentionally disabled — since in a same-cluster split, those services are reachable via in-cluster DNS and don't need to be exposed externally.
Affected ingress resources: Commander (gRPC + metadata), Registry, Elasticsearch, Prometheus, and the external ES proxy.

## Related Issues

https://linear.app/astronomer/issue/PINF-888/add-ingress-config-support-for-cp-dp-split-same-cluster-mode

## Testing

Existing tests were updated to reflect the new domainPrefix-gated rendering behavior, and new parametrized tests were added to cover both the same-cluster (no domainPrefix) and split-with-external-ingress (domainPrefix set) cases.

## Merging

merge to master and release-2.1
