### PR TITLE
PINF-893 Apply globalBaseDomain precedence to adjacent auth-flow chart templates

### DIFF
--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{ include "houston.internalauthurl" . | indent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    {{- include "houston.authsignin" . | nindent 4 }}
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{ include "houston.internalauthurl" . | indent 4 }}
-    {{- include "houston.authsignin" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/alertmanager/templates/ingress.yaml
+++ b/charts/alertmanager/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{ include "houston.internalauthurl" . | indent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "global.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | indent 4}}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "global.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | indent 4}}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    {{- include "houston.authsignin" . | nindent 4 }}
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -22,7 +22,7 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | indent 4}}
-    {{- include "houston.authsignin" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | nindent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "global.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | nindent 4 }}
-    {{- include "houston.authsignin" . | nindent 4 }}
+    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ include "houston.authBaseDomain" . }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/charts/prometheus/templates/ingress.yaml
+++ b/charts/prometheus/templates/ingress.yaml
@@ -23,7 +23,7 @@ metadata:
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     {{- include "houston.internalauthurl" . | nindent 4 }}
-    nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+    {{- include "houston.authsignin" . | nindent 4 }}
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -22,9 +22,9 @@ auth-flow URL regardless of annotation key.
 */}}
 {{- define "houston.authBaseDomain" -}}
 {{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
-{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- .Values.global.controlPlaneHA.globalBaseDomain -}}
 {{- else -}}
-{{ .Values.global.baseDomain }}
+{{- .Values.global.baseDomain -}}
 {{- end -}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -20,7 +20,7 @@ rendering unchanged) or when globalBaseDomain is unset (e.g. data planes, where 
 never templated). Consumers template the surrounding URL/key, so this is reusable for any
 auth-flow URL regardless of annotation key.
 */}}
-{{- define "houston.authBaseDomain" -}}
+{{- define "global.authBaseDomain" -}}
 {{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
 {{- .Values.global.controlPlaneHA.globalBaseDomain -}}
 {{- else -}}
@@ -32,7 +32,7 @@ auth-flow URL regardless of annotation key.
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 nginx.ingress.kubernetes.io/auth-url: http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}.svc.cluster.local:8871/v1/authorization
 {{- else }}
-nginx.ingress.kubernetes.io/auth-url: https://houston.{{ include "houston.authBaseDomain" . }}/v1/authorization
+nginx.ingress.kubernetes.io/auth-url: https://houston.{{ include "global.authBaseDomain" . }}/v1/authorization
 {{- end }}
 {{- end }}
 
@@ -112,7 +112,7 @@ imagePullSecrets:
 {{- if eq .Values.global.plane.mode "unified" -}}
 proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;
 {{- else -}}
-proxy_pass https://houston.{{ include "houston.authBaseDomain" . }}/v1/elasticsearch;
+proxy_pass https://houston.{{ include "global.authBaseDomain" . }}/v1/elasticsearch;
 {{- end -}}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -11,30 +11,30 @@ fluentd
 {{- end -}}
 
 
+{{/*
+Base domain for the control-plane auth flow (auth-url / auth-signin subrequests and
+redirects, elasticsearch proxy_pass). Under control-plane HA the customer enters via the
+global hostname and the session cookie is scoped to globalBaseDomain, so these auth URLs
+must resolve to the global host. Falls back to baseDomain when HA is off (single-CP
+rendering unchanged) or when globalBaseDomain is unset (e.g. data planes, where it is
+never templated). Consumers template the surrounding URL/key, so this is reusable for any
+auth-flow URL regardless of annotation key.
+*/}}
+{{- define "houston.authBaseDomain" -}}
+{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
+{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- else -}}
+{{ .Values.global.baseDomain }}
+{{- end -}}
+{{- end -}}
+
 {{ define "houston.internalauthurl" -}}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 nginx.ingress.kubernetes.io/auth-url: http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}.svc.cluster.local:8871/v1/authorization
-{{- else if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain }}
-nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/v1/authorization
 {{- else }}
-nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
+nginx.ingress.kubernetes.io/auth-url: https://houston.{{ include "houston.authBaseDomain" . }}/v1/authorization
 {{- end }}
 {{- end }}
