### PR TITLE
PINF-972: wire global.podLabels through commander-jwks-hook Job

### DIFF
--- a/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
+++ b/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
@@ -31,6 +31,7 @@ spec:
         app: commander-jwks-hook
         version: {{ .Chart.Version }}
         plane: {{ .Values.global.plane.mode }}
+        {{- include "global.podLabels" . | nindent 8 }}
       {{- if or .Values.global.podAnnotations .Values.global.istio.enabled }}
       annotations:
         {{- if .Values.global.istio.enabled }}

--- a/tests/chart_tests/test_astronomer_commander_hook_job.py
+++ b/tests/chart_tests/test_astronomer_commander_hook_job.py
@@ -77,6 +77,26 @@ class TestCommanderJWKSHookJob:
         assert configmap_doc["metadata"]["name"] == "release-name-commander-jwks-hook-config"
         assert "commander-jwks.py" in configmap_doc["data"]
 
+    def test_jwks_hook_job_global_pod_labels(self, kube_version):
+        """PINF-972: global.podLabels must reach this Job's pod template, same as every
+        other pod-owning template. This one is easy to miss in the repo-wide sweep
+        (test_global_pod_labels.py) because it only renders in data-plane mode."""
+
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": "data"}, "podLabels": {"gatekeeper.policy": "approved"}},
+                "astronomer": {"commander": {"serviceAccount": {"create": True}}},
+            },
+            show_only=["charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml"],
+        )
+
+        job_doc = docs[0]
+        pod_labels = job_doc["spec"]["template"]["metadata"]["labels"]
+        assert pod_labels["gatekeeper.policy"] == "approved"
+        # merge, not replace
+        assert pod_labels["component"] == "commander-jwks-hook"
+
     def test_jwks_hook_job_disabled_control_plane(self, kube_version):
         """Test JWKS Hook Job is not rendered on control plane."""
 


### PR DESCRIPTION
## Description

`commander-jwks-hooks.yaml` was the one pod-owning template (of ~50) that didn't call the `global.podLabels` helper, so a customer-configured label (e.g. a customer's required pod SID label) never reached this Job's pod template while every other pod-owning template already picks it up. This adds the missing include -- a one-line fix, no new mechanism.

Not caught by the repo-wide sweep (`test_global_pod_labels.py`) because that test renders with the default `unified` plane mode, and this Job only renders in `data`-plane mode. Added a dedicated test to this template's own existing test file (`test_astronomer_commander_hook_job.py`) instead, which already knows how to render it correctly.

`global.podLabels` already accepts an arbitrary customer-supplied `map[string]string`, which is the shape needed here, and it's already documented in `docs/api/fern/docs/pages/apc-2.0/add-podlabels.mdx` -- a copy for apc-2.1 is a separate, smaller follow-up in the docs repo, not included here.

## Related Issues

Closes [PINF-972](https://linear.app/astronomer/issue/PINF-972/wire-amexs-pod-sid-label-through-existing-labels-injection-points)

## Testing

`uv run pytest tests/chart_tests/test_astronomer_commander_hook_job.py tests/chart_tests/test_global_pod_labels.py` -- all passed, including the new test asserting `global.podLabels` values merge onto the Job's pod template labels (and don't replace the existing `tier`/`component`/`release` labels).

## Merging

release-2.1
