### PR TITLE
PINF-932 Add global.controlPlaneHA.bootstrapJwks flag for fresh HA install

### DIFF
--- a/charts/astronomer/templates/houston/api/houston-jwt-certificate-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-jwt-certificate-secret.yaml
@@ -1,7 +1,7 @@
 ############################
 ## Houston JWT Key Secret ##
 ############################
-{{- if and (or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified")) .Values.houston.jwks.generation.enabled (not .Values.global.controlPlaneHA.enabled) }}
+{{- if and (or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified")) .Values.houston.jwks.generation.enabled (or (not .Values.global.controlPlaneHA.enabled) .Values.global.controlPlaneHA.bootstrapJwks) }}
 {{- $ca := genCA "ca" 3650 }}
 {{- $cn := printf "%s-houston" .Release.Name }}
 {{- $altName1 := printf "%s.%s" $cn .Release.Namespace }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -136,8 +136,12 @@ houston:
   jwtSigningCertificateSecretName: ~
 
   # Houston JWT (JWKS) signing keypair generation. Default true generates a
-  # self-signed keypair at install. Set false (or enable global.controlPlaneHA)
-  # to consume an externally-provisioned / ESO-synced shared keypair instead.
+  # self-signed keypair at install for single-CP mode. In HA mode
+  # (global.controlPlaneHA.enabled: true), this flag is overridden and generation
+  # is SKIPPED — Secrets must be pre-provisioned in the astronomer namespace.
+  # Exception: set global.controlPlaneHA.bootstrapJwks: true on the FIRST CP
+  # install of a fresh HA cluster to generate the shared material once; copy the
+  # resulting Secrets to subsequent CPs before installing them.
   jwks:
     generation:
       enabled: true

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -138,7 +138,7 @@ houston:
   # Houston JWT (JWKS) signing keypair generation. Default true generates a
   # self-signed keypair at install for single-CP mode. In HA mode
   # (global.controlPlaneHA.enabled: true), this flag is overridden and generation
-  # is SKIPPED — Secrets must be pre-provisioned in the astronomer namespace.
+  # is SKIPPED — Secrets must be pre-provisioned in the release namespace.
   # Exception: set global.controlPlaneHA.bootstrapJwks: true on the FIRST CP
   # install of a fresh HA cluster to generate the shared material once; copy the
   # resulting Secrets to subsequent CPs before installing them.

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,7 +2,7 @@ Thank you for installing Astronomer!
 Your release is named {{ .Release.Name }}.
 
 {{- $planeMode := .Values.global.plane.mode }}
-{{- $domainPrefix := .Values.global.plane.domainsuffix }}
+{{- $domainPrefix := .Values.global.plane.domainPrefix }}
 Astronomer has been installed in {{ $planeMode }} plane mode.
 
 {{- $astronomerEnabled := true }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -62,9 +62,9 @@ We have guides available at https://www.astronomer.io/docs/learn/ and are always
 To see dashboard URLs here, provide baseDomain in your config.
 {{- end }}
 
-{{- if and (or (eq $planeMode "control") (eq $planeMode "unified")) $astronomerEnabled $platformEnabled .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.bootstrapJwks (dig "houston" "jwks" "generation" "enabled" true .Values.astronomer) }}
+{{- if and .Release.IsInstall (or (eq $planeMode "control") (eq $planeMode "unified")) $astronomerEnabled $platformEnabled .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.bootstrapJwks (dig "houston" "jwks" "generation" "enabled" true .Values.astronomer) }}
 
-First-CP HA bootstrap complete. The chart has generated the following Secrets in this cluster's {{ .Release.Namespace }} namespace:
+First-CP HA bootstrap (bootstrapJwks enabled): this install generates the following Secrets in this cluster's {{ .Release.Namespace }} namespace:
 
 - {{ include "houston.jwtKeySecret" (dict "Release" .Release "Values" .Values.astronomer) | trim }} — Houston JWT signing keypair (private key)
 - {{ include "houston.jwtCertificateSecret" (dict "Release" .Release "Values" .Values.astronomer) | trim }} — JWT signing certificate (also signs Docker registry tokens)

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -60,3 +60,15 @@ We have guides available at https://www.astronomer.io/docs/learn/ and are always
 {{- else }}
 To see dashboard URLs here, provide baseDomain in your config.
 {{- end }}
+
+{{- if and (or (eq $planeMode "control") (eq $planeMode "unified")) .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.bootstrapJwks (dig "houston" "jwks" "generation" "enabled" true .Values.astronomer) }}
+
+First-CP HA bootstrap complete. The chart has generated the following Secrets in this cluster's {{ .Release.Namespace }} namespace:
+
+- {{ include "houston.jwtKeySecret" (dict "Release" .Release "Values" .Values.astronomer) | trim }} — Houston JWT signing keypair (private key)
+- {{ include "houston.jwtCertificateSecret" (dict "Release" .Release "Values" .Values.astronomer) | trim }} — JWT signing certificate (also signs Docker registry tokens)
+
+Copy these Secrets to each subsequent CP cluster's namespace BEFORE installing additional CPs.
+Any tool works: `kubectl get secret -o yaml` + `kubectl apply -f`, sealed-secrets, Terraform,
+GitOps, External Secrets Operator, HashiCorp Vault, etc. See the runbook for detailed steps.
+{{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -5,14 +5,15 @@ Your release is named {{ .Release.Name }}.
 {{- $domainPrefix := .Values.global.plane.domainsuffix }}
 Astronomer has been installed in {{ $planeMode }} plane mode.
 
-{{- if .Values.global.baseDomain }}
-The platform components may take a few minutes to spin up.
-
 {{- $astronomerEnabled := true }}
 {{- if and (hasKey .Values.global "astronomer") (kindIs "map" .Values.global.astronomer) (hasKey .Values.global.astronomer "enabled") }}
 {{- $astronomerEnabled = .Values.global.astronomer.enabled }}
 {{- end }}
 {{- $platformEnabled := hasKey .Values.tags "platform" | ternary .Values.tags.platform true }}
+
+{{- if .Values.global.baseDomain }}
+The platform components may take a few minutes to spin up.
+
 {{- $grafanaEnabled := true }}
 {{- if and (hasKey .Values.global "grafana") (kindIs "map" .Values.global.grafana) (hasKey .Values.global.grafana "enabled") }}
 {{- $grafanaEnabled = .Values.global.grafana.enabled }}
@@ -61,7 +62,7 @@ We have guides available at https://www.astronomer.io/docs/learn/ and are always
 To see dashboard URLs here, provide baseDomain in your config.
 {{- end }}
 
-{{- if and (or (eq $planeMode "control") (eq $planeMode "unified")) .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.bootstrapJwks (dig "houston" "jwks" "generation" "enabled" true .Values.astronomer) }}
+{{- if and (or (eq $planeMode "control") (eq $planeMode "unified")) $astronomerEnabled $platformEnabled .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.bootstrapJwks (dig "houston" "jwks" "generation" "enabled" true .Values.astronomer) }}
 
 First-CP HA bootstrap complete. The chart has generated the following Secrets in this cluster's {{ .Release.Namespace }} namespace:
 

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -131,6 +131,22 @@ class TestJwtKeypairGating:
         )
         assert docs == []
 
+    def test_generated_when_ha_with_bootstrap(self, kube_version):
+        """bootstrapJwks=true overrides the HA-mode block (fresh HA first-CP bootstrap)."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[JWT_SECRET_FILE],
+            values=_ha_values(bootstrapJwks=True),
+        )
+        assert len(docs) == 2
+
+    def test_bootstrap_skipped_when_generation_disabled(self, kube_version):
+        """jwks.generation.enabled=false wins over bootstrapJwks (explicit disable)."""
+        values = _ha_values(bootstrapJwks=True)
+        values["astronomer"] = {"houston": {"jwks": {"generation": {"enabled": False}}}}
+        docs = render_chart(kube_version=kube_version, show_only=[JWT_SECRET_FILE], values=values)
+        assert docs == []
+
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 @pytest.mark.parametrize(

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,14 @@ global:
   # Default false keeps single-CP installs unchanged (no behavior change).
   controlPlaneHA:
     enabled: false
+    # Only for the FIRST CP install of a fresh HA cluster. When true (with
+    # enabled: true), overrides the HA-mode hard-block on JWKS + registry
+    # keypair generation, allowing the chart to generate the shared secret
+    # material into local k8s Secrets. Customer then copies those Secrets to
+    # subsequent CP clusters before installing them (see runbook).
+    # Default false: subsequent CPs and single-CP-to-HA migrations skip
+    # generation and expect Secrets to be pre-provisioned.
+    bootstrapJwks: false
     # Parent domain of the global customer-facing hostname. REQUIRED when enabled.
     # E.g. set to "astro.example.com" when the global URL is "app.astro.example.com".
     #


### PR DESCRIPTION
## Description

Adds a bootstrap escape hatch so a **fresh HA install** (net-new customer, no existing single-CP install) can generate the shared JWT + registry signing keypairs on the first CP.

HA mode (`global.controlPlaneHA.enabled: true`) hard-blocks JWKS generation at `charts/astronomer/templates/houston/api/houston-jwt-certificate-secret.yaml` so every CP consumes pre-provisioned shared secret material. That works for single-CP→HA migration (Secrets already exist) but leaves fresh HA customers with no way to bootstrap through the chart.

Changes:

- **New value** `global.controlPlaneHA.bootstrapJwks` (default `false`). When true (with `enabled: true`), overrides the HA-mode block on keypair generation. Set only on the FIRST CP install of a fresh HA cluster; the operator copies the generated Secrets to subsequent CP clusters before installing them.
- **Template gate**: the HA clause becomes `(or (not .Values.global.controlPlaneHA.enabled) .Values.global.controlPlaneHA.bootstrapJwks)`. Explicit `houston.jwks.generation.enabled: false` still wins (remains ANDed). HA=false behavior unchanged.
- **NOTES.txt**: when a bootstrap install is detected, prints the generated Secret names (`<release>-houston-jwt-signing-key`, `<release>-houston-jwt-signing-certificate`) and instructions to copy them to subsequent CP clusters before installing additional CPs.
- **values.yaml comment** for `houston.jwks.generation.enabled` updated to describe the HA override and the bootstrap exception.

## Related Issues

[PINF-932](https://linear.app/astronomer/issue/PINF-932/astronomer-chart-add-bootstrapjwks-flag-for-fresh-ha-install) (parent: [PINF-760](https://linear.app/astronomer/issue/PINF-760))

## Testing

- New chart tests in `tests/chart_tests/test_control_plane_ha.py` (`TestJwtKeypairGating`): HA + bootstrapJwks generates both Secrets; explicit `jwks.generation.enabled: false` wins over the bootstrap flag. Existing tests cover the other matrix rows (HA=false generates, HA=true without bootstrap skips).
- Full chart suite: 4787 passed, 72 skipped, 0 failures.
- `helm template` renders verified: HA+bootstrap → 2 Secrets; HA without bootstrap → none; default install → 2 Secrets (unchanged).
- `helm install --dry-run=client` verified NOTES output: bootstrap message with correct Secret names when bootstrapping; absent for HA-without-bootstrap, generation-disabled, and default installs.

## Merging

Merge into `feature/cp-ha-dr` only (CP HA/DR feature branch, targeted at the 2.1.0 release).