### PR TITLE
PINF-855: Worker Id chart change. 

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -465,6 +465,8 @@ s3:
   value: {{ .Release.Name }}-stan
 {{- if .Values.global.controlPlaneHA.enabled }}
 {{- include "houston.cpIdEnv" . | nindent 0 }}
+- name: DPLINK_WORKER_ID
+  value: "$(CP_ID):$(HOSTNAME)"
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/navigator/navigator-deployment.yaml
+++ b/charts/astronomer/templates/navigator/navigator-deployment.yaml
@@ -116,6 +116,8 @@ spec:
               value: {{ .Release.Name }}-stan
             {{- if .Values.global.controlPlaneHA.enabled }}
             {{- include "houston.cpIdEnv" . | nindent 12 }}
+            - name: NAVIGATOR_WORKER_ID
+              value: "$(CP_ID):$(HOSTNAME)"
             {{- end }}
 
             # Failover request reconcile loop


### PR DESCRIPTION
## Description

In HA mode, dp-link and navigator pods across multiple CP clusters need globally unique worker identities for DB-backed claim/lease operations. The chart already injects `CP_ID` into these pods (via `houston.cpIdEnv`) when `controlPlaneHA.enabled`, but it didn't set the worker-specific identity env vars to the canonical `${CP_ID}:${pod_hostname}` format.


## Related Issues

Do not merge this PR until this text is replaced with links to related issues.

Related astronomer/issues#XXXX

## Testing

verify via `helm template` that:
- With `global.controlPlaneHA.enabled: false` (default): neither `DPLINK_WORKER_ID` nor `NAVIGATOR_WORKER_ID` appear in rendered output.
- With `global.controlPlaneHA.enabled: true`: both vars appear with value `$(CP_ID):$(HOSTNAME)` in their respective pod specs, after `CP_ID` is already declared from the `cp-identity` Secret — so Kubernetes variable interpolation resolves correctly.


## Merging

cp-ha-dr