### PR TITLE
2.0.1-beta9: Bump houston-api to 2.0.32, apc-ui to 2.0.14

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: astronomer
-version: 2.0.1-beta8
-appVersion: 2.0.1-beta8
+version: 2.0.1-beta9
+appVersion: 2.0.1-beta9
 description: Helm chart to deploy the Astronomer Platform
 icon: https://www.astronomer.io/static/iconforLIGHTbackground.svg
 keywords:

--- a/charts/astronomer/Chart.yaml
+++ b/charts/astronomer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: astronomer
-version: 2.0.1-beta8
+version: 2.0.1-beta9
 description: A Helm chart to deploy the Astronomer module
 keywords:
   - astronomer

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,11 +24,11 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.0.31
+    tag: 2.0.32
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui
-    tag: 2.0.13
+    tag: 2.0.14
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Addressed issues with DELETE_KEY sentinel persisting as a value for cluster config override instead of deleting the key.


Component | Field | Previous Version | New Version | Change
-- | -- | -- | -- | --
Chart | version | 2.0.1-beta8 | 2.0.1-beta9 | Bumped chart version
Houston | tag | 2.0.31 | 2.0.32 | Updated Houston image tag
APC UI | tag | 2.0.13 | 2.0.14 | Updated Astro UI image tag

</body></html>

## Related Issues

Related https://linear.app/astronomer/issue/PLX-676/fix-delete-key-sentinel-in-cluster-deployments-configuration

## Testing

Local testing

## Merging

- 2.0.1
