### PR TITLE
PINF-957: Ungate cp-identity Secret generation from controlPlaneHA.enabled

### DIFF
--- a/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
+++ b/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
@@ -1,5 +1,5 @@
 ######################################################
-## Control Plane identity Secret (Control Plane HA)  ##
+## Control Plane identity Secret                    ##
 ######################################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
 {{- if .Values.global.controlPlaneHA.enabled }}

--- a/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
+++ b/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
@@ -1,12 +1,13 @@
 ######################################################
 ## Control Plane identity Secret (Control Plane HA)  ##
 ######################################################
-{{- if .Values.global.controlPlaneHA.enabled }}
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if .Values.global.controlPlaneHA.enabled }}
 {{- /* globalBaseDomain is only consumed on control/unified planes, so only enforce it here.
    This keeps data-plane renders working when HA is enabled via a shared global values file. */}}
 {{- if not .Values.global.controlPlaneHA.globalBaseDomain }}
 {{- fail "global.controlPlaneHA.globalBaseDomain is required when global.controlPlaneHA.enabled is true" }}
+{{- end }}
 {{- end }}
 {{- /*
   Stable per-CP UUID, mounted as the CP_ID env var on every CP pod that runs a
@@ -54,5 +55,4 @@ metadata:
 type: Opaque
 data:
   cp_id: {{ $cpId | b64enc | quote }}
-{{- end }}
 {{- end }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
@@ -8,18 +8,20 @@
   refresh path via `yarn refresh-cp-chart-version` (update-only, idempotent, no-op
   when the CP is unregistered).
 
-  Rendered on every control/unified plane, mirroring the houston-db-migrations and
-  houston-upgrade-deployments hooks. Cross-CP version coordination only matters
-  under Control Plane HA: the CP_ID env (from the cp-identity Secret) is injected
-  by houston_environment only when controlPlaneHA is enabled, so on single-CP /
-  non-HA installs the script finds no CP_ID and cleanly no-ops.
+  Gated on both plane mode (control/unified) and controlPlaneHA.enabled: unlike the
+  cp-identity Secret (deliberately generated pre-HA so the id is stable ahead of an
+  HA-enable), this job has no pre-HA value. Cross-CP chartVersion coordination is
+  only meaningful with multiple active CPs; on a single-CP/non-HA install the CP_ID
+  env (from the cp-identity Secret, via houston_environment) isn't wired either, so
+  the job would just spin up a pod and no-op. Gating it here avoids that wasted run
+  on every single-CP/unified helm upgrade.
 
   Ordering: this is a `post-upgrade` hook while houston-db-migrations is a
   `pre-upgrade` hook, so migrations always complete before this runs — a CP only
   advertises its new chartVersion once its new schema is live. hook-weight "0"
   runs it ahead of the post-upgrade houston-upgrade-deployments hook (weight "1").
 */}}
