### PR TITLE
PINF-692 Drop session affinity from prometheus by default

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.1.0
+    tag: 2.1.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/charts/prometheus/templates/prometheus-service.yaml
+++ b/charts/prometheus/templates/prometheus-service.yaml
@@ -52,7 +52,9 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 spec:
-  sessionAffinity: ClientIP
+{{- with .Values.sessionAffinity }}
+  sessionAffinity: {{ . }}
+{{- end }}
   type: ClusterIP
   selector:
     tier: monitoring

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -15,6 +15,22 @@ podLabels: {}
 # such that only one is replaced at a time.
 replicas: 1
 
+# Session affinity for the aggregate Prometheus Service. Left unset by default
+# so the rendered Service carries no spec.sessionAffinity / sessionAffinityConfig
+# fields, which some clusters forbid (e.g. Gatekeeper's deny-ingress-sticky-sessions).
+# Set to "ClientIP" to pin clients to a single Prometheus pod, which is only
+# meaningful when replicas > 1 (active/passive query consistency).
+#
+# UPGRADE NOTE: Versions prior to 2.1.0 hardcoded sessionAffinity: ClientIP on
+# this Service. As of 2.1.0 it is unset by default to satisfy clusters that
+# forbid sticky sessions. This is a no-op at the default replicas: 1, but HA
+# deployments running replicas > 1 should set sessionAffinity: "ClientIP" here.
+# Otherwise the aggregate Service round-robins across pods, and since Prometheus
+# replicas are active/passive (each scrapes independently and may hold different
+# data/gaps), the default consumers that query this Service -- Grafana datasource
+# and Houston -- can see inconsistent results across requests.
+sessionAffinity: ""
+
 images:
   prometheus:
     repository: quay.io/astronomer/ap-prometheus

--- a/tests/chart_tests/test_prometheus_service.py
+++ b/tests/chart_tests/test_prometheus_service.py
@@ -1,0 +1,50 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+
+@pytest.mark.parametrize(
+    "kube_version",
+    supported_k8s_versions,
+)
+class TestPrometheusService:
+    show_only = ["charts/prometheus/templates/prometheus-service.yaml"]
+
+    def aggregate_service(self, kube_version, values=None):
+        """Render and return the aggregate (load-balancing) prometheus Service."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=self.show_only,
+        )
+        aggregate = [d for d in docs if d["metadata"]["name"] == "release-name-prometheus"]
+        assert len(aggregate) == 1
+        doc = aggregate[0]
+        assert doc["kind"] == "Service"
+        return doc
+
+    def test_no_session_affinity_by_default(self, kube_version):
+        """sessionAffinity must be absent by default so the rendered Service carries no
+        spec.sessionAffinity / sessionAffinityConfig (forbidden by e.g. Gatekeeper's
+        deny-ingress-sticky-sessions). See PINF-692."""
+        # default install is replicas=1, so the aggregate Service is the only doc
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=self.show_only,
+        )
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc["kind"] == "Service"
+        assert doc["metadata"]["name"] == "release-name-prometheus"
+        assert doc["spec"]["type"] == "ClusterIP"
+        assert "sessionAffinity" not in doc["spec"]
+        assert "sessionAffinityConfig" not in doc["spec"]
+
+    def test_session_affinity_opt_in(self, kube_version):
+        """Setting prometheus.sessionAffinity restores the field for multi-replica HA."""
+        doc = self.aggregate_service(
+            kube_version,
+            values={"prometheus": {"sessionAffinity": "ClientIP"}},
+        )
+        assert doc["spec"]["sessionAffinity"] == "ClientIP"


### PR DESCRIPTION
## Description

Drop sticky sessions from prometheus by default

## Related Issues

- <https://linear.app/astronomer/issue/PINF-692/remove-sticky-session-settings-from-prometheus-service>

## Testing

Unit tests have been added. This has not been tested in a cluster yet.

## Merging

This is only for 2.1