### PR TITLE
update houston api version v2.1.11

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.1.10
+    tag: 2.1.11
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

update houston api version v2.1.11

## Related Issues

https://linear.app/astronomer/issue/PINF-1074/commander-grpc-clients-not-refreshed-after-commander-endpoint-change

## Testing

refer linked linear ticket

## Merging

merge to master and release-2.1
