### PR TITLE
APC-1539 - fix logging baseline policies (#3411)

### DIFF
--- a/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
+++ b/charts/elasticsearch/templates/curator/es-curator-cronjob.yaml
@@ -55,8 +55,7 @@ spec:
             command: ["/bin/sh", "-c"]
             args: ["sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"]
             securityContext:
-              {{- $required := dict "readOnlyRootFilesystem" true }}
-              {{- merge $required .Values.curator.securityContext | toYaml | nindent 14 }}
+              {{- include "platform.containerSecurityContext" (list . .Values.curator.securityContext) | nindent 14 }}
             resources: {{ toYaml .Values.curator.resources | nindent 14 }}
             volumeMounts:
               - name: config-volume

--- a/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
+++ b/charts/elasticsearch/templates/exporter/es-exporter-deployment.yaml
@@ -70,8 +70,7 @@ spec:
                     "--web.telemetry-path={{ .Values.exporter.web.path }}"]
 
           securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.exporter.securityContext | toYaml | nindent 12 }}
+            {{- include "platform.containerSecurityContext" (list . .Values.exporter.securityContext) | nindent 12 }}
           resources: {{- toYaml .Values.exporter.resources | nindent 12 }}
           ports:
             - containerPort: {{ .Values.exporter.service.httpPort }}

--- a/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
+++ b/charts/elasticsearch/templates/nginx/nginx-es-deployment.yaml
@@ -52,8 +52,7 @@ spec:
           image: {{ template "nginx-es.image" . }}
           imagePullPolicy: {{ .Values.images.nginx.pullPolicy }}
           securityContext:
-            {{- $required := dict "readOnlyRootFilesystem" true }}
-            {{- merge $required .Values.nginx.securityContext | toYaml | nindent 12 }}
+            {{- include "platform.containerSecurityContext" (list . .Values.nginx.securityContext) | nindent 12 }}
           resources: {{- toYaml .Values.nginx.resources | nindent 12 }}
           volumeMounts:
             - name: tmp

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -232,7 +232,11 @@ curator:
   enabled: true
   schedule: "0 1 * * *"
   securityContext:
+    allowPrivilegeEscalation: false
     runAsNonRoot: true
+    capabilities:
+      drop:
+      - ALL
   resources: {}
 
   # Allows modification of the default age-based filter. If you require more

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -50,7 +50,13 @@ class TestElasticSearch:
         assert curator_container["args"] == [
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
         ]
-        assert curator_container["securityContext"] == {"readOnlyRootFilesystem": True, "runAsNonRoot": True}
+        assert curator_container["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
+            "readOnlyRootFilesystem": True,
+            "runAsNonRoot": True,
+            "runAsUser": 1000,
+        }
 
         # elasticsearch master
         assert master_doc["kind"] == "StatefulSet"
@@ -684,8 +690,11 @@ class TestElasticSearch:
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
         ]
         assert curator_container["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
             "readOnlyRootFilesystem": True,
             "runAsNonRoot": True,
+            "runAsUser": 1000,
             "snoopy": "dog",
             "woodstock": "bird",
         }
@@ -729,8 +738,11 @@ class TestElasticSearch:
             "sleep 5; /usr/bin/curator --config /etc/config/config.yml /etc/config/action_file.yml; exit_code=$?; wget --timeout=5 -O- --post-data='not=used' http://127.0.0.1:15020/quitquitquit; exit $exit_code;"
         ]
         assert curator_container["securityContext"] == {
+            "allowPrivilegeEscalation": False,
+            "capabilities": {"drop": ["ALL"]},
             "readOnlyRootFilesystem": True,
             "runAsNonRoot": True,
+            "runAsUser": 1000,
             "snoopy": "dog",
             "woodstock": "bird",
         }


### PR DESCRIPTION
## Description

elasticsearch curator, nginx, exporter not using the updated baseline policies this PR fixes the behaviour.

## Related Issues

https://linear.app/astronomer/issue/PINF-1022/qa-automation-for-the-k8s-policy-for-platfrom-level-validation-and

## Testing

general kyverno policy tests

## Merging

merge to master and release-2.1 , release-1.2
