### PR TITLE
PINF-934: Render cp-identity Secret as a pre-install/pre-upgrade hook

### DIFF
--- a/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
+++ b/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
@@ -15,6 +15,11 @@
     1. explicit global.controlPlaneHA.cpId  - deterministic for GitOps / offline render
     2. existing cp-identity Secret           - preserved across `helm upgrade`
     3. freshly generated UUID                - first install
+
+  Rendered as a pre-install/pre-upgrade hook: the houston db-migration
+  hook job runs pre-upgrade and mounts CP_ID, so the Secret must exist before the hook phase.
+  resource-policy keep is required: prevents helm's main-phase prune from deleting the hook-created Secret,
+  and also preserves the cp_id across an HA disable/re-enable toggle.
 */}}
 {{- $cpId := "" }}
 {{- if .Values.global.controlPlaneHA.cpId }}
@@ -38,10 +43,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     heritage: {{ .Release.Service }}
     plane: {{ .Values.global.plane.mode }}
-  {{ if .Values.global.argoCD.annotation.enabled }}
   annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
+    {{ if .Values.global.argoCD.annotation.enabled }}
     argocd.argoproj.io/sync-wave: "-1"
-  {{- end }}
+    {{- end }}
 type: Opaque
 data:
   cp_id: {{ $cpId | b64enc | quote }}

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -19,6 +19,7 @@ from tests.utils.chart import render_chart
 
 JWT_SECRET_FILE = "charts/astronomer/templates/houston/api/houston-jwt-certificate-secret.yaml"
 CP_IDENTITY_FILE = "charts/astronomer/templates/houston/api/cp-identity-secret.yaml"
+DB_MIGRATION_JOB_FILE = "charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml"
 CONFIGMAP_FILE = "charts/astronomer/templates/houston/houston-configmap.yaml"
 HOUSTON_API_FILE = "charts/astronomer/templates/houston/api/houston-deployment.yaml"
 HOUSTON_WORKER_FILE = "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml"
@@ -88,6 +89,37 @@ class TestCpIdentitySecret:
                 values={"global": {"plane": {"mode": "control"}, "controlPlaneHA": {"enabled": True}}},
             )
         assert "global.controlPlaneHA.globalBaseDomain is required" in excinfo.value.stderr.decode("utf-8")
+
+    def test_hook_annotations(self, kube_version):
+        """cp-identity is a pre-install/pre-upgrade hook so it exists before the hook jobs that mount CP_ID (PINF-934).
+
+        resource-policy keep protects the hook-created Secret from the main-phase prune on the
+        release that converts it from a regular resource, and preserves cp_id across HA toggles.
+        """
+        docs = render_chart(kube_version=kube_version, show_only=[CP_IDENTITY_FILE], values=_ha_values())
+        annotations = docs[0]["metadata"]["annotations"]
+        assert annotations["helm.sh/hook"] == "pre-install,pre-upgrade"
+        assert annotations["helm.sh/hook-weight"] == "-1"
+        assert annotations["helm.sh/hook-delete-policy"] == "before-hook-creation"
+        assert annotations["helm.sh/resource-policy"] == "keep"
+
+    def test_hook_runs_before_db_migration_hook_job(self, kube_version):
+        """Regression for the HA-enable upgrade deadlock (PINF-934).
+
+        The db-migration job runs as a pre-upgrade hook and mounts CP_ID from cp-identity,
+        so the Secret hook must run in the same phase with a strictly lower weight.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE, DB_MIGRATION_JOB_FILE],
+            values=_ha_values(),
+        )
+        by_kind = {doc["kind"]: doc for doc in docs}
+        secret_annotations = by_kind["Secret"]["metadata"]["annotations"]
+        job_annotations = by_kind["Job"]["metadata"]["annotations"]
+        assert "pre-upgrade" in job_annotations["helm.sh/hook"]
+        assert "pre-upgrade" in secret_annotations["helm.sh/hook"]
+        assert int(secret_annotations["helm.sh/hook-weight"]) < int(job_annotations["helm.sh/hook-weight"])
 
     def test_data_plane_render_not_gated_on_global_base_domain(self, kube_version):
         """A data-plane render with HA enabled (e.g. shared values) must not require globalBaseDomain.


### PR DESCRIPTION
## Description

Enabling `global.controlPlaneHA.enabled: true` via `helm upgrade` on an existing non-HA install deadlocked: the pre-upgrade houston db-migration hook job mounts `CP_ID` from the `cp-identity` Secret (via the shared `houston.cpIdEnv` helper), but the Secret was a regular release resource that helm only applies in the main phase, after pre-upgrade hooks. The hook pod stuck in `CreateContainerConfigError: secret "cp-identity" not found` until the `--wait` timeout.

This makes the Secret a `pre-install,pre-upgrade` hook at weight `-1` (below the migration job's `0`) with `before-hook-creation` delete policy, mirroring the houston-configmap hook pattern, so it exists before any hook job that consumes `CP_ID`.

Notes:

- `helm.sh/resource-policy: keep` is load-bearing, not cosmetic: on the release that converts the Secret from a regular resource to a hook, helm's main-phase prune sees it removed from the release manifest and would delete the freshly hook-created Secret (breaking the post-upgrade cp-refresh job). Helm checks the **live object** for `keep`, and the pre-upgrade hook has already recreated the Secret with that annotation by the time the prune runs — so the conversion is safe in a single upgrade. `keep` also preserves the cp_id across an HA disable/re-enable toggle 
- cp_id stability is unchanged: the template's `lookup` runs at render time, before `before-hook-creation` deletes the old Secret, so the existing value carries into the hook-created Secret. The cpId precedence (explicit value → lookup → fresh UUID) is untouched.
- Fresh HA-from-day-one installs were never affected (the migration job is `post-install` there). This only re-orders the pre-upgrade phase.

Follow-up (not in this PR): drop the manual cp-identity pre-creation workaround from runbook Step 8b once this merges.

## Related Issues

[PINF-934](https://linear.app/astronomer/issue/PINF-934/enabling-controlplaneha-via-helm-upgrade-deadlocks-pre-upgrade-hooks) - related: [PINF-933](https://linear.app/astronomer/issue/PINF-933/mutation-gate-deadlocks-greenfield-cp-ha-bootstrap), [PINF-930](https://github.com/astronomer/astronomer/pull/3366)

## Testing

- Two new chart tests in `tests/chart_tests/test_control_plane_ha.py::TestCpIdentitySecret`: one asserting the four hook annotations, and `test_hook_runs_before_db_migration_hook_job` asserting the Secret shares the `pre-upgrade` phase with the db-migration job at a strictly lower weight (direct regression guard for the deadlock).
- All 105 tests in `test_control_plane_ha.py` and all 60 in `test_astronomer_houston_hook_job.py` pass; `uvx prek run --all-files` clean.
- `helm template` render verified with and without `global.argoCD.annotation.enabled`.
- Pending manual verification on the k3d CP-HA env: HA-enable upgrade from a non-HA install without pre-creating the secret, and one upgrade of the existing HA env to confirm the hook conversion keeps the Secret with an unchanged cp_id.

## Merging

Merge into `feature/cp-ha-dr` only (CP HA/DR feature branch, targeted at 2.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)