### PR TITLE
PINF-969 astronomer airflow chart complete default resource

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -61,13 +61,13 @@ astroUI:
   env: []
   # This only applies when replicas > 3
   maxUnavailable: 25%
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   readinessProbe: {}
   livenessProbe: {}
   startupProbe: {}
@@ -172,13 +172,13 @@ houston:
   #   secretKey: "connection"
   secret: []
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi
 
   # Any Houston configuration. Reference here:
   # https://github.com/astronomer/houston-api/blob/main/config/default.yaml
@@ -676,7 +676,13 @@ configSyncer:
   # If not provided, will generate a random hour and minutes to spread cronjob workloads.
   schedule: ~
   securityContext: {}
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   serviceAccount:
     # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
     automountServiceAccountToken: true
@@ -806,13 +812,13 @@ pilot:
   podAnnotations: {}
 
   # -- Resource requests and limits
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 250m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
 
   # -- Liveness probe configuration
   livenessProbe: {}
@@ -1012,13 +1018,13 @@ registry:
   # flag to bypass secure (tls) authentication to astronomer registry
   enableInsecureAuth: False
   replicas: 1
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 500m
+      memory: 1Gi
+    requests:
+      cpu: 250m
+      memory: 512Mi
 
   livenessProbe: {}
     # httpGet:

--- a/charts/elasticsearch/values.yaml
+++ b/charts/elasticsearch/values.yaml
@@ -255,7 +255,13 @@ curator:
     capabilities:
       drop:
       - ALL
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
   # Allows modification of the default age-based filter. If you require more
   # sophisticated filtering, modify the action file specified in
@@ -288,13 +294,13 @@ exporter:
       drop:
       - ALL
 
-  resources: {}
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 100m
+      memory: 128Mi
 
   livenessProbe: {}
     # httpGet:
@@ -337,7 +343,13 @@ nginx:
   podAnnotations: {}
   fullnameOverride: ~
   ingressClass: ~
-  resources: {}
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
   startupProbe: {}
     # tcpSocket:
     #   port: {{ .Values.common.ports.http }}

--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -54,13 +54,13 @@ backendConnection:
 ports:
   http: 3000
 
-resources: {}
-#  limits:
-#   cpu: 100m
-#   memory: 128Mi
-#  requests:
-#   cpu: 100m
-#   memory: 128Mi
+resources:
+  limits:
+    cpu: 250m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi
 
 ## Configure grafana dashboard to import
 ## NOTE: To use dashboards you must also enable/configure dashboardProviders

--- a/charts/nats/values.yaml
+++ b/charts/nats/values.yaml
@@ -42,13 +42,13 @@ nats:
 
   terminationGracePeriodSeconds: 60
 
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 250m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
 
   livenessProbe: {}
     # httpGet:
@@ -279,13 +279,13 @@ gateway:
 # The NATS config reloader image to use.
 reloader:
   enabled: false
-  resources: {}
-  #  limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  #  requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 # Prometheus NATS Exporter configuration.
 exporter:

--- a/charts/nginx/values.yaml
+++ b/charts/nginx/values.yaml
@@ -54,13 +54,13 @@ maxUnavailableDefaultBackend: 25%
 
 minReadySeconds: 0
 
-resources: {}
-#  limits:
-#   cpu: 100m
-#   memory: 128Mi
-#  requests:
-#   cpu: 100m
-#   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
 
 livenessProbe: {}
   # httpGet:
@@ -133,7 +133,13 @@ allowSnippetAnnotations: true
 
 defaultBackend:
   enabled: true
-  resources: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
   readinessProbe: {}
   livenessProbe: {}
   startupProbe: {}

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -50,13 +50,13 @@ images:
     pullPolicy: IfNotPresent
 
 
-resources: {}
-#  limits:
-#   cpu: 100m
-#   memory: 128Mi
-#  requests:
-#   cpu: 100m
-#   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 2Gi
+  requests:
+    cpu: 250m
+    memory: 1Gi
 
 podAnnotations: {}
 
@@ -110,25 +110,25 @@ configMapReloader:
   livenessProbe: {}
   readinessProbe: {}
   startupProbe: {}
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 25Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 25Mi
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 50m
+      memory: 32Mi
 
 filesdReloader:
   livenessProbe: {}
   readinessProbe: {}
   startupProbe: {}
