### PR TITLE
PINF-566 Updates for git-sync http private repo

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.18.0
+airflowChartVersion: 1.18.1
 
 nodeSelector: {}
 affinity: {}
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.1.1
+    tag: 2.1.2
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.1.0
+    tag: 2.1.1
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui

--- a/values.yaml
+++ b/values.yaml
@@ -367,7 +367,7 @@ global:
         tag: 2026.7.1
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
-        tag: 0.2.13
+        tag: 0.3.0
     metrics:
       enabled: false
   certgenerator:


### PR DESCRIPTION
## Description

Merge all code that enables the core git-sync from private https repo feature. apc-ui is excluded because it has not been built yet.

## Related Issues

- <https://linear.app/astronomer/issue/PINF-566>

## Testing

I have manually tested all of these changes in a k3d cluster.

## Merging

This is only for release-2.1