### PR TITLE
Fix webhook namespace for vwebserverscale validating webhook

### DIFF
--- a/charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml
+++ b/charts/airflow-operator/templates/webhooks/validating-webhook-configuration.yaml
@@ -152,11 +152,7 @@ webhooks:
   sideEffects: None
 - admissionReviewVersions:
   - v1
-  clientConfig:
-    service:
-      name: {{ .Release.Name }}-airflow-operator-webhook-service
-      namespace: airflow-operator-system
-      path: /validate-airflow-apache-org-v1beta1-webserver-scale
+  clientConfig: {{ include "webhooks.clientConfig" (dict "path" "/validate-airflow-apache-org-v1beta1-webserver-scale" "Values" .Values "Release" .Release) | indent 4 }}
   failurePolicy: Fail
   name: vwebserverscale.kb.io
   rules:


### PR DESCRIPTION
## Description

The vwebserverscale validating webhook hardcoded namespace: airflow-operator-system in an inline clientConfig instead of using the shared webhooks.clientConfig helper. Outside that namespace it targeted a nonexistent service, blocking webserver scaling (failurePolicy: Fail). Now routed through the helper so the namespace tracks .Release.Namespace, matching the other 9 webhooks.


## Merging

Main and 2.1
