### PR TITLE
PINF-924 - Update postgres exporter to v0.20.1

### DIFF
--- a/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
           - "--disable-default-metrics"
           {{- end }}
           {{- if .Values.config.disableSettingsMetrics }}
-          - "--disable-settings-metrics"
+          - "--no-collector.settings"
           {{- end }}
           {{- if .Values.config.autoDiscoverDatabases }}
           - "--auto-discover-databases"

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 2
 
 image:
   repository: quay.io/astronomer/ap-postgres-exporter
-  tag: 0.19.1-13
+  tag: 0.20.1
   pullPolicy: IfNotPresent
 
 


### PR DESCRIPTION
## Description

Breaking change:
```
The --disable-settings-metrics flag and
PG_EXPORTER_DISABLE_SETTINGS_METRICS environment variable have been removed.
Use --no-collector.settings instead.
```

Full release notes: https://github.com/prometheus-community/postgres_exporter/releases#release-v0.20.0

## Related Issues

https://linear.app/astronomer/issue/PINF-924/upgrade-postgres-exporter-to-v0200

## Testing



## Merging

1.2.0
