### PR TITLE
PINF-1069/PINF-1070: make DP→CP URLs CP-HA aware + enforce globalBaseDomain on all planes

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -761,7 +761,7 @@ tls:
 
 {{- define "houston.eventsUrl" -}}
 {{- if (eq .Values.global.plane.mode "data") -}}
-https://houston.{{ .Values.global.baseDomain }}/v1/registry/events
+https://houston.{{ include "houston.controlPlaneBaseDomain" . }}/v1/registry/events
 {{- else -}}
 http://{{ .Release.Name }}-houston:{{ .Values.ports.houstonHTTP }}/v1/registry/events
 {{- end }}
@@ -814,16 +814,29 @@ checksum/jetstream-tls-cert: {{ $actualCert }}
 {{- end }}
 {{- end }}
 
+{{- /*
+CP-HA: the control-plane base domain a data plane targets for control-plane services (Houston).
+Under Control Plane HA this must be the GLOBAL base domain so DP->CP requests health-route to
+whichever control plane is currently active; pinning to a single CP's per-CP baseDomain breaks
+DP->CP calls after a CP/region failover (the pinned CP is the one that is down).
+Hard-fails if HA is enabled but globalBaseDomain is unset (rather than silently falling back to a
+pinned per-CP endpoint). Uses the per-CP baseDomain only when Control Plane HA is disabled. Only
+meaningful on data planes.
+*/ -}}
+{{- define "houston.controlPlaneBaseDomain" -}}
+{{- if .Values.global.controlPlaneHA.enabled -}}
+{{- if not .Values.global.controlPlaneHA.globalBaseDomain -}}
+{{- fail "global.controlPlaneHA.globalBaseDomain is required when global.controlPlaneHA.enabled is true" -}}
+{{- end -}}
+{{- .Values.global.controlPlaneHA.globalBaseDomain -}}
+{{- else -}}
+{{- .Values.global.baseDomain -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "houston.authServiceURL" -}}
 {{- if (eq .Values.global.plane.mode "data") -}}
