### PR TITLE
Change config to airflowOperator

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -82,11 +82,11 @@ dependencies:
   # Airflow Operator
   - name: airflow-operator
     # First-found path wins: `airflow-operator.enabled`, if set, decides whether this subchart
-    # installs; if unset, `global.operator.enabled` decides instead. Set
+    # installs; if unset, `global.airflowOperator.enabled` decides instead. Set
     # `airflow-operator.enabled: false` to skip installing the operator subchart on a data plane
     # whose cluster already runs a standalone Astro Runtime Operator, while keeping
-    # `global.operator.enabled: true` so Houston/Commander stay operator-aware.
-    condition: airflow-operator.enabled,global.operator.enabled
+    # `global.airflowOperator.enabled: true` so Houston/Commander stay operator-aware.
+    condition: airflow-operator.enabled,global.airflowOperator.enabled
     tags:
       - airflow-operator
 

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -358,7 +358,7 @@ def _version_specific_values_file(chart_version: str | None) -> Path:
 
 
 def _cp_values_yaml(settings: Settings) -> str:
-    operator_block = "  operator:\n    enabled: true\n" if settings.enable_operator else ""
+    operator_block = "  airflowOperator:\n    enabled: true\n" if settings.enable_operator else ""
     operator_subchart_block = (
         """\
 airflow-operator:
@@ -416,8 +416,8 @@ postgresql:
 def _dp_values_yaml(settings: Settings, dp: DataPlane) -> str:
     """Generate DP Helm values. Postgres on/off is decided by main() via configs/postgres-*.yaml
     depending on --dp-airflow-db — each DP runs its own database rather than sharing the CP's."""
-    global_operator_block = "  operator:\n    enabled: true\n" if settings.enable_operator else ""
-    # The airflow-operator subchart is enabled by `global.operator.enabled`
+    global_operator_block = "  airflowOperator:\n    enabled: true\n" if settings.enable_operator else ""
+    # The airflow-operator subchart is enabled by `global.airflowOperator.enabled`
     # (see Chart.yaml condition). The values block below is only consumed when
     # that flag is on; we emit it only in that case for clarity.
     operator_subchart_block = (
@@ -1227,7 +1227,7 @@ def parse_args() -> argparse.Namespace:
         action=argparse.BooleanOptionalAction,
         default=None,
         help=(
-            "Enable Airflow operator mode. Sets global.operator.enabled=true on "
+            "Enable Airflow operator mode. Sets global.airflowOperator.enabled=true on "
             "both CP and DP, and renders the airflow-operator subchart values on the DP. "
             "Pass --no-enable-operator to fall back to the helm-based airflow path. "
             "Omit to fall back to enabled (pass --interactive to be prompted instead)."

--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -157,7 +157,7 @@ Whether airflow-operator resources should render: the operator must be enabled
 and the plane mode must be data or unified.
 */}}
 {{- define "operator.enabled" -}}
-{{- if and (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) .Values.global.operator.enabled -}}
+{{- if and (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) .Values.global.airflowOperator.enabled -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/astronomer/templates/commander/commander-role.yaml
+++ b/charts/astronomer/templates/commander/commander-role.yaml
@@ -41,7 +41,7 @@ rules:
   resources: ["clusterexternalsecrets", "clusterpushsecrets", "clustersecretstores", "externalsecrets", "pushsecrets", "secretstores", "generatorstates"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end }}
-{{- if $.Values.global.operator.enabled }}
+{{- if $.Values.global.airflowOperator.enabled }}
 - apiGroups: ["airflow.apache.org"]
   resources: ["airflows"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -112,7 +112,7 @@ data:
 
       mode:
         operator:
-          enabled: {{.Values.global.operator.enabled}}
+          enabled: {{.Values.global.airflowOperator.enabled}}
 
       deployMechanisms:
         dagOnlyDeployment:
@@ -687,7 +687,7 @@ data:
     operator:
       adoption:
         # Adoption requires operator mode to be enabled; only both together enable it.
-        enabled: {{ and .Values.global.operator.enabled .Values.global.operator.adoption.enabled }}
+        enabled: {{ and .Values.global.airflowOperator.enabled .Values.global.airflowOperator.adoption.enabled }}
 
   # These are any user-specified config overrides.
   local-production.yaml: |

--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -290,7 +290,7 @@ data:
             action: replace
       {{- end }}
 
-      {{- if and $useClusterRoles .Values.global.operator.enabled   }}
+      {{- if and $useClusterRoles .Values.global.airflowOperator.enabled   }}
       - job_name: airflow-operator
         scrape_interval: 10s # Faster scrape to power dashboards
         kubernetes_sd_configs:

--- a/configs/enable-all-features-control.yaml
+++ b/configs/enable-all-features-control.yaml
@@ -23,7 +23,7 @@ astronomer:
     worker:
       enabled: true
 global:
-  operator:
+  airflowOperator:
     enabled: true
   authSidecar:
     enabled: true

--- a/configs/enable-all-features-data.yaml
+++ b/configs/enable-all-features-data.yaml
@@ -13,7 +13,7 @@ astronomer:
         cpu: 100m
         memory: 128Mi
 global:
-  operator:
+  airflowOperator:
     enabled: true
   authSidecar:
     enabled: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,7 +65,7 @@ These render in every mode (subject to their own enable flag) and run independen
 | PostgreSQL                   | In-cluster database for dev/test (production should use external) | `global.postgresql.enabled`                 |
 | PgBouncer                    | Connection pooling in front of Postgres                           | `global.pgbouncer.enabled`                  |
 | prometheus-postgres-exporter | Database metrics                                                  | `global.prometheusPostgresExporter.enabled` |
-| airflow-operator             | Optional CRD-based Airflow management                             | `global.operator.enabled`                   |
+| airflow-operator             | Optional CRD-based Airflow management                             | `global.airflowOperator.enabled`            |
 | external-secrets (ESO)       | Secret synchronization                                            | `external-secrets.enabled`                  |
 
 `Chart.yaml` is the canonical source for conditions and tags; `values.yaml` is the canonical source for `global.plane.*` defaults.

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -39,7 +39,7 @@ class TestAirflowOperator:
                     "certManager": {"enabled": True},
                 },
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=sorted(
@@ -67,7 +67,7 @@ class TestAirflowOperator:
                     "crd": {"create": True},
                 },
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=sorted(
@@ -88,7 +88,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "crd": {"create": crd_create},
@@ -121,7 +121,7 @@ class TestAirflowOperator:
                 "crd": {"create": True},
             },
             "global": {
-                "operator": {"enabled": True},
+                "airflowOperator": {"enabled": True},
                 "plane": {"mode": plane_mode},
             },
         }
@@ -162,7 +162,7 @@ class TestAirflowOperator:
                     },
                 },
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=["charts/airflow-operator/templates/secrets/webhooks-tls.yaml"],
@@ -183,7 +183,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {"webhooks": {"enabled": True}},
             },
