### PR TITLE
PINF-1068: bump airflowChartVersion 1.18.5 -> 1.18.6 to pick up pgbouncer probe fix

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -5,7 +5,7 @@
 # This version number controls the default Airflow chart version that will be installed
 # when creating a new deployment in the system. This is also used to ensure all
 # child airflow deployments are kept up to date and on the latest version.
-airflowChartVersion: 1.18.5
+airflowChartVersion: 1.18.6
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
## Description

The `deployment-lifecycle` functional-test scenario started failing on `master` after #3437 (a bot-driven image update) bumped `airflowChartVersion` from `1.18.4` to `1.18.5`. CI hangs for the full 10-minute timeout waiting for the test deployment to reach ready.

`1.18.5` still pins apc-airflow `1.17.14-astro`, which has a broken pgbouncer metrics-exporter `startupProbe` (an invalid `pgbouncer_exporter health` exec command — fixed in [apc-airflow#25](https://github.com/astronomer/apc-airflow/pull/25) / PINF-1068). That sidecar CrashLoopBackOffs forever. A Kubernetes Deployment only counts a pod `Ready` once *every* container in it is Ready, so pgbouncer's pod never goes Ready even though the `pgbouncer` container itself is healthy — its Service never gets an endpoint, and every DB-dependent component (scheduler, webserver, worker, triggerer) hangs in `PodInitializing` indefinitely.

[airflow-chart 1.18.6](https://github.com/astronomer/airflow-chart/pull/756) already bumped its own apc-airflow dependency to `1.17.15-astro`, which includes the fix. This PR bumps `astronomer`'s pin to match.

## Related Issues

[PINF-1068](https://linear.app/astronomer/issue/PINF-1068)

## Testing

Ran the full chart-render test suite (`uv run pytest tests/chart_tests/`); no hardcoded assertions reference `airflowChartVersion`'s default value, so no test needed updating. This is a one-line version-pin change with no template logic — the actual fix and its own test coverage (`test_metrics_exporter_startup_probe_uses_http_not_broken_exec`) live in apc-airflow#25. The `deployment-lifecycle` scenario in CI is the real end-to-end confirmation once this merges.

## Merging

Should follow wherever #3437 (the bot image update) is going — same release train.