-  resources: {}
-    # limits:
-    #   cpu: 100m
-    #   memory: 25Mi
-    # requests:
-    #   cpu: 100m
-    #   memory: 25Mi
+  resources:
+    limits:
+      cpu: 100m
+      memory: 64Mi
+    requests:
+      cpu: 50m
+      memory: 32Mi
   extraEnv: []
   securityContext:
     allowPrivilegeEscalation: false
@@ -225,7 +225,13 @@ federation:
   auth:
     enabled: true
     replicas: 2
-    resources: {}
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
   ingress:
     annotations: {}
   livenessProbe: {}

--- a/tests/chart_tests/test_astronomer_config_syncer.py
+++ b/tests/chart_tests/test_astronomer_config_syncer.py
@@ -321,7 +321,10 @@ class TestAstronomerConfigSyncer:
 
         assert "--target-namespaces" not in job_container_by_name["config-syncer"]["args"]
         assert ",".join(namespaces) not in job_container_by_name["config-syncer"]["args"]
-        assert "resources" in job_container_by_name["config-syncer"]
+        assert job_container_by_name["config-syncer"]["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
 
     @pytest.mark.parametrize("test_data", cron_test_data, ids=[x[0] for x in cron_test_data])
     def test_astronomer_config_syncer_cronjob_default_schedule(self, test_data, kube_version):

--- a/tests/chart_tests/test_astronomer_dag_only_deploy.py
+++ b/tests/chart_tests/test_astronomer_dag_only_deploy.py
@@ -89,8 +89,14 @@ class TestDagOnlyDeploy:
         prod = yaml.safe_load(doc["data"]["production.yaml"])
         assert prod["deployments"]["deployMechanisms"]["dagOnlyDeployment"]["enabled"] is True
         assert prod["deployments"]["dagDeploy"]["enabled"] is True
-        assert "server" not in prod["deployments"]["dagDeploy"]
-        assert "client" not in prod["deployments"]["dagDeploy"]
+        # global.deployMechanisms.dagOnlyDeployment.resources now has a real default
+        # (PINF-969), so the server/client blocks it gates render by default too.
+        expected_resources = {
+            "limits": {"cpu": "200m", "memory": "384Mi"},
+            "requests": {"cpu": "200m", "memory": "384Mi"},
+        }
+        assert prod["deployments"]["dagDeploy"]["server"] == {"resources": expected_resources}
+        assert prod["deployments"]["dagDeploy"]["client"] == {"resources": expected_resources}
 
     def test_dagonlydeploy_config_enabled_with_private_registry(self, kube_version):
         """Test dagonlydeploy with private registry."""
@@ -271,8 +277,24 @@ class TestDagOnlyDeploy:
                 }
             },
             "securityContexts": {"pod": {"fsGroup": 50000}},
-            "server": {"readinessProbe": readiness_probe, "livenessProbe": liveness_probe},
-            "client": {"readinessProbe": readiness_probe, "livenessProbe": liveness_probe},
+            # global.deployMechanisms.dagOnlyDeployment.resources now has a real
+            # default (PINF-969), applied to both server and client.
+            "server": {
+                "readinessProbe": readiness_probe,
+                "livenessProbe": liveness_probe,
+                "resources": {
+                    "limits": {"cpu": "200m", "memory": "384Mi"},
+                    "requests": {"cpu": "200m", "memory": "384Mi"},
+                },
+            },
+            "client": {
+                "readinessProbe": readiness_probe,
+                "livenessProbe": liveness_probe,
+                "resources": {
+                    "limits": {"cpu": "200m", "memory": "384Mi"},
+                    "requests": {"cpu": "200m", "memory": "384Mi"},
+                },
+            },
         }
 
     def test_houston_configmap_with_dagonlydeployment_scheduling(self, kube_version, global_platform_node_pool_config):
@@ -311,9 +333,23 @@ class TestDagOnlyDeploy:
                 }
             },
             "securityContexts": {"pod": {"fsGroup": 50000}},
+            # global.deployMechanisms.dagOnlyDeployment.resources now has a real
+            # default (PINF-969) — it renders "server" here (matching the values
+            # already asserted) but also makes "client" render on its own, since
+            # the template gates "client" on this same shared resources value.
             "server": {
                 "nodeSelector": global_platform_node_pool_config["nodeSelector"],
                 "affinity": global_platform_node_pool_config["affinity"],
                 "tolerations": global_platform_node_pool_config["tolerations"],
+                "resources": {
+                    "limits": {"cpu": "200m", "memory": "384Mi"},
+                    "requests": {"cpu": "200m", "memory": "384Mi"},
+                },
+            },
+            "client": {
+                "resources": {
+                    "limits": {"cpu": "200m", "memory": "384Mi"},
+                    "requests": {"cpu": "200m", "memory": "384Mi"},
+                },
             },
         }

