### PR TITLE
PINF-1107 - incorrect service mapping in registry ingress service definition

### DIFF
--- a/charts/astronomer/templates/ingress.yaml
+++ b/charts/astronomer/templates/ingress.yaml
@@ -108,7 +108,7 @@ spec:
           pathType: Prefix
           backend:
             service:
-              name: {{ .Release.Name }}-registry
+              name: {{ template "registry.fullname" . }}
               port:
                 name: registry-http
 {{- end }}

--- a/tests/chart_tests/test_ingress.py
+++ b/tests/chart_tests/test_ingress.py
@@ -326,3 +326,48 @@ class TestIngress:
 
         assert len(docs) == 1
         assert "tls" not in docs[0]["spec"]
+
+    def test_registry_name_per_host_ingress_overrides(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"perHostIngress": {"enabled": True}},
+                "astronomer": {"registry": {"fullnameOverride": "custom-registry"}},
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-ingress.yaml",
+                "charts/astronomer/templates/ingress.yaml",
+            ],
+        )
+        assert len(docs) == 1
+        expected_rules_v1 = json.loads(
+            """
+                [{"host":"registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+                {"service":{"name":"custom-registry","port":{"name":"registry-http"}}}}]}}]
+                """
+        )
+        assert docs[0]["spec"]["rules"] == expected_rules_v1
+
+    def test_registry_name_common_ingress_overrides(self, kube_version):
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {"registry": {"fullnameOverride": "custom-registry"}},
+            },
+            show_only=[
+                "charts/astronomer/templates/registry/registry-ingress.yaml",
+                "charts/astronomer/templates/ingress.yaml",
+            ],
+        )
+        assert len(docs) == 1
+        expected_rules_v1 = json.loads(
+            """
+                    [{"host":"example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+                    {"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},
+                    {"host":"app.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+                    {"service":{"name":"release-name-astro-ui","port":{"name":"astro-ui-http"}}}}]}},
+                    {"host":"registry.example.com","http":{"paths":[{"path":"/","pathType":"Prefix","backend":
+                    {"service":{"name":"custom-registry","port":{"name":"registry-http"}}}}]}}]
+                    """
+        )
+        assert docs[0]["spec"]["rules"] == expected_rules_v1


### PR DESCRIPTION
## Description

incorrect service mapping in registry ingress service definition

## Related Issues

https://linear.app/astronomer/issue/PINF-1107/registry-ingress-routes-to-wrong-service-name-in-astronomer-helm-chart

## Testing

covered by unit tests

## Merging

merge to master and release-2.1
