### PR TITLE
PINF-894/PINF-895 Auth-sidecar support under control-plane HA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   release_bom:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     steps:
       - checkout
       - run:
@@ -69,7 +69,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-06
+      - image: quay.io/astronomer/ci-pre-commit:2026-07
     resource_class: small
     steps:
       - checkout
@@ -93,7 +93,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     # https://circleci.com/docs/using-docker/#x86
     resource_class: large
     parallelism: 4
@@ -128,7 +128,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     parameters:
       qa_release:
         type: boolean
@@ -150,7 +150,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     parameters:
       artifact_subdir:
         type: string
@@ -187,7 +187,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-06
+      - image: quay.io/astronomer/ci-helm-release:2026-07
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -342,7 +342,7 @@ jobs:
 
   create_linear_milestone:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-06
+      - image: quay.io/astronomer/ci-pre-commit:2026-07
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
+++ b/charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml
@@ -27,14 +27,14 @@ data:
       server_tokens off;
 
       location  = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass  https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host houston.{{ include "global.authBaseDomain" . }};
+        proxy_pass  https://houston.{{ include "global.authBaseDomain" . }}/v1/authorization;
 {{.Values.global.authSidecar.default_nginx_settings | indent 8  }}
       }
       location @401_auth_error {
         internal;
         add_header Set-Cookie $auth_cookie;
-        return 302 https://app.{{ .Values.global.baseDomain }}/login?rd=https://$http_host$request_uri;
+        return 302 https://app.{{ include "global.authBaseDomain" . }}/login?rd=https://$http_host$request_uri;
       }
       location / {
         # Custom headers to proxied server

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -15,8 +15,8 @@ metadata:
     plane: {{ .Values.global.plane.mode }}
   annotations:
     # gRPC/HTTP-2 backend protocol for the CP->DP commander channel. NGINX-Ingress-specific;
-    # emitted unconditionally (including auth-sidecar / BYO mode) because it is our own
-    # protocol plumbing, not customer config. Non-NGINX BYO controllers (ALB, Istio, ...)
+    # emitted unconditionally (including auth-sidecar / BYO mode).
+    # Non-NGINX BYO controllers (ALB, Istio, ...)
     # ignore these harmlessly and must enable gRPC backend + HTTP/2 via their own mechanism.
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/enable-http2: "true"

--- a/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
+++ b/charts/astronomer/templates/commander/commander-grpc-ingress.yaml
@@ -14,11 +14,17 @@ metadata:
     heritage: {{ .Release.Service }}
     plane: {{ .Values.global.plane.mode }}
   annotations:
-    {{- if .Values.global.authSidecar.enabled  }}
-{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
-    {{- else }}
+    # gRPC/HTTP-2 backend protocol for the CP->DP commander channel. NGINX-Ingress-specific;
+    # emitted unconditionally (including auth-sidecar / BYO mode) because it is our own
+    # protocol plumbing, not customer config. Non-NGINX BYO controllers (ALB, Istio, ...)
+    # ignore these harmlessly and must enable gRPC backend + HTTP/2 via their own mechanism.
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
     nginx.ingress.kubernetes.io/enable-http2: "true"
+    {{- if .Values.global.authSidecar.enabled  }}
+    {{- if .Values.global.extraAnnotations }}
+{{- toYaml .Values.global.extraAnnotations | nindent 4 }}
+    {{- end }}
+    {{- else }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
     {{- if .Values.global.extraAnnotations }}
 {{- toYaml .Values.global.extraAnnotations | nindent 4 }}

--- a/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
+++ b/charts/grafana/templates/grafana-auth-sidecar-configmap.yaml
@@ -26,14 +26,14 @@ data:
       server_tokens off;
 
       location = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host houston.{{ include "global.authBaseDomain" . }};
+        proxy_pass https://houston.{{ include "global.authBaseDomain" . }}/v1/authorization;
 {{.Values.global.authSidecar.default_nginx_settings | indent 8 }}
       }
       location @401_auth_error {
         internal;
         add_header Set-Cookie $auth_cookie;
-        return 302 https://app.{{ .Values.global.baseDomain }}/login?rd=https://$http_host$request_uri;
+        return 302 https://app.{{ include "global.authBaseDomain" . }}/login?rd=https://$http_host$request_uri;
       }
       location / {
         # Custom headers to proxied server

--- a/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml
@@ -25,15 +25,15 @@ data:
       server_tokens off;
 
       location = /auth {
-        proxy_set_header Host houston.{{ .Values.global.baseDomain }};
-        proxy_pass https://houston.{{ .Values.global.baseDomain }}/v1/authorization;
+        proxy_set_header Host houston.{{ include "global.authBaseDomain" . }};
+        proxy_pass https://houston.{{ include "global.authBaseDomain" . }}/v1/authorization;
         {{ .Values.global.default_nginx_settings }}
 {{.Values.global.authSidecar.default_nginx_settings | indent 8 }}
       }
       location @401_auth_error {
         internal;
         add_header Set-Cookie $auth_cookie;
-        return 302 https://app.{{ .Values.global.baseDomain }}/login?rd=https://$http_host$request_uri;
+        return 302 https://app.{{ include "global.authBaseDomain" . }}/login?rd=https://$http_host$request_uri;
       }
       location / {
         # Custom headers to proxied server

--- a/tests/chart_tests/test_auth_sidecar_global_base_domain.py
+++ b/tests/chart_tests/test_auth_sidecar_global_base_domain.py
@@ -1,0 +1,120 @@
+"""Tests for the auth-sidecar / commander-gRPC chart gaps in control-plane HA (PINF-894, PINF-895).
+
+Sibling to test_auth_flow_global_base_domain.py (PINF-893). Two auth-sidecar / BYO-ingress
+surfaces still assumed the per-CP host under control-plane HA:
+
+PINF-894 — the three monitoring auth-sidecar nginx configmaps (prometheus / alertmanager /
+grafana) templated the auth subrequest `Host`, the auth `proxy_pass`, and the login `302`
+redirect from `global.baseDomain`. Under HA the customer enters via the global host and the
+session cookie is scoped to `controlPlaneHA.globalBaseDomain`, so these must resolve to the
+global host. They now reuse the shared `global.authBaseDomain` helper: HA-on +
+globalBaseDomain -> global host, else baseDomain (single-CP / HA-off rendering unchanged).
+
+PINF-895 — the commander gRPC ingress emitted `backend-protocol: GRPC` and
+`enable-http2: true` only in the auth-sidecar-off branch, so auth-sidecar installs lost the
+CP->DP gRPC/HTTP-2 backend protocol unless manually patched. Both annotations are now
+emitted unconditionally.
+"""
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+PROMETHEUS_CONFIGMAP = "charts/prometheus/templates/prometheus-auth-sidecar-configmap.yaml"
+ALERTMANAGER_CONFIGMAP = "charts/alertmanager/templates/alertmanager-auth-sidecar-configmap.yaml"
+GRAFANA_CONFIGMAP = "charts/grafana/templates/grafana-auth-sidecar-configmap.yaml"
+
+AUTH_SIDECAR_CONFIGMAPS = [PROMETHEUS_CONFIGMAP, ALERTMANAGER_CONFIGMAP, GRAFANA_CONFIGMAP]
+
+COMMANDER_GRPC_INGRESS = "charts/astronomer/templates/commander/commander-grpc-ingress.yaml"
+
+BASE_DOMAIN = "example.com"
+GLOBAL_BASE_DOMAIN = "astro.example.com"
+
+BACKEND_PROTOCOL = "nginx.ingress.kubernetes.io/backend-protocol"
+ENABLE_HTTP2 = "nginx.ingress.kubernetes.io/enable-http2"
+
+
+def _auth_sidecar_values(plane_mode, *, ha=False, global_base_domain=None):
+    cpha = {}
+    if ha:
+        cpha["enabled"] = True
+    if global_base_domain is not None:
+        cpha["globalBaseDomain"] = global_base_domain
+    global_values = {
+        "plane": {"mode": plane_mode},
+        "baseDomain": BASE_DOMAIN,
+        "authSidecar": {"enabled": True},
+    }
+    if cpha:
+        global_values["controlPlaneHA"] = cpha
+    return {"global": global_values}
+
+
+def _nginx_conf(docs):
+    """Return the default.conf string from the rendered auth-sidecar ConfigMap."""
+    configmaps = [d for d in docs if d and d.get("kind") == "ConfigMap"]
+    assert len(configmaps) == 1
+    return configmaps[0]["data"]["default.conf"]
+
+
+def _assert_auth_urls_use(conf, domain):
+    """All three auth-sidecar URL refs (Host header, auth proxy_pass, login 302) resolve to `domain`."""
+    assert f"Host houston.{domain};" in conf
+    assert f"https://houston.{domain}/v1/authorization" in conf
+    assert f"https://app.{domain}/login?rd=" in conf
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+@pytest.mark.parametrize("configmap_file", AUTH_SIDECAR_CONFIGMAPS)
+class TestAuthSidecarGlobalBaseDomain:
+    """PINF-894: Host header, auth proxy_pass, and login 302 redirect on all three configmaps."""
+
+    def test_ha_on_uses_global_host(self, kube_version, configmap_file):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[configmap_file],
+            values=_auth_sidecar_values("control", ha=True, global_base_domain=GLOBAL_BASE_DOMAIN),
+        )
+        _assert_auth_urls_use(_nginx_conf(docs), GLOBAL_BASE_DOMAIN)
+
+    def test_ha_off_uses_base_domain(self, kube_version, configmap_file):
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[configmap_file],
+            values=_auth_sidecar_values("control"),
+        )
+        conf = _nginx_conf(docs)
+        _assert_auth_urls_use(conf, BASE_DOMAIN)
+        # No broken empty-host URLs (regression guard on the fallback path).
+        assert "houston./v1/authorization" not in conf
+        assert "app./login" not in conf
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestCommanderGrpcIngressProtocolAnnotations:
+    """PINF-895: commander gRPC ingress keeps backend-protocol/HTTP-2 in every mode."""
+
+    def _annotations(self, kube_version, *, auth_sidecar):
+        global_values = {"plane": {"mode": "data"}, "baseDomain": BASE_DOMAIN}
+        if auth_sidecar:
+            global_values["authSidecar"] = {"enabled": True}
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[COMMANDER_GRPC_INGRESS],
+            values={"global": global_values},
+        )
+        return docs[0]["metadata"]["annotations"]
+
+    def test_auth_sidecar_on_keeps_grpc_annotations(self, kube_version):
+        """Auth-sidecar mode must render gRPC/HTTP-2 without a manual commander.ingress.annotation."""
+        annotations = self._annotations(kube_version, auth_sidecar=True)
+        assert annotations[BACKEND_PROTOCOL] == "GRPC"
+        assert annotations[ENABLE_HTTP2] == "true"
+
+    def test_auth_sidecar_off_keeps_grpc_annotations(self, kube_version):
+        """Regression guard: default (non-auth-sidecar) mode still has both annotations."""
+        annotations = self._annotations(kube_version, auth_sidecar=False)
+        assert annotations[BACKEND_PROTOCOL] == "GRPC"
+        assert annotations[ENABLE_HTTP2] == "true"

--- a/tests/chart_tests/test_auth_sidecar_global_base_domain.py
+++ b/tests/chart_tests/test_auth_sidecar_global_base_domain.py
@@ -1,16 +1,15 @@
 """Tests for the auth-sidecar / commander-gRPC chart gaps in control-plane HA (PINF-894, PINF-895).
 
-Sibling to test_auth_flow_global_base_domain.py (PINF-893). Two auth-sidecar / BYO-ingress
+Sibling to test_auth_flow_global_base_domain.py. Two auth-sidecar / BYO-ingress
 surfaces still assumed the per-CP host under control-plane HA:
 
-PINF-894 — the three monitoring auth-sidecar nginx configmaps (prometheus / alertmanager /
+The three monitoring auth-sidecar nginx configmaps (prometheus / alertmanager /
 grafana) templated the auth subrequest `Host`, the auth `proxy_pass`, and the login `302`
 redirect from `global.baseDomain`. Under HA the customer enters via the global host and the
 session cookie is scoped to `controlPlaneHA.globalBaseDomain`, so these must resolve to the
-global host. They now reuse the shared `global.authBaseDomain` helper: HA-on +
-globalBaseDomain -> global host, else baseDomain (single-CP / HA-off rendering unchanged).
+global host.
 
-PINF-895 — the commander gRPC ingress emitted `backend-protocol: GRPC` and
+The commander gRPC ingress emitted `backend-protocol: GRPC` and
 `enable-http2: true` only in the auth-sidecar-off branch, so auth-sidecar installs lost the
 CP->DP gRPC/HTTP-2 backend protocol unless manually patched. Both annotations are now
 emitted unconditionally.


### PR DESCRIPTION
## Summary

Closes two auth-sidecar / customer-BYO-ingress chart gaps that block auth-sidecar from working in control-plane HA (multi-CP active-active) mode out of the box. Both were surfaced by [PINF-745](https://linear.app/astronomer/issue/PINF-745) and live on the same auth-sidecar/BYO chart surface, so they ship together.

### PINF-894: auth-sidecar configmap base-domain precedence
The three monitoring auth-sidecar nginx configmaps (prometheus, alertmanager, grafana) templated the auth subrequest `Host` header, the auth `proxy_pass`, and the login `302` redirect from `global.baseDomain`. Under HA the customer enters via the **global** host and the session cookie is scoped to `controlPlaneHA.globalBaseDomain`, so a user hitting the global host was authenticated/redirected against the per-CP host.

These now reuse the shared `global.authBaseDomain` helper (added by [PINF-893](https://linear.app/astronomer/issue/PINF-893)): HA-on + `globalBaseDomain` set → global host, else `baseDomain`. Single-CP / HA-off rendering is byte-identical to before.

### PINF-895: commander gRPC ingress protocol annotations
`charts/astronomer/templates/commander/commander-grpc-ingress.yaml` emitted `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` and `enable-http2: "true"` **only** in the auth-sidecar-off branch, so auth-sidecar installs lost the CP→DP gRPC/HTTP-2 backend protocol unless manually patched with `commander.ingress.annotation`. Both annotations are now hoisted above the branch and rendered unconditionally.

While fixing this, guarded `extraAnnotations` in the auth-sidecar branch (matching the else branch) to avoid a bare `{}` YAML render when `extraAnnotations` is empty which was previously masked, now exposed once real keys precede it.

Non-NGINX BYO controllers (ALB/Istio/etc.) ignore the `nginx.ingress.*` annotations harmlessly and must enable gRPC backend + HTTP/2 via their own mechanism. Documented as an inline template comment.

## Tests
New `tests/chart_tests/test_auth_sidecar_global_base_domain.py` (40 cases across supported k8s versions):
- **PINF-894**: all three configmaps: HA-on resolves `Host` / `proxy_pass` / login-302 to the global host; HA-off resolves to `baseDomain` with no broken empty-host URLs.
- **PINF-895**: commander gRPC ingress renders both annotations in auth-sidecar mode (without a manual override) **and** in default mode (regression guard).

Verified: new suite + existing `test_auth_flow_global_base_domain.py`, `test_dual_host_ingress.py`, and `test_astronomer_commander_ingress.py` all pass. Manual `helm template` spot-checks confirm correct rendering across auth-sidecar-on/off and HA-on/off.

## Merging

Target: `feature/cp-ha-dr`