### PR TITLE
backport 1.2 fixes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: docker23
+          version: docker28
       - cosign/install:
           version: "v2.5.0"
       - run:
@@ -202,7 +202,7 @@ jobs:
 
   scenario-unified-1-31-14:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.05.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.31.14
@@ -229,7 +229,7 @@ jobs:
           path: test-results
   scenario-unified-1-32-11:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.05.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.32.11
@@ -256,7 +256,7 @@ jobs:
           path: test-results
   scenario-unified-1-33-7:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.05.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.33.7
@@ -283,7 +283,7 @@ jobs:
           path: test-results
   scenario-unified-1-34-3:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.05.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.34.3
@@ -310,7 +310,7 @@ jobs:
           path: test-results
   scenario-unified-1-35-0:
     machine:
-      image: ubuntu-2404:2025.09.1
+      image: ubuntu-2404:2026.05.1
       resource_class: xlarge
     environment:
       KUBE_VERSION: v1.35.0

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -24,7 +24,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: docker23
+          version: docker28
       - cosign/install:
           version: "v2.5.0"
       - run:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
+---
 exclude: '(venv|\.vscode|tests/k8s_schema|tests/chart_tests/test_data)' # regex
+auto_update:
+  cooldown_days: 7
 repos:
   - repo: local
     hooks:
@@ -50,7 +53,7 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.14.8"
+    rev: "v0.15.19"
     hooks:
       - id: ruff-check
         args:

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -13,7 +13,7 @@ metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
 ci_runner_version = "2026-05"  # This should be the current YYYY-MM
-machine_image_version = "ubuntu-2404:2025.09.1"  # https://circleci.com/developer/machine/image/ubuntu-2404
+machine_image_version = "ubuntu-2404:2026.05.1"  # https://circleci.com/developer/machine/image/ubuntu-2404
 
 
 def list_docker_images():

--- a/charts/alertmanager/templates/_helpers.tpl
+++ b/charts/alertmanager/templates/_helpers.tpl
@@ -84,6 +84,17 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "alertmanager.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "alertmanager.serviceAccountName" -}}
 {{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s" (include "alertmanager.fullname" . )) .Values.serviceAccount.name }}

--- a/charts/alertmanager/templates/alertmanager-statefulset.yaml
+++ b/charts/alertmanager/templates/alertmanager-statefulset.yaml
@@ -44,9 +44,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "alertmanager.serviceAccountName" . }}
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "alertmanager.podSecurityContext" . | nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -16,13 +16,13 @@
 {{- end }}
 {{- end }}
 
-{{ define "commander.metadata.namespaceLabels" }}
+{{- define "commander.metadata.namespaceLabels" -}}
 {{- if .Values.global.rbacEnabled -}}
