### PR TITLE
PM-4446 - update commander version 2.1.5

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.1.4
+    tag: 2.1.5
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

fix the isSecretClusterStore metadata information

## Related Issues

https://linear.app/astronomer/issue/PM-4446/isclustersecretstore-incorrectly-set-to-true-when-external

## Testing

NA

## Merging

merge to master and release-2.1
