### PR TITLE
PINF-1031 Add new scenario mechanism for running functional tests agasint arbitrary scenarios

### DIFF
--- a/.agents/skills/functional-tests/SKILL.md
+++ b/.agents/skills/functional-tests/SKILL.md
@@ -14,7 +14,7 @@ Functional tests run against a live Kubernetes cluster (kind) with the Helm char
 ## Critical Rules
 
 1. **Always run tests with `uv run`** — never `python3 -m pytest` or `python -m pytest`
-2. **Always set `TEST_SCENARIO`** before running or the kubeconfig path will be `None`
+2. **Pass `--topology` to `bin/reset-local-dev`** (`unified`/`control`/`data`) before running — pytest itself needs no env var, it infers topology from the test's own location on disk
 3. **Always use uppercase kubeconfig constants** from `tests.utils.k8s` — `KUBECONFIG_UNIFIED`, `KUBECONFIG_CONTROL`, `KUBECONFIG_DATA` (not lowercase variants)
 4. **Run `bin/reset-local-dev` before the first test run** to set up the cluster
 
@@ -37,16 +37,13 @@ Three scenarios exist, each with its own test directory:
 ## Local Setup Workflow
 
 ```bash
-# 1. Choose a scenario
-export TEST_SCENARIO=unified   # or: control, data
+# 1. Set up the cluster for your chosen topology (downloads tools, generates certs, launches kind, installs chart)
+bin/reset-local-dev --topology=unified   # or: control, data
 
-# 2. Set up the cluster (downloads tools, generates certs, launches kind, installs chart)
-bin/reset-local-dev
+# 2. Run the tests (does NOT tear down the cluster — re-run freely while iterating)
+uv run pytest tests/functional/unified
 
-# 3. Run the tests (does NOT tear down the cluster — re-run freely while iterating)
-uv run pytest tests/functional/${TEST_SCENARIO}
-
-# 4. See helper file paths (kubeconfig, etc.)
+# 3. See helper file paths (kubeconfig, etc.)
 make show-test-helper-files
 ```
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,6 +353,7 @@ jobs:
       - run:
           name: "Scenario: auth-sidecar"
           command: |
+            eval "$(uv run bin/run-scenario.py --print-env auth-sidecar)"
             uv run bin/run-scenario.py auth-sidecar
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/auth-sidecar"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,7 @@ jobs:
       - run:
           name: "Scenario: auth-sidecar"
           command: |
-            bin/run-scenario.py auth-sidecar
+            uv run bin/run-scenario.py auth-sidecar
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/auth-sidecar"
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -353,7 +353,6 @@ jobs:
       - run:
           name: "Scenario: auth-sidecar"
           command: |
-            eval "$(uv run bin/run-scenario.py --print-env auth-sidecar)"
             uv run bin/run-scenario.py auth-sidecar
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/auth-sidecar"
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,35 @@ jobs:
       - store_test_results:
           path: test-results
 
+  scenario-auth-sidecar:
+    machine:
+      image: ubuntu-2404:2026.05.1
+      resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Create venv-cache-key.txt
+          command: |
+            cp uv.lock /tmp/uv-lock-cache-key.txt
+      - restore_cache:
+          keys:
+            - test-venv-{{ checksum "/tmp/uv-lock-cache-key.txt" }}
+      - run:
+          name: Install uv
+          command: curl -fsSL https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Create venv
+          command: uv venv -p 3.13 --seed && uv sync
+      - run:
+          name: "Scenario: auth-sidecar"
+          command: |
+            bin/run-scenario.py auth-sidecar
+            uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/auth-sidecar"
+      - store_test_results:
+          path: test-results
+
   check-commander-airflow-version:
     docker:
       - image: cimg/base:current-24.04
@@ -391,6 +420,9 @@ workflows:
             - approve-test-all-platforms
 
       - scenario-unified-1-35-1:
+          requires:
+            - build-artifact
+      - scenario-auth-sidecar:
           requires:
             - build-artifact
       - approve-stage-cluster-test:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -266,7 +266,7 @@ jobs:
       - run:
           name: "Scenario: {{ scenario }}"
           command: |
-            bin/run-scenario.py {{ scenario }}
+            uv run bin/run-scenario.py {{ scenario }}
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/{{ scenario }}"
       - store_test_results:
           path: test-results

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -266,6 +266,7 @@ jobs:
       - run:
           name: "Scenario: {{ scenario }}"
           command: |
+            eval "$(uv run bin/run-scenario.py --print-env {{ scenario }})"
             uv run bin/run-scenario.py {{ scenario }}
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/{{ scenario }}"
       - store_test_results:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -266,7 +266,6 @@ jobs:
       - run:
           name: "Scenario: {{ scenario }}"
           command: |
-            eval "$(uv run bin/run-scenario.py --print-env {{ scenario }})"
             uv run bin/run-scenario.py {{ scenario }}
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/{{ scenario }}"
       - store_test_results:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -241,6 +241,36 @@ jobs:
       - store_test_results:
           path: test-results
 {%- endfor %}
+{% for scenario in scenarios %}
+  scenario-{{ scenario }}:
+    machine:
+      image: {{ machine_image_version }}
+      resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - checkout
+      - run:
+          name: Create venv-cache-key.txt
+          command: |
+            cp uv.lock /tmp/uv-lock-cache-key.txt
+      - restore_cache:
+          keys:
+            - test-venv-{{ '{{' }} checksum "/tmp/uv-lock-cache-key.txt" }}
+      - run:
+          name: Install uv
+          command: curl -fsSL https://astral.sh/uv/install.sh | sh
+      - run:
+          name: Create venv
+          command: uv venv -p {{ python_image_version }} --seed && uv sync
+      - run:
+          name: "Scenario: {{ scenario }}"
+          command: |
+            bin/run-scenario.py {{ scenario }}
+            uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/{{ scenario }}"
+      - store_test_results:
+          path: test-results
+{%- endfor %}
 
   check-commander-airflow-version:
     docker:
@@ -293,7 +323,11 @@ workflows:
           requires:
             - build-artifact
             - approve-test-all-platforms
-{% endif %}{% endfor %}
+{% endif %}{% endfor %}{% for scenario in scenarios %}
+      - scenario-{{ scenario }}:
+          requires:
+            - build-artifact
+{%- endfor %}
       - approve-stage-cluster-test:
           type: approval
           filters:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,7 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.15.20"
+    rev: "v0.15.21"
     hooks:
       - id: ruff-check
         args:

--- a/Makefile
+++ b/Makefile
@@ -17,22 +17,19 @@ venv: .venv  ## Setup venv required for testing
 	uv sync
 
 .PHONY: test-functional-control
-test-functional-control: export TEST_SCENARIO=control
 test-functional-control: venv ## Run functional tests on the control installation scenario
