### PR TITLE
pinf-1071-helm-upgrade-deletes-crds-when-crdcreate-is-disabled

### DIFF
--- a/charts/airflow-operator/templates/crds/airflow.yaml
+++ b/charts/airflow-operator/templates/crds/airflow.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: airflows.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/apiserver.yaml
+++ b/charts/airflow-operator/templates/crds/apiserver.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: apiservers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/dagprocessor.yaml
+++ b/charts/airflow-operator/templates/crds/dagprocessor.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: dagprocessors.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/eventscheduler.yaml
+++ b/charts/airflow-operator/templates/crds/eventscheduler.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: eventschedulers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/pgbouncer.yaml
+++ b/charts/airflow-operator/templates/crds/pgbouncer.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: pgbouncers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/postgres.yaml
+++ b/charts/airflow-operator/templates/crds/postgres.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: postgres.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/rbac.yaml
+++ b/charts/airflow-operator/templates/crds/rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: rbacs.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/redis.yaml
+++ b/charts/airflow-operator/templates/crds/redis.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: redis.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/scheduler.yaml
+++ b/charts/airflow-operator/templates/crds/scheduler.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: schedulers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/statsd.yaml
+++ b/charts/airflow-operator/templates/crds/statsd.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: statsds.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/triggerer.yaml
+++ b/charts/airflow-operator/templates/crds/triggerer.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: triggerers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/webserver.yaml
+++ b/charts/airflow-operator/templates/crds/webserver.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: webservers.airflow.apache.org
 spec:

--- a/charts/airflow-operator/templates/crds/worker.yaml
+++ b/charts/airflow-operator/templates/crds/worker.yaml
@@ -4,6 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/airflow-operator-serving-cert'
   name: workers.airflow.apache.org
 spec:

--- a/values.yaml
+++ b/values.yaml
@@ -101,16 +101,16 @@ global:
     priorityClassName: ~
   airflowOperator:
     # Turn on operator-based Airflow deployments. When enabled, this chart installs
-    # the airflow-operator by default and grants Astronomer the permissions it needs
+    # the airflow-operator by default and grants APC the permissions it needs
     # to manage Airflow deployments through the operator.
     #
     # Already running your own operator on the cluster? Keep this enabled, but set
-    # `airflow-operator.enabled: false` (see Chart.yaml) so Astronomer works with your
+    # `airflow-operator.enabled: false` (see Chart.yaml) so APC works with your
     # existing operator instead of installing its own.
     enabled: false
 
     adoption:
-      # Allow Astronomer to adopt Airflow deployments that already exist on your
+      # Allow APC to adopt Airflow deployments that already exist on your
       # cluster, so you can bring them under management without recreating them.
       enabled: true
 


### PR DESCRIPTION
## Description

Toggling crd.create=true to false on a Helm upgrade deletes the CRD, which deletes all deployments.

Expected behavior: Helm should stop owning the CRD when it is removed from chart ownership, but the CRD object itself should not be deleted. Existing Airflow CRs and the operator should continue functioning. This behavior should also be documented explicitly.

Proposed solution: add the helm.sh/resource-policy: keep annotation to all CRDs.

## Related Issues

https://linear.app/astronomer/issue/PINF-1071/helm-upgrade-deletes-crds-when-crdcreate-is-disabled

## Testing

Local K3d testing

## Merging

main and 2.1
