### PR TITLE
PLX-740 Federate git_sync metrics

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -76,6 +76,7 @@ data:
         params:
           'match[]':
             - '{job=~".*-kube-state$|airflow|airflow-operator|kubernetes-nodes-cadvisor|node-exporter"}'
+            - '{__name__=~"git_sync.*"}'
         file_sd_configs:
           - files:
             - /prometheusreloader/airflow/clusters.json


### PR DESCRIPTION
## Description

Fedreate git_sync metrics. This is needed to show the status indicator for git-sync in split CP/DP modes.

<img width="224" height="114" alt="Screenshot 2026-07-15 at 14 50 35" src="https://github.com/user-attachments/assets/63a35044-6cbb-427e-afdf-a372361c2d3e" />

## Related Issues

- https://linear.app/astronomer/issue/PLX-740
- https://linear.app/astronomer/issue/PINF-1042

## Testing

I have manually tested this change in a k3d cluster and it solved the bug of git_sync metrics not being shown in CP prometheus, and thus not in a split CP/DP UI status.

## Merging

This should go into 2.1