### PR TITLE
bump reloader version 0.2.2

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -26,7 +26,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.2.1
+    tag: 0.2.2
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

bump reloader version 0.2.2

## Related Issues

https://linear.app/astronomer/issue/PINF-734/fresh-apc-install-hangs-when-filesd-reloader-crashes
https://linear.app/astronomer/issue/PINF-886/fresh-apc-201-beta5-install-logs-json-parsing-error-in-astronomer

## Testing

refer linked tickets

## Merging

merge to master