### PR TITLE
Use Shorten name for airflow operator

### DIFF
--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -117,11 +117,11 @@ service:
 
 {{/*
 Name of the controller-manager ServiceAccount. Defaults to
-"airflow-operator-controller-manager" name; override via serviceAccount.name.
+"aocm" name; override via serviceAccount.name.
 */}}
 {{- define "operator.serviceAccountName" -}}
 {{- if and .Values.serviceAccount.create .Values.global.rbac.enabled -}}
-    {{- default (printf "%s-airflow-operator-controller-manager" .Release.Name) .Values.serviceAccount.name }}
+    {{- default (printf "%s-aocm" .Release.Name) .Values.serviceAccount.name }}
 {{- else -}}
     {{- default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/airflow-operator/templates/manager/controller-manager-deployment.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     chart: {{ template "operator.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  name: {{ .Release.Name }}-airflow-operator-controller-manager
+  name: {{ .Release.Name }}-aocm
   namespace: '{{ .Release.Namespace }}'
 spec:
   replicas: {{ .Values.manager.replicas }}

--- a/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
+++ b/charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml
@@ -14,7 +14,7 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/port: "{{ .Values.ports.managerContainerPort }}"
 
-  name: {{ .Release.Name }}-airflow-operator-controller-manager-metrics-service
+  name: {{ .Release.Name }}-aocm-metrics-service
   namespace: '{{ .Release.Namespace }}'
 
 spec:

--- a/charts/airflow-operator/templates/manager/manager-config-configmap.yaml
+++ b/charts/airflow-operator/templates/manager/manager-config-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-airflow-operator-manager-config
+  name: {{ .Release.Name }}-aom-config
   namespace: {{ .Release.Namespace }}
   labels:
     tier: operator

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -60,7 +60,7 @@ webhooks:
 serviceAccount:
   create: true
   # Override the name of the controller-manager ServiceAccount.
-  # Leave empty to use the default "airflow-operator-controller-manager".
+  # Leave empty to use the default "aocm".
   name: ""
   # Whether the ServiceAccount's API token is automatically mounted into the pod.
   automountServiceAccountToken: true

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.1.0
+    tag: 2.1.1
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -222,13 +222,13 @@ class TestAirflowOperator:
         assert len(docs) == 4
         assert docs[0]["apiVersion"] == "apps/v1"
         assert docs[0]["kind"] == "Deployment"
-        assert docs[0]["metadata"]["name"] == "release-name-airflow-operator-controller-manager"
+        assert docs[0]["metadata"]["name"] == "release-name-aocm"
         assert all(doc["metadata"]["labels"]["component"] == "controller-manager" for doc in docs[:3])
         assert all(doc["apiVersion"] == "v1" for doc in docs[1:4])
         assert docs[1]["kind"] == "Service"
-        assert docs[1]["metadata"]["name"] == "release-name-airflow-operator-controller-manager-metrics-service"
+        assert docs[1]["metadata"]["name"] == "release-name-aocm-metrics-service"
         assert docs[2]["kind"] == "ConfigMap"
-        assert docs[2]["metadata"]["name"] == "release-name-airflow-operator-manager-config"
+        assert docs[2]["metadata"]["name"] == "release-name-aom-config"
         assert docs[3]["kind"] == "Service"
         assert docs[3]["metadata"]["name"] == "release-name-airflow-operator-webhook-service"
 
@@ -279,7 +279,7 @@ class TestAirflowOperator:
         assert "/manager" in c_by_name["manager"]["command"]
         doc = docs[1]
         assert doc["kind"] == "Service"
-        assert doc["metadata"]["name"] == "release-name-airflow-operator-controller-manager-metrics-service"
+        assert doc["metadata"]["name"] == "release-name-aocm-metrics-service"
         assert doc["spec"]["selector"]["component"] == "controller-manager"
         assert doc["spec"]["type"] == "ClusterIP"
         assert doc["spec"]["ports"] == [
@@ -336,3 +336,52 @@ class TestAirflowOperator:
         image = c_by_name["manager"]["image"]
         # When privateRegistry is enabled the image is built from the private repo + the dev image name.
         assert image.startswith("my.private.registry/astronomer/airflow-operator-dev:")
+
+    def test_operator_resource_names_within_dns_limits(self, kube_version):
+        """Operator resource names must stay within k8s name limits with a long release name.
+
+        The manager Deployment/Service/ConfigMap/ServiceAccount names were deliberately
+        shortened (e.g. -aocm, -aom-config) so they don't consume a customer's release-name
+        headroom against the 63-char DNS-label limit that k8s/helm enforce. This guards
+        against an upstream chart sync silently re-lengthening them (see review on commit
+        44e45982). The webhook Service keeps the longest release-prefixed suffix
+        (-airflow-operator-webhook-service, 33 chars), so a 30-char release name must still
+        leave its name <= 63 (33 + 30 = 63).
+        """
+        long_release_name = "a" * 30
+        show_only = [
+            "charts/airflow-operator/templates/manager/controller-manager-deployment.yaml",
+            "charts/airflow-operator/templates/manager/controller-manager-metrics-service.yaml",
+            "charts/airflow-operator/templates/manager/manager-config-configmap.yaml",
+            "charts/airflow-operator/templates/manager/webhook-service.yaml",
+            "charts/airflow-operator/templates/rbac/controller-manager-serviceaccount.yaml",
+            "charts/airflow-operator/templates/rbac/leader-election-role.yaml",
+            "charts/airflow-operator/templates/rbac/leader-election-rolebinding.yaml",
+            "charts/airflow-operator/templates/certmanager/selfsigned-issuer.yaml",
+            "charts/airflow-operator/templates/certmanager/serving-cert-certificate.yaml",
+            "charts/airflow-operator/templates/webhooks/mutating-webhook-configuration.yaml",
+            "charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml",
+        ]
+        docs = render_chart(
+            name=long_release_name,
+            validate_objects=False,
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "airflowOperator": {"enabled": True},
+                },
+                "airflow-operator": {
+                    "manager": {"metrics": {"enabled": True}},
+                    "webhooks": {"enabled": True},
+                    "certManager": {"enabled": True},
+                },
+            },
+            show_only=show_only,
+        )
+        assert docs, "expected operator resources to render"
+        for doc in docs:
+            name = doc["metadata"]["name"]
+            # Service names become DNS labels (63-char cap); other resource names are
+            # DNS subdomains (253-char cap).
+            limit = 63 if doc["kind"] == "Service" else 253
+            assert len(name) <= limit, f"{doc['kind']}/{name} is {len(name)} chars, exceeds {limit}"

--- a/tests/chart_tests/test_probes.py
+++ b/tests/chart_tests/test_probes.py
@@ -55,16 +55,16 @@ class TestDefaultProbes:
 
     # Expected container liveness probes. This block should contain all of the expected default liveness probes.
     expected_clp = {
-        "airflow-operator-controller-manager_manager": {
-            "httpGet": {
-                "path": "/healthz",
-                "port": 8081,
-            }
-        },
         "alertmanager_auth-proxy": {
             "httpGet": {"path": "/healthz", "port": 8084, "scheme": "HTTP"},
             "initialDelaySeconds": 10,
             "periodSeconds": 10,
+        },
+        "aocm_manager": {
+            "httpGet": {
+                "path": "/healthz",
+                "port": 8081,
+            }
         },
         "astro-ui_astro-ui": {"httpGet": {"path": "/", "port": 8080}, "initialDelaySeconds": 10, "periodSeconds": 10},
         "commander_commander": {
@@ -160,12 +160,6 @@ class TestDefaultProbes:
 
     # Expected container readiness probes. This block should contain all of the expected default readiness probes.
     expected_crp = {
-        "airflow-operator-controller-manager_manager": {
-            "httpGet": {
-                "path": "/readyz",
-                "port": 8081,
-            }
-        },
         "alertmanager_alertmanager": {
             "httpGet": {"path": "/#/status", "port": 9093},
             "initialDelaySeconds": 30,
@@ -175,6 +169,12 @@ class TestDefaultProbes:
             "httpGet": {"path": "/healthz", "port": 8084, "scheme": "HTTP"},
             "initialDelaySeconds": 10,
             "periodSeconds": 10,
+        },
+        "aocm_manager": {
+            "httpGet": {
+                "path": "/readyz",
+                "port": 8081,
+            }
         },
         "astro-ui_astro-ui": {"httpGet": {"path": "/", "port": 8080}, "initialDelaySeconds": 10, "periodSeconds": 10},
         "commander_commander": {"httpGet": {"path": "/healthz", "port": 8880}, "initialDelaySeconds": 10, "periodSeconds": 10},


### PR DESCRIPTION
## Description

The 1.6.0 rc3 sync ([#3338](https://github.com/astronomer/astronomer/pull/3338)) re-lengthened manager resource names we had deliberately shortened. Long names eat into customers' release-name room against the 63-char DNS limit ([review](https://github.com/astronomer/astronomer/commit/44e45982c932aec1c9dab0938419fe6e4cb47b64#r190612515)). This reverts those four names to short form and adds a name-length regression test.

## Related Issues

https://linear.app/astronomer/issue/PINF-887/upgrade-airflow-operator-to-160-rc3-in-astronomer-chart

## Testing

Test cases added

## Merging

2.1.0