-{{- /* CP-HA: a data plane must fetch Houston's JWKS from the GLOBAL hostname so
-       token validation health-routes to whichever control plane is currently active. 
-       Falls back to the per-CP baseDomain when Control Plane HA is disabled. */ -}}
-{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
-https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
-{{- else -}}
-https://houston.{{ .Values.global.baseDomain }}
-{{- end -}}
+https://houston.{{ include "houston.controlPlaneBaseDomain" . }}
 {{- else -}}
 http://{{ .Release.Name }}-houston.{{ .Release.Namespace}}.svc.cluster.local:{{ .Values.ports.houstonHTTP }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -816,7 +816,14 @@ checksum/jetstream-tls-cert: {{ $actualCert }}
 
 {{- define "houston.authServiceURL" -}}
 {{- if (eq .Values.global.plane.mode "data") -}}
+{{- /* CP-HA: a data plane must fetch Houston's JWKS from the GLOBAL hostname so
+       token validation health-routes to whichever control plane is currently active. 
+       Falls back to the per-CP baseDomain when Control Plane HA is disabled. */ -}}
+{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
+https://houston.{{ .Values.global.controlPlaneHA.globalBaseDomain }}
+{{- else -}}
 https://houston.{{ .Values.global.baseDomain }}
+{{- end -}}
 {{- else -}}
 http://{{ .Release.Name }}-houston.{{ .Release.Namespace}}.svc.cluster.local:{{ .Values.ports.houstonHTTP }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -816,18 +816,14 @@ checksum/jetstream-tls-cert: {{ $actualCert }}
 
 {{- /*
 CP-HA: the control-plane base domain a data plane targets for control-plane services (Houston).
-Under Control Plane HA this must be the GLOBAL base domain so DP->CP requests health-route to
-whichever control plane is currently active; pinning to a single CP's per-CP baseDomain breaks
-DP->CP calls after a CP/region failover (the pinned CP is the one that is down).
-Hard-fails if HA is enabled but globalBaseDomain is unset (rather than silently falling back to a
-pinned per-CP endpoint). Uses the per-CP baseDomain only when Control Plane HA is disabled. Only
-meaningful on data planes.
+Under Control Plane HA this is the GLOBAL base domain so DP->CP requests health-route to whichever
+control plane is active as pinning to a single CP's per-CP baseDomain breaks DP->CP calls after a
+CP/region failover (if the pinned CP is the one that is down).
+When HA is enabled, globalBaseDomain is REQUIRED on every plane, so the HA branch always resolves. The
+per-CP fallback below is reached only when HA is disabled. Only meaningful on data planes.
 */ -}}
 {{- define "houston.controlPlaneBaseDomain" -}}
-{{- if .Values.global.controlPlaneHA.enabled -}}
-{{- if not .Values.global.controlPlaneHA.globalBaseDomain -}}
-{{- fail "global.controlPlaneHA.globalBaseDomain is required when global.controlPlaneHA.enabled is true" -}}
-{{- end -}}
+{{- if and .Values.global.controlPlaneHA.enabled .Values.global.controlPlaneHA.globalBaseDomain -}}
 {{- .Values.global.controlPlaneHA.globalBaseDomain -}}
 {{- else -}}
 {{- .Values.global.baseDomain -}}

--- a/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
+++ b/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
@@ -79,7 +79,9 @@ spec:
           resources: {{ toYaml .Values.commander.resources | nindent 12 }}
           env:
             - name: CONTROL_PLANE_ENDPOINT
-              value: "https://houston.{{ .Values.global.baseDomain }}"
+              # CP-HA: target the global control-plane host under HA so the
+              # JWKS bootstrap health-routes to whichever CP is active, not a pinned per-CP host.
+              value: "https://houston.{{ include "houston.controlPlaneBaseDomain" . }}"
             - name: SECRET_NAME
               value: "{{ .Release.Name }}-houston-jwt-signing-certificate"
             - name: NAMESPACE

--- a/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
+++ b/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml
@@ -79,8 +79,6 @@ spec:
           resources: {{ toYaml .Values.commander.resources | nindent 12 }}
           env:
             - name: CONTROL_PLANE_ENDPOINT
-              # CP-HA: target the global control-plane host under HA so the
-              # JWKS bootstrap health-routes to whichever CP is active, not a pinned per-CP host.
               value: "https://houston.{{ include "houston.controlPlaneBaseDomain" . }}"
             - name: SECRET_NAME
               value: "{{ .Release.Name }}-houston-jwt-signing-certificate"

--- a/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
+++ b/charts/astronomer/templates/houston/api/cp-identity-secret.yaml
@@ -2,13 +2,8 @@
 ## Control Plane identity Secret                    ##
 ######################################################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- if .Values.global.controlPlaneHA.enabled }}
-{{- /* globalBaseDomain is only consumed on control/unified planes, so only enforce it here.
-   This keeps data-plane renders working when HA is enabled via a shared global values file. */}}
-{{- if not .Values.global.controlPlaneHA.globalBaseDomain }}
-{{- fail "global.controlPlaneHA.globalBaseDomain is required when global.controlPlaneHA.enabled is true" }}
-{{- end }}
-{{- end }}
+{{- /* The globalBaseDomain requirement is enforced for all planes in
+   templates/validate-controlplane-ha.yaml, not here. */}}
 {{- /*
   Stable per-CP UUID, mounted as the CP_ID env var on every CP pod that runs a
   reconciliation loop so they can resolve their region's active state (Region-gating).

--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -3,7 +3,9 @@
 ########################
 {{- if and .Values.global.baseDomain ( not .Values.global.perHostIngress.enabled ) }}
 {{- $planeControlMode := or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- /* Global customer-facing host is control-plane-only (globalBaseDomain is unset on data planes). */}}
+{{- /* The global customer-facing host is served from the control plane only (customer UIs live on
+   the CP). It is gated on plane.mode, so a data plane never emits it even though globalBaseDomain is now
+   also set on DP installs under HA. */}}
 {{- $emitGlobalHost := and .Values.global.controlPlaneHA.enabled $planeControlMode }}
 {{- $registryEnabled := eq (include "registry.enabled" .) "true" }}
 {{- if or $planeControlMode $registryEnabled }}

--- a/charts/astronomer/templates/registry/registry-configmap.yaml
+++ b/charts/astronomer/templates/registry/registry-configmap.yaml
@@ -56,7 +56,7 @@ data:
     {{- if not .Values.registry.enableInsecureAuth }}
     auth:
       token:
-        realm: "https://houston.{{ .Values.global.baseDomain }}/v1/registry/authorization"
+        realm: "https://houston.{{ include "houston.controlPlaneBaseDomain" . }}/v1/registry/authorization"
         service: {{ .Values.registry.auth.service | quote }}
         issuer: {{ .Values.registry.auth.issuer | quote }}
         rootcertbundle: /etc/docker/ssl/tls.crt

--- a/charts/astronomer/templates/validate-controlplane-ha.yaml
+++ b/charts/astronomer/templates/validate-controlplane-ha.yaml
@@ -1,0 +1,15 @@
+{{- /*
+Control Plane HA value validation.
+
+globalBaseDomain is REQUIRED on ANY plane when controlPlaneHA is enabled as data planes consume it
+too. DP->CP service URLs (commander JWKS endpoint, registry events, the JWKS bootstrap hook) are
+templated from the global control-plane host so they health-route to whichever CP is active. A
+per-CP-pinned URL breaks after a CP/region failover.
+Enabling CP-HA now requires every data plane to be helm-upgraded with globalBaseDomain provided.
+
+This guard is intentionally NOT gated on global.plane.mode so it renders on every install and
+`helm template` / `helm upgrade` fails fast with a clear message. It emits no Kubernetes object.
+*/ -}}
+{{- if and .Values.global.controlPlaneHA.enabled (not .Values.global.controlPlaneHA.globalBaseDomain) }}
+{{- fail "global.controlPlaneHA.globalBaseDomain is required when global.controlPlaneHA.enabled is true (required on data-plane installs too)" }}
+{{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -992,3 +992,31 @@ class TestAstronomerCommander:
         jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
         assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
         assert jwks_entries[0]["value"] == expected_jwks_endpoint
+
+    def test_commander_houston_auth_service_url_cp_ha_data_plane(self, kube_version):
+        """CP-HA: a data plane must fetch Houston JWKS from the GLOBAL hostname.
+
+        Pinning the JWKS endpoint to a single CP's per-CP baseDomain breaks deployment
+        operations after a CP/region failover (the pinned CP is the one that is down). Under
+        Control Plane HA it must use the global hostname so validation health-routes to the
+        active control plane.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "baseDomain": "cp01.example.com",
+                    "controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"},
+                }
+            },
+            show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        commander_env = get_containers_by_name(docs[0])["commander"]["env"]
+        jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
+        assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
+        assert jwks_entries[0]["value"] == "https://houston.example.com", (
+            "data plane under CP-HA must fetch JWKS from the global hostname (globalBaseDomain), "
+            "not the per-CP baseDomain"
+        )

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import jmespath
 import pytest
 import yaml
@@ -1017,6 +1019,24 @@ class TestAstronomerCommander:
         jwks_entries = [e for e in commander_env if e["name"] == "COMMANDER_HOUSTON_JWKS_ENDPOINT"]
         assert len(jwks_entries) == 1, "duplicate COMMANDER_HOUSTON_JWKS_ENDPOINT entries would break helm upgrade"
         assert jwks_entries[0]["value"] == "https://houston.example.com", (
-            "data plane under CP-HA must fetch JWKS from the global hostname (globalBaseDomain), "
-            "not the per-CP baseDomain"
+            "data plane under CP-HA must fetch JWKS from the global hostname (globalBaseDomain), not the per-CP baseDomain"
         )
+
+    def test_commander_houston_auth_service_url_cp_ha_missing_global_base_domain(self, kube_version):
+        """CP-HA (PINF-1069): with HA enabled but globalBaseDomain unset, rendering must hard-fail
+        rather than silently pinning the data-plane JWKS endpoint to the per-CP baseDomain (which
+        would reintroduce the failover bug under a misconfiguration).
+        """
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            render_chart(
+                kube_version=kube_version,
+                values={
+                    "global": {
+                        "plane": {"mode": "data"},
+                        "baseDomain": "cp01.example.com",
+                        "controlPlaneHA": {"enabled": True},
+                    }
+                },
+                show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
+            )
+        assert "globalBaseDomain is required" in exc_info.value.stderr.decode("utf-8")

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -1,5 +1,3 @@
-import subprocess
-
 import jmespath
 import pytest
 import yaml
@@ -1003,12 +1001,15 @@ class TestAstronomerCommander:
         Control Plane HA it must use the global hostname so validation health-routes to the
         active control plane.
         """
+        # baseDomain is passed as the render arg (render_chart --set's global.baseDomain, which
+        # overrides values files) and deliberately differs from globalBaseDomain, so this asserts
+        # the helper uses globalBaseDomain rather than the per-CP baseDomain.
         docs = render_chart(
             kube_version=kube_version,
+            baseDomain="cp01.example.com",
             values={
                 "global": {
                     "plane": {"mode": "data"},
-                    "baseDomain": "cp01.example.com",
                     "controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"},
                 }
             },
@@ -1021,22 +1022,3 @@ class TestAstronomerCommander:
         assert jwks_entries[0]["value"] == "https://houston.example.com", (
             "data plane under CP-HA must fetch JWKS from the global hostname (globalBaseDomain), not the per-CP baseDomain"
         )
-
-    def test_commander_houston_auth_service_url_cp_ha_missing_global_base_domain(self, kube_version):
-        """CP-HA (PINF-1069): with HA enabled but globalBaseDomain unset, rendering must hard-fail
-        rather than silently pinning the data-plane JWKS endpoint to the per-CP baseDomain (which
-        would reintroduce the failover bug under a misconfiguration).
-        """
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            render_chart(
-                kube_version=kube_version,
-                values={
-                    "global": {
-                        "plane": {"mode": "data"},
-                        "baseDomain": "cp01.example.com",
-                        "controlPlaneHA": {"enabled": True},
-                    }
-                },
-                show_only=["charts/astronomer/templates/commander/commander-deployment.yaml"],
-            )
-        assert "globalBaseDomain is required" in exc_info.value.stderr.decode("utf-8")

--- a/tests/chart_tests/test_astronomer_commander_hook_job.py
+++ b/tests/chart_tests/test_astronomer_commander_hook_job.py
@@ -77,6 +77,31 @@ class TestCommanderJWKSHookJob:
         assert configmap_doc["metadata"]["name"] == "release-name-commander-jwks-hook-config"
         assert "commander-jwks.py" in configmap_doc["data"]
 
+    def test_jwks_hook_job_control_plane_endpoint_cp_ha(self, kube_version):
+        """CP-HA: the JWKS bootstrap hook's CONTROL_PLANE_ENDPOINT must target the
+        GLOBAL control-plane host so it health-routes to the active CP, not a pinned per-CP host.
+
+        baseDomain is passed as the render arg (render_chart --set's global.baseDomain, which
+        overrides values files) and deliberately differs from globalBaseDomain, so this proves the
+        endpoint is built from globalBaseDomain rather than the per-CP baseDomain.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            baseDomain="cp01.example.com",
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"},
+                }
+            },
+            show_only=["charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml"],
+        )
+        container = get_containers_by_name(docs[0], include_init_containers=True)["commander-jwks-hook"]
+        env_vars = get_env_vars_dict(container["env"])
+        assert env_vars["CONTROL_PLANE_ENDPOINT"] == "https://houston.example.com", (
+            "JWKS bootstrap must target the global Houston host under CP-HA, not the per-CP baseDomain"
+        )
+
     def test_jwks_hook_job_global_pod_labels(self, kube_version):
         """PINF-972: global.podLabels must reach this Job's pod template, same as every
         other pod-owning template. This one is easy to miss in the repo-wide sweep

--- a/tests/chart_tests/test_astronomer_houston_hook_job.py
+++ b/tests/chart_tests/test_astronomer_houston_hook_job.py
@@ -282,10 +282,19 @@ class TestRefreshCpChartVersionHookJob:
         assert docs == []
 
     def test_absent_on_data_plane(self, kube_version):
-        """A data-plane render emits no refresh Job (no CP registry on the data plane), even with HA enabled."""
+        """A data-plane render emits no refresh Job (no CP registry on the data plane), even with HA enabled.
+
+        globalBaseDomain is required on data planes too once HA is enabled, so it is
+        supplied here to get past the render guard.
+        """
         docs = render_chart(
             kube_version=kube_version,
-            values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": True}}},
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "controlPlaneHA": {"enabled": True, "globalBaseDomain": "astro.example.com"},
+                }
+            },
             show_only=[REFRESH_CP_CHART_VERSION_FILE],
         )
         assert docs == []

--- a/tests/chart_tests/test_auth_flow_global_base_domain.py
+++ b/tests/chart_tests/test_auth_flow_global_base_domain.py
@@ -3,17 +3,20 @@
 Follow-up to the dual-host work (PINF-809). Five non-auth-sidecar templates on the auth
 flow still hardcoded `global.baseDomain`; under control-plane HA they must resolve to
 `global.controlPlaneHA.globalBaseDomain` (the global customer-facing host the session cookie
-is scoped to), falling back to `baseDomain` when HA is off or globalBaseDomain is unset:
+is scoped to), falling back to `baseDomain` when HA is off:
 
   * `houston.internalauthurl` helper  -> `auth-url` annotation (shared by the three ingresses)
   * `houston-proxy` helper            -> elasticsearch `proxy_pass`
   * `auth-signin` annotation          -> prometheus / alertmanager / grafana ingresses
 
-Precedence is gated on `and controlPlaneHA.enabled controlPlaneHA.globalBaseDomain`: the
-auth-url / proxy_pass helper branches are only reachable in non-control modes, where
-globalBaseDomain may be unset (e.g. data planes) and must fall back to baseDomain rather
-than render a broken `https://houston./...` URL.
+Precedence is gated on `and controlPlaneHA.enabled controlPlaneHA.globalBaseDomain`. The
+helper fallback to `baseDomain` is now reachable only when HA is off: PINF-1070 makes
+globalBaseDomain REQUIRED on every plane (data planes included) whenever HA is enabled, so an
+HA-on-without-globalBaseDomain render is a hard failure (validate-controlplane-ha.yaml guard)
+rather than the graceful data-plane fallback assumed here originally.
 """
+
+from subprocess import CalledProcessError
 
 import pytest
 
@@ -81,22 +84,19 @@ class TestAuthSigninGlobalBaseDomain:
         )
         assert docs[0]["metadata"]["annotations"][AUTH_SIGNIN] == f"https://app.{BASE_DOMAIN}/login"
 
-    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
-        """HA on but globalBaseDomain unset must not emit a broken empty-host redirect.
-
-        Only the prometheus ingress can render auth-signin in this state: grafana/alertmanager
-        render on control/unified only, and a control-plane render with HA on + no
-        globalBaseDomain fails the cp-identity-secret guard. The prometheus data-plane render
-        exercises the shared global.authBaseDomain fallback for the auth-signin annotation.
+    def test_ha_on_without_global_base_domain_fails(self, kube_version):
+        """PINF-1070: enabling HA without globalBaseDomain is a hard render failure on every plane
+        (the shared validate-controlplane-ha.yaml guard), so the data-plane auth-signin fallback
+        path is now unreachable. Previously this rendered and fell back to baseDomain, under the
+        now-corrected "globalBaseDomain is control-plane-only" framing.
         """
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=[PROMETHEUS_INGRESS],
-            values=_values("data", ha=True),
-        )
-        auth_signin = docs[0]["metadata"]["annotations"][AUTH_SIGNIN]
-        assert auth_signin == f"https://app.{BASE_DOMAIN}/login"
-        assert "app./login" not in auth_signin
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                kube_version=kube_version,
+                show_only=[PROMETHEUS_INGRESS],
+                values=_values("data", ha=True),
+            )
+        assert "global.controlPlaneHA.globalBaseDomain is required" in excinfo.value.stderr.decode("utf-8")
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -123,17 +123,17 @@ class TestAuthUrlGlobalBaseDomain:
         )
         assert docs[0]["metadata"]["annotations"][AUTH_URL] == f"https://houston.{BASE_DOMAIN}/v1/authorization"
 