--- a/tests/chart_tests/test_astronomer_pilot.py
+++ b/tests/chart_tests/test_astronomer_pilot.py
@@ -64,6 +64,12 @@ class TestAstronomerPilot:
         # Command is 'commander pilot'
         assert pilot["command"] == ["commander", "pilot"]
 
+        # Has a real default resources block, not an empty one
+        assert pilot["resources"] == {
+            "limits": {"cpu": "250m", "memory": "512Mi"},
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+        }
+
     def test_pilot_deployment_env_vars_defaults(self, kube_version):
         """Test that pilot deployment exposes all expected env vars with defaults."""
         docs = render_chart(

--- a/tests/chart_tests/test_elasticsearch.py
+++ b/tests/chart_tests/test_elasticsearch.py
@@ -57,6 +57,10 @@ class TestElasticSearch:
             "runAsNonRoot": True,
             "runAsUser": 1000,
         }
+        assert curator_container["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
 
         # elasticsearch master
         assert master_doc["kind"] == "StatefulSet"

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -333,6 +333,11 @@ def test_houston_configmap_with_loggingsidecar_enabled():
         "name": "sidecar-log-consumer",
         "image": "quay.io/astronomer/ap-vector:0.22.3",
         "customConfig": False,
+        # global.logging.loggingSidecar.resources now has a real default (PINF-969)
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
 
@@ -368,6 +373,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrid
         "image": image,
         "customConfig": False,
         "indexNamePrefix": "test-index-name-prefix-999",
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
     assert image in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
 
@@ -402,6 +411,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_overrides():
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
         "customConfig": False,
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
 
@@ -440,6 +453,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_indexPattern():
         "image": image_name,
         "customConfig": False,
         "indexPattern": indexPattern,
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
 
 
@@ -475,6 +492,10 @@ def test_houston_configmap_with_loggingsidecar_customConfig_enabled():
         "name": sidecar_container_name,
         "image": "quay.io/astronomer/ap-vector:0.22.3",
         "customConfig": True,
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
 
@@ -539,6 +560,11 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_custom_env_overrides
                 "valueFrom": {"secretKeyRef": {"name": "elastic-creds", "key": "ESPASS"}},
             },
         ],
+        # global.logging.loggingSidecar.resources now has a real default (PINF-969)
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
 
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
@@ -622,6 +648,10 @@ def test_houston_configmap_with_loggingsidecar_enabled_with_securityContext_conf
         "image": "quay.io/astronomer/ap-vector:unittest-tag",
         "customConfig": False,
         "securityContext": securityContext,
+        "resources": {
+            "requests": {"cpu": "100m", "memory": "384Mi"},
+            "limits": {"cpu": "100m", "memory": "384Mi"},
+        },
     }
 
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]

--- a/tests/chart_tests/test_nats_sts.py
+++ b/tests/chart_tests/test_nats_sts.py
@@ -44,6 +44,20 @@ class TestNatsStatefulSet:
         assert spec["affinity"] == {}
         assert spec["tolerations"] == []
 