@@ -214,7 +214,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {"airgapped": True, "runtimeVersions": {"versionsJson": runtime_releases_json}},
             },
@@ -235,7 +235,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "manager": {
@@ -276,7 +276,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "webhooks": {"enabled": False},
@@ -293,7 +293,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "manager": {
@@ -335,7 +335,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=[
@@ -353,7 +353,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                     "privateRegistry": {
                         "enabled": True,
                         "repository": "my.private.registry/astronomer",
@@ -387,7 +387,7 @@ class TestAirflowOperator:
         np_file = "charts/airflow-operator/templates/manager/controller-manager-networkpolicy.yaml"
         values = {
             "global": {
-                "operator": {"enabled": operator_enabled},
+                "airflowOperator": {"enabled": operator_enabled},
                 "networkPolicy": {"enabled": np_enabled},
             },
         }
@@ -426,7 +426,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                     "networkPolicy": {"enabled": True},
                 },
             },
@@ -495,7 +495,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "manager": {"metrics": {"enabled": True}},
@@ -526,7 +526,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
                 "airflow-operator": {
                     "manager": {"metrics": {"enabled": True}},
@@ -555,7 +555,7 @@ class TestAirflowOperator:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                     "openshift": {"enabled": openshift_enabled},
                 },
             },
@@ -579,7 +579,7 @@ class TestAirflowOperator:
     ):
         values = {
             "global": {
-                "operator": {"enabled": True},
+                "airflowOperator": {"enabled": True},
                 "rbac": {"enabled": rbac_enabled},
             },
             "airflow-operator": {
@@ -608,7 +608,7 @@ class TestAirflowOperator:
     @pytest.mark.parametrize(
         "operator_values",
         [
-            pytest.param({"global": {"operator": {"enabled": False}}}, id="explicitly-disabled"),
+            pytest.param({"global": {"airflowOperator": {"enabled": False}}}, id="explicitly-disabled"),
             pytest.param({}, id="default-unset"),
         ],
     )
@@ -637,7 +637,7 @@ class TestAirflowOperator:
     def test_airflow_operator_subchart_flag_precedence(self, kube_version, airflow_operator_values, global_enabled, should_render):
         values = {
             "global": {
-                "operator": {"enabled": global_enabled},
+                "airflowOperator": {"enabled": global_enabled},
                 "plane": {"mode": "unified"},
             },
         }

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -564,7 +564,7 @@ class TestAstronomerCommander:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": True},
+                    "airflowOperator": {"enabled": True},
                 },
             },
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],
@@ -582,7 +582,7 @@ class TestAstronomerCommander:
             kube_version=kube_version,
             values={
                 "global": {
-                    "operator": {"enabled": False},
+                    "airflowOperator": {"enabled": False},
                 },
             },
             show_only=["charts/astronomer/templates/commander/commander-role.yaml"],

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -191,7 +191,7 @@ class TestServiceAccounts:
                 "prometheusPostgresExporter": {"enabled": True},
                 "nodeExporter": {"enabled": True},
                 "pgbouncer": {"enabled": True},