-    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
-        """Data plane with HA on but no globalBaseDomain (never templated there) must not
-        emit a broken empty-host URL — it falls back to baseDomain."""
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=[PROMETHEUS_INGRESS],
-            values=_values("data", ha=True),
-        )
-        auth_url = docs[0]["metadata"]["annotations"][AUTH_URL]
-        assert auth_url == f"https://houston.{BASE_DOMAIN}/v1/authorization"
-        assert "houston./" not in auth_url
+    def test_ha_on_without_global_base_domain_fails(self, kube_version):
+        """PINF-1070: HA on without globalBaseDomain now fails the render on every plane (the
+        shared validate-controlplane-ha.yaml guard), so the data-plane auth-url fallback path is
+        unreachable. Previously this rendered and fell back to baseDomain."""
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                kube_version=kube_version,
+                show_only=[PROMETHEUS_INGRESS],
+                values=_values("data", ha=True),
+            )
+        assert "global.controlPlaneHA.globalBaseDomain is required" in excinfo.value.stderr.decode("utf-8")
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -160,12 +160,14 @@ class TestHoustonProxyGlobalBaseDomain:
         )
         assert f"proxy_pass https://houston.{BASE_DOMAIN}/v1/elasticsearch;" in _es_nginx_conf(docs)
 