-{{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
+{{- if and (or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified")) .Values.global.controlPlaneHA.enabled }}
 apiVersion: {{ include "apiVersion.batch" . }}
 kind: Job
 metadata:

--- a/tests/chart_tests/test_astronomer_houston_hook_job.py
+++ b/tests/chart_tests/test_astronomer_houston_hook_job.py
@@ -235,13 +235,19 @@ class TestHoustonHookJob:
     supported_k8s_versions,
 )
 class TestRefreshCpChartVersionHookJob:
-    """The CP chartVersion refresh post-upgrade hook (PINF-930)."""
+    """The CP chartVersion refresh post-upgrade hook (PINF-930).
 
-    def test_defaults_on_control_plane(self, kube_version):
-        """Rendered on a control plane (mirrors db-migration/upgrade-deployments): name, args, mount."""
+    Unlike the cp-identity Secret, this job is gated on controlPlaneHA.enabled in addition
+    to plane mode: cross-CP chartVersion coordination is meaningless with a single CP, and
+    (without HA) CP_ID is never wired to the job either, so running it would just spin up a
+    pod that no-ops.
+    """
+
+    def test_defaults_on_control_plane_with_ha(self, kube_version):
+        """Rendered on a control plane with HA enabled (mirrors db-migration/upgrade-deployments): name, args, mount."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "control"}}},
+            values=_ha_values(),
             show_only=[REFRESH_CP_CHART_VERSION_FILE],
         )
 
@@ -265,11 +271,21 @@ class TestRefreshCpChartVersionHookJob:
             "subPath": "production.yaml",
         } in job["volumeMounts"]
 
-    def test_absent_on_data_plane(self, kube_version):
-        """A data-plane render emits no refresh Job (no CP registry on the data plane)."""
+    @pytest.mark.parametrize("mode", ["control", "unified"])
+    def test_absent_when_ha_disabled(self, kube_version, mode):
+        """No refresh Job on control/unified installs while HA is off (new behavior)."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "data"}}},
+            values={"global": {"plane": {"mode": mode}, "controlPlaneHA": {"enabled": False}}},
+            show_only=[REFRESH_CP_CHART_VERSION_FILE],
+        )
+        assert docs == []
+
+    def test_absent_on_data_plane(self, kube_version):
+        """A data-plane render emits no refresh Job (no CP registry on the data plane), even with HA enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": True}}},
             show_only=[REFRESH_CP_CHART_VERSION_FILE],
         )
         assert docs == []
@@ -278,7 +294,7 @@ class TestRefreshCpChartVersionHookJob:
         """post-upgrade hook, ordered after the pre-upgrade db-migration job."""
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "control"}}},
+            values=_ha_values(),
             show_only=[REFRESH_CP_CHART_VERSION_FILE],
         )
 
@@ -300,16 +316,3 @@ class TestRefreshCpChartVersionHookJob:
         c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
         env = get_env_vars_dict(c_by_name["refresh-cp-chart-version-job"].get("env", []))
         assert env.get("CP_ID") == {"secretKeyRef": {"name": "cp-identity", "key": "cp_id"}}
-
-    def test_cp_id_env_absent_without_ha(self, kube_version):
-        """Without HA there is no cp-identity Secret, so the script no-ops (no CP_ID wired)."""
-        docs = render_chart(
-            kube_version=kube_version,
-            values={"global": {"plane": {"mode": "control"}}},
-            show_only=[REFRESH_CP_CHART_VERSION_FILE],
-        )
-
-        assert len(docs) == 1
-        c_by_name = get_containers_by_name(docs[0], include_init_containers=True)
-        env = get_env_vars_dict(c_by_name["refresh-cp-chart-version-job"].get("env", []))
-        assert "CP_ID" not in env

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -334,6 +334,11 @@ def test_default_serviceaccount_names(template_name):
     }
     if any(substring in template_name for substring in data_plane_only_template_substrings):
         default_serviceaccount_names_overrides["global"]["plane"] = {"mode": "data"}
+    if any(substring in template_name for substring in ha_only_template_substrings):
+        default_serviceaccount_names_overrides["global"]["controlPlaneHA"] = {
+            "enabled": True,
+            "globalBaseDomain": "example.com",
+        }
     values = always_merger.merge(get_all_features(), default_serviceaccount_names_overrides)
 
     docs = render_chart(show_only=template_name, values=values)
@@ -502,6 +507,9 @@ data_plane_only_template_substrings = (
     "commander-jwks-hooks",
 )
 
+# Templates gated on Control Plane HA; render them with controlPlaneHA.enabled=True.
+ha_only_template_substrings = ("houston-cp-refresh-job",)
+
 
 @pytest.mark.parametrize(
     "template_name",
@@ -531,6 +539,9 @@ def test_custom_serviceaccount_names(template_name):
     if any(substring in template_name for substring in data_plane_only_template_substrings):
         plane_config = {"global": {"plane": {"mode": "data"}}}
         values = always_merger.merge(values, plane_config)
+    if any(substring in template_name for substring in ha_only_template_substrings):
+        ha_config = {"global": {"controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"}}}
+        values = always_merger.merge(values, ha_config)
     values = always_merger.merge(values, enable_pgsql_sa)
 
     docs = render_chart(show_only=template_name, values=values)

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -178,6 +178,7 @@ class TestCpIdentitySecret:
             show_only=[CP_IDENTITY_FILE],
             values={"global": {"plane": {"mode": "control"}, "controlPlaneHA": {"enabled": False}}},
         )
+        assert len(initial) == 1
         cp_id = base64.b64decode(initial[0]["data"]["cp_id"]).decode()
 
         # HA-enable: on a real cluster `lookup` would find the Secret above and reuse cp_id.

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -1,9 +1,12 @@
 """Tests for the Control Plane HA (global.controlPlaneHA) chart wiring (PINF-768).
 
-Covers, behind the default-off `global.controlPlaneHA.enabled` flag:
-  * cp-identity Secret (generated only in HA mode; required-globalBaseDomain guard)
+Covers:
+  * cp-identity Secret: generated on every control/unified plane install regardless of
+    HA state (PINF-760), so a stable cp_id exists from initial single-CP install and is
+    already available if/when HA is later enabled; data-plane installs never generate it;
+    required-globalBaseDomain guard still applies only when HA is enabled.
   * JWT signing keypair generation gating (jwks.generation.enabled / HA)
-  * CP_ID env var on every CP reconciliation-loop pod
+  * CP_ID env var on every CP reconciliation-loop pod, still gated on HA
     (Houston API + worker, dp-link, navigator)
   * helm.globalBaseDomain / cookieDomain / cookieName in the houston configmap
 """
@@ -54,13 +57,36 @@ def _no_container_has_cp_id(doc):
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestCpIdentitySecret:
-    def test_absent_when_ha_disabled(self, kube_version):
-        """No cp-identity Secret on a default (non-HA) install."""
-        docs = render_chart(kube_version=kube_version, show_only=[CP_IDENTITY_FILE])
+    @pytest.mark.parametrize("mode", ["control", "unified"])
+    def test_generated_when_ha_disabled(self, kube_version, mode):
+        """cp-identity Secret is generated on control/unified installs even with HA off (PINF-760).
+
+        This is the core behavior change: a stable cp_id must exist from the initial
+        single-CP install so it's already available if/when the customer later enables HA,
+        rather than being minted for the first time at the HA-enable flip.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE],
+            values={"global": {"plane": {"mode": mode}, "controlPlaneHA": {"enabled": False}}},
+        )
+        assert len(docs) == 1
+        secret = docs[0]
+        assert secret["kind"] == "Secret"
+        assert secret["metadata"]["name"] == "cp-identity"
+        assert secret["data"]["cp_id"]  # non-empty (uuid, base64-encoded)
+
+    def test_absent_on_data_plane_when_ha_disabled(self, kube_version):
+        """Data-plane installs never generate cp-identity; the plane-mode gate still applies."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE],
+            values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": False}}},
+        )
         assert docs == []
 
     def test_generated_when_ha_enabled(self, kube_version):
-        """cp-identity Secret rendered with a base64 cp_id in HA mode."""
+        """cp-identity Secret rendered with a base64 cp_id in HA mode (existing behavior preserved)."""
         docs = render_chart(kube_version=kube_version, show_only=[CP_IDENTITY_FILE], values=_ha_values())
         assert len(docs) == 1
         secret = docs[0]
@@ -133,6 +159,47 @@ class TestCpIdentitySecret:
             values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": True}}},
         )
         assert docs == []
+
+    def test_cp_id_survives_ha_disable_then_reenable(self, kube_version):
+        """cp_id minted at single-CP install time is preserved across an HA disable/re-enable toggle.
+
+        `helm template` has no cluster to run `lookup` against (it always sees an empty
+        cluster), so the `lookup`-finds-the-existing-Secret branch can't be exercised directly
+        in this render-only test harness. This instead pins the cp_id captured from the initial
+        HA-off render via the explicit `global.controlPlaneHA.cpId` override for the later
+        renders — the same value the chart would read back from the real cp-identity Secret
+        (protected by `helm.sh/resource-policy: keep`) during an actual `helm upgrade` toggle.
+        """
+        import base64
+
+        # Single-CP install: cp-identity is generated for the first time (HA off).
+        initial = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE],
+            values={"global": {"plane": {"mode": "control"}, "controlPlaneHA": {"enabled": False}}},
+        )
+        cp_id = base64.b64decode(initial[0]["data"]["cp_id"]).decode()
+
+        # HA-enable: on a real cluster `lookup` would find the Secret above and reuse cp_id.
+        enabled = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE],
+            values=_ha_values(cpId=cp_id),
+        )
+        assert base64.b64decode(enabled[0]["data"]["cp_id"]).decode() == cp_id
+
+        # HA-disable again: the same cp_id remains in place for a future re-enable.
+        disabled_again = render_chart(
+            kube_version=kube_version,
+            show_only=[CP_IDENTITY_FILE],
+            values={
+                "global": {
+                    "plane": {"mode": "control"},
+                    "controlPlaneHA": {"enabled": False, "cpId": cp_id},
+                }
+            },
+        )
+        assert base64.b64decode(disabled_again[0]["data"]["cp_id"]).decode() == cp_id
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)

--- a/values.yaml
+++ b/values.yaml
@@ -47,7 +47,9 @@ global:
     # One physical cert per CP serves both families. Issue via DNS-01 ACME — HTTP-01 will
     # not work because the global host only routes to active-region CPs.
     globalBaseDomain: ~
-    # Stable per-CP identity (UUID), exposed to pods as the CP_ID env var.
+    # Stable per-CP identity (UUID), exposed to pods as the CP_ID env var. Generated on
+    # every control/unified plane install regardless of controlPlaneHA.enabled — the value
+    # is preserved for future HA enablement even if not currently in use.
     # When unset, the chart looks up the existing cp-identity Secret and reuses its value,
     # or generates a new UUID on first install (preserved across `helm upgrade`).
     # Set explicitly to keep cp_id deterministic for GitOps / offline `helm template`


### PR DESCRIPTION
## Description

Two related but opposite-direction gating fixes for Control Plane HA (PINF-760):

- **cp-identity Secret is no longer HA-gated.** Previously it only rendered once `controlPlaneHA.enabled` was true, so `cp_id` didn't exist until the exact helm upgrade that flipped HA on — forcing `registerControlPlane` to run immediately after, and leaving an ambiguous state if that follow-up step didn't happen right away. Now it renders on every control/unified install regardless of HA state, so `cp_id` is stable from the initial single-CP install and just gets reused as-is if/when HA is enabled later.

- **houston-cp-refresh-job is now HA-gated** (added, not removed). This job re-records the CP's chartVersion for cross-CP version coordination, which is meaningless with a single CP. It previously ran unconditionally on every control/unified upgrade and simply no-op'd without HA (since CP_ID was never wired to it either) — pure wasted job execution on every non-HA upgrade. Gating it skips that no-op run.


## Related Issues

https://linear.app/astronomer/issue/PINF-957/astronomer-chart-ungate-cp-identity-secret-generation-from

## Testing

- Unittest added.
- Default install (HA off, plane=unified by default) — Secret should now render:
<img width="1474" height="382" alt="Screenshot 2026-07-09 at 11 51 55 AM" src="https://github.com/user-attachments/assets/f61d9c2f-8467-4ffc-847d-1b7c3a787934" />

- HA off, plane=control — Secret should render:
<img width="1901" height="392" alt="Screenshot 2026-07-09 at 11 53 37 AM" src="https://github.com/user-attachments/assets/d17eaea6-4997-4733-8d63-0df11f3ee6c9" />

- HA off, plane=data — Secret should NOT render 
<img width="1734" height="127" alt="Screenshot 2026-07-09 at 11 54 28 AM" src="https://github.com/user-attachments/assets/53efbf03-3e5f-4d36-8672-8c45d157d6df" />

## Merging

Master, 2.1
