### PR TITLE
APC-1536 - update houston version 1.2.3

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 1.2.2
+    tag: 1.2.3
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

Adds baseline security context to the authSidecar container spec

## Related Issues

https://linear.app/astronomer/issue/APC-1536/create-deployment-failed

## Testing

refer linked ticket

## Merging

merge to release-1.2