-    def test_ha_on_without_global_base_domain_falls_back_to_base_domain(self, kube_version):
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=[ES_NGINX_CONFIGMAP],
-            values=_values("data", ha=True),
-        )
-        nginx_conf = _es_nginx_conf(docs)
-        assert f"proxy_pass https://houston.{BASE_DOMAIN}/v1/elasticsearch;" in nginx_conf
-        assert "houston./v1/elasticsearch" not in nginx_conf
+    def test_ha_on_without_global_base_domain_fails(self, kube_version):
+        """PINF-1070: HA on without globalBaseDomain now fails the render on every plane (the
+        shared validate-controlplane-ha.yaml guard), so the data-plane proxy_pass fallback path is
+        unreachable. Previously this rendered and fell back to baseDomain."""
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                kube_version=kube_version,
+                show_only=[ES_NGINX_CONFIGMAP],
+                values=_values("data", ha=True),
+            )
+        assert "global.controlPlaneHA.globalBaseDomain is required" in excinfo.value.stderr.decode("utf-8")

--- a/tests/chart_tests/test_control_plane_ha.py
+++ b/tests/chart_tests/test_control_plane_ha.py
@@ -3,8 +3,9 @@
 Covers:
   * cp-identity Secret: generated on every control/unified plane install regardless of
     HA state (PINF-760), so a stable cp_id exists from initial single-CP install and is