-	bin/reset-local-dev
-	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/$${TEST_SCENARIO}
+	bin/reset-local-dev --topology=control
+	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/control
 
 .PHONY: test-functional-data
-test-functional-data: export TEST_SCENARIO=data
 test-functional-data: venv ## Run functional tests on the data installation scenario
-	bin/reset-local-dev
-	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/$${TEST_SCENARIO}
+	bin/reset-local-dev --topology=data
+	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/data
 
 .PHONY: test-functional-unified
-test-functional-unified: export TEST_SCENARIO=unified
 test-functional-unified: venv ## Run functional tests on the unified installation scenario
-	bin/reset-local-dev
-	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/$${TEST_SCENARIO}
+	bin/reset-local-dev --topology=unified
+	uv run pytest -sv --junitxml=test-results/junit.xml tests/functional/unified
 
 # unittest-charts is deprecated
 .PHONY: unittest-charts

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -13,6 +13,18 @@ kube_versions = metadata["test_k8s_versions"]
 ci_runner_version = (datetime.datetime.now()).strftime("%Y-%m")
 
 
+def discover_scenarios() -> list[str]:
+    """Find scenario names under tests/functional/scenarios/*/test_profile.yaml.
+
+    The manifest file's presence is the signal, not bare directory presence, so a
+    half-finished or stray directory can't silently create (or hide) a CI job.
+    """
+    scenarios_dir = git_root_dir / "tests" / "functional" / "scenarios"
+    if not scenarios_dir.is_dir():
+        return []
+    return sorted(p.parent.name for p in scenarios_dir.glob("*/test_profile.yaml"))
+
+
 def main():
     """Render the Jinja2 template file."""
     for version in kube_versions:
@@ -27,6 +39,7 @@ def main():
     config = template.render(
         ci_runner_version=ci_runner_version,
         kube_versions=kube_versions,
+        scenarios=discover_scenarios(),
     )
     with open(config_file_path, "w") as circle_ci_config_file:
         warning_header = (

--- a/bin/helm-install.py
+++ b/bin/helm-install.py
@@ -40,6 +40,24 @@ def parse_args() -> argparse.Namespace:
     """
     parser = argparse.ArgumentParser(description="Install the current chart into the given cluster.")
     parser.add_argument("--debug", action="store_true", help="Enable debug mode (can also be set via DEBUG environment variable)")
+    parser.add_argument(
+        "--helm-values",
+        action="append",
+        default=[],
+        dest="helm_values",
+        metavar="FILE",
+        help="Extra Helm values file, relative to the repo root unless absolute (can be repeated).",
+    )
+    parser.add_argument(
+        "--namespace-label",
+        action="append",
+        default=[],
+        dest="namespace_labels",
+        metavar="KEY=VALUE",
+        help="Label to apply to the astronomer namespace before install (can be repeated). "
+        "Creates the namespace ahead of `helm install` instead of using --create-namespace, "
+        "since PSA enforcement labels must be present before pods are created.",
+    )
     return parser.parse_args()
 
 
@@ -132,11 +150,39 @@ def run_and_monitor_subprocess(command: list, monitor_function: callable, interv
         proc.wait()
 
 
-def helm_install(values: str | list[str] = f"{GIT_ROOT_DIR}/configs/local-dev.yaml") -> None:
+def create_and_label_namespace(labels: dict[str, str], namespace: str = "astronomer") -> None:
+    """
+    Create a namespace and apply labels to it before anything is installed into it.
+
+    Pod Security Admission is enforced at pod-creation time, not retroactively, so labels
+    meant to trigger enforcement (e.g. pod-security.kubernetes.io/enforce) must land before
+    `helm install` creates any pods -- `helm install --create-namespace` applies no labels.
+
+    :param labels: Namespace labels to apply, e.g. {"pod-security.kubernetes.io/enforce": "restricted"}.
+    :param namespace: Namespace name to create and label.
+    """
+    debug_print(f"Creating namespace {namespace} with labels: {labels}")
+    subprocess.run(
+        [KUBECTL_EXE, f"--kubeconfig={KUBECONFIG_FILE}", "create", "namespace", namespace],
+        check=True,
+    )
+    label_args = [f"{key}={value}" for key, value in labels.items()]
+    subprocess.run(
+        [KUBECTL_EXE, f"--kubeconfig={KUBECONFIG_FILE}", "label", "namespace", namespace, *label_args],
+        check=True,
+    )
+
+
+def helm_install(
+    values: str | list[str] = f"{GIT_ROOT_DIR}/configs/local-dev.yaml",
+    create_namespace: bool = True,
+) -> None:
     """
     Install a Helm chart using the provided kubeconfig and values file.
 
     :param values: Path to the Helm values file or a list of values files.
+    :param create_namespace: Pass --create-namespace to helm. Set False when the namespace
+        was already created (and labeled) ahead of install via create_and_label_namespace().
     """
     debug_print(f"Starting Helm install with values: {values}")
     debug_print(f"Using kubeconfig: {KUBECONFIG_FILE}")
@@ -147,11 +193,12 @@ def helm_install(values: str | list[str] = f"{GIT_ROOT_DIR}/configs/local-dev.ya
         "install",
         "astronomer",
         str(GIT_ROOT_DIR),
-        "--create-namespace",
         "--namespace=astronomer",
         f"--timeout={HELM_INSTALL_TIMEOUT}",
         f"--kubeconfig={KUBECONFIG_FILE}",
     ]
+    if create_namespace:
+        helm_install_command.append("--create-namespace")
 
     if isinstance(values, str):
         values = [values]
@@ -270,6 +317,9 @@ if __name__ == "__main__":
         f"{GIT_ROOT_DIR}/configs/local-dev.yaml",
         f"{GIT_ROOT_DIR}/tests/data_files/scenario-{TEST_SCENARIO}.yaml",
     ]
+    for extra_values_file in args.helm_values:
+        path = Path(extra_values_file)
+        values.append(str(path if path.is_absolute() else GIT_ROOT_DIR / path))
 
     debug_print(f"Preparing to install with values files: {values}")
     for value_file in values:
@@ -278,5 +328,8 @@ if __name__ == "__main__":
         else:
             debug_print(f"WARNING - Values file not found: {value_file}")
 
-    helm_install(values=values)
+    namespace_labels = dict(kv.split("=", 1) for kv in args.namespace_labels)
+    if namespace_labels:
+        create_and_label_namespace(namespace_labels)
+    helm_install(values=values, create_namespace=not namespace_labels)
     wait_for_healthy_pods()

--- a/bin/helm-install.py
+++ b/bin/helm-install.py
@@ -162,13 +162,17 @@ def create_and_label_namespace(labels: dict[str, str], namespace: str = "astrono
     :param namespace: Namespace name to create and label.
     """
     debug_print(f"Creating namespace {namespace} with labels: {labels}")
-    subprocess.run(
+    result = subprocess.run(
         [KUBECTL_EXE, f"--kubeconfig={KUBECONFIG_FILE}", "create", "namespace", namespace],
-        check=True,
+        capture_output=True,
+        text=True,
     )
+    if result.returncode != 0 and "AlreadyExists" not in result.stderr:
+        raise RuntimeError(f"Failed to create namespace {namespace}: {result.stderr}")
+
     label_args = [f"{key}={value}" for key, value in labels.items()]
     subprocess.run(
-        [KUBECTL_EXE, f"--kubeconfig={KUBECONFIG_FILE}", "label", "namespace", namespace, *label_args],
+        [KUBECTL_EXE, f"--kubeconfig={KUBECONFIG_FILE}", "label", "namespace", namespace, *label_args, "--overwrite"],
         check=True,
     )
 

--- a/bin/helm-install.py
+++ b/bin/helm-install.py
@@ -11,24 +11,13 @@ import sys
 import time
 from pathlib import Path
 
-PREREQUISITES = """You MUST set your environment variable TEST_SCENARIO to one of the following values:
-- unified: Install with the unified application mode.
-- data: Install the with the dataplane application mode.
-- control: Install with the controlplane application mode.
-"""
-
 GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
 HELPER_BIN_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "bin"
 KUBECTL_EXE = str(HELPER_BIN_DIR / "kubectl")
 HELM_EXE = str(HELPER_BIN_DIR / "helm")
 HELM_INSTALL_TIMEOUT = os.getenv("HELM_INSTALL_TIMEOUT", "10m0s")
-if not all([(TEST_SCENARIO := os.getenv("TEST_SCENARIO")), TEST_SCENARIO in ["unified", "data", "control"]]):
-    print("ERROR: TEST_SCENARIO environment variable is not set!", file=sys.stderr)
-    print(PREREQUISITES, file=sys.stderr)
-    raise SystemExit(1)
 KUBECONFIG_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "kubeconfig"
 KUBECONFIG_DIR.mkdir(parents=True, exist_ok=True)
-KUBECONFIG_FILE = str(KUBECONFIG_DIR / TEST_SCENARIO)
 
 
 def parse_args() -> argparse.Namespace:
@@ -39,6 +28,12 @@ def parse_args() -> argparse.Namespace:
         argparse.Namespace: Parsed command line arguments.
     """
     parser = argparse.ArgumentParser(description="Install the current chart into the given cluster.")
+    parser.add_argument(
+        "--topology",
+        required=True,
+        choices=["unified", "control", "data"],
+        help="Install topology: unified (control+data in one cluster), control, or data.",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug mode (can also be set via DEBUG environment variable)")
     parser.add_argument(
         "--helm-values",
@@ -305,12 +300,14 @@ def wait_for_healthy_pods(ignore_substrings: list[str] | None = None, max_wait_t
 
 if __name__ == "__main__":
     args = parse_args()
+    TOPOLOGY = args.topology
+    KUBECONFIG_FILE = str(KUBECONFIG_DIR / TOPOLOGY)
 
     # Set DEBUG based on command line argument or environment variable
     DEBUG = args.debug or os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
 
     debug_print("Debug mode enabled")
-    debug_print(f"{TEST_SCENARIO=}")
+    debug_print(f"{TOPOLOGY=}")
     debug_print(f"{GIT_ROOT_DIR=}")
     debug_print(f"{KUBECONFIG_FILE=}")
     debug_print(f"{KUBECTL_EXE=}")
@@ -319,7 +316,7 @@ if __name__ == "__main__":
 
     values = [
         f"{GIT_ROOT_DIR}/configs/local-dev.yaml",
-        f"{GIT_ROOT_DIR}/tests/data_files/scenario-{TEST_SCENARIO}.yaml",
+        f"{GIT_ROOT_DIR}/tests/data_files/scenario-{TOPOLOGY}.yaml",
     ]
     for extra_values_file in args.helm_values:
         path = Path(extra_values_file)

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -25,4 +25,4 @@ set -ex
 "${BIN_DIR}/setup-kind.py"
 
 # Install helm chart
-"${BIN_DIR}/helm-install.py"
+"${BIN_DIR}/helm-install.py" "$@"

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -16,6 +16,11 @@ set -ex
 # Download helper tools to ~/.local/share/astronomer-software/bin
 "${BIN_DIR}/install-ci-tools.py"
 
+# install-ci-tools.py only puts this directory on PATH within its own process, which
+# doesn't help anything shelled out to below (e.g. setup-kind.py -> show-docker-images.py's
+# bare `helm template` call). Export it here so it's on PATH for the rest of this script.
+export PATH="${HOME}/.local/share/astronomer-software/bin:${PATH}"
+
 # Generate certificates in ~/.local/share/astronomer-software/certs
 "${BIN_DIR}/certs.py" cleanup
 "${BIN_DIR}/certs.py" generate-tls

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -1,9 +1,20 @@
 #!/usr/bin/env bash
-# This is used in local dev, and in CI. Usage of this script requires exporting the
-# TEST_SCENARIO env var to data, unified, or control.
+# This is used in local dev, and in CI. Usage: reset-local-dev --topology=<unified|control|data>
+# [extra flags forwarded to helm-install.py, e.g. --helm-values=... --namespace-label=key=value]
 
 GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
 BIN_DIR="${GIT_ROOT_DIR}/bin"
+
+TOPOLOGY=""
+for arg in "$@"; do
+  case "$arg" in
+    --topology=*) TOPOLOGY="${arg#--topology=}" ;;
+  esac
+done
+if [[ -z "$TOPOLOGY" ]]; then
+  echo "ABORT: --topology=<unified|control|data> is required" >&2
+  exit 1
+fi
 
 # Use the venv if it exists
 [[ -f .venv/bin/activate ]] || { echo "ABORT: .venv does not exist!" ; exit 1 ; }
@@ -27,7 +38,7 @@ export PATH="${HOME}/.local/share/astronomer-software/bin:${PATH}"
 "${BIN_DIR}/certs.py" generate-private-ca
 
 # Create a KIND cluster and configure it for testing
-"${BIN_DIR}/setup-kind.py"
+"${BIN_DIR}/setup-kind.py" "--topology=${TOPOLOGY}"
 
 # Install helm chart
 "${BIN_DIR}/helm-install.py" "$@"

--- a/bin/run-scenario.py
+++ b/bin/run-scenario.py
@@ -25,14 +25,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "scenario", help="Scenario name, e.g. auth-sidecar (must have a tests/functional/scenarios/<name>/test_profile.yaml)"
     )
-    parser.add_argument(
-        "--print-env",
-        action="store_true",
-        help="Print `export TEST_SCENARIO=...`/`export KUBE_VERSION=...` for this scenario and exit, "
-        "instead of running it. Meant to be eval'd by the caller's shell before running pytest, since "
-        "TEST_SCENARIO is resolved here (from the manifest) and pytest's conftest.py needs it too, but "
-        "a subprocess can't export env vars back into the shell that spawned it.",
-    )
     return parser.parse_args()
 
 
@@ -60,16 +52,11 @@ def main() -> None:
     profile = load_profile(args.scenario)
     kube_version = resolve_kube_version(profile)
 
-    if args.print_env:
-        print(f"export TEST_SCENARIO={profile['topology']}")
-        print(f"export KUBE_VERSION=v{kube_version}")
-        return
-
     env = os.environ.copy()
-    env["TEST_SCENARIO"] = profile["topology"]
     env["KUBE_VERSION"] = f"v{kube_version}"
 
-    reset_local_dev_args = [f"--helm-values={value_file}" for value_file in profile["values"]]
+    reset_local_dev_args = [f"--topology={profile['topology']}"]
+    reset_local_dev_args += [f"--helm-values={value_file}" for value_file in profile["values"]]
     for key, value in profile.get("namespace_labels", {}).items():
         reset_local_dev_args.append(f"--namespace-label={key}={value}")
 

--- a/bin/run-scenario.py
+++ b/bin/run-scenario.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run a named test scenario from tests/functional/scenarios/<name>/test_profile.yaml.
+
+A scenario composes an existing install topology (unified/control/data) with extra
+values overlays, an optional pinned k8s version, and optional namespace labels applied
+before install. See tests/functional/scenarios/README.md for the manifest format.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+SCENARIOS_DIR = GIT_ROOT_DIR / "tests" / "functional" / "scenarios"
+CHART_METADATA = yaml.safe_load((GIT_ROOT_DIR / "metadata.yaml").read_text())
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "scenario", help="Scenario name, e.g. auth-sidecar (must have a tests/functional/scenarios/<name>/test_profile.yaml)"
+    )
+    return parser.parse_args()
+
+
+def load_profile(scenario: str) -> dict:
+    """Load and validate a scenario's test_profile.yaml."""
+    profile_path = SCENARIOS_DIR / scenario / "test_profile.yaml"
+    if not profile_path.exists():
+        raise SystemExit(f"ERROR: no such scenario manifest: {profile_path}")
+    profile = yaml.safe_load(profile_path.read_text())
+
+    if profile.get("topology") not in ["unified", "control", "data"]:
+        raise SystemExit(f"ERROR: {profile_path} must set topology to one of unified/control/data, got {profile.get('topology')!r}")
+    if not profile.get("values"):
+        raise SystemExit(f"ERROR: {profile_path} must set a non-empty 'values' list")
+    return profile
+
+
+def resolve_kube_version(profile: dict) -> str:
+    """Resolve the k8s version to test against: the manifest's own pin, or the latest tested version."""
+    return profile.get("kube_version") or CHART_METADATA["test_k8s_versions"][-1]
+
+
+def main() -> None:
+    args = parse_args()
+    profile = load_profile(args.scenario)
+    kube_version = resolve_kube_version(profile)
+
+    env = os.environ.copy()
+    env["TEST_SCENARIO"] = profile["topology"]
+    env["KUBE_VERSION"] = f"v{kube_version}"
+
+    reset_local_dev_args = [f"--helm-values={value_file}" for value_file in profile["values"]]
+    for key, value in profile.get("namespace_labels", {}).items():
+        reset_local_dev_args.append(f"--namespace-label={key}={value}")
+
+    command = [str(GIT_ROOT_DIR / "bin" / "reset-local-dev"), *reset_local_dev_args]
+    print(f"Running scenario {args.scenario!r}: topology={profile['topology']} kube_version={kube_version}")
+    print(f"Command: {command}")
+    subprocess.run(command, env=env, cwd=GIT_ROOT_DIR, check=True)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: scenario setup failed: {e}", file=sys.stderr)
+        raise SystemExit(1) from e

--- a/bin/run-scenario.py
+++ b/bin/run-scenario.py
@@ -25,6 +25,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "scenario", help="Scenario name, e.g. auth-sidecar (must have a tests/functional/scenarios/<name>/test_profile.yaml)"
     )
+    parser.add_argument(
+        "--print-env",
+        action="store_true",
+        help="Print `export TEST_SCENARIO=...`/`export KUBE_VERSION=...` for this scenario and exit, "
+        "instead of running it. Meant to be eval'd by the caller's shell before running pytest, since "
+        "TEST_SCENARIO is resolved here (from the manifest) and pytest's conftest.py needs it too, but "
+        "a subprocess can't export env vars back into the shell that spawned it.",
+    )
     return parser.parse_args()
 
 
@@ -51,6 +59,11 @@ def main() -> None:
     args = parse_args()
     profile = load_profile(args.scenario)
     kube_version = resolve_kube_version(profile)
+
+    if args.print_env:
+        print(f"export TEST_SCENARIO={profile['topology']}")
+        print(f"export KUBE_VERSION=v{kube_version}")
+        return
 
     env = os.environ.copy()
     env["TEST_SCENARIO"] = profile["topology"]

--- a/bin/setup-kind.py
+++ b/bin/setup-kind.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Setup KIND cluster and install Astronomer software for testing."""
 
+import argparse
 import os
 import shlex
 import subprocess
@@ -17,27 +18,27 @@ from certs import (
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
 
-PREREQUISITES = """You MUST set your environment variable TEST_SCENARIO to one of the following values:
-- unified: Install with the unified application mode.
-- data: Install the with the dataplane application mode.
-- control: Install with the controlplane application mode.
-"""
-
 GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
 HELPER_BIN_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "bin"
 KIND_EXE = str(HELPER_BIN_DIR / "kind")
 KUBECTL_EXE = str(HELPER_BIN_DIR / "kubectl")
 CHART_METADATA = yaml.safe_load((Path(GIT_ROOT_DIR) / "metadata.yaml").read_text())
 KUBECTL_VERSION = os.environ.get("KUBE_VERSION", f"v{CHART_METADATA['test_k8s_versions'][-2]}").removeprefix("v")
-
-if (TEST_SCENARIO := os.getenv("TEST_SCENARIO", "")) not in ["unified", "data", "control"]:
-    print("ERROR: TEST_SCENARIO environment variable is not set!", file=sys.stderr)
-    print(PREREQUISITES, file=sys.stderr)
-    raise SystemExit(1)
 KUBECONFIG_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "kubeconfig"
 KUBECONFIG_DIR.mkdir(parents=True, exist_ok=True)
-KUBECONFIG_FILE = str(KUBECONFIG_DIR / TEST_SCENARIO)
 DEBUG = os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--topology",
+        required=True,
+        choices=["unified", "control", "data"],
+        help="Install topology to set up: unified (control+data in one cluster), control, or data.",
+    )
+    return parser.parse_args()
 
 
 def run_command(command: str | list) -> str:
@@ -168,7 +169,7 @@ def create_kind_cluster() -> None:
             f"{KIND_EXE}",
             "create",
             "cluster",
-            f"--name={TEST_SCENARIO}",
+            f"--name={TOPOLOGY}",
             f"--kubeconfig={KUBECONFIG_FILE}",
             f"--config={GIT_ROOT_DIR}/tests/kind/calico-config.yaml",
             f"--image=kindest/node:v{KUBECTL_VERSION}",
@@ -178,7 +179,7 @@ def create_kind_cluster() -> None:
             run_command(create_cluster_cmd)
         except RuntimeError as e:
             if "already exist for a cluster" in str(e):
-                print(f"ABORT: Cluster '{TEST_SCENARIO}' already exists.", file=sys.stderr)
+                print(f"ABORT: Cluster '{TOPOLOGY}' already exists.", file=sys.stderr)
             else:
                 raise RuntimeError(f"Failed to create KIND cluster: {e}") from e
 
@@ -212,7 +213,7 @@ def create_kind_cluster() -> None:
 
     except Exception:
         # Cleanup if cluster creation fails
-        delete_cluster_cmd = [f"{KIND_EXE}", "delete", "cluster", f"--name={TEST_SCENARIO}"]
+        delete_cluster_cmd = [f"{KIND_EXE}", "delete", "cluster", f"--name={TOPOLOGY}"]
         print(f"Cleaning up after failed cluster creation with command: {shlex.join(delete_cluster_cmd)}")
         run_command(delete_cluster_cmd)
         Path(KUBECONFIG_FILE).unlink(missing_ok=True)
@@ -371,7 +372,7 @@ def check_kube_system_health(apps_v1: client.AppsV1Api, max_wait_seconds: int = 
                 if deployment.status.ready_replicas != deployment.spec.replicas
             ]
             if not unhealthy_deployments:
-                return True, f"All kube-system deployments in {TEST_SCENARIO} cluster are healthy."
+                return True, f"All kube-system deployments in {TOPOLOGY} cluster are healthy."
             last_error = None
         except Exception as e:  # noqa: BLE001
             last_error = e
@@ -379,17 +380,21 @@ def check_kube_system_health(apps_v1: client.AppsV1Api, max_wait_seconds: int = 
         elapsed = time.monotonic() - start_time
         if elapsed >= max_wait_seconds:
             if last_error:
-                return False, f"Failed to check deployment health in {TEST_SCENARIO} cluster: {last_error}"
+                return False, f"Failed to check deployment health in {TOPOLOGY} cluster: {last_error}"
             return False, f"Unhealthy deployments found after {int(elapsed)}s: {', '.join(unhealthy_deployments)}"
         time.sleep(interval)
 
 
 if __name__ == "__main__":
+    args = parse_args()
+    TOPOLOGY = args.topology
+    KUBECONFIG_FILE = str(KUBECONFIG_DIR / TOPOLOGY)
+
     create_kind_cluster()
     setup_common_cluster_configs()
 
     # Load Docker images into the KIND cluster
-    kind_load_docker_images(TEST_SCENARIO)
+    kind_load_docker_images(TOPOLOGY)
 
     # Check deployment health
     config.load_kube_config(config_file=KUBECONFIG_FILE)
@@ -401,4 +406,4 @@ if __name__ == "__main__":
     else:
         print(message)
 
-    print(f"KIND cluster '{TEST_SCENARIO}' setup completed successfully.")
+    print(f"KIND cluster '{TOPOLOGY}' setup completed successfully.")

--- a/configs/enable-auth-sidecar.yaml
+++ b/configs/enable-auth-sidecar.yaml
@@ -1,0 +1,7 @@
+# Enables global.authSidecar, the optional bring-your-own-ingress auth proxy.
+# Needed for OpenShift/BYO-ingress customers, since APC's default security
+# model is otherwise coupled to the nginx ingress the chart ships.
+---
+global:
+  authSidecar:
+    enabled: true

--- a/configs/psa-restricted.yaml
+++ b/configs/psa-restricted.yaml
@@ -1,5 +1,3 @@
-# PSA restricted demo overlay.
-#
 # Disables the platform components that cannot meet PSS-Restricted. The list is
 # one-to-one with PSS_RESTRICTED_EXEMPT in
 # tests/chart_tests/test_default_chart.py (L15-L24) -- the components the render
@@ -9,24 +7,14 @@
 #   helm install <release> . \
 #     -f configs/local-dev.yaml \
 #     -f configs/enable-psa.yaml \
-#     -f configs/psa-restricted-demo.yaml
+#     -f configs/psa-restricted.yaml
 #
 # enable-psa.yaml labels app-deployed Airflow (and pool) namespaces. The chart
-# does NOT label the platform install namespace, so to demo enforcement on
+# does NOT label the platform install namespace, so to test enforcement on
 # PLATFORM pods, label that namespace directly after install:
 #   kubectl label namespace <astronomer-namespace> \
 #     pod-security.kubernetes.io/enforce=restricted \
 #     pod-security.kubernetes.io/enforce-version=latest
-#
-# NOTE -- in-cluster postgres. configs/local-dev.yaml enables the bundled
-# bitnami `postgresql`. Its primary container is already PSS-Restricted compliant
-# (charts/postgresql/templates/statefulset.yaml hardcodes seccompProfile:
-# RuntimeDefault, allowPrivilegeEscalation:false, capabilities.drop:[ALL],
-# readOnlyRootFilesystem, runAsNonRoot, runAsUser), so it admits under
-# enforce=restricted as configured here. Two off-by-default paths are NOT
-# compliant -- leave them off for the demo (local-dev already does):
-#   - metrics sidecar (postgresql metrics.enabled): missing capabilities.drop:[ALL] + runAsNonRoot
-#   - replication slaves (postgresql replication.enabled): root volume-permissions init container
 ---
 global:
   # DaemonSet/*-private-ca + DaemonSet/*-containerd-ca-update:
@@ -46,7 +34,7 @@ global:
     enabled: false
 
   # Host-level exporters (hostNetwork / hostPath). Off by default; pinned off
-  # here so the demo doesn't regress if a base overlay enables them.
+  # here so the test doesn't regress if a base overlay enables them.
   nodeExporter:
     enabled: false
   cadvisor:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -107,7 +107,7 @@ The KinD-based setup is a simpler single-cluster alternative. It does not exerci
 Run this script from the root of this repository:
 
 ```sh
-bin/reset-local-dev
+bin/reset-local-dev --topology=unified
 ```
 
 Each time you run the script, the platform will be fully reset to the current helm chart.
@@ -151,7 +151,7 @@ kubectl edit deployment -n astronomer <your deployment>
 #### Specify the Kubernetes version
 
 ```sh
-bin/reset-local-dev -K 1.28.6
+KUBE_VERSION=v1.28.6 bin/reset-local-dev --topology=unified
 ```
 
 ## Searching code

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -6,22 +6,21 @@ Astronomer "Software" version 1.0 introduces an optional separation of the contr
 - control: install only the control plane components into the cluster
 - data: install only the data plane components into the cluster
 
-When running these tests, you **MUST** `export TEST_SCENARIO` with one of the above values. (EG: `export TEST_SCENARIO=unified`)
+Pass one of the above values to `bin/reset-local-dev` as `--topology` (EG: `bin/reset-local-dev --topology=unified`). Pytest itself needs no configuration to know which topology a test targets -- `tests/functional/conftest.py` infers it from the test's own location on disk (directly under `tests/functional/<unified|control|data>/`, or read from `test_profile.yaml` for anything under `tests/functional/scenarios/<name>/`), not an env var.
 
 ## Things to know about this test setup
 
 - All downloaded tools are stored in `~/.local/share/astronomer-software/bin`, which means we have one cached, consistent location to store tools with known versions that does not conflict with tools installed elsewhere in the OS.
 - All generated kind configs are stored in `~/.local/share/astronomer-software/kubeconfig` which means we have one consistent location for kubeconfigs for each installation scenario that can be configured in developer tools, making it easier to debug the kind clusters used in testing.
 - All generated certificates are stored in `~/.local/share/astronomer-software/certs`. These certificates are automatically recreated during test setup if they will expire within 4 weeks.
-- There is one test directory per scenario: `tests/functional/unified`, `tests/functional/control`, `tests/functional/data`.
+- There is one test directory per scenario: `tests/functional/unified`, `tests/functional/control`, `tests/functional/data`. See `tests/functional/scenarios/README.md` for the open-ended scenario mechanism (e.g. `auth-sidecar`).
 - Common functions are stored in `tests/utils`
-- Common configurations and fixtuers are in `tests/functional/conftest.py`
-- Per-scenario configs and fixtures are in `tests/functional/<scenario/conftest.py`
+- Common configurations and fixtures are in `tests/functional/conftest.py`
+- Per-scenario configs and fixtures are in `tests/functional/<scenario>/conftest.py`
 - `export DEBUG=1` will enable additional logging, `helm install --debug`, and `kubectl -v=9` output.
 
 ## Local testing
 
-1. Run `export TEST_SCENARIO=unified` or whatever scenario you intend to test.
-1. Run `bin/reset-local-dev` to set up the local test environment, including downloading tools to `~/.local/share/astronomer-software/bin`, creating certs in `~/.local/share/astronomer-software/certs` if needed, storing kubeconfigs in `~/.local/share/astronomer-software/kubeconfig`, launching a kind cluster, and installing the helm chart.
-3. Run `uv run pytest tests/functional/${TEST_SCENARIO}` to run functional tests for your chosen scenario. This will not automatically tear down the cluster after running, so you can run the tests repeatedly while iterating on changes.
-4. Run `make show-test-helper-files` to show files that may be helpful while developing, such as the path to the kubeconfig for your chosen test scenario.
+1. Run `bin/reset-local-dev --topology=unified` (or `control`/`data`) to set up the local test environment, including downloading tools to `~/.local/share/astronomer-software/bin`, creating certs in `~/.local/share/astronomer-software/certs` if needed, storing kubeconfigs in `~/.local/share/astronomer-software/kubeconfig`, launching a kind cluster, and installing the helm chart.
+2. Run `uv run pytest tests/functional/unified` (matching whichever topology you set up) to run functional tests for your chosen scenario. This will not automatically tear down the cluster after running, so you can run the tests repeatedly while iterating on changes.
+3. Run `make show-test-helper-files` to show files that may be helpful while developing, such as the path to the kubeconfig for your chosen test scenario.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -29,7 +29,12 @@ def _topology_for(test_path: Path) -> str:
         return parts[0]
     if parts[0] == "scenarios":
         profile_path = FUNCTIONAL_DIR / "scenarios" / parts[1] / "test_profile.yaml"
-        return yaml.safe_load(profile_path.read_text())["topology"]
+        if not profile_path.exists():
+            raise RuntimeError(f"Scenario '{parts[1]}' is missing its test_profile.yaml at {profile_path}")
+        topology = yaml.safe_load(profile_path.read_text()).get("topology")
+        if topology not in TOPOLOGIES:
+            raise RuntimeError(f"{profile_path} must set 'topology' to one of {TOPOLOGIES}, got {topology!r}")
+        return topology
     raise RuntimeError(
         f"Could not infer topology for test at {test_path} -- expected it under "
         "tests/functional/{unified,control,data}/ or tests/functional/scenarios/<name>/"

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 import testinfra
+import yaml
 from kubernetes import client, config
 
 from tests.utils.k8s import get_pod_by_label_selector
@@ -10,95 +11,102 @@ from tests.utils.k8s import get_pod_by_label_selector
 DEBUG = os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
 
 KUBECONFIG_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "kubeconfig"
-TEST_SCENARIO = os.getenv("TEST_SCENARIO")
+FUNCTIONAL_DIR = Path(__file__).parent
+TOPOLOGIES = ("unified", "control", "data")
+
+
+def _topology_for(test_path: Path) -> str:
+    """
+    Infer install topology from a test's own location, rather than an env var.
+
+    Tests directly under tests/functional/<unified|control|data>/ are self-evidently
+    that topology. Tests under the open-ended scenario mechanism,
+    tests/functional/scenarios/<name>/, declare their topology in that scenario's own
+    test_profile.yaml.
+    """
+    parts = Path(test_path).relative_to(FUNCTIONAL_DIR).parts
+    if parts[0] in TOPOLOGIES:
+        return parts[0]
+    if parts[0] == "scenarios":
+        profile_path = FUNCTIONAL_DIR / "scenarios" / parts[1] / "test_profile.yaml"
+        return yaml.safe_load(profile_path.read_text())["topology"]
+    raise RuntimeError(
+        f"Could not infer topology for test at {test_path} -- expected it under "
+        "tests/functional/{unified,control,data}/ or tests/functional/scenarios/<name>/"
+    )
 
 
 @pytest.fixture(scope="function")
-def k8s_core_v1_client() -> client.CoreV1Api:
-    """
-    Provide a Kubernetes core/v1 client for the resolved target cluster.
+def kubeconfig_file(request) -> str:
+    """This test's kubeconfig path, inferred from where the test lives (see _topology_for)."""
+    return str(KUBECONFIG_DIR / _topology_for(request.node.path))
 
-    :param request: Pytest request object for accessing test metadata.
-    :return: A Kubernetes CoreV1Api client for the target cluster.
-    """
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
+
+@pytest.fixture(scope="function")
+def k8s_core_v1_client(kubeconfig_file) -> client.CoreV1Api:
+    """Provide a Kubernetes core/v1 client for the resolved target cluster."""
     config.load_kube_config(config_file=kubeconfig_file)
     return client.CoreV1Api()
 
 
 @pytest.fixture(scope="function")
-def k8s_apps_v1_client() -> client.AppsV1Api:
-    """
-    Provide a Kubernetes apps/v1 client for the resolved target cluster.
-
-    :param request: Pytest request object for accessing test metadata.
-    :return: A Kubernetes AppsV1Api client for the target cluster.
-    """
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
+def k8s_apps_v1_client(kubeconfig_file) -> client.AppsV1Api:
+    """Provide a Kubernetes apps/v1 client for the resolved target cluster."""
     config.load_kube_config(config_file=kubeconfig_file)
     return client.AppsV1Api()
 
 
 @pytest.fixture(scope="function")
-def cp_nginx(k8s_core_v1_client):
+def cp_nginx(kubeconfig_file, k8s_core_v1_client):
     """Fixture for accessing the cp-nginx pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = get_pod_by_label_selector("astronomer", "component=cp-ingress-controller", kubeconfig_file)
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def dp_nginx(k8s_core_v1_client):
+def dp_nginx(kubeconfig_file, k8s_core_v1_client):
     """Fixture for accessing the dp-nginx pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = get_pod_by_label_selector("astronomer", "component=dp-ingress-controller", kubeconfig_file)
     yield testinfra.get_host(f"kubectl://{pod}?container=nginx&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def grafana(k8s_core_v1_client):
+def grafana(kubeconfig_file, k8s_core_v1_client):
     """Fixture for accessing the grafana pod."""
-
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = get_pod_by_label_selector("astronomer", "component=grafana", kubeconfig_file)
     yield testinfra.get_host(f"kubectl://{pod}?container=grafana&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def houston_api(k8s_core_v1_client):
+def houston_api(kubeconfig_file, k8s_core_v1_client):
     """Fixture for accessing the houston-api pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = get_pod_by_label_selector("astronomer", "component=houston", kubeconfig_file)
     yield testinfra.get_host(f"kubectl://{pod}?container=houston&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def prometheus():
+def prometheus(kubeconfig_file):
     """Fixture for accessing the prometheus pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = "astronomer-prometheus-0"
     yield testinfra.get_host(f"kubectl://{pod}?container=prometheus&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def es_master():
+def es_master(kubeconfig_file):
     """Fixture for accessing the es-master pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = "astronomer-elasticsearch-master-0"
     yield testinfra.get_host(f"kubectl://{pod}?container=es-master&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def es_data():
+def es_data(kubeconfig_file):
     """Fixture for accessing the es-data pod."""
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
     pod = "astronomer-elasticsearch-data-0"
     yield testinfra.get_host(f"kubectl://{pod}?container=es-data&namespace=astronomer", kubeconfig=kubeconfig_file)
 
 
 @pytest.fixture(scope="function")
-def all_containers(k8s_core_v1_client) -> list[testinfra.host.Host]:
-    kubeconfig_file = str(KUBECONFIG_DIR / TEST_SCENARIO)
+def all_containers(kubeconfig_file, k8s_core_v1_client) -> list[testinfra.host.Host]:
     all_pods = k8s_core_v1_client.list_namespaced_pod(namespace="astronomer").items
     results = []
     for pod in all_pods:

--- a/tests/functional/scenarios/README.md
+++ b/tests/functional/scenarios/README.md
@@ -30,7 +30,12 @@ tests/functional/scenarios/<name>/
 
 ## Running a scenario locally
 
+`TEST_SCENARIO` (topology) is resolved from the manifest, not something you set yourself --
+`--print-env` resolves it and `eval`'s it into your shell so both the setup step and pytest
+see the same value (a subprocess can't export env vars back into the shell that started it):
+
 ```sh
+eval "$(uv run bin/run-scenario.py --print-env auth-sidecar)"
 uv run bin/run-scenario.py auth-sidecar
 uv run pytest tests/functional/scenarios/auth-sidecar
 ```

--- a/tests/functional/scenarios/README.md
+++ b/tests/functional/scenarios/README.md
@@ -31,6 +31,6 @@ tests/functional/scenarios/<name>/
 ## Running a scenario locally
 
 ```sh
-bin/run-scenario.py auth-sidecar
+uv run bin/run-scenario.py auth-sidecar
 uv run pytest tests/functional/scenarios/auth-sidecar
 ```

--- a/tests/functional/scenarios/README.md
+++ b/tests/functional/scenarios/README.md
@@ -2,11 +2,15 @@
 
 A **scenario** here is a named test configuration: an install topology, an ordered list of
 values overlays, an optional pinned k8s version, and optional namespace labels to apply
-before install. This is a different axis from `TEST_SCENARIO` (`unified`/`control`/`data`,
-see `tests/functional/README.md`) — that's install topology only. A scenario here composes
-a topology with extra values/labels on top; `topology: unified` in a scenario's
-`test_profile.yaml` means it installs using the existing `unified` topology, with this
-scenario's own overlays layered on.
+before install. This is a different axis from topology (`unified`/`control`/`data`, see
+`tests/functional/README.md`) — a scenario composes a topology with extra values/labels on
+top; `topology: unified` in a scenario's `test_profile.yaml` means it installs using the
+existing `unified` topology, with this scenario's own overlays layered on.
+
+Topology is never read from an env var anywhere in this mechanism — `bin/run-scenario.py`
+passes it to `bin/reset-local-dev`/`bin/helm-install.py` as an explicit `--topology` flag,
+and pytest's `tests/functional/conftest.py` infers it directly from this manifest for any
+test under `tests/functional/scenarios/<name>/`.
 
 Existing `tests/functional/{unified,control,data}/` tests are not part of this mechanism
 and aren't being migrated into it.
@@ -30,12 +34,7 @@ tests/functional/scenarios/<name>/
 
 ## Running a scenario locally
 
-`TEST_SCENARIO` (topology) is resolved from the manifest, not something you set yourself --
-`--print-env` resolves it and `eval`'s it into your shell so both the setup step and pytest
-see the same value (a subprocess can't export env vars back into the shell that started it):
-
 ```sh
-eval "$(uv run bin/run-scenario.py --print-env auth-sidecar)"
 uv run bin/run-scenario.py auth-sidecar
 uv run pytest tests/functional/scenarios/auth-sidecar
 ```

--- a/tests/functional/scenarios/README.md
+++ b/tests/functional/scenarios/README.md
@@ -1,0 +1,36 @@
+# Scenarios
+
+A **scenario** here is a named test configuration: an install topology, an ordered list of
+values overlays, an optional pinned k8s version, and optional namespace labels to apply
+before install. This is a different axis from `TEST_SCENARIO` (`unified`/`control`/`data`,
+see `tests/functional/README.md`) — that's install topology only. A scenario here composes
+a topology with extra values/labels on top; `topology: unified` in a scenario's
+`test_profile.yaml` means it installs using the existing `unified` topology, with this
+scenario's own overlays layered on.
+
+Existing `tests/functional/{unified,control,data}/` tests are not part of this mechanism
+and aren't being migrated into it.
+
+## Layout
+
+```
+tests/functional/scenarios/<name>/
+├── test_profile.yaml   # manifest: topology, values, kube_version (optional), namespace_labels (optional)
+└── test_*.py           # this scenario's own assertions
+```
+
+## `test_profile.yaml` fields
+
+| Field             | Required | Meaning                                                                                   |
+| ------------------ | -------- | ------------------------------------------------------------------------------------------ |
+| `topology`         | yes      | `unified`, `control`, or `data` — which existing install topology to layer this scenario on |
+| `values`            | yes      | ordered list of values files (repo-relative), passed as `--helm-values` in order            |
+| `kube_version`      | no       | pinned k8s version; defaults to the latest entry in `metadata.yaml`'s `test_k8s_versions`   |
+| `namespace_labels`  | no       | labels to apply to the `astronomer` namespace *before* install (PSA is not retroactive)      |
+
+## Running a scenario locally
+
+```sh
+bin/run-scenario.py auth-sidecar
+uv run pytest tests/functional/scenarios/auth-sidecar
+```

--- a/tests/functional/scenarios/auth-sidecar/test_auth_sidecar.py
+++ b/tests/functional/scenarios/auth-sidecar/test_auth_sidecar.py
@@ -1,0 +1,32 @@
+"""PINF-1031: catches the class of regression in PINF-1033 (a PSS-Restricted hardening
+change broke global.authSidecar, not caught until QA). See test_profile.yaml for why
+this scenario combines authSidecar with a PSS-Restricted-enforcing namespace rather
+than testing them separately.
+"""
+
+GRAFANA_DEPLOYMENT_NAME = "astronomer-grafana"
+NAMESPACE = "astronomer"
+
+
+def test_grafana_deployment_reaches_ready(k8s_apps_v1_client):
+    """
+    A pod Pod Security Admission rejects is never created -- it never becomes an
+    unhealthy Pod object, it surfaces as a FailedCreate event on the Deployment's
+    ReplicaSet. Asserting readyReplicas == spec.replicas (rather than "every visible
+    pod is healthy") is what actually catches a rejected auth-proxy container.
+    """
+    deployment = k8s_apps_v1_client.read_namespaced_deployment(GRAFANA_DEPLOYMENT_NAME, NAMESPACE)
+    desired = deployment.spec.replicas
+    ready = deployment.status.ready_replicas or 0
+    assert ready == desired, (
+        f"{GRAFANA_DEPLOYMENT_NAME} has {ready}/{desired} ready replicas. Check for "
+        "FailedCreate events on its ReplicaSet -- a pod rejected by Pod Security "
+        "Admission never becomes a Pod object, so it shows up as missing, not unhealthy."
+    )
+
+
+def test_grafana_has_auth_proxy_container(k8s_apps_v1_client):
+    """Confirms global.authSidecar.enabled actually wired the auth-proxy container into the pod spec."""
+    deployment = k8s_apps_v1_client.read_namespaced_deployment(GRAFANA_DEPLOYMENT_NAME, NAMESPACE)
+    container_names = [c.name for c in deployment.spec.template.spec.containers]
+    assert "auth-proxy" in container_names, f"Expected an auth-proxy container, got: {container_names}"

--- a/tests/functional/scenarios/auth-sidecar/test_profile.yaml
+++ b/tests/functional/scenarios/auth-sidecar/test_profile.yaml
@@ -5,7 +5,7 @@
 topology: unified
 values:
   - configs/enable-auth-sidecar.yaml
-  - configs/psa-restricted-demo.yaml
+  - configs/psa-restricted.yaml
 namespace_labels:
   pod-security.kubernetes.io/enforce: restricted
   pod-security.kubernetes.io/enforce-version: latest

--- a/tests/functional/scenarios/auth-sidecar/test_profile.yaml
+++ b/tests/functional/scenarios/auth-sidecar/test_profile.yaml
@@ -1,0 +1,13 @@
+# PINF-1031: catches the class of regression in PINF-1033 (a PSS-Restricted
+# hardening change broke global.authSidecar, not caught until QA). Neither
+# toggle alone would catch it -- the failure was in the interaction between
+# them, so this scenario combines both rather than testing them separately.
+topology: unified
+values:
+  - configs/enable-auth-sidecar.yaml
+  - configs/psa-restricted-demo.yaml
+namespace_labels:
+  pod-security.kubernetes.io/enforce: restricted
+  pod-security.kubernetes.io/enforce-version: latest
+  pod-security.kubernetes.io/audit: restricted
+  pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
## Description

### What's new

- Add a "scenario" mechanism to functional tests: a named test profile (topology, values overlays, k8s version, namespace labels), auto-discovered from `tests/functional/scenarios/*/test_profile.yaml` and rendered into its own CircleCI job by `bin/generate_circleci_config.py`.
- Add the first scenario, `auth-sidecar`: combines `global.authSidecar.enabled` with a PSS-Restricted-enforcing namespace. Closes the gap that let PINF-1033 reach QA instead of CI -- no test run had ever exercised the interaction between the two.
- Add `bin/run-scenario.py`: loads a scenario's `test_profile.yaml` and drives `reset-local-dev`/`helm-install.py` with the right flags.
- Add `configs/enable-auth-sidecar.yaml` values overlay.

### What changed

- Replace the `TEST_SCENARIO` env var with an explicit `--topology` CLI flag across `helm-install.py`, `setup-kind.py`, `reset-local-dev`, `conftest.py`, and the `Makefile`. The env var didn't reliably survive CI step/process boundaries; `--topology` does.
- `bin/helm-install.py`: add repeatable `--helm-values` and `--namespace-label` flags. Create and label the namespace before install when labels are given -- PSA enforcement isn't retroactive, so it has to land before `--create-namespace`.
- `bin/reset-local-dev`: export the tools dir onto `PATH` for the rest of the script (fixes a bare-`helm` shell-out failure downstream).
- Tolerate the `astronomer` namespace already existing when creating and labeling it.
- Update docs to match: `docs/local-development.md`, `tests/functional/README.md`, `.agents/skills/functional-tests/SKILL.md`, new `tests/functional/scenarios/README.md`.

The existing k8s version test mechanism is untouched -- scenarios are additive.

<img width="1343" height="778" alt="Screenshot 2026-07-17 at 11 51 08" src="https://github.com/user-attachments/assets/e442aa2d-d5e4-4d03-848e-45c196b4f301" />

## Related Issues

- <https://linear.app/astronomer/issue/PINF-1031/improve-astronomerastronomer-repo-ci>

## Testing

I have run this through CI several times during debugging, which is sufficient. All of these changes are CI related.

## Merging

For now this is only for 2.1.
