### PR TITLE
pinf-953-add-missing-network-policy-for-houston-cp-refresh

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -70,6 +70,11 @@ spec:
         matchLabels:
           tier: astronomer
           release: {{ .Release.Name }}
+          component: houston-cp-refresh
+    - podSelector:
+        matchLabels:
+          tier: astronomer
+          release: {{ .Release.Name }}
           component: houston-update-check
     - podSelector:
         matchLabels:

--- a/charts/astronomer/templates/registry/registry-networkpolicy.yaml
+++ b/charts/astronomer/templates/registry/registry-networkpolicy.yaml
@@ -57,6 +57,11 @@ spec:
     - podSelector:
         matchLabels:
           tier: astronomer
+          component: houston-cp-refresh
+          release: {{ .Release.Name }}
+    - podSelector:
+        matchLabels:
+          tier: astronomer
           component: houston
           release: {{ .Release.Name }}
     - podSelector:

--- a/tests/chart_tests/test_astronomer_commander_networkpolicy.py
+++ b/tests/chart_tests/test_astronomer_commander_networkpolicy.py
@@ -80,3 +80,42 @@ class TestCommanderNetworkPolicyDataplaneFailover:
         ingress_from = docs[0]["spec"]["ingress"][0]["from"]
         pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "astronomer", "tier": "astronomer"}}}
         assert pilot_selector in ingress_from
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestCommanderNetworkPolicyHoustonCpRefresh:
+    def test_unified_mode_adds_houston_cp_refresh_ingress_rule(self, kube_version):
+        """houston-cp-refresh podSelector is present in unified mode so the post-upgrade job can reach commander."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "unified"},
+                }
+            },
+        )
+        assert len(docs) == 1
+        ingress_from = docs[0]["spec"]["ingress"][0]["from"]
+        cp_refresh_selector = {
+            "podSelector": {"matchLabels": {"component": "houston-cp-refresh", "release": "release-name", "tier": "astronomer"}}
+        }
+        assert cp_refresh_selector in ingress_from
+
+    def test_data_mode_omits_houston_cp_refresh_ingress_rule(self, kube_version):
+        """houston-cp-refresh podSelector is absent in data mode, where the job is not rendered."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "data"},
+                }
+            },
+        )
+        assert len(docs) == 1
+        all_from_rules = [rule for ingress in docs[0]["spec"]["ingress"] for rule in ingress.get("from", [])]
+        components = [r.get("podSelector", {}).get("matchLabels", {}).get("component") for r in all_from_rules]
+        assert "houston-cp-refresh" not in components

--- a/tests/chart_tests/test_astronomer_registry_networkpolicy.py
+++ b/tests/chart_tests/test_astronomer_registry_networkpolicy.py
@@ -1,0 +1,45 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils.chart import render_chart
+
+NP_FILE = "charts/astronomer/templates/registry/registry-networkpolicy.yaml"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestRegistryNetworkPolicyHoustonCpRefresh:
+    def test_unified_mode_adds_houston_cp_refresh_ingress_rule(self, kube_version):
+        """houston-cp-refresh podSelector is present in unified mode so the post-upgrade job can reach the registry."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "unified"},
+                }
+            },
+        )
+        assert len(docs) == 1
+        ingress_from = docs[0]["spec"]["ingress"][0]["from"]
+        cp_refresh_selector = {
+            "podSelector": {"matchLabels": {"component": "houston-cp-refresh", "release": "release-name", "tier": "astronomer"}}
+        }
+        assert cp_refresh_selector in ingress_from
+
+    def test_data_mode_omits_houston_cp_refresh_ingress_rule(self, kube_version):
+        """houston-cp-refresh podSelector is absent in data mode, where the job is not rendered."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[NP_FILE],
+            values={
+                "global": {
+                    "networkPolicy": {"enabled": True},
+                    "plane": {"mode": "data"},
+                }
+            },
+        )
+        assert len(docs) == 1
+        all_from_rules = [rule for ingress in docs[0]["spec"]["ingress"] for rule in ingress.get("from", [])]
+        components = [r.get("podSelector", {}).get("matchLabels", {}).get("component") for r in all_from_rules]
+        assert "houston-cp-refresh" not in components


### PR DESCRIPTION
## Description

In 2.1.0-beta1, unified-plane Helm installs hang: the astronomer-houston-cp-refresh post-upgrade job's wait-for-db container can't reach astronomer-commander:50051. The commander and registry network policies list every other houston hook (houston-db-migrations, houston-upgrader, etc.) but were missing houston-cp-refresh.

## Related Issues

https://linear.app/astronomer/issue/PINF-953/add-missing-network-policy-for-houston-cp-refresh-in-210-beta1

## Testing

Tested manaully by patching resources in a cluster. https://astronomer.slack.com/archives/C0A8A36G7HT/p1783494794245529

## Merging

2.1