-    already available if/when HA is later enabled; data-plane installs never generate it;
-    required-globalBaseDomain guard still applies only when HA is enabled.
+    already available if/when HA is later enabled; data-plane installs never generate it.
+  * globalBaseDomain requirement when HA is enabled: enforced on EVERY plane, data planes
+    included. see templates/validate-controlplane-ha.yaml.
   * JWT signing keypair generation gating (jwks.generation.enabled / HA)
   * CP_ID env var on every CP reconciliation-loop pod, still gated on HA
     (Houston API + worker, dp-link, navigator)
@@ -147,16 +148,36 @@ class TestCpIdentitySecret:
         assert "pre-upgrade" in secret_annotations["helm.sh/hook"]
         assert int(secret_annotations["helm.sh/hook-weight"]) < int(job_annotations["helm.sh/hook-weight"])
 
-    def test_data_plane_render_not_gated_on_global_base_domain(self, kube_version):
-        """A data-plane render with HA enabled (e.g. shared values) must not require globalBaseDomain.
+    def test_data_plane_render_fails_ha_enabled_without_global_base_domain(self, kube_version):
+        """A data-plane render with HA enabled but no globalBaseDomain must fail the render (PINF-1070).
 
-        globalBaseDomain is control-plane-only, so the fail guard is scoped to control/unified;
-        the data plane renders cleanly and emits no cp-identity Secret.
+        This inverts the earlier expectation. globalBaseDomain was previously treated as
+        control-plane-only, so the guard was scoped to control/unified and a data plane rendered
+        cleanly without it. That framing was incorrect: data planes consume globalBaseDomain too
+        (DP->CP service URLs health-route via the global host, see PINF-1069), so enabling CP-HA
+        now requires globalBaseDomain on every plane and the guard
+        (templates/validate-controlplane-ha.yaml) fires regardless of plane.mode.
         """
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                kube_version=kube_version,
+                show_only=[CP_IDENTITY_FILE],
+                values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": True}}},
+            )
+        assert "global.controlPlaneHA.globalBaseDomain is required" in excinfo.value.stderr.decode("utf-8")
+
+    def test_data_plane_render_succeeds_ha_enabled_with_global_base_domain(self, kube_version):
+        """Positive companion: a data-plane HA render WITH globalBaseDomain renders cleanly and
+        still emits no cp-identity Secret (the Secret remains control/unified-only)."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=[CP_IDENTITY_FILE],
-            values={"global": {"plane": {"mode": "data"}, "controlPlaneHA": {"enabled": True}}},
+            values={
+                "global": {
+                    "plane": {"mode": "data"},
+                    "controlPlaneHA": {"enabled": True, "globalBaseDomain": "astro.example.com"},
+                }
+            },
         )
         assert docs == []
 
