### PR TITLE
PINF-971: test that node-exporter's tolerations are configurable and have desired defaults

### DIFF
--- a/tests/chart_tests/test_prometheus_node_exporter.py
+++ b/tests/chart_tests/test_prometheus_node_exporter.py
@@ -61,6 +61,15 @@ class TestPrometheusNodeExporterDaemonset:
             "requests": {"cpu": "10m", "memory": "128Mi"},
         }
 
+        # PINF-971: node-exporter is a DaemonSet and needs to run on every
+        # node, including control-plane/master, so it tolerates that taint by
+        # default. This default is a plain, fully-overridable values.yaml
+        # entry (see test_node_exporter_nodepool_config_overrides) — same
+        # pattern as nodeSelector/affinity on this same DaemonSet.
+        assert doc["spec"]["template"]["spec"]["tolerations"] == [
+            {"effect": "NoSchedule", "operator": "Exists"},
+        ]
+
     def test_prometheus_node_exporter_daemonset_custom_resources(self, kube_version):
         doc = render_chart(
             kube_version=kube_version,


### PR DESCRIPTION
## Description

Resolves the `DENYlistTolerations` policy question for `prometheus-node-exporter`'s default toleration, same shape of resolution as #3424's `PINF-970` sibling (nginx `LoadBalancer`): keep the current default, confirm/document that it's already customer-overridable, no chart or values change needed.

`charts/prometheus-node-exporter/values.yaml` defaults `tolerations` to:

```yaml
tolerations:
  - effect: NoSchedule
    operator: Exists
```

**Decision: keep this as the default.** `prometheus-node-exporter` is a DaemonSet that needs to run on every node — including control-plane/master — to collect accurate host metrics; without this toleration it would never schedule onto tainted control-plane nodes.

Verified against source: `.Values.tolerations` is already a plain, fully customer-overridable values.yaml entry with no special gating — `charts/prometheus-node-exporter/templates/daemonset.yaml` renders it straight through (`tolerations: {{ toYaml .Values.tolerations | nindent 8 }}`), the same unconditional pass-through pattern used for `nodeSelector`/`affinity` on this same DaemonSet. A customer who needs a narrower or empty toleration set can already override `prometheus-node-exporter.tolerations` today.

The only real gap was test coverage — nothing previously asserted what the *default* toleration renders as, only that overriding it works (`test_node_exporter_nodepool_config_overrides`). This PR adds that missing assertion.

## Related Issues

Closes [PINF-971](https://linear.app/astronomer/issue/PINF-971/resolve-prometheus-node-exporter-default-toleration-vs)

## Testing

`uv run pytest tests/chart_tests/test_prometheus_node_exporter.py` — all 35 passed, including the new default-value assertion.

## Merging

release-2.1
