### PR TITLE
PLX-575: Adds logic in migration scripts to remove hard delete deployment flag

### DIFF
--- a/bin/helm_chart_values_migration_shared.py
+++ b/bin/helm_chart_values_migration_shared.py
@@ -514,11 +514,9 @@ HOUSTON_DEPLOYMENT_PATH_MIGRATIONS: list[tuple[str, str | None, str]] = [
         "deploymentLifecycle.deployRollback",
         "object-or-boolean-to-nested",
     ),
-    (
-        "hardDeleteDeployment",
-        "deploymentLifecycle.hardDeleteDeployment.enabled",
-        "boolean-to-enabled",
-    ),
+    # Deprecated (PLX-575): hard delete is now the default and only behaviour,
+    # so the legacy flat flag is removed rather than migrated.
+    ("hardDeleteDeployment", None, "deprecated-unset"),
     (
         "cleanupAirflowDb",
         "deploymentLifecycle.cleanupAirflowDb",
@@ -571,12 +569,15 @@ HOUSTON_DEPLOYMENT_PATH_MIGRATIONS: list[tuple[str, str | None, str]] = [
 # Nested renames under ``deployments`` (old path → new path). Kept in sync with
 # ``DEPLOYMENTS_NESTED_PATH_MIGRATIONS`` in houston-api
 # ``src/lib/deployments-config-path-migration/index.js``.
-HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS: list[tuple[str, str, str]] = [
+HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS: list[tuple[str, str | None, str]] = [
     (
         "deploymentLifecycle.deployRollback.enableDagTarballVersionValidation",
         "deploymentLifecycle.deployRollback.dagTarballVersionValidation.enabled",
         "boolean-to-enabled",
     ),
+    # Deprecated (PLX-575): hard delete is now the default and only behaviour,
+    # so the nested flag is removed from stored configs.
+    ("deploymentLifecycle.hardDeleteDeployment", None, "deprecated-unset"),
 ]
 
 HOUSTON_DEPLOYMENT_CHART_ONLY_DELETE_KEYS: Final[frozenset[str]] = frozenset(
@@ -770,6 +771,13 @@ def _apply_houston_deployments_path_migrations(
     for old_dotted, new_dotted, transform in HOUSTON_DEPLOYMENT_NESTED_PATH_MIGRATIONS:
         old_keys = old_dotted.split(".")
         if not _path_exists(deployments, old_keys):
+            continue
+        if transform == "deprecated-unset":
+            _unset_dotted_path(deployments, old_dotted)
+            p = f"{HOUSTON_DEPLOYMENTS_PREFIX}.{old_dotted}"
+            changes.append(MigrationChange(p, "(deleted)", f"Deprecated key removed: {p}"))
+            continue
+        if not new_dotted:
             continue
         new_keys = new_dotted.split(".")
         if _path_exists(deployments, new_keys):

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -93,8 +93,6 @@ data:
         {{- range $i, $namespaceName := .Values.global.namespaceManagement.namespacePools.namespaces.names }}
           - name: {{ $namespaceName }}
         {{- end }}
-        hardDeleteDeployment:
-          enabled: true
         manualNamespaceNames:
           enabled: true
         {{- end }}

--- a/tests/chart_tests/test_astronomer_namespace_pools.py
+++ b/tests/chart_tests/test_astronomer_namespace_pools.py
@@ -228,7 +228,9 @@ class TestAstronomerNamespacePools:
 
         deployments_config = yaml.safe_load(doc["data"]["production.yaml"])
 
-        assert deployments_config["deployments"]["namespaceManagement"]["hardDeleteDeployment"]["enabled"]
+        # hardDeleteDeployment was removed from the chart (PLX-575): hard delete
+        # is now the default and only behaviour in Houston.
+        assert "hardDeleteDeployment" not in deployments_config["deployments"]["namespaceManagement"]
         assert deployments_config["deployments"]["namespaceManagement"]["manualNamespaceNames"]["enabled"]
         assert deployments_config["deployments"]["namespaceManagement"]["preCreatedNamespaces"] == [
             {"name": namespace} for namespace in namespaces

--- a/tests/migration/test_migrate_helm_chart_values_037x.py
+++ b/tests/migration/test_migrate_helm_chart_values_037x.py
@@ -173,7 +173,8 @@ class TestPartialOverrideMigration:
         assert deployments["runtimeManagement"]["listAllRuntimeVersions"]["enabled"] is True
         assert deployments["deploymentImagesRegistry"]["updateDeploymentImageEndpoint"]["enabled"] is True
         assert deployments["metricsReporting"]["grafana"]["enabled"] is True
-        assert deployments["deploymentLifecycle"]["hardDeleteDeployment"]["enabled"] is True
+        # Deprecated (PLX-575): hardDeleteDeployment is removed, not migrated.
+        assert "hardDeleteDeployment" not in deployments.get("deploymentLifecycle", {})
         assert deployments["logHelmValues"]["enabled"] is True
         assert deployments["namespaceManagement"]["manualReleaseNames"]["enabled"] is False
         # Move migrations


### PR DESCRIPTION
## Description

Adds logic in migration scripts to remove hard delete deployment flag. 

## Related Issues

Resolves [PLX-575](https://linear.app/astronomer/issue/PLX-575/remove-soft-delete-and-default-to-hard-delete-in-apc)

## Testing

- Unit tests

## Merging

2.1, master