-
-{{/*
-auth-signin annotation shared by the prometheus/alertmanager/grafana ingresses.
-Under control-plane HA the customer enters via the global hostname and the session
-cookie is scoped to globalBaseDomain, so the sign-in redirect must resolve to the
-global host. Falls back to baseDomain when HA is off (single-CP rendering unchanged)
-or when globalBaseDomain is unset (e.g. data planes, where it is never templated).
-*/}}
-{{- define "houston.authsignin" -}}
-{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
-nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/login
-{{- else -}}
-nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
-{{- end -}}
-{{- end -}}
 
 
 {{/*
@@ -111,10 +111,8 @@ imagePullSecrets:
 {{- define "houston-proxy" -}}
 {{- if eq .Values.global.plane.mode "unified" -}}
 proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;
-{{- else if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
-proxy_pass https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/v1/elasticsearch;
 {{- else -}}
-proxy_pass https://houston.{{ .Values.global.baseDomain }}/v1/elasticsearch;
+proxy_pass https://houston.{{ include "houston.authBaseDomain" . }}/v1/elasticsearch;
 {{- end -}}
 {{- end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -14,10 +14,27 @@ fluentd
 {{ define "houston.internalauthurl" -}}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 nginx.ingress.kubernetes.io/auth-url: http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}.svc.cluster.local:8871/v1/authorization
+{{- else if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain }}
+nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/v1/authorization
 {{- else }}
 nginx.ingress.kubernetes.io/auth-url: https://houston.{{ .Values.global.baseDomain }}/v1/authorization
 {{- end }}
 {{- end }}
+
+{{/*
+auth-signin annotation shared by the prometheus/alertmanager/grafana ingresses.
+Under control-plane HA the customer enters via the global hostname and the session
+cookie is scoped to globalBaseDomain, so the sign-in redirect must resolve to the
+global host. Falls back to baseDomain when HA is off (single-CP rendering unchanged)
+or when globalBaseDomain is unset (e.g. data planes, where it is never templated).
+*/}}
+{{- define "houston.authsignin" -}}
+{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
+nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/login
+{{- else -}}
+nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
+{{- end -}}
+{{- end -}}
 
 
 {{/*
@@ -94,6 +111,8 @@ imagePullSecrets:
 {{- define "houston-proxy" -}}
 {{- if eq .Values.global.plane.mode "unified" -}}
 proxy_pass http://{{ .Release.Name }}-houston.{{ .Release.Namespace }}:8871/v1/elasticsearch;
+{{- else if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
+proxy_pass https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}/v1/elasticsearch;
 {{- else -}}
 proxy_pass https://houston.{{ .Values.global.baseDomain }}/v1/elasticsearch;
 {{- end -}}

--- a/tests/chart_tests/test_auth_flow_global_base_domain.py
+++ b/tests/chart_tests/test_auth_flow_global_base_domain.py
@@ -1,0 +1,148 @@
+"""Tests for globalBaseDomain precedence on adjacent auth-flow templates (PINF-893).
+
+Follow-up to the dual-host work (PINF-809). Five non-auth-sidecar templates on the auth
+flow still hardcoded `global.baseDomain`; under control-plane HA they must resolve to
+`global.controlPlaneHA.globalBaseDomain` (the global customer-facing host the session cookie
+is scoped to), falling back to `baseDomain` when HA is off or globalBaseDomain is unset:
+
+  * `houston.internalauthurl` helper  -> `auth-url` annotation (shared by the three ingresses)
+  * `houston-proxy` helper            -> elasticsearch `proxy_pass`
+  * `auth-signin` annotation          -> prometheus / alertmanager / grafana ingresses
+
+Precedence is gated on `and controlPlaneHA.enabled controlPlaneHA.globalBaseDomain`: the
+auth-url / proxy_pass helper branches are only reachable in non-control modes, where
+globalBaseDomain may be unset (e.g. data planes) and must fall back to baseDomain rather
+than render a broken `https://houston./...` URL.
+"""
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+PROMETHEUS_INGRESS = "charts/prometheus/templates/ingress.yaml"
+ALERTMANAGER_INGRESS = "charts/alertmanager/templates/ingress.yaml"
+GRAFANA_INGRESS = "charts/grafana/templates/grafana-ingress.yaml"
+ES_NGINX_CONFIGMAP = "charts/elasticsearch/templates/nginx/nginx-es-configmap.yaml"
+
+AUTH_SIGNIN_INGRESSES = [PROMETHEUS_INGRESS, ALERTMANAGER_INGRESS, GRAFANA_INGRESS]
+
+BASE_DOMAIN = "example.com"
+GLOBAL_BASE_DOMAIN = "astro.example.com"
+
+AUTH_SIGNIN = "nginx.ingress.kubernetes.io/auth-signin"
+AUTH_URL = "nginx.ingress.kubernetes.io/auth-url"
+
+
+def _values(plane_mode, *, ha=False, global_base_domain=None):
+    cpha = {}
+    if ha:
+        cpha["enabled"] = True
+    if global_base_domain is not None:
+        cpha["globalBaseDomain"] = global_base_domain
+    global_values = {"plane": {"mode": plane_mode}, "baseDomain": BASE_DOMAIN}
+    if cpha:
+        global_values["controlPlaneHA"] = cpha
+    return {"global": global_values}
+
+
+def _es_nginx_conf(docs):
+    """Return the nginx.conf string from the rendered elasticsearch nginx ConfigMap."""
+    configmaps = [d for d in docs if d and d.get("kind") == "ConfigMap"]
+    assert len(configmaps) == 1
+    return configmaps[0]["data"]["nginx.conf"]
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestAuthSigninGlobalBaseDomain:
+    """auth-signin annotation on the three monitoring ingresses (control plane)."""
+
+    @pytest.mark.parametrize("ingress_file", AUTH_SIGNIN_INGRESSES)
+    def test_ha_on_uses_global_host(self, kube_version, ingress_file):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[ingress_file],
+            values=_values("control", ha=True, global_base_domain=GLOBAL_BASE_DOMAIN),
+        )
+        assert docs[0]["metadata"]["annotations"][AUTH_SIGNIN] == f"https://app.{GLOBAL_BASE_DOMAIN}/login"
+
+    @pytest.mark.parametrize("ingress_file", AUTH_SIGNIN_INGRESSES)
+    def test_ha_off_uses_base_domain(self, kube_version, ingress_file):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[ingress_file],
+            values=_values("control"),
+        )
+        assert docs[0]["metadata"]["annotations"][AUTH_SIGNIN] == f"https://app.{BASE_DOMAIN}/login"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestAuthUrlGlobalBaseDomain:
+    """auth-url annotation via the houston.internalauthurl helper.
+
+    The helper's domain branch is only reachable in data mode (control/unified use the
+    in-cluster service URL), so HA resolution is exercised on a data-plane render.
+    """
+
+    def test_ha_on_with_global_base_domain_uses_global_host(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[PROMETHEUS_INGRESS],
+            values=_values("data", ha=True, global_base_domain=GLOBAL_BASE_DOMAIN),
+        )
+        assert docs[0]["metadata"]["annotations"][AUTH_URL] == f"https://houston.{GLOBAL_BASE_DOMAIN}/v1/authorization"
+
+    def test_ha_off_uses_base_domain(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[PROMETHEUS_INGRESS],
+            values=_values("data"),
+        )
+        assert docs[0]["metadata"]["annotations"][AUTH_URL] == f"https://houston.{BASE_DOMAIN}/v1/authorization"
+
+    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
+        """Data plane with HA on but no globalBaseDomain (never templated there) must not
+        emit a broken empty-host URL — it falls back to baseDomain."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[PROMETHEUS_INGRESS],
+            values=_values("data", ha=True),
+        )
+        auth_url = docs[0]["metadata"]["annotations"][AUTH_URL]
+        assert auth_url == f"https://houston.{BASE_DOMAIN}/v1/authorization"
+        assert "houston./" not in auth_url
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestHoustonProxyGlobalBaseDomain:
+    """elasticsearch proxy_pass via the houston-proxy helper.
+
+    The configmap renders in data/unified mode; unified uses the in-cluster URL, so the
+    domain branch is exercised on a data-plane render (parity with the auth-url helper).
+    """
+
+    def test_ha_on_with_global_base_domain_uses_global_host(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[ES_NGINX_CONFIGMAP],
+            values=_values("data", ha=True, global_base_domain=GLOBAL_BASE_DOMAIN),
+        )
+        assert f"proxy_pass https://houston.{GLOBAL_BASE_DOMAIN}/v1/elasticsearch;" in _es_nginx_conf(docs)
+
+    def test_ha_off_uses_base_domain(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[ES_NGINX_CONFIGMAP],
+            values=_values("data"),
+        )
+        assert f"proxy_pass https://houston.{BASE_DOMAIN}/v1/elasticsearch;" in _es_nginx_conf(docs)
+
+    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[ES_NGINX_CONFIGMAP],
+            values=_values("data", ha=True),
+        )
+        nginx_conf = _es_nginx_conf(docs)
+        assert f"proxy_pass https://houston.{BASE_DOMAIN}/v1/elasticsearch;" in nginx_conf
+        assert "houston./v1/elasticsearch" not in nginx_conf

--- a/tests/chart_tests/test_auth_flow_global_base_domain.py
+++ b/tests/chart_tests/test_auth_flow_global_base_domain.py
@@ -81,6 +81,23 @@ class TestAuthSigninGlobalBaseDomain:
         )
         assert docs[0]["metadata"]["annotations"][AUTH_SIGNIN] == f"https://app.{BASE_DOMAIN}/login"
 
+    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
+        """HA on but globalBaseDomain unset must not emit a broken empty-host redirect.
+
+        Only the prometheus ingress can render auth-signin in this state: grafana/alertmanager
+        render on control/unified only, and a control-plane render with HA on + no
+        globalBaseDomain fails the cp-identity-secret guard. The prometheus data-plane render
+        exercises the shared houston.authBaseDomain fallback for the auth-signin annotation.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[PROMETHEUS_INGRESS],
+            values=_values("data", ha=True),
+        )
+        auth_signin = docs[0]["metadata"]["annotations"][AUTH_SIGNIN]
+        assert auth_signin == f"https://app.{BASE_DOMAIN}/login"
+        assert "app./login" not in auth_signin
+
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestAuthUrlGlobalBaseDomain:

--- a/tests/chart_tests/test_auth_flow_global_base_domain.py
+++ b/tests/chart_tests/test_auth_flow_global_base_domain.py
@@ -87,7 +87,7 @@ class TestAuthSigninGlobalBaseDomain:
         Only the prometheus ingress can render auth-signin in this state: grafana/alertmanager
         render on control/unified only, and a control-plane render with HA on + no
         globalBaseDomain fails the cp-identity-secret guard. The prometheus data-plane render
-        exercises the shared houston.authBaseDomain fallback for the auth-signin annotation.
+        exercises the shared global.authBaseDomain fallback for the auth-signin annotation.
         """
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_auth_flow_global_base_domain.py
+++ b/tests/chart_tests/test_auth_flow_global_base_domain.py
@@ -29,6 +29,7 @@ AUTH_SIGNIN_INGRESSES = [PROMETHEUS_INGRESS, ALERTMANAGER_INGRESS, GRAFANA_INGRE
 
 BASE_DOMAIN = "example.com"
 GLOBAL_BASE_DOMAIN = "astro.example.com"
+DOMAIN_PREFIX = "dp"
 
 AUTH_SIGNIN = "nginx.ingress.kubernetes.io/auth-signin"
 AUTH_URL = "nginx.ingress.kubernetes.io/auth-url"
@@ -40,7 +41,12 @@ def _values(plane_mode, *, ha=False, global_base_domain=None):
         cpha["enabled"] = True
     if global_base_domain is not None:
         cpha["globalBaseDomain"] = global_base_domain
-    global_values = {"plane": {"mode": plane_mode}, "baseDomain": BASE_DOMAIN}
+    plane = {"mode": plane_mode}
+    # Data-plane hosts are prefixed with domainPrefix (e.g. prometheus.dp.<baseDomain>);
+    # set it so data-mode renders match real installs (parity with test_dual_host_ingress.py).
+    if plane_mode == "data":
+        plane["domainPrefix"] = DOMAIN_PREFIX
+    global_values = {"plane": plane, "baseDomain": BASE_DOMAIN}
     if cpha:
         global_values["controlPlaneHA"] = cpha
     return {"global": global_values}


### PR DESCRIPTION
## Description

Under control-plane HA, customers enter via the **global** hostname and the session cookie is scoped to `globalBaseDomain`, so these auth redirect/subrequest URLs must resolve to the global host (otherwise the auth handshake redirects to a host the cookie isn't valid for).

This PR makes the five non-auth-sidecar spots prefer `global.controlPlaneHA.globalBaseDomain` under HA, falling back to `global.baseDomain` otherwise — matching the precedence pattern PINF-809 established for the `*.globalUrl` host helpers.

### Implementation

The precedence rule (`globalBaseDomain` when HA is enabled **and** set, else `baseDomain`) lives in a single new helper in `templates/_helpers.tpl`:

It returns just the bare domain, so each consumer templates it inline inside whatever URL/annotation it needs — no annotation-emitting helper, no `nindent`/`indent` whitespace splicing, and reusable regardless of annotation key. The five spots:

- `templates/_helpers.tpl` — `houston.internalauthurl` (the `auth-url` annotation, `include`d by all three monitoring ingresses) and `houston-proxy` (elasticsearch `proxy_pass`) delegate their domain to `houston.authBaseDomain`.
- `charts/{prometheus,alertmanager,grafana}/templates/*ingress.yaml` — the `auth-signin` annotation resolves its domain via `https://app.{{ include "houston.authBaseDomain" . }}/login`.

### Notes

- The guard is `and .enabled .globalBaseDomain`, **not** just `.enabled`. The `auth-url`/`proxy_pass` branches are only reachable in non-control (data-plane) mode, where `globalBaseDomain` is intentionally never templated 

## Related Issues

- [PINF-893](https://linear.app/astronomer/issue/PINF-893)

## Testing

- New chart unit tests in `tests/chart_tests/test_auth_flow_global_base_domain.py` covering all five spots:
  - **HA on → global host**: `auth-signin` on all three ingresses, `auth-url` helper, and elasticsearch `proxy_pass`.
  - **HA off → baseDomain** (unchanged).
  - **HA on + `globalBaseDomain` unset → baseDomain fallback** for `auth-url`, `proxy_pass`, and `auth-signin` (no broken empty-host URL). Data-mode renders set `domainPrefix` to match real data-plane installs.
- Full chart suite passes (`uv run pytest tests/chart_tests/ -n auto`); HA-off rendering verified byte-for-byte identical to base.

## Merging

merge to feature/cp-ha-dr