@@ -399,18 +420,16 @@ class TestNginxCspGlobalDomain:
             assert self.GLOBAL_WILDCARD not in sources
             assert self.GLOBAL_WSS not in sources
 
-    def test_no_global_host_when_enabled_but_global_base_domain_unset(self, kube_version):
-        """Guard requires BOTH enabled and globalBaseDomain.
+    def test_ha_enabled_without_global_base_domain_fails_on_all_planes(self, kube_version):
+        """Enabling HA without globalBaseDomain is a hard render failure on EVERY plane (PINF-1070).
 
-        Data plane: renders with `enabled` alone and injects nothing — neither the wildcard
-        nor the `wss://` source. Control plane: enabling HA without globalBaseDomain is a hard
-        render failure (the cp-identity guard), so the CP headers can never reach an
-        enabled-but-unset state; assert that failure rather than a header that never renders.
+        The CSP global host can therefore never reach an enabled-but-unset state — the render
+        aborts first — so assert the failure on both the data-plane and control-plane headers
+        ConfigMaps. (Previously the data plane rendered cleanly and simply injected no global host,
+        under the now-corrected "globalBaseDomain is control-plane-only" framing.)
         """
-        csp = self._headers(kube_version, DP_HEADERS_FILE, "data", "dp.example.com", {"enabled": True})
-        for sources in csp.values():
-            assert self.GLOBAL_WILDCARD not in sources
-            assert self.GLOBAL_WSS not in sources
+        with pytest.raises(CalledProcessError):
+            self._headers(kube_version, DP_HEADERS_FILE, "data", "dp.example.com", {"enabled": True})
 
         with pytest.raises(CalledProcessError):
             self._headers(kube_version, CP_HEADERS_FILE, "control", "cp.example.com", {"enabled": True})

--- a/tests/chart_tests/test_dual_host_ingress.py
+++ b/tests/chart_tests/test_dual_host_ingress.py
@@ -98,16 +98,18 @@ class TestDualHostIngress:
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 def test_prometheus_data_plane_ha_no_global_host(kube_version):
-    """Prometheus ingress renders on data planes; globalBaseDomain is control-plane-only.
+    """Prometheus ingress renders on data planes and never emits the global customer host.
 
-    A data-plane render with HA enabled (e.g. shared values) and no globalBaseDomain must
-    render cleanly and emit no global host (mirrors PINF-768's data-plane guard).
+    The global host is control-plane-only *by design* (customer UIs live on the CP. The ingress
+    gates it on plane.mode), so a data plane suppresses it even though globalBaseDomain is now
+    also set on DP installs under HA. globalBaseDomain is supplied here because the HA render guard
+    now requires it on every plane.
     """
     values = {
         "global": {
             "plane": {"mode": "data", "domainPrefix": "dp"},
             "baseDomain": BASE_DOMAIN,
-            "controlPlaneHA": {"enabled": True},
+            "controlPlaneHA": {"enabled": True, "globalBaseDomain": GLOBAL_BASE_DOMAIN},
         }
     }
     ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[PROMETHEUS_INGRESS], values=values))
@@ -129,14 +131,15 @@ def test_public_ingress_global_bare_domain_redirect(kube_version):
 def test_public_ingress_data_plane_ha_no_global_redirect(kube_version):
     """Public ingress renders on data planes; the global bare-domain redirect is control-plane-only.
 
-    A data-plane render with HA enabled and no globalBaseDomain must not emit the global
-    redirect (which would otherwise template `<no value>` into the nginx snippet).
+    The global bare-domain redirect is control-plane-only (gated on plane.mode), so a data-plane
+    render must not emit it even though globalBaseDomain is now also set on DP installs under HA.
+    globalBaseDomain is supplied here because the HA render guard now requires it on every plane.
     """
     values = {
         "global": {
             "plane": {"mode": "data"},
             "baseDomain": BASE_DOMAIN,
-            "controlPlaneHA": {"enabled": True},
+            "controlPlaneHA": {"enabled": True, "globalBaseDomain": GLOBAL_BASE_DOMAIN},
         }
     }
     ingress = _find_ingress(render_chart(kube_version=kube_version, show_only=[PUBLIC_INGRESS], values=values))

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -1,5 +1,3 @@
-import subprocess
-
 import pytest
 import yaml
 
@@ -127,14 +125,18 @@ class Test_Registry_Configmap:
         assert houston_endpoint["url"] == "https://houston.example.com/v1/registry/events"
 
     def test_registry_configmap_houston_event_url_cp_ha(self, kube_version):
-        """CP-HA (PINF-1069): the registry's Houston notification URL must target the GLOBAL
-        hostname under HA so it health-routes to the active control plane, not a pinned per-CP host.
+        """CP-HA: the registry's DP->CP Houston references (the notification
+        events URL AND the token auth realm) must both target the GLOBAL hostname under HA so they
+        health-route to the active control plane, not a pinned per-CP host.
         """
+        # baseDomain is passed as the render arg (render_chart --set's global.baseDomain, which
+        # overrides values files) and deliberately differs from globalBaseDomain, so this asserts
+        # the URLs use globalBaseDomain rather than the per-CP baseDomain.
         docs = render_chart(
             kube_version=kube_version,
+            baseDomain="cp01.example.com",
             values={
                 "global": {
-                    "baseDomain": "cp01.example.com",
                     "plane": {"mode": "data"},
                     "controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"},
                 },
@@ -150,21 +152,6 @@ class Test_Registry_Configmap:
         assert houston_endpoint["url"] == "https://houston.example.com/v1/registry/events", (
             "registry notifications must target the global Houston hostname under CP-HA, not the per-CP baseDomain"
         )
-
-    def test_registry_configmap_houston_event_url_cp_ha_missing_global_base_domain(self, kube_version):
-        """CP-HA (PINF-1069): HA enabled but globalBaseDomain unset must hard-fail rather than
-        silently pinning the registry notification URL to the per-CP baseDomain.
-        """
-        with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            render_chart(
-                kube_version=kube_version,
-                values={
-                    "global": {
-                        "baseDomain": "cp01.example.com",
-                        "plane": {"mode": "data"},
-                        "controlPlaneHA": {"enabled": True},
-                    },
-                },
-                show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
-            )
-        assert "globalBaseDomain is required" in exc_info.value.stderr.decode("utf-8")
+        assert config["auth"]["token"]["realm"] == "https://houston.example.com/v1/registry/authorization", (
+            "registry token auth realm must target the global Houston hostname under CP-HA, not the per-CP baseDomain"
+        )

--- a/tests/chart_tests/test_registry_configmap.py
+++ b/tests/chart_tests/test_registry_configmap.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 import yaml
 
@@ -123,3 +125,46 @@ class Test_Registry_Configmap:
             None,
         )
         assert houston_endpoint["url"] == "https://houston.example.com/v1/registry/events"
+
+    def test_registry_configmap_houston_event_url_cp_ha(self, kube_version):
+        """CP-HA (PINF-1069): the registry's Houston notification URL must target the GLOBAL
+        hostname under HA so it health-routes to the active control plane, not a pinned per-CP host.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "baseDomain": "cp01.example.com",
+                    "plane": {"mode": "data"},
+                    "controlPlaneHA": {"enabled": True, "globalBaseDomain": "example.com"},
+                },
+            },
+            show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
+        )
+        assert len(docs) == 1
+        config = yaml.safe_load(docs[0]["data"]["config.yml"])
+        houston_endpoint = next(
+            (endpoint for endpoint in config["notifications"]["endpoints"] if endpoint["name"] == "houston"),
+            None,
+        )
+        assert houston_endpoint["url"] == "https://houston.example.com/v1/registry/events", (
+            "registry notifications must target the global Houston hostname under CP-HA, not the per-CP baseDomain"
+        )
+
+    def test_registry_configmap_houston_event_url_cp_ha_missing_global_base_domain(self, kube_version):
+        """CP-HA (PINF-1069): HA enabled but globalBaseDomain unset must hard-fail rather than
+        silently pinning the registry notification URL to the per-CP baseDomain.
+        """
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            render_chart(
+                kube_version=kube_version,
+                values={
+                    "global": {
+                        "baseDomain": "cp01.example.com",
+                        "plane": {"mode": "data"},
+                        "controlPlaneHA": {"enabled": True},
+                    },
+                },
+                show_only=["charts/astronomer/templates/registry/registry-configmap.yaml"],
+            )
+        assert "globalBaseDomain is required" in exc_info.value.stderr.decode("utf-8")


### PR DESCRIPTION
## Description

Makes the data plane's DP→control-plane URLs CP-HA aware. Under Control Plane HA these URLs must
target the **global** control-plane host so they health-route to whichever CP is active; pinning
them to a single CP's per-CP hostname breaks DP→CP calls after a CP/region failover (the pinned CP
is the one that is down).

### PINF-1069
- Added shared helper `houston.controlPlaneBaseDomain` (`charts/astronomer/templates/_helpers.yaml`):
  returns `global.controlPlaneHA.globalBaseDomain` under HA, else falls back to the per-CP
  `global.baseDomain`.
- Routed the runtime `COMMANDER_HOUSTON_JWKS_ENDPOINT` (via `houston.authServiceURL`) and the
  registry notification events URL (`houston.eventsUrl`) through the helper.
- DP-local URLs (registry ingress, elasticsearch, commander self URL) were verified to be
  correctly per-CP and deliberately left unchanged.

### PINF-1070
Resolves the design tension surfaced in review: rather than a data-plane render silently tolerating
a missing `globalBaseDomain`, enabling CP-HA now **requires** `globalBaseDomain` on every plane,
data planes included. Design doc updated accordingly.

1. **JWKS bootstrap hook** (`commander/jwks-hooks/commander-jwks-hooks.yaml`): `CONTROL_PLANE_ENDPOINT`
   now uses `houston.controlPlaneBaseDomain` instead of the per-CP `baseDomain`.
2. **Universal validation guard**: moved the `globalBaseDomain`-required fail guard out of
   `cp-identity-secret.yaml` (control/unified-only) into a new always-rendered
   `templates/validate-controlplane-ha.yaml` that fires on **any** plane when HA is enabled without
   `globalBaseDomain`. It emits no Kubernetes object.
3. **Test rewrite**: renamed `test_data_plane_render_not_gated_on_global_base_domain` →
   `test_data_plane_render_fails_ha_enabled_without_global_base_domain`, inverted the assertion, and
   added a positive companion. The old "globalBaseDomain is control-plane-only" framing was
   incorrect.
4. **Audit sweep** for remaining per-CP-pinned DP→CP URLs:
   the registry **token auth realm** (`registry-configmap.yaml`) was still pinned to the per-CP
   `baseDomain` which was right next to the events URL already converted in PINF-1069. Converted it to the helper. comments in `_helpers.yaml` and `ingress.yaml` were also refreshed.

### Migration implication
Enabling CP-HA now requires **every data plane** to be `helm upgrade`d with `globalBaseDomain`
provided. `helm template` / `helm upgrade` fails fast with a clear message otherwise.

## Related Issues

- https://linear.app/astronomer/issue/PINF-1069/cp-ha-dp-commander-jwks-endpoint-pinned-to-per-cp-houston-hostname
- https://linear.app/astronomer/issue/PINF-1070/cp-ha-enforce-globalbasedomain-on-dp-renders-fix-commander-jwks

Out of scope / flagged: `astro-ui-deployment.yaml` points the UI's Houston API/WS endpoints at the
per-CP `baseDomain` (browser→CP), which looks like the PINF-1050 sibling per-CP-vs-global bug and
is intentionally left untouched here.

## Testing

- Unit tests added/updated: JWKS bootstrap hook endpoint under HA, registry realm + events URL under
  HA, the inverted guard test + positive companion, and the tests that encoded the old invariant
  (houston hook job, dual-host ingress CSP/redirect) updated for the universal guard.
- Repo-wide sweep confirms no other `controlPlaneHA.enabled`-without-`globalBaseDomain` site.
- All affected chart-test suites pass; ruff + full pre-commit clean.
- Dev tested in the AWS test CP-HA environment (PINF-1069 fix validated: deployment opens after
  repointing the DP JWKS endpoint to the global host).

## Merging

Merge to main