-                "operator": {"enabled": True},
+                "airflowOperator": {"enabled": True},
             },
             "astronomer": {
                 "commander": {"serviceAccount": {"create": False}},
@@ -243,7 +243,7 @@ class TestServiceAccounts:
                 "prometheusPostgresExporter": {"enabled": True},
                 "nodeExporter": {"enabled": True},
                 "pgbouncer": {"enabled": True},
-                "operator": {"enabled": True},
+                "airflowOperator": {"enabled": True},
             },
             "astronomer": {
                 "commander": {"serviceAccount": {"create": True, "annotations": annotations}},

--- a/tests/chart_tests/test_data/enable_all_probes.yaml
+++ b/tests/chart_tests/test_data/enable_all_probes.yaml
@@ -465,7 +465,7 @@ vector:
         command:
         - /bin/true
 global:
-  operator:
+  airflowOperator:
     enabled: true
   authSidecar:
     enabled: true

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1124,13 +1124,13 @@ def test_houston_configmap_certgenerator_custom_tag():
 @pytest.mark.parametrize(
     "values,expected",
     [
-        # Adoption requires operator mode; both flags must be true. operator.enabled
+        # Adoption requires operator mode; both flags must be true. airflowOperator.enabled
         # defaults to false, so adoption is off unless operator mode is turned on.
         ({}, False),
-        ({"global": {"operator": {"enabled": True}}}, True),
-        ({"global": {"operator": {"enabled": True, "adoption": {"enabled": True}}}}, True),
-        ({"global": {"operator": {"enabled": True, "adoption": {"enabled": False}}}}, False),
-        ({"global": {"operator": {"enabled": False, "adoption": {"enabled": True}}}}, False),
+        ({"global": {"airflowOperator": {"enabled": True}}}, True),
+        ({"global": {"airflowOperator": {"enabled": True, "adoption": {"enabled": True}}}}, True),
+        ({"global": {"airflowOperator": {"enabled": True, "adoption": {"enabled": False}}}}, False),
+        ({"global": {"airflowOperator": {"enabled": False, "adoption": {"enabled": True}}}}, False),
     ],
     ids=[
         "default-operator-off",
@@ -1141,8 +1141,8 @@ def test_houston_configmap_certgenerator_custom_tag():
     ],
 )
 def test_houston_configmap_operator_adoption(values, expected):
-    """production.yaml adoption is the AND of global.operator.enabled and
-    global.operator.adoption.enabled — both must be true (PLX-500)."""
+    """production.yaml adoption is the AND of global.airflowOperator.enabled and
+    global.airflowOperator.adoption.enabled — both must be true (PLX-500)."""
     docs = render_chart(
         values=values,
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
@@ -1153,12 +1153,12 @@ def test_houston_configmap_operator_adoption(values, expected):
 
 
 def test_houston_configmap_operator_mode_reflects_operator_enabled():
-    """global.operator.enabled drives deployments.mode.operator.enabled, and gates
+    """global.airflowOperator.enabled drives deployments.mode.operator.enabled, and gates
     adoption regardless of the adoption flag."""
     docs = render_chart(
         values={
             "global": {
-                "operator": {"enabled": True, "adoption": {"enabled": False}},
+                "airflowOperator": {"enabled": True, "adoption": {"enabled": False}},
             }
         },
         show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],

--- a/tests/chart_tests/test_prometheus_config_configmap.py
+++ b/tests/chart_tests/test_prometheus_config_configmap.py
@@ -322,7 +322,7 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             name="astronomer",
-            values={"global": {"operator": {"enabled": True}}},
+            values={"global": {"airflowOperator": {"enabled": True}}},
         )[0]
         scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
         airflow_operator_scrape_config = [scrape for scrape in scrape_configs if scrape["job_name"] == "airflow-operator"]
@@ -336,7 +336,7 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             name="astronomer",
-            values={"global": {"operator": {"enabled": False}}},
+            values={"global": {"airflowOperator": {"enabled": False}}},
         )[0]
         scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
         airflow_operator_scrape_config = [scrape for scrape in scrape_configs if scrape["job_name"] == "airflow-operator"]
@@ -347,7 +347,7 @@ class TestPrometheusConfigConfigmap:
             kube_version=kube_version,
             show_only=self.show_only,
             name="astronomer",
-            values={"global": {"operator": {"enabled": True}, "clusterRoles": False}},
+            values={"global": {"airflowOperator": {"enabled": True}, "clusterRoles": False}},
         )[0]
         scrape_configs = yaml.safe_load(doc["data"]["config"])["scrape_configs"]
         airflow_operator_scrape_config = [scrape for scrape in scrape_configs if scrape["job_name"] == "airflow-operator"]

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -32,7 +32,7 @@ astronomer:
     worker:
       enabled: true
 global:
-  operator:
+  airflowOperator:
     enabled: true
   authSidecar:
     enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -99,7 +99,7 @@ global:
     containerdCertCopier:
       startupProbe: {}
     priorityClassName: ~
-  operator:
+  airflowOperator:
     # Turn on operator-based Airflow deployments. When enabled, this chart installs
     # the airflow-operator by default and grants Astronomer the permissions it needs
     # to manage Airflow deployments through the operator.


### PR DESCRIPTION
## Description

A cluster runs many operators, so a bare global.operator flag is very generic and can be miss leading. 

Renames the value everywhere it's consumed (values, Chart.yaml condition, templates, setup script, configs, docs, tests). 


## Testing

All test passing

## Merging

main and 2.1