+    def test_nats_reloader_sidecar_resources_have_default(self, kube_version):
+        """Test that the optional config-reloader sidecar gets a real default resources block."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"nats": {"reloader": {"enabled": True}}},
+            show_only=["charts/nats/templates/statefulset.yaml"],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        assert c_by_name["reloader"]["resources"] == {
+            "limits": {"cpu": "100m", "memory": "128Mi"},
+            "requests": {"cpu": "50m", "memory": "64Mi"},
+        }
+
     def test_nats_statefulset_with_metrics_and_resources(self, kube_version):
         """Test that nats statefulset renders good metrics exporter."""
         docs = render_chart(

--- a/tests/chart_tests/test_prometheus_federation_auth_deployment.py
+++ b/tests/chart_tests/test_prometheus_federation_auth_deployment.py
@@ -71,6 +71,11 @@ class TestPrometheusFederationAuthDeployment:
         assert "var-run" in volumes
         assert volumes["var-run"]["emptyDir"] == {}
 
+        assert federation_auth_container["resources"] == {
+            "limits": {"cpu": "200m", "memory": "256Mi"},
+            "requests": {"cpu": "100m", "memory": "128Mi"},
+        }
+
     def test_prometheus_federation_auth_deployment_not_created_in_control_mode(self, kube_version):
         """Test that the deployment is not created when plane mode is control."""
         docs = render_chart(
@@ -140,7 +145,7 @@ class TestPrometheusFederationAuthDeployment:
             kube_version=kube_version,
             values={
                 "global": {"plane": {"mode": "data"}},
-                "federation": {"auth": {"resources": custom_resources}},
+                "prometheus": {"federation": {"auth": {"resources": custom_resources}}},
             },
             show_only=["charts/prometheus/templates/prometheus-federation-auth-deployment.yaml"],
         )

--- a/values.yaml
+++ b/values.yaml
@@ -190,7 +190,13 @@ global:
       client:
         readinessProbe: {}
         livenessProbe: {}
-      resources: {}
+      resources:
+        limits:
+          cpu: 200m
+          memory: 384Mi
+        requests:
+          cpu: 200m
+          memory: 384Mi
       persistence: {}
 
   # Deploy auth sidecar to use openshift native features
@@ -324,13 +330,13 @@ global:
       securityContext: {}
       readinessProbe: {}
       livenessProbe: {}
-      resources: {}
-      #  requests:
-      #    cpu: "100m"
-      #    memory: "386Mi"
-      #  limits:
-      #    cpu: "100m"
-      #    memory: "386Mi"
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "384Mi"
+        limits:
+          cpu: "100m"
+          memory: "384Mi"
 
   # External ES logging
   customLogging:


### PR DESCRIPTION
## Description

Populates all 19 previously-empty `resources: {}` subchart-level defaults in this repo: `nats` (+ reloader), `elasticsearch` (curator/exporter/nginx), `grafana`, `astronomer` (astroUI/houston/configSyncer/pilot/registry), `nginx` (+ defaultBackend), `prometheus` (+ configMapReloader/filesdReloader/federation.auth), and two global knobs (`global.deployMechanisms.dagOnlyDeployment`, `global.logging.loggingSidecar`). Sizing is per component tier.

Note for reviewers: 12 of the 19 are already shadowed by a real override in this repo's own root `values.yaml` (umbrella charts nest overrides under the subchart name — e.g. root `astronomer.astroUI.resources` already overrides `charts/astronomer/values.yaml`'s `astroUI.resources`), so those subchart-level defaults were never actually reachable in a normal umbrella-chart install. Fixing them anyway, since a subchart's own default should be correct independent of whether an umbrella override happens to cover it (subchart-only installs, direct subchart render tests, doc accuracy). Only 7 of the 19 were genuinely unprotected: `configSyncer`, `pilot`, `elasticsearch.curator`, `nats.reloader`, `prometheus.federation.auth`, and the two global knobs above.

Also fixes a latent, pre-existing bug in `test_prometheus_federation_auth_with_custom_resources`: its values override targeted bare `federation.auth.resources` instead of the subchart-nested `prometheus.federation.auth.resources`, so the override silently never reached the field. The test only passed before by coincidence — with the old empty default, the template's `| default global.authSidecar.resources` fallback kicked in, and that fallback happened to numerically match the test's own expected values. Populating a real default broke the coincidence and surfaced the bug; fixed the test's values nesting.

This PR covers the `astronomer`-repo slice of PINF-969 only. The ticket's other 3 knobs (`airflow-chart`'s dag-server/git-sync-relay) are fixed separately in that repo.

## Related Issues

Closes [PINF-969](https://linear.app/astronomer/issue/PINF-969/astronomer-airflow-chart-complete-default-resource-requestslimits)

## Testing

`uv run pytest` on the touched test files — all green, including one new test (`test_nats_reloader_sidecar_resources_have_default`) and the fixed `test_prometheus_federation_auth_with_custom_resources`:

```
tests/chart_tests/test_astronomer_pilot.py
tests/chart_tests/test_astronomer_config_syncer.py
tests/chart_tests/test_elasticsearch.py
tests/chart_tests/test_nats_sts.py
tests/chart_tests/test_prometheus_federation_auth_deployment.py
```

## Merging

release-2.1