-{{ .Values.global.namespaceLabels | toYaml | nindent 6 -}}
+{{ .Values.global.namespaceLabels | toYaml }}
 {{- else -}}
 {}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}
 
 {{ define "commander.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -605,3 +605,26 @@ hostAliases:
 {{ toYaml .Values.commander.hostAliases }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Return shared podSecurityContext (astro-ui, navigator, pilot, dp-link),
+omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "astronomer.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return registry podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "astronomer.registry.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.registry.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.registry.podSecurityContext }}
+{{- end -}}
+{{- end }}

--- a/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
+++ b/charts/astronomer/templates/astro-ui/astro-ui-deployment.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "astroUI.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       nodeSelector:
 {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | indent 8 }}
       affinity:

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -57,6 +57,7 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       serviceAccountName: {{ template "commander.serviceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       restartPolicy: Always
       {{- include "astronomer.imagePullSecrets" . | nindent 6 }}
       {{- include "commander.hostAliases" . | nindent 6 }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -17,7 +17,8 @@ data:
   metadata.yaml: |-
     registry:
       version: {{ .Values.images.registry.tag | quote }}
-    namespaceLabels: {{ include "commander.metadata.namespaceLabels" . }}
+    namespaceLabels:
+      {{- include "commander.metadata.namespaceLabels" . | nindent 6 }}
     customLogging:
       enabled: {{ ternary "true" "false" .Values.global.customLogging.enabled }}
     openshift:

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -47,6 +47,7 @@ spec:
       {{- include "houston.hostAliases" . | nindent 6 }}
       restartPolicy: Always
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
       initContainers:
         - name: etc-ssl-certs-copier

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -19,7 +19,7 @@ metadata:
     heritage: {{ .Release.Service }}
     plane: {{ .Values.global.plane.mode }}
 data:
-  {{ if and .Values.houston.runtimeReleasesConfig ( not .Values.houston.runtimeReleasesConfigMapName ) }}
+  {{- if and .Values.houston.runtimeReleasesConfig ( not .Values.houston.runtimeReleasesConfigMapName ) }}
   astro_runtime_releases.json: |
     {{ .Values.houston.runtimeReleasesConfig | toJson }}
   # These are system-specified config overrides.
@@ -64,7 +64,9 @@ data:
 
     helm:
       baseDomain: {{ .Values.global.baseDomain }}
+      {{- if .Values.registry.auth.secretName }}
       registryAuthSecret: {{ .Values.registry.auth.secretName }}
+      {{- end }}
       releaseName: {{ .Release.Name }}
       releaseNamespace: {{ .Release.Namespace }}
       releaseVersion: {{ .Chart.Version }}
@@ -102,7 +104,7 @@ data:
       cleanupAirflowDb:
         enabled: {{ .Values.houston.cleanupAirflowDb.enabled }}
 
-      {{ if .Values.global.features.namespacePools.enabled }}
+      {{- if .Values.global.features.namespacePools.enabled }}
       hardDeleteDeployment: true
       manualNamespaceNames: true
       preCreatedNamespaces:
@@ -178,7 +180,7 @@ data:
             repository: {{ (splitList ":" $dagOnlyDeployment ) | first }}
             tag: {{ (splitList ":" $dagOnlyDeployment ) | last }}
         {{- if .Values.global.dagOnlyDeployment.securityContexts }}
-        securityContexts: {{ template "dagOnlyDeployment.securityContexts" . }}
+        securityContexts: {{- template "dagOnlyDeployment.securityContexts" . }}
         {{- end }}
         {{- if or
           .Values.global.dagOnlyDeployment.resources
@@ -227,7 +229,7 @@ data:
         {{- if .Values.global.dagOnlyDeployment.persistence }}
         persistence: {{- .Values.global.dagOnlyDeployment.persistence | toYaml | nindent 10 }}
         {{- end }}
-        {{ if .Values.global.dagOnlyDeployment.serviceAccount }}
+        {{- if .Values.global.dagOnlyDeployment.serviceAccount }}
         serviceAccount: {{- .Values.global.dagOnlyDeployment.serviceAccount | toYaml | nindent 10 }}
         {{- end }}
       {{- end }}
@@ -301,28 +303,28 @@ data:
           networkPolicies:
           # Enabled network polices to restrict the way pods can communicate.
             enabled: true
-          {{ end }}
+          {{- end }}
           {{- if .Values.global.openshiftEnabled }}
           dags:
               gitSync:
                 securityContexts:
                   container:
                     runAsNonRoot: true
-          {{ end }}
+          {{- end }}
           # Enable FlowerUI flag by default
           flower:
             enabled: true
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
-            {{ end }}
+            {{- end }}
           apiServer:
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
-            {{ end }}
+            {{- end }}
             resources:
               limits:
                 # XXX: There is an alert configured to trigger when ephemeral storage reaches
@@ -332,11 +334,11 @@ data:
               requests:
                 ephemeral-storage: "1Gi"
           webserver:
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
-            {{ end }}
+            {{- end }}
             resources:
               limits:
                 # XXX: There is an alert configured to trigger when ephemeral storage reaches
@@ -357,11 +359,11 @@ data:
 
           # Worker configuration (applies to Celery and Kubernetes task pods).
           workers:
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
-            {{ end }}
+            {{- end }}
             resources:
               limits:
                 ephemeral-storage: "2Gi"
@@ -473,7 +475,7 @@ data:
                       container.args = container.command + container.args
                   container.command = ["tini", "--", "/entrypoint"]
                   pod.spec.containers[0] = container
-      {{ if .Values.global.loggingSidecar.enabled }}
+      {{- if .Values.global.loggingSidecar.enabled }}
                   # For sidecar logging we override the default entrypoint to redirect logs to
                   # files that are consumed by the sidecar container. The command ends by creating
                   # the file /var/log/sidecar-log-consumer/finished, which signals the sidecar log
@@ -515,7 +517,7 @@ data:
                       )
                       new_args.append(command_str)
                       container.args = new_args
-      {{ end }}
+      {{- end }}
               else:
                   # In the case of KPO, we allow Airflow to overwrite the entrypoint
                   # because we do not know what the container will be (and it's probably
@@ -535,13 +537,13 @@ data:
           redis:
             # This is here for upgrading to 0.11.2+ of airflow-chart
             safeToEvict: true
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
-            {{ end }}
+            {{- end }}
 
-          {{ if .Values.global.openshiftEnabled }}
+          {{- if .Values.global.openshiftEnabled }}
           # Statsd settings
           statsd:
             securityContexts:
@@ -566,16 +568,16 @@ data:
               pod:
                 runAsNonRoot: true
 
-          {{ end }}
+          {{- end }}
 
           # Pgbouncer settings
           pgbouncer:
-            {{ if .Values.global.openshiftEnabled }}
+            {{- if .Values.global.openshiftEnabled }}
             securityContexts:
               pod:
                 runAsNonRoot: true
             command: ["pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]
-            {{ end }}
+            {{- end }}
             podDisruptionBudget:
               enabled: false
 
@@ -601,7 +603,7 @@ data:
           # to cleanup evicted/failed/succeeded pods.
           cleanup:
             enabled: true
-            {{/*
+            {{- /*
             Generate a deterministic random-ish decimal digit from the .Release.Name, which is used to generate
             the minute field of the cron schedule. This is effectively a splay seeded by the release name.
             This is used to spread the load of this job away from high-use minutes 0,15,30,45.

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -47,6 +47,7 @@ spec:
       {{- include "houston.worker.hostAliases" . | nindent 6 }}
       restartPolicy: Always
       serviceAccountName: {{ template "houston.bootstrapperServiceAccountName" . }}
+      securityContext: {{- include "astronomer.podSecurityContext" . | nindent 8 }}
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
       {{- if and (not .Values.houston.airflowBackendSecretName) (not .Values.houston.airflowBackendConnection) (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
       initContainers:

--- a/charts/astronomer/templates/registry/registry-statefulset.yaml
+++ b/charts/astronomer/templates/registry/registry-statefulset.yaml
@@ -64,9 +64,7 @@ spec:
       tolerations:
 {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | indent 8 }}
       restartPolicy: Always
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.registry.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "astronomer.registry.podSecurityContext" . | nindent 8 }}
 {{- include "astronomer.imagePullSecrets" . | indent 6 }}
       {{- if .Values.registry.hostAliases }}
       hostAliases: {{- toYaml .Values.registry.hostAliases | nindent 8 }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -39,6 +39,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 astroUI:
   replicas: 2
   env: []

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -161,6 +161,28 @@ imagePullSecrets:
 {{- end -}}
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "elasticsearch.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return exporter podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "elasticsearch.exporter.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.exporter.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.exporter.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{- define "elasticsearch.ingressurl" -}}
 {{ if eq .Values.global.plane.mode "data" -}}
 elasticsearch.{{ .Values.global.plane.domainPrefix }}.{{ .Values.global.baseDomain }}

--- a/charts/elasticsearch/templates/_helpers.tpl
+++ b/charts/elasticsearch/templates/_helpers.tpl
@@ -153,11 +153,10 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "elasticsearch.securityContext" -}}
-{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshiftEnabled ) }}
 {{- $required := dict "readOnlyRootFilesystem" true }}
+{{- if .Values.global.openshiftEnabled }}
 {{- merge $required (omit .Values.securityContext "runAsUser") | toYaml }}
 {{- else }}
-{{- $required := dict "readOnlyRootFilesystem" true }}
 {{- merge $required .Values.securityContext | toYaml }}
 {{- end -}}
 {{- end }}

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -88,7 +88,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.client.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+        {{- if .Values.client.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.client.securityContext | toYaml | nindent 10}}
+        {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/elasticsearch/templates/client/es-client-deployment.yaml
+++ b/charts/elasticsearch/templates/client/es-client-deployment.yaml
@@ -45,9 +45,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "elasticsearch.serviceAccountName" . }}
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.client.antiAffinity "hard" }}

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -49,9 +49,7 @@ spec:
         {{- end }}
     spec:
       terminationGracePeriodSeconds: 3600
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.data.antiAffinity "hard" }}

--- a/charts/elasticsearch/templates/data/es-data-statefulset.yaml
+++ b/charts/elasticsearch/templates/data/es-data-statefulset.yaml
@@ -92,7 +92,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.data.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+          {{- if .Values.data.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.data.securityContext | toYaml | nindent 10 }}
+          {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+          {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -55,7 +55,7 @@ spec:
       affinity: {{- toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{- toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: {{ .Values.exporter.restartPolicy }}
-      securityContext: {{- toYaml .Values.exporter.podSecurityContext | nindent 8 }}
+      securityContext: {{- include "elasticsearch.exporter.podSecurityContext" . | nindent 8 }}
       {{- include "elasticsearch.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: metrics-exporter

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -91,7 +91,12 @@ spec:
         imagePullPolicy: {{ .Values.images.init.pullPolicy }}
         resources: {{- toYaml .Values.master.initResources | nindent 10 }}
         securityContext:
-          readOnlyRootFilesystem: true
+          {{- if .Values.master.securityContext }}
+          {{- $required := dict "readOnlyRootFilesystem" true }}
+          {{- merge $required .Values.master.securityContext | toYaml | nindent 10 }}
+          {{- else }}
+          {{- include "elasticsearch.securityContext" . | nindent 10 }}
+          {{- end }}
         volumeMounts:
           - name: es-config-dir
             mountPath: /usr/share/elasticsearch/config_copy

--- a/charts/elasticsearch/templates/master/es-master-statefulset.yaml
+++ b/charts/elasticsearch/templates/master/es-master-statefulset.yaml
@@ -48,9 +48,7 @@ spec:
         {{- toYaml .Values.master.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{- toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "elasticsearch.podSecurityContext" . | nindent 8 }}
       nodeSelector:
         {{- toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       {{- if eq .Values.master.antiAffinity "hard" }}

--- a/charts/grafana/templates/_helpers.yaml
+++ b/charts/grafana/templates/_helpers.yaml
@@ -79,3 +79,14 @@ imagePullSecrets:
   - name: {{ .Values.global.privateRegistry.secretName }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "grafana.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}

--- a/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/grafana/templates/grafana-deployment.yaml
@@ -43,6 +43,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "grafana.bootstrapper.serviceAccountName" . }}
+      securityContext: {{- include "grafana.podSecurityContext" . | nindent 8 }}
       {{- include "grafana.imagePullSecrets" . | nindent 6 }}
     {{- if and (not .Values.backendSecretName) (not .Values.backendConnection) }}
       initContainers:

--- a/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/grafana/templates/grafana-ingress.yaml
@@ -21,20 +21,14 @@ metadata:
     {{- toYaml .Values.global.extraAnnotations | nindent 4 }}
     {{- end }}
     kubernetes.io/ingress.class: "{{ .Release.Name }}-nginx"
-    kubernetes.io/tls-acme: {{ eq .Values.global.acme true | quote }}
     {{- include "houston.internalauthurl" . | indent 4}}
     nginx.ingress.kubernetes.io/auth-signin: https://app.{{ .Values.global.baseDomain }}/login
     nginx.ingress.kubernetes.io/auth-response-headers: authorization, username, email
     {{- end }}
 spec:
-  {{- if or .Values.global.tlsSecret .Values.global.acme }}
-  tls:
-  {{- if .Values.global.acme }}
-    - secretName: grafana-tls
-  {{- end }}
   {{- if .Values.global.tlsSecret }}
+  tls:
     - secretName: {{ .Values.global.tlsSecret }}
-  {{- end }}
       hosts:
         - {{ template "grafana.url" . }}
   {{- end }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -21,6 +21,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/kube-state/templates/_helpers.yaml
+++ b/charts/kube-state/templates/_helpers.yaml
@@ -49,6 +49,17 @@ imagePullSecrets:
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "kube-state.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "kube-state.serviceAccountName" -}}
 {{- if and .Values.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s" (include "kube-state.fullname" . )) .Values.serviceAccount.name }}

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -2,7 +2,7 @@
 ## Kube State Deployment ##
 ###########################
 {{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
-{{- $useRoles := or .Values.global.features.namespacePools.enabled .Values.global.singleNamespace }}
+{{- $useRoles := .Values.global.features.namespacePools.enabled }}
 {{- $namespaces := .Values.global.features.namespacePools.namespaces.names }}
 {{- $namespaces = append $namespaces .Release.Namespace }}
 {{- $namespaceList := join "," $namespaces }}

--- a/charts/kube-state/templates/kube-state-deployment.yaml
+++ b/charts/kube-state/templates/kube-state-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "kube-state.serviceAccountName" . }}
+      securityContext: {{- include "kube-state.podSecurityContext" . | nindent 8 }}
       {{- include "kube-state.imagePullSecrets" . | nindent 6 }}
       containers:
         - name: kube-state

--- a/charts/kube-state/values.yaml
+++ b/charts/kube-state/values.yaml
@@ -15,6 +15,9 @@ images:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 env: {}
 resources:
   limits:

--- a/charts/nats/templates/_helpers.tpl
+++ b/charts/nats/templates/_helpers.tpl
@@ -77,6 +77,17 @@ imagePullSecrets:
 {{- end }}
 
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "nats.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "nats.serviceAccountName" -}}
 {{- if and .Values.nats.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s" (include "nats.name" . )) .Values.nats.serviceAccount.name }}

--- a/charts/nats/templates/statefulset.yaml
+++ b/charts/nats/templates/statefulset.yaml
@@ -54,9 +54,7 @@ spec:
     spec:
       serviceAccountName: {{ template "nats.serviceAccountName" . }}
     {{- include "nats.imagePullSecrets" . | nindent 6 }}
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
+      securityContext: {{- include "nats.podSecurityContext" . | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}

--- a/charts/nginx/templates/_helpers.tpl
+++ b/charts/nginx/templates/_helpers.tpl
@@ -77,6 +77,30 @@ imagePullSecrets:
 {{ printf "%s-default-backend" (include "nginx.fullname" .)}}
 {{- end -}}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "nginx.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Return container securityContext, always enforcing readOnlyRootFilesystem: true.
+Omits runAsUser on OpenShift (UIDs are assigned dynamically).
+*/}}
+{{- define "nginx.securityContext" -}}
+{{- $required := dict "readOnlyRootFilesystem" true }}
+{{- if .Values.global.openshiftEnabled }}
+{{- merge $required (omit .Values.securityContext "runAsUser") | toYaml }}
+{{- else }}
+{{- merge $required .Values.securityContext | toYaml }}
+{{- end -}}
+{{- end }}
+
 {{ define "defaultBackend.serviceAccountName" -}}
 {{- if and .Values.defaultBackend.serviceAccount.create .Values.global.rbacEnabled -}}
 {{ default (printf "%s" (include "defaultBackend.fullname" . )) .Values.defaultBackend.serviceAccount.name }}

--- a/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-deployment.yaml
@@ -46,14 +46,13 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}-cp
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-nginx-copier
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/sh
@@ -71,9 +70,7 @@ spec:
               mountPath: /etc/ingress-controller
       containers:
         - name: nginx
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/nginx/templates/controlplane/nginx-cp-role.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-role.yaml
@@ -2,7 +2,6 @@
 ## NGINX Control Plane Role/ClusterRole ##
 ##########################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/nginx/templates/controlplane/nginx-cp-rolebinding.yaml
+++ b/charts/nginx/templates/controlplane/nginx-cp-rolebinding.yaml
@@ -2,7 +2,6 @@
 ## NGINX Control Plane RoleBinding/ClusterRoleBinding ##
 ########################################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
 kind: ClusterRoleBinding
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-deployment.yaml
@@ -44,14 +44,13 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "nginx.serviceAccountName" . }}-dp
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       {{- include "nginx.imagePullSecrets" . | nindent 6 }}
       initContainers:
         - name: etc-nginx-copier
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/sh
@@ -69,9 +68,7 @@ spec:
               mountPath: /etc/ingress-controller
       containers:
         - name: nginx
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           image: {{ template "nginx.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           resources: {{ toYaml .Values.resources | nindent 12 }}

--- a/charts/nginx/templates/dataplane/nginx-dp-role.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-role.yaml
@@ -2,7 +2,6 @@
 ## NGINX Data Plane Role/ClusterRole ##
 #######################################
 {{- if eq .Values.global.plane.mode "data" }}
-{{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
 kind: ClusterRole
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/nginx/templates/dataplane/nginx-dp-rolebinding.yaml
+++ b/charts/nginx/templates/dataplane/nginx-dp-rolebinding.yaml
@@ -2,7 +2,6 @@
 ## NGINX Data Plane RoleBinding/ClusterRoleBinding ##
 #####################################################
 {{- if eq .Values.global.plane.mode "data" }}
-{{- $singleNamespace := .Values.global.singleNamespace }}
 {{- if .Values.global.rbacEnabled }}
 kind: ClusterRoleBinding
 apiVersion: {{ template "apiVersion.rbac" . }}

--- a/charts/nginx/templates/nginx-deployment-default.yaml
+++ b/charts/nginx/templates/nginx-deployment-default.yaml
@@ -39,6 +39,7 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "defaultBackend.serviceAccountName" . }}
+      securityContext: {{- include "nginx.podSecurityContext" . | nindent 8 }}
       nodeSelector: {{ toYaml (default .Values.global.platformNodePool.nodeSelector .Values.nodeSelector) | nindent 8 }}
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
@@ -48,9 +49,7 @@ spec:
         - name: default-backend
           image: {{ template "nginx.defaultBackend.image" . }}
           imagePullPolicy: {{ .Values.images.defaultBackend.pullPolicy }}
-          securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.securityContext | toYaml | nindent 12 }}
+          securityContext: {{- include "nginx.securityContext" . | nindent 12 }}
           {{- if .Values.defaultBackend.readinessProbe }}
           readinessProbe: {{ toYaml .Values.defaultBackend.readinessProbe | nindent 12 }}
           {{- end }}

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -26,6 +26,9 @@ securityContext:
       - NET_BIND_SERVICE
   allowPrivilegeEscalation: false
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true

--- a/charts/pgbouncer/templates/_helpers.yaml
+++ b/charts/pgbouncer/templates/_helpers.yaml
@@ -32,6 +32,17 @@
 {{ .Release.Name }}-pgbouncer-stats
 {{- end }}
 
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "pgbouncer.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
 {{ define "pgbouncer.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{ default (printf "%s-pgbouncer" .Release.Name ) .Values.serviceAccount.name }}

--- a/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "pgbouncer.serviceAccountName" . }}
+      securityContext: {{- include "pgbouncer.podSecurityContext" . | nindent 8 }}
       volumes:
         - name: tmp-workspace
           emptyDir: {}

--- a/charts/pgbouncer/values.yaml
+++ b/charts/pgbouncer/values.yaml
@@ -9,6 +9,9 @@ image:
 securityContext:
   runAsNonRoot: true
 
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+podSecurityContext: {}
+
 internalPort: 6543
 servicePort: 6543
 

--- a/charts/prometheus-postgres-exporter/templates/_helpers.tpl
+++ b/charts/prometheus-postgres-exporter/templates/_helpers.tpl
@@ -59,6 +59,17 @@ Set DATA_SOURCE_URI environment variable
 {{- end }}
 
 {{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "prometheus-postgres-exporter.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "prometheus-postgres-exporter.imagePullSecrets" -}}

--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -45,6 +45,7 @@ spec:
       affinity: {{ toYaml (default .Values.global.platformNodePool.affinity .Values.affinity) | nindent 8 }}
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
+      securityContext: {{- include "prometheus-postgres-exporter.podSecurityContext" . | nindent 8 }}
 {{- include "prometheus-postgres-exporter.imagePullSecrets" . | indent 6 }}
       containers:
         - name: {{ .Chart.Name }}
@@ -125,20 +126,6 @@ spec:
 {{- with .Values.extraContainers }}
 {{ tpl . $ | indent 8 }}
 {{- end }}
-      securityContext:
-{{ toYaml .Values.podSecurityContext | indent 8 }}
-     {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
       volumes:
       - configMap:
           defaultMode: 420

--- a/charts/prometheus/templates/_helpers.yaml
+++ b/charts/prometheus/templates/_helpers.yaml
@@ -101,8 +101,29 @@ imagePullSecrets:
 {{- end -}}
 
 {{- define "prometheus.securityContext" -}}
-{{- if or (eq ( toString ( .Values.securityContext.runAsUser )) "auto") ( .Values.global.openshiftEnabled ) }}
+{{- if .Values.global.openshiftEnabled }}
 {{- omit  .Values.securityContext "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.securityContext }}
+{{- end -}}
+{{- end }}
+
+{{- define "filesdreloader.securityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.filesdReloader.securityContext "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.filesdReloader.securityContext }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return podSecurityContext, omitting fsGroup,runAsGroup and runAsUser fields on OpenShift Based Installation.
+*/}}
+{{- define "prometheus.podSecurityContext" -}}
+{{- if .Values.global.openshiftEnabled }}
+{{- omit .Values.podSecurityContext "fsGroup" "runAsGroup" "runAsUser" | toYaml }}
+{{- else }}
+{{- toYaml .Values.podSecurityContext }}
 {{- end -}}
 {{- end }}
 

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -154,7 +154,8 @@ spec:
           image: {{ include "filesdReloader.image" . }}
           imagePullPolicy: {{ .Values.images.filesdReloader.pullPolicy }}
           securityContext:
-            readOnlyRootFilesystem: true
+            {{- $required := dict "readOnlyRootFilesystem" true }}
+            {{- merge $required (include "filesdreloader.securityContext" . | fromYaml) | toYaml | nindent 12 }}
           resources: {{ toYaml .Values.filesdReloader.resources | nindent 12 }}
           {{- if .Values.filesdReloader.livenessProbe }}
           livenessProbe: {{ tpl (toYaml .Values.filesdReloader.livenessProbe) . | nindent 12 }}

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -60,6 +60,7 @@ spec:
       tolerations: {{ toYaml (default .Values.global.platformNodePool.tolerations .Values.tolerations) | nindent 8 }}
       restartPolicy: Always
       serviceAccountName: {{ template "prometheus.serviceAccountName" . }}
+      securityContext: {{- include "prometheus.podSecurityContext" . | nindent 8 }}
       {{- include "prometheus.imagePullSecrets" . | nindent 6 }}
       {{- include "prometheus.hostAliases" . | nindent 6 }}
       initContainers:
@@ -266,9 +267,6 @@ spec:
             failureThreshold: 3
             timeoutSeconds: 1
           {{- end }}
-{{- if eq .Values.global.openshiftEnabled false }}
-      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
-{{- end }}
       volumes:
         {{- if .Values.global.authSidecar.enabled }}
         - name: nginx-write-dir

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -98,6 +98,7 @@ filesdReloader:
     #   cpu: 100m
     #   memory: 25Mi
   extraEnv: []
+  securityContext: {}
 
 # Which directory prometheus data should be stored
 dataDir: "/prometheus"

--- a/templates/scc/astronomer-scc-anyuid.yaml
+++ b/templates/scc/astronomer-scc-anyuid.yaml
@@ -23,7 +23,8 @@ users:
 - system:serviceaccount:{{ .Release.Namespace }}:default
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-commander
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-houston-bootstrapper
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-{{ ternary "dp" "cp" (eq .Values.global.plane.mode "data") }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-nginx-default-backend
 - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-prometheus
 volumes:
 - configMap

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -256,6 +256,7 @@ class TestElasticSearch:
                     "securityContext": {
                         "denver": "colorado",
                         "detroit": "michigan",
+                        "allowPrivilegeEscalation": False,
                     }
                 }
             },
@@ -277,6 +278,7 @@ class TestElasticSearch:
                     "detroit": "michigan",
                     "runAsNonRoot": True,
                     "runAsUser": 1000,
+                    "allowPrivilegeEscalation": False,
                 }.items()
             )
 

--- a/tests/chart_tests/test_openshift.py
+++ b/tests/chart_tests/test_openshift.py
@@ -40,7 +40,7 @@ non_airflow_components_list = [
 )
 class TestOpenshift:
     def test_openshift_flag_defaults_with_enabled_and_validate_podsecuritycontext(self, kube_version):
-        "Validate podSecurityContext is not set when openshiftEnabled is True"
+        "Validate podSecurityContext is rendered via the shared helper when openshiftEnabled is True"
         docs = render_chart(
             kube_version=kube_version,
             values={
@@ -51,7 +51,7 @@ class TestOpenshift:
 
         assert len(docs) == 6
         for doc in docs:
-            assert "securityContext" not in doc["spec"]["template"]["spec"]
+            assert "securityContext" in doc["spec"]["template"]["spec"]
 
     def test_openshift_flag_defaults_with_enabled_and_validate_container_securitycontext(self, kube_version):
         "Validate containerSecurityContext when openshiftEnabled is Enabled"

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -246,7 +246,7 @@ class TestPrometheusStatefulset:
             "requests": {"cpu": "250m", "memory": "128Mi"},
         }
         values = {
-            "global": {"rbac": {"enabled": False}},
+            "global": {"rbacEnabled": False},
             "prometheus": {"filesdReloader": {"resources": resources}},
         }
         docs = render_chart(

--- a/tests/chart_tests/test_prometheus_statefulset.py
+++ b/tests/chart_tests/test_prometheus_statefulset.py
@@ -239,6 +239,27 @@ class TestPrometheusStatefulset:
         c_by_name = get_containers_by_name(docs[0])
         assert {"name": "CUSTOM_DATABASE_NAME", "values": "astrohouston"} in c_by_name["filesd-reloader"]["env"]
 
+    def test_prometheus_filesd_reloader_resources_overrides(self, kube_version):
+        """Test Prometheus filesd reloader with custom cpu/memory requests and limits."""
+        resources = {
+            "limits": {"cpu": "500m", "memory": "256Mi"},
+            "requests": {"cpu": "250m", "memory": "128Mi"},
+        }
+        values = {
+            "global": {"rbac": {"enabled": False}},
+            "prometheus": {"filesdReloader": {"resources": resources}},
+        }
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=["charts/prometheus/templates/prometheus-statefulset.yaml"],
+        )
+
+        assert len(docs) == 1
+        self.prometheus_common_tests(docs[0])
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["filesd-reloader"]["resources"] == resources
+
     @pytest.mark.parametrize(
         "plane_mode,expected_present,expected_container_count",
         [

--- a/tests/chart_tests/test_scc.py
+++ b/tests/chart_tests/test_scc.py
@@ -11,6 +11,7 @@ from tests.utils.chart import render_chart
 show_only = [
     "charts/astronomer/templates/commander/commander-role.yaml",
     "charts/astronomer/templates/houston/houston-configmap.yaml",
+    "templates/scc/astronomer-scc-anyuid.yaml",
 ]
 
 
@@ -62,6 +63,24 @@ class TestScc:
         )
         houston_values = yaml.safe_load(docs[1]["data"]["production.yaml"])
 
-        assert len(docs) == 2
+        assert len(docs) == 3
         assert commander_expected_result in docs[0]["rules"]
         assert houston_values["deployments"]["helm"]["sccEnabled"] is True
+
+    def test_scc_privileges(self, kube_version):
+        """Test scc privileges when scc is enabled."""
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "clusterRoles": True,
+                    "sccEnabled": True,
+                }
+            },
+            show_only=["templates/scc/astronomer-scc-anyuid.yaml"],
+            # SecurityContextConstraints is not part of the k8s schema we validate against.
+            validate_objects=False,
+        )
+        assert len(docs) == 1
+        assert len(docs[0]["users"]) == 6

--- a/values.yaml
+++ b/values.yaml
@@ -71,8 +71,6 @@ global:
     # pod-security.kubernetes.io/enforce: baseline
 
   namespaceFreeFormEntry: false
-  # Use kube-lego
-  acme: false
 
   # If RBAC on cluster is enabled
   rbacEnabled: true


### PR DESCRIPTION

## Description

collective backports part-1

## Related Issues

PINF-939  - remove leftover singlenamespace (#3387)
PINF-829 - fix security context diverged config (#3288) 
PINF-765 - fix security context diverged config (#3288)
PINF-844 - fix missing scc privileges (#3321)
PINF-680 - remove deprecated acme flag (PR #3260)
PINF-682 - rework openshift enabled to support podsecurity context (#3265)


## Testing

refer above linked linear tickets 

## Merging

merge to release-1.2
