### PR TITLE
PINF-988 -  grafana datasources

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -11,7 +11,7 @@ replicas: 1
 images:
   grafana:
     repository: quay.io/astronomer/ap-grafana
-    tag: 12.4.5
+    tag: 12.4.5-2
     pullPolicy: IfNotPresent
   dbBootstrapper:
     repository: quay.io/astronomer/ap-db-bootstrapper


### PR DESCRIPTION
## Description

Grafana dashboard are bound to default grafana datasources - generating dummy data's causing in correct metrics 

## Related Issues

https://linear.app/astronomer/issue/PINF-988/grafana-bundled-dashboards-silently-render-fake-random-walk-data

## Testing

refer issue ticket

## Merging

merge to all valid branches
