### PR TITLE
PINF-1034 kyverno policy scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
       - run:
           name: "Kyverno report: auth-sidecar"
           command: |
-            uv run bin/report-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/unified"
+            uv run bin/report-kyverno-scan.py --verbose --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/unified"
   scenario-deployment-lifecycle:
     machine:
       image: ubuntu-2404:2026.05.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,13 +354,16 @@ jobs:
           name: "Scenario: auth-sidecar"
           command: |
             uv run bin/run-scenario.py auth-sidecar
-            # Installed here, right after the cluster + platform chart are up but before
-            # pytest creates this scenario's own resources -- a live admission controller
-            # audits everything from this point on, including short-lived resources (a Job
-            # that completes and may get cleaned up) that a point-in-time scan run only at
-            # the end could never see. Doesn't cover whatever Jobs the platform chart's own
-            # install just created above (no earlier hook point without touching
-            # reset-local-dev/helm-install.py, shared by every topology, not just this one).
+            # bin/install-kyverno-scan.py installs a real Kyverno admission controller into
+            # the test cluster, right after run-scenario.py has finished installing the
+            # Astronomer Helm chart above but before pytest below creates this scenario's own
+            # test resources. Because it's a live admission controller rather than a one-time
+            # scan, it evaluates every resource from this point forward as it's created,
+            # including short-lived ones (e.g. a Job that finishes and gets cleaned up) that a
+            # scan run only once at the end of this job would never see. It cannot see
+            # anything the chart install above already created before it started -- there's
+            # no earlier point to run it from without changing reset-local-dev/
+            # bin/helm-install.py, which every scenario shares, not just this one.
             uv run bin/install-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/unified"
             # run-scenario.py's own PATH export (inside reset-local-dev) only reaches that
             # subprocess tree, not this shell -- needed here too for any fixture (e.g.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -354,6 +354,14 @@ jobs:
           name: "Scenario: auth-sidecar"
           command: |
             uv run bin/run-scenario.py auth-sidecar
+            # Installed here, right after the cluster + platform chart are up but before
+            # pytest creates this scenario's own resources -- a live admission controller
+            # audits everything from this point on, including short-lived resources (a Job
+            # that completes and may get cleaned up) that a point-in-time scan run only at
+            # the end could never see. Doesn't cover whatever Jobs the platform chart's own
+            # install just created above (no earlier hook point without touching
+            # reset-local-dev/helm-install.py, shared by every topology, not just this one).
+            uv run bin/install-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/unified"
             # run-scenario.py's own PATH export (inside reset-local-dev) only reaches that
             # subprocess tree, not this shell -- needed here too for any fixture (e.g.
             # testinfra's kubectl:// backend) that shells out to kubectl from within pytest.
@@ -361,6 +369,10 @@ jobs:
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/auth-sidecar"
       - store_test_results:
           path: test-results
+      - run:
+          name: "Kyverno report: auth-sidecar"
+          command: |
+            uv run bin/report-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/unified"
   scenario-deployment-lifecycle:
     machine:
       image: ubuntu-2404:2026.05.1
@@ -447,6 +459,8 @@ workflows:
       - scenario-auth-sidecar:
           requires:
             - build-artifact
+          context:
+            - github-repo
       - scenario-deployment-lifecycle:
           requires:
             - build-artifact

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -267,6 +267,16 @@ jobs:
           name: "Scenario: {{ scenario.name }}"
           command: |
             uv run bin/run-scenario.py {{ scenario.name }}
+{%- if scenario.kyverno_scan %}
+            # Installed here, right after the cluster + platform chart are up but before
+            # pytest creates this scenario's own resources -- a live admission controller
+            # audits everything from this point on, including short-lived resources (a Job
+            # that completes and may get cleaned up) that a point-in-time scan run only at
+            # the end could never see. Doesn't cover whatever Jobs the platform chart's own
+            # install just created above (no earlier hook point without touching
+            # reset-local-dev/helm-install.py, shared by every topology, not just this one).
+            uv run bin/install-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/{{ scenario.topology }}"
+{%- endif %}
             # run-scenario.py's own PATH export (inside reset-local-dev) only reaches that
             # subprocess tree, not this shell -- needed here too for any fixture (e.g.
             # testinfra's kubectl:// backend) that shells out to kubectl from within pytest.
@@ -274,6 +284,12 @@ jobs:
             uv run pytest -sv --junitxml=test-results/junit.xml "tests/functional/scenarios/{{ scenario.name }}"
       - store_test_results:
           path: test-results
+{%- if scenario.kyverno_scan %}
+      - run:
+          name: "Kyverno report: {{ scenario.name }}"
+          command: |
+            uv run bin/report-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/{{ scenario.topology }}"
+{%- endif %}
 {%- endfor %}
 
   check-commander-airflow-version:
@@ -317,6 +333,10 @@ workflows:
       - scenario-{{ scenario.name }}:
           requires:
             - build-artifact
+{%- if scenario.kyverno_scan %}
+          context:
+            - github-repo
+{%- endif %}
 {%- endfor %}
       - approve-stage-cluster-test:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -268,13 +268,16 @@ jobs:
           command: |
             uv run bin/run-scenario.py {{ scenario.name }}
 {%- if scenario.kyverno_scan %}
-            # Installed here, right after the cluster + platform chart are up but before
-            # pytest creates this scenario's own resources -- a live admission controller
-            # audits everything from this point on, including short-lived resources (a Job
-            # that completes and may get cleaned up) that a point-in-time scan run only at
-            # the end could never see. Doesn't cover whatever Jobs the platform chart's own
-            # install just created above (no earlier hook point without touching
-            # reset-local-dev/helm-install.py, shared by every topology, not just this one).
+            # bin/install-kyverno-scan.py installs a real Kyverno admission controller into
+            # the test cluster, right after run-scenario.py has finished installing the
+            # Astronomer Helm chart above but before pytest below creates this scenario's own
+            # test resources. Because it's a live admission controller rather than a one-time
+            # scan, it evaluates every resource from this point forward as it's created,
+            # including short-lived ones (e.g. a Job that finishes and gets cleaned up) that a
+            # scan run only once at the end of this job would never see. It cannot see
+            # anything the chart install above already created before it started -- there's
+            # no earlier point to run it from without changing reset-local-dev/
+            # bin/helm-install.py, which every scenario shares, not just this one.
             uv run bin/install-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/{{ scenario.topology }}"
 {%- endif %}
             # run-scenario.py's own PATH export (inside reset-local-dev) only reaches that

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -291,7 +291,7 @@ jobs:
       - run:
           name: "Kyverno report: {{ scenario.name }}"
           command: |
-            uv run bin/report-kyverno-scan.py --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/{{ scenario.topology }}"
+            uv run bin/report-kyverno-scan.py --verbose --kubeconfig="${HOME}/.local/share/astronomer-software/kubeconfig/{{ scenario.topology }}"
 {%- endif %}
 {%- endfor %}
 

--- a/bin/certs.py
+++ b/bin/certs.py
@@ -96,7 +96,12 @@ def create_astronomer_tls_certificates():
     development and testing, and because it makes this whole process easy.
     """
 
-    domain = "localtest.me"  # localtest.me and *.localtest.me resolve to 127.0.0.1 using any DNS server
+    domains = [
+        "localtest.me",  # localtest.me and *.localtest.me resolve to 127.0.0.1 using any DNS server
+        "host.docker.internal",  # Orbstack routes this from inside a container to your laptop
+    ]
+
+    domains = [*domains, *[f"*.{x}" for x in domains]]
 
     if astronomer_tls_key_file.exists() and astronomer_tls_cert_file.exists():
         print("Using existing astronomer-tls certificates")
@@ -105,7 +110,7 @@ def create_astronomer_tls_certificates():
     # Install the mkcert CA, then generate a wildcard cert and key.
     subprocess.run([MKCERT_EXE, "-install"], check=True)
     subprocess.run(
-        [MKCERT_EXE, f"-cert-file={astronomer_tls_cert_file}", f"-key-file={astronomer_tls_key_file}", domain, f"*.{domain}"],
+        [MKCERT_EXE, f"-cert-file={astronomer_tls_cert_file}", f"-key-file={astronomer_tls_key_file}", *domains],
         check=True,
     )
 

--- a/bin/certs.py
+++ b/bin/certs.py
@@ -96,12 +96,7 @@ def create_astronomer_tls_certificates():
     development and testing, and because it makes this whole process easy.
     """
 
-    domains = [
-        "localtest.me",  # localtest.me and *.localtest.me resolve to 127.0.0.1 using any DNS server
-        "host.docker.internal",  # Orbstack routes this from inside a container to your laptop
-    ]
-
-    domains = [*domains, *[f"*.{x}" for x in domains]]
+    domain = "localtest.me"  # localtest.me and *.localtest.me resolve to 127.0.0.1 using any DNS server
 
     if astronomer_tls_key_file.exists() and astronomer_tls_cert_file.exists():
         print("Using existing astronomer-tls certificates")
@@ -110,7 +105,7 @@ def create_astronomer_tls_certificates():
     # Install the mkcert CA, then generate a wildcard cert and key.
     subprocess.run([MKCERT_EXE, "-install"], check=True)
     subprocess.run(
-        [MKCERT_EXE, f"-cert-file={astronomer_tls_cert_file}", f"-key-file={astronomer_tls_key_file}", *domains],
+        [MKCERT_EXE, f"-cert-file={astronomer_tls_cert_file}", f"-key-file={astronomer_tls_key_file}", domain, f"*.{domain}"],
         check=True,
     )
 

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -18,10 +18,18 @@ def discover_scenarios() -> list[dict]:
 
     The manifest file's presence is the signal, not bare directory presence, so a
     half-finished or stray directory can't silently create (or hide) a CI job. Each
-    scenario's own test_profile.yaml may set an optional `resource_class` (any
-    CircleCI machine-executor resource class, e.g. xlarge/2xlarge) to size that
-    scenario's CI job independently -- most scenarios don't need more than the
-    default, but one running multiple concurrent Airflow Deployments can exhaust it.
+    scenario's own test_profile.yaml may set:
+    - `resource_class` (any CircleCI machine-executor resource class, e.g.
+      xlarge/2xlarge) to size that scenario's CI job independently -- most scenarios
+      don't need more than the default, but one running multiple concurrent Airflow
+      Deployments can exhaust it.
+    - `kyverno_scan: true` (PINF-1034) to install a live Kyverno admission controller
+      (bin/install-kyverno-scan.py) right after this scenario's cluster/platform chart
+      come up but before its own tests run, then report the policy violations it
+      recorded (bin/report-kyverno-scan.py) after those tests pass, without failing
+      the build. Needs a GITHUB_TOKEN with read access to the private
+      astronomer/apc-terraform-modules repo, so this also adds the `github-repo`
+      CircleCI context to just this scenario's job.
     """
     scenarios_dir = git_root_dir / "tests" / "functional" / "scenarios"
     if not scenarios_dir.is_dir():
@@ -30,10 +38,16 @@ def discover_scenarios() -> list[dict]:
     scenarios = []
     for profile_path in profile_paths:
         profile = yaml.safe_load(profile_path.read_text()) or {}
+        if profile.get("topology") not in ("unified", "control", "data"):
+            raise SystemExit(
+                f"ERROR: {profile_path} must set topology to one of unified/control/data, got {profile.get('topology')!r}"
+            )
         scenarios.append(
             {
                 "name": profile_path.parent.name,
+                "topology": profile["topology"],
                 "resource_class": profile.get("resource_class", "xlarge"),
+                "kyverno_scan": profile.get("kyverno_scan", False),
             }
         )
     return scenarios

--- a/bin/install-kyverno-scan.py
+++ b/bin/install-kyverno-scan.py
@@ -1,21 +1,24 @@
 #!/usr/bin/env python3
-"""Install the real Kyverno admission controller + policies, audit-only (PINF-1034).
+"""Install a real, live Kyverno admission controller into a test cluster, audit-only.
 
-Run this BEFORE the scenario provisions anything (before bin/run-scenario.py, not
-after it) -- the point of installing the real controller rather than just running
-`kyverno apply --cluster` at the end is a live admission webhook that evaluates every
-resource as it's created. A point-in-time scan run only at the end can't see a
-short-lived resource (a Job like migrateDatabaseJob or houston-db-migrations that
-completes and may get cleaned up) that already came and went by then; a live webhook
-running for the scenario's whole lifetime catches it regardless, via
-bin/report-kyverno-scan.py reading the PolicyReport/ClusterPolicyReport objects this
-produces (those persist as their own objects independent of whatever resource they
-describe).
+Installs the actual Kyverno Helm chart plus a set of Kyverno ClusterPolicy manifests,
+and waits for them to be ready to evaluate resources. Call this before creating any of
+the resources you want evaluated (i.e. before a test suite provisions its fixtures),
+not afterward.
 
-Every policy's validationFailureAction is force-overridden to Audit here regardless of
-its own real-world setting (two of the three current policies are Enforce) -- this
-scan must never actually reject anything the scenario creates, matching PINF-1034's
-explicit "don't fail the build" scope.
+The reason to install a real, live admission controller instead of just running a
+one-time `kyverno apply --cluster` scan at the end of a test run is that a live
+controller evaluates every resource as it's created and keeps a permanent record
+(see bin/report-kyverno-scan.py) of the result. A scan run only once, after the fact,
+can only see whatever resources are still alive at that moment -- it will silently
+miss a short-lived resource, such as a Job that runs to completion and is cleaned up
+(e.g. a database-migration Job), even if that resource violated a policy while it
+existed.
+
+Every policy's validationFailureAction is force-overridden to Audit here, regardless
+of what it's set to in the source policy file (some ship as Enforce), because this
+tooling is meant only to report on policy compliance, never to block or fail a build
+over it. See Linear ticket PINF-1034 for the background on why this exists.
 """
 
 import argparse
@@ -34,16 +37,19 @@ HELM_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "h
 KUBECTL_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "kubectl"
 
 KYVERNO_NAMESPACE = "kyverno"
-# Matches astronomer/apc-terraform-modules' real Terraform pin for the actual
-# admission controller (its kyverno_chart_version input) -- confirmed this maps to
-# appVersion v1.18.2, the same version this scan used before it ran the standalone
-# CLI instead of the real controller.
+# Pinned to the same Kyverno Helm chart version (which maps to Kyverno appVersion
+# v1.18.2) that astronomer/apc-terraform-modules' own Terraform module installs for
+# real customer clusters (its "kyverno_chart_version" input, defined in
+# src/kyverno/variables.tf in that repo). Keeping the two in sync means this test is
+# exercising the same policy-engine version real deployments actually run.
 KYVERNO_CHART_VERSION = "3.8.2"
 
-# Verified by reading the real Terraform, not guessed: openshift-automation's
-# modules/platform/kyverno.tf pulls this exact module/path for its own Kyverno install.
-# If this scan starts erroring on clone, or runs clean with suspiciously few results,
-# re-trace that chain before assuming these two constants are still right.
+# The astronomer/apc-terraform-modules repo (private) is where Astronomer's actual
+# Kyverno policies live, at the path below -- see that repo's src/kyverno/main.tf,
+# which applies every *.yaml file under this same directory the same way this script
+# does. If cloning starts failing, or this scan runs clean with suspiciously few
+# results, check whether that repo moved the policies directory before assuming these
+# two constants are still right.
 POLICIES_REPO = "astronomer/apc-terraform-modules"
 POLICIES_PATH = "src/kyverno/policies"
 
@@ -154,10 +160,12 @@ def get_ready_condition_field(kubeconfig: str, name: str, field: str) -> str | N
 def wait_for_policies_ready(kubeconfig: str, policy_names: list[str], timeout: int = 120) -> None:
     """Poll each ClusterPolicy's Ready condition until true, or raise on timeout.
 
-    Resources created before a policy's own webhook configuration is actually live
-    (not just the pod Ready, the policy itself registered and validated) wouldn't be
-    evaluated at all -- this is the same kind of pod-Ready-vs-actually-reachable gap
-    PINF-1049 hit with commander's JWKS fetch, just for a different component.
+    Applying a ClusterPolicy manifest and having Kyverno actually register and
+    validate that policy against its admission webhook are two different moments --
+    the object can exist in the API server before Kyverno has finished processing it.
+    Any resource created in that gap would not be evaluated by the policy at all, so
+    this function exists to make callers wait past that gap rather than assuming the
+    policy is active as soon as `kubectl apply` returns.
     """
     deadline = time.monotonic() + timeout
     pending = set(policy_names)

--- a/bin/install-kyverno-scan.py
+++ b/bin/install-kyverno-scan.py
@@ -126,8 +126,33 @@ def apply_policies(kubeconfig: str, policies_dir: Path) -> None:
     subprocess.run([str(KUBECTL_EXE), f"--kubeconfig={kubeconfig}", "apply", "-f", str(policies_dir)], check=True)
 
 
+def get_ready_condition_field(kubeconfig: str, name: str, field: str) -> str | None:
+    """Read one field (status or message) off a ClusterPolicy's Ready condition, or None before it exists.
+
+    Readiness is a status.conditions entry (type == "Ready"), not a top-level
+    status.ready boolean -- Kyverno v1.18's ClusterPolicy CRD only defines
+    status.conditions/status.rulecount, confirmed against its own CRD schema. A flat
+    `-o jsonpath={.status.ready}` check always returns empty and can never see
+    readiness, which is why this used to hang until the timeout with no explanation.
+    """
+    result = subprocess.run(
+        [
+            str(KUBECTL_EXE),
+            f"--kubeconfig={kubeconfig}",
+            "get",
+            "clusterpolicy",
+            name,
+            "-o",
+            f'jsonpath={{.status.conditions[?(@.type=="Ready")].{field}}}',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() or None
+
+
 def wait_for_policies_ready(kubeconfig: str, policy_names: list[str], timeout: int = 120) -> None:
-    """Poll each ClusterPolicy's status.ready until true, or raise on timeout.
+    """Poll each ClusterPolicy's Ready condition until true, or raise on timeout.
 
     Resources created before a policy's own webhook configuration is actually live
     (not just the pod Ready, the policy itself registered and validated) wouldn't be
@@ -136,27 +161,21 @@ def wait_for_policies_ready(kubeconfig: str, policy_names: list[str], timeout: i
     """
     deadline = time.monotonic() + timeout
     pending = set(policy_names)
+    last_message: dict[str, str] = {}
     while pending:
         for name in list(pending):
-            result = subprocess.run(
-                [
-                    str(KUBECTL_EXE),
-                    f"--kubeconfig={kubeconfig}",
-                    "get",
-                    "clusterpolicy",
-                    name,
-                    "-o",
-                    "jsonpath={.status.ready}",
-                ],
-                capture_output=True,
-                text=True,
-            )
-            if result.stdout.strip() == "true":
+            message = get_ready_condition_field(kubeconfig, name, "message")
+            if message:
+                last_message[name] = message
+            if get_ready_condition_field(kubeconfig, name, "status") == "True":
                 pending.discard(name)
         if not pending:
             return
         if time.monotonic() >= deadline:
-            raise SystemExit(f"ERROR: ClusterPolicy(s) never became ready within {timeout}s: {sorted(pending)}")
+            details = "\n".join(
+                f"  {name}: {last_message.get(name, '(no Ready condition reported yet)')}" for name in sorted(pending)
+            )
+            raise SystemExit(f"ERROR: ClusterPolicy(s) never became ready within {timeout}s:\n{details}")
         print(f"Waiting for ClusterPolicy readiness: {sorted(pending)} ({int(deadline - time.monotonic())}s remaining)")
         time.sleep(5)
 

--- a/bin/install-kyverno-scan.py
+++ b/bin/install-kyverno-scan.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Install the real Kyverno admission controller + policies, audit-only (PINF-1034).
+
+Run this BEFORE the scenario provisions anything (before bin/run-scenario.py, not
+after it) -- the point of installing the real controller rather than just running
+`kyverno apply --cluster` at the end is a live admission webhook that evaluates every
+resource as it's created. A point-in-time scan run only at the end can't see a
+short-lived resource (a Job like migrateDatabaseJob or houston-db-migrations that
+completes and may get cleaned up) that already came and went by then; a live webhook
+running for the scenario's whole lifetime catches it regardless, via
+bin/report-kyverno-scan.py reading the PolicyReport/ClusterPolicyReport objects this
+produces (those persist as their own objects independent of whatever resource they
+describe).
+
+Every policy's validationFailureAction is force-overridden to Audit here regardless of
+its own real-world setting (two of the three current policies are Enforce) -- this
+scan must never actually reject anything the scenario creates, matching PINF-1034's
+explicit "don't fail the build" scope.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import yaml
+
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+HELM_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "helm"
+KUBECTL_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "kubectl"
+
+KYVERNO_NAMESPACE = "kyverno"
+# Matches astronomer/apc-terraform-modules' real Terraform pin for the actual
+# admission controller (its kyverno_chart_version input) -- confirmed this maps to
+# appVersion v1.18.2, the same version this scan used before it ran the standalone
+# CLI instead of the real controller.
+KYVERNO_CHART_VERSION = "3.8.2"
+
+# Verified by reading the real Terraform, not guessed: openshift-automation's
+# modules/platform/kyverno.tf pulls this exact module/path for its own Kyverno install.
+# If this scan starts erroring on clone, or runs clean with suspiciously few results,
+# re-trace that chain before assuming these two constants are still right.
+POLICIES_REPO = "astronomer/apc-terraform-modules"
+POLICIES_PATH = "src/kyverno/policies"
+
+VALIDATION_FAILURE_ACTION_RE = re.compile(r"^(\s*validationFailureAction:\s*)\S+", re.MULTILINE)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kubeconfig", required=True, help="Path to the kubeconfig for the cluster to install into.")
+    return parser.parse_args()
+
+
+def clone_policies(dest: Path) -> Path:
+    """Sparse-clone just POLICIES_PATH out of POLICIES_REPO (a private repo) into dest.
+
+    Requires a GITHUB_TOKEN env var with read access to POLICIES_REPO -- CircleCI's
+    `github-repo` context provides this (already used elsewhere in this pipeline for
+    the same kind of private cross-repo access, e.g. bin/release-bom).
+    """
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        raise SystemExit(
+            f"ERROR: GITHUB_TOKEN is required to clone the private {POLICIES_REPO} repo "
+            "(CircleCI's github-repo context provides this)."
+        )
+    url = f"https://{token}@github.com/{POLICIES_REPO}.git"
+    subprocess.run(
+        ["git", "clone", "--quiet", "--depth=1", "--filter=blob:none", "--sparse", url, str(dest)],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(dest), "sparse-checkout", "set", POLICIES_PATH], check=True)
+    policies_dir = dest / POLICIES_PATH
+    if not policies_dir.is_dir():
+        raise SystemExit(f"ERROR: {POLICIES_PATH} not found in {POLICIES_REPO} after clone -- did it move again?")
+    return policies_dir
+
+
+def force_audit_mode(policies_dir: Path) -> None:
+    """Rewrite every policy's validationFailureAction to Audit in place, whatever it was."""
+    for policy_file in policies_dir.glob("*.yaml"):
+        text = policy_file.read_text()
+        patched, count = VALIDATION_FAILURE_ACTION_RE.subn(r"\1Audit", text)
+        if count:
+            policy_file.write_text(patched)
+
+
+def load_policy_names(policies_dir: Path) -> list[str]:
+    """Read metadata.name out of each policy file -- used to poll ClusterPolicy readiness below."""
+    return [yaml.safe_load(policy_file.read_text())["metadata"]["name"] for policy_file in policies_dir.glob("*.yaml")]
+
+
+def install_kyverno_chart(kubeconfig: str) -> None:
+    """Install (or upgrade) the real Kyverno Helm chart, waiting for it to be Ready."""
+    subprocess.run(
+        [str(HELM_EXE), "repo", "add", "--force-update", "kyverno", "https://kyverno.github.io/kyverno/"],
+        check=True,
+    )
+    subprocess.run([str(HELM_EXE), "repo", "update", "kyverno"], check=True)
+    subprocess.run(
+        [
+            str(HELM_EXE),
+            "upgrade",
+            "--install",
+            "kyverno",
+            "kyverno/kyverno",
+            f"--version={KYVERNO_CHART_VERSION}",
+            f"--namespace={KYVERNO_NAMESPACE}",
+            "--create-namespace",
+            f"--kubeconfig={kubeconfig}",
+            "--wait",
+            "--timeout=5m",
+        ],
+        check=True,
+    )
+
+
+def apply_policies(kubeconfig: str, policies_dir: Path) -> None:
+    """Apply the (already audit-forced) ClusterPolicy manifests."""
+    subprocess.run([str(KUBECTL_EXE), f"--kubeconfig={kubeconfig}", "apply", "-f", str(policies_dir)], check=True)
+
+
+def wait_for_policies_ready(kubeconfig: str, policy_names: list[str], timeout: int = 120) -> None:
+    """Poll each ClusterPolicy's status.ready until true, or raise on timeout.
+
+    Resources created before a policy's own webhook configuration is actually live
+    (not just the pod Ready, the policy itself registered and validated) wouldn't be
+    evaluated at all -- this is the same kind of pod-Ready-vs-actually-reachable gap
+    PINF-1049 hit with commander's JWKS fetch, just for a different component.
+    """
+    deadline = time.monotonic() + timeout
+    pending = set(policy_names)
+    while pending:
+        for name in list(pending):
+            result = subprocess.run(
+                [
+                    str(KUBECTL_EXE),
+                    f"--kubeconfig={kubeconfig}",
+                    "get",
+                    "clusterpolicy",
+                    name,
+                    "-o",
+                    "jsonpath={.status.ready}",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout.strip() == "true":
+                pending.discard(name)
+        if not pending:
+            return
+        if time.monotonic() >= deadline:
+            raise SystemExit(f"ERROR: ClusterPolicy(s) never became ready within {timeout}s: {sorted(pending)}")
+        print(f"Waiting for ClusterPolicy readiness: {sorted(pending)} ({int(deadline - time.monotonic())}s remaining)")
+        time.sleep(5)
+
+
+def main() -> None:
+    args = parse_args()
+    install_kyverno_chart(args.kubeconfig)
+    with tempfile.TemporaryDirectory() as tmp:
+        policies_dir = clone_policies(Path(tmp) / "apc-terraform-modules")
+        force_audit_mode(policies_dir)
+        policy_names = load_policy_names(policies_dir)
+        apply_policies(args.kubeconfig, policies_dir)
+        wait_for_policies_ready(args.kubeconfig, policy_names)
+    print(f"Kyverno controller + {len(policy_names)} policy(ies) (forced audit-only) ready: {sorted(policy_names)}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: kyverno install failed: {e}", file=sys.stderr)
+        raise SystemExit(1) from e

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -61,12 +61,14 @@ def summarize_reports(reports: list[dict]) -> list[str]:
 def count_evaluations(reports: list[dict]) -> dict[str, Counter]:
     """Per-policy count of each result type seen across the given reports.
 
-    A policy whose namespaceSelector matches zero resources produces zero results,
-    which prints identically to "zero violations" in summarize_reports() above --
-    the exact ambiguity this repo's own notes warn about (a missing namespace label
-    makes the scan "run clean" by matching nothing, not because nothing's wrong).
-    This makes that distinction visible: a policy with an all-zero counter here
-    never actually got evaluated against anything.
+    A policy is only evaluated against resources that match its own `match`/
+    `namespaceSelector` rules. If nothing in the cluster matches (for example, because
+    an expected namespace label was never applied), the policy produces zero results
+    -- which looks identical, in summarize_reports() above, to a policy that was
+    evaluated many times and never found a violation. This function exists to make
+    that difference visible: a policy with an all-zero counter here was never
+    actually evaluated against anything, which is a configuration problem, not a
+    clean compliance result.
     """
     counts: dict[str, Counter] = defaultdict(Counter)
     for report in reports:

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Report Kyverno policy violations, audit-only (PINF-1034).
+
+Reads PolicyReport/ClusterPolicyReport objects (group wgpolicyk8s.io, version
+v1alpha2 -- confirmed against Kyverno v1.18.2's own CRD manifests) rather than
+running a point-in-time scan. These accumulate from real admission-time evaluations
+made by the live controller bin/install-kyverno-scan.py installed earlier in this
+job, and persist as their own objects independent of whatever resource they
+describe -- so a short-lived resource (a Job that already completed and may be
+cleaned up) that violated a policy while it existed still shows up here, unlike a
+`kyverno apply --cluster` scan run only at this point, which can only see whatever's
+still alive right now.
+
+Never fails the build over violations found (prints them, that's the acceptance
+criterion) -- only over a genuine failure to read reports at all (missing CRDs, API
+errors), which means the scan itself didn't run, not that it found something.
+"""
+
+import argparse
+import sys
+
+from kubernetes import client, config
+
+REPORT_GROUP = "wgpolicyk8s.io"
+REPORT_VERSION = "v1alpha2"
+PASSING_RESULTS = {"pass", "skip"}
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--kubeconfig", required=True, help="Path to the kubeconfig for the cluster to read reports from.")
+    return parser.parse_args()
+
+
+def describe_subject(result: dict, report: dict) -> str:
+    """One resource reference for a result -- its own resources[] entry if present,
+    falling back to the report's own scope (its default subject) otherwise."""
+    resources = result.get("resources") or [report.get("scope", {})]
+    subject = resources[0]
+    namespace = subject.get("namespace")
+    name = subject.get("name", "?")
+    return f"{namespace}/{name}" if namespace else name
+
+
+def summarize_reports(reports: list[dict]) -> list[str]:
+    """One line per non-passing result across the given PolicyReport/ClusterPolicyReport items."""
+    lines = []
+    for report in reports:
+        for result in report.get("results", []):
+            if result.get("result") in PASSING_RESULTS:
+                continue
+            lines.append(
+                f"{result.get('result', '?').upper()} {result.get('policy', '?')}/{result.get('rule', '?')} "
+                f"on {describe_subject(result, report)}: {result.get('message', '')}"
+            )
+    return lines
+
+
+def main() -> None:
+    args = parse_args()
+    config.load_kube_config(config_file=args.kubeconfig)
+    api = client.CustomObjectsApi()
+
+    # list_cluster_custom_object hits the collection-level (no-namespace-segment)
+    # endpoint, which the k8s API serves across all namespaces for a namespaced CRD
+    # like PolicyReport too, not just for genuinely cluster-scoped ones.
+    cluster_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "clusterpolicyreports")["items"]
+    namespaced_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "policyreports")["items"]
+
+    findings = summarize_reports(cluster_reports) + summarize_reports(namespaced_reports)
+    print(f"--- Kyverno policy report findings ({len(findings)}) ---")
+    for line in findings:
+        print(line)
+    if not findings:
+        print("No non-passing results found.")
+    print("Not failing the build over these -- audit-only, see PINF-1034.")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        print(f"ERROR: reading Kyverno policy reports failed: {e}", file=sys.stderr)
+        raise SystemExit(1) from e

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -18,6 +18,7 @@ errors), which means the scan itself didn't run, not that it found something.
 
 import argparse
 import sys
+from collections import Counter, defaultdict
 
 from kubernetes import client, config
 
@@ -57,6 +58,23 @@ def summarize_reports(reports: list[dict]) -> list[str]:
     return lines
 
 
+def count_evaluations(reports: list[dict]) -> dict[str, Counter]:
+    """Per-policy count of each result type seen across the given reports.
+
+    A policy whose namespaceSelector matches zero resources produces zero results,
+    which prints identically to "zero violations" in summarize_reports() above --
+    the exact ambiguity this repo's own notes warn about (a missing namespace label
+    makes the scan "run clean" by matching nothing, not because nothing's wrong).
+    This makes that distinction visible: a policy with an all-zero counter here
+    never actually got evaluated against anything.
+    """
+    counts: dict[str, Counter] = defaultdict(Counter)
+    for report in reports:
+        for result in report.get("results", []):
+            counts[result.get("policy", "?")][result.get("result", "?")] += 1
+    return counts
+
+
 def main() -> None:
     args = parse_args()
     config.load_kube_config(config_file=args.kubeconfig)
@@ -67,6 +85,23 @@ def main() -> None:
     # like PolicyReport too, not just for genuinely cluster-scoped ones.
     cluster_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "clusterpolicyreports")["items"]
     namespaced_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "policyreports")["items"]
+
+    # The definitive list of policies that were actually installed -- these persist as
+    # their own ClusterPolicy objects from bin/install-kyverno-scan.py, independent of
+    # whether any report ever mentions them. Used below to catch a policy that matched
+    # zero resources, which otherwise looks identical to a policy with zero violations.
+    installed_policies = sorted(
+        item["metadata"]["name"] for item in api.list_cluster_custom_object("kyverno.io", "v1", "clusterpolicies")["items"]
+    )
+    counts = count_evaluations(cluster_reports + namespaced_reports)
+
+    print("--- Kyverno policy evaluation counts ---")
+    for policy in installed_policies:
+        counter = counts.get(policy)
+        if not counter:
+            print(f"{policy}: NO RESULTS -- matched zero resources, this policy was never actually evaluated")
+        else:
+            print(f"{policy}: {dict(counter)}")
 
     findings = summarize_reports(cluster_reports) + summarize_reports(namespaced_reports)
     print(f"--- Kyverno policy report findings ({len(findings)}) ---")

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -31,16 +31,29 @@ def parse_args() -> argparse.Namespace:
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--kubeconfig", required=True, help="Path to the kubeconfig for the cluster to read reports from.")
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help=(
+            "Also print every individual scanned object -- its namespace, name, and result -- "
+            "not just the non-passing ones. Useful for checking whether a given namespace was "
+            "scanned at all, not only whether it had violations."
+        ),
+    )
     return parser.parse_args()
 
 
-def describe_subject(result: dict, report: dict) -> str:
-    """One resource reference for a result -- its own resources[] entry if present,
+def resource_ref(result: dict, report: dict) -> tuple[str | None, str]:
+    """(namespace, name) for a result -- its own resources[] entry if present,
     falling back to the report's own scope (its default subject) otherwise."""
     resources = result.get("resources") or [report.get("scope", {})]
     subject = resources[0]
-    namespace = subject.get("namespace")
-    name = subject.get("name", "?")
+    return subject.get("namespace"), subject.get("name", "?")
+
+
+def describe_subject(result: dict, report: dict) -> str:
+    """One resource reference for a result, formatted as namespace/name (or just name for a cluster-scoped resource)."""
+    namespace, name = resource_ref(result, report)
     return f"{namespace}/{name}" if namespace else name
 
 
@@ -56,6 +69,33 @@ def summarize_reports(reports: list[dict]) -> list[str]:
                 f"on {describe_subject(result, report)}: {result.get('message', '')}"
             )
     return lines
+
+
+def list_all_results(reports: list[dict]) -> list[str]:
+    """One line per individual result across the given reports, regardless of pass/fail.
+
+    Unlike summarize_reports() below, this includes passing results too. It exists so
+    --verbose can show exactly which namespaces and objects were actually scanned, not
+    just which ones failed -- a namespace that never appears here at all was never
+    evaluated by anything, which looks nothing like a namespace full of passing pods
+    once you can see the full list, but is indistinguishable from one if you can only
+    see violations.
+    """
+    rows = []
+    for report in reports:
+        for result in report.get("results", []):
+            namespace, name = resource_ref(result, report)
+            rows.append(
+                (
+                    namespace or "(cluster-scoped)",
+                    name,
+                    result.get("policy", "?"),
+                    result.get("rule", "?"),
+                    result.get("result", "?"),
+                )
+            )
+    rows.sort()
+    return [f"ns={namespace} {name}: {policy}/{rule} -> {result.upper()}" for namespace, name, policy, rule, result in rows]
 
 
 def count_evaluations(reports: list[dict]) -> dict[str, Counter]:
@@ -87,6 +127,11 @@ def main() -> None:
     # like PolicyReport too, not just for genuinely cluster-scoped ones.
     cluster_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "clusterpolicyreports")["items"]
     namespaced_reports = api.list_cluster_custom_object(REPORT_GROUP, REPORT_VERSION, "policyreports")["items"]
+
+    if args.verbose:
+        print("--- Kyverno scanned objects (verbose, includes passing results) ---")
+        for line in list_all_results(cluster_reports + namespaced_reports):
+            print(line)
 
     # The definitive list of policies that were actually installed -- these persist as
     # their own ClusterPolicy objects from bin/install-kyverno-scan.py, independent of

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -109,7 +109,8 @@ def main() -> None:
         print(line)
     if not findings:
         print("No non-passing results found.")
-    print("Not failing the build over these -- audit-only, see PINF-1034.")
+    else:
+        print("Not failing the build over these -- audit-only, see PINF-1034.")
 
 
 if __name__ == "__main__":

--- a/bin/report-kyverno-scan.py
+++ b/bin/report-kyverno-scan.py
@@ -72,7 +72,7 @@ def summarize_reports(reports: list[dict]) -> list[str]:
 
 
 def list_all_results(reports: list[dict]) -> list[str]:
-    """One line per individual result across the given reports, regardless of pass/fail.
+    """One column-aligned line per individual result across the given reports, regardless of pass/fail.
 
     Unlike summarize_reports() below, this includes passing results too. It exists so
     --verbose can show exactly which namespaces and objects were actually scanned, not
@@ -80,6 +80,11 @@ def list_all_results(reports: list[dict]) -> list[str]:
     evaluated by anything, which looks nothing like a namespace full of passing pods
     once you can see the full list, but is indistinguishable from one if you can only
     see violations.
+
+    Sorted by (namespace, object name) rather than by policy or result, so every result
+    for a given pod (or its Deployment/ReplicaSet/CronJob) reads together as one group
+    -- that's the grouping that answers "was this object scanned at all", which is the
+    question this flag exists to answer.
     """
     rows = []
     for report in reports:
@@ -89,13 +94,20 @@ def list_all_results(reports: list[dict]) -> list[str]:
                 (
                     namespace or "(cluster-scoped)",
                     name,
-                    result.get("policy", "?"),
-                    result.get("rule", "?"),
-                    result.get("result", "?"),
+                    result.get("result", "?").upper(),
+                    f"{result.get('policy', '?')}/{result.get('rule', '?')}",
                 )
             )
-    rows.sort()
-    return [f"ns={namespace} {name}: {policy}/{rule} -> {result.upper()}" for namespace, name, policy, rule, result in rows]
+    rows.sort(key=lambda row: row[:2])
+    if not rows:
+        return []
+    result_width = max(len(result) for _, _, result, _ in rows)
+    namespace_width = max(len(namespace) for namespace, _, _, _ in rows)
+    name_width = max(len(name) for _, name, _, _ in rows)
+    return [
+        f"{result:<{result_width}}  {namespace:<{namespace_width}}  {name:<{name_width}}  {policy_rule}"
+        for namespace, name, result, policy_rule in rows
+    ]
 
 
 def count_evaluations(reports: list[dict]) -> dict[str, Counter]:

--- a/configs/enable-kyverno-scan.yaml
+++ b/configs/enable-kyverno-scan.yaml
@@ -1,0 +1,14 @@
+# PINF-1034: bin/install-kyverno-scan.py installs a live Kyverno admission controller
+# with astronomer/apc-terraform-modules' policies applied -- but every one of those
+# policies scopes its `match` to namespaces labeled `platform: astronomer` (a
+# namespaceSelector, not a pod label), and nothing in this repo sets that label by
+# default. Without it, the scan runs clean by matching nothing, not because nothing's
+# wrong. This only reaches the Airflow-Deployment-namespace tier (global.namespaceLabels
+# flows through the commander-metadata ConfigMap, and Commander stamps it onto every
+# namespace it creates) -- a scenario also wanting the platform namespace itself
+# scanned needs `platform=astronomer` in its own test_profile.yaml namespace_labels too,
+# the same way PSA labels need both halves (see configs/enable-psa.yaml).
+---
+global:
+  namespaceLabels:
+    platform: astronomer

--- a/configs/enable-kyverno-scan.yaml
+++ b/configs/enable-kyverno-scan.yaml
@@ -1,13 +1,21 @@
-# PINF-1034: bin/install-kyverno-scan.py installs a live Kyverno admission controller
-# with astronomer/apc-terraform-modules' policies applied -- but every one of those
-# policies scopes its `match` to namespaces labeled `platform: astronomer` (a
-# namespaceSelector, not a pod label), and nothing in this repo sets that label by
-# default. Without it, the scan runs clean by matching nothing, not because nothing's
-# wrong. This only reaches the Airflow-Deployment-namespace tier (global.namespaceLabels
-# flows through the commander-metadata ConfigMap, and Commander stamps it onto every
-# namespace it creates) -- a scenario also wanting the platform namespace itself
-# scanned needs `platform=astronomer` in its own test_profile.yaml namespace_labels too,
-# the same way PSA labels need both halves (see configs/enable-psa.yaml).
+# Every policy installed by bin/install-kyverno-scan.py restricts its `match` rules to
+# namespaces carrying the label `platform: astronomer` (matched via namespaceSelector,
+# not a pod label). Nothing in this chart sets that namespace label by default, so
+# without this file, none of those policies would ever match any pod -- the scan would
+# report zero violations not because everything is compliant, but because it never
+# evaluated anything.
+#
+# This value only reaches namespaces that Commander creates for individual Airflow
+# Deployments (the "global.namespaceLabels" value flows into a ConfigMap that
+# Commander reads, and Commander stamps those labels onto every namespace it creates).
+# It does NOT reach the platform namespace that the Astronomer chart itself is
+# installed into -- that namespace already exists (via `helm install
+# --create-namespace`) before Commander or this value comes into play at all. A test
+# scenario that also wants pods in the platform namespace covered by these policies
+# has to label that namespace separately, via its own test_profile.yaml's
+# `namespace_labels` key (see tests/functional/scenarios/auth-sidecar/test_profile.yaml
+# for an example, and configs/enable-psa.yaml for the same two-namespace-tier split
+# applied to a different label).
 ---
 global:
   namespaceLabels:

--- a/tests/functional/scenarios/README.md
+++ b/tests/functional/scenarios/README.md
@@ -31,6 +31,8 @@ tests/functional/scenarios/<name>/
 | `values`            | yes      | ordered list of values files (repo-relative), passed as `--helm-values` in order; an empty list is fine if the scenario needs no overlay |
 | `kube_version`      | no       | pinned k8s version; defaults to the latest entry in `metadata.yaml`'s `test_k8s_versions`   |
 | `namespace_labels`  | no       | labels to apply to the `astronomer` namespace *before* install (PSA is not retroactive)      |
+| `resource_class`    | no       | CircleCI machine-executor resource class for this scenario's CI job (e.g. `xlarge`, `2xlarge`); defaults to `xlarge` |
+| `kyverno_scan`      | no       | if `true`, installs a live Kyverno admission controller before this scenario's own tests run (`bin/install-kyverno-scan.py`) and reports the violations it recorded afterward (`bin/report-kyverno-scan.py`), without failing the build (PINF-1034); defaults to `false` |
 
 ## Running a scenario locally
 

--- a/tests/functional/scenarios/auth-sidecar/test_profile.yaml
+++ b/tests/functional/scenarios/auth-sidecar/test_profile.yaml
@@ -15,13 +15,23 @@ topology: unified
 # FailedScheduling territory even after scenario-airflow-reduce-resources.yaml -- see
 # PINF-1080.
 resource_class: 2xlarge
+# PINF-1034: installs a live Kyverno admission controller (audit-only) before this
+# scenario's own tests run, reporting the violations it recorded afterward. Reuses
+# this scenario rather than a dedicated one since it already creates a real Airflow
+# Deployment across both dagDeployment types, giving the scan the broadest existing
+# surface -- see bin/install-kyverno-scan.py and bin/report-kyverno-scan.py.
+kyverno_scan: true
 values:
   - configs/enable-auth-sidecar.yaml
   - configs/psa-restricted.yaml
   - configs/enable-psa.yaml
   - configs/scenario-airflow-reduce-resources.yaml
+  - configs/enable-kyverno-scan.yaml
 namespace_labels:
   pod-security.kubernetes.io/enforce: restricted
   pod-security.kubernetes.io/enforce-version: latest
   pod-security.kubernetes.io/audit: restricted
   pod-security.kubernetes.io/warn: restricted
+  # See configs/enable-kyverno-scan.yaml -- this half covers the platform namespace,
+  # that file's global.namespaceLabels covers Airflow Deployment namespaces.
+  platform: astronomer

--- a/tests/functional/scenarios/auth-sidecar/test_profile.yaml
+++ b/tests/functional/scenarios/auth-sidecar/test_profile.yaml
@@ -15,11 +15,13 @@ topology: unified
 # FailedScheduling territory even after scenario-airflow-reduce-resources.yaml -- see
 # PINF-1080.
 resource_class: 2xlarge
-# PINF-1034: installs a live Kyverno admission controller (audit-only) before this
-# scenario's own tests run, reporting the violations it recorded afterward. Reuses
-# this scenario rather than a dedicated one since it already creates a real Airflow
-# Deployment across both dagDeployment types, giving the scan the broadest existing
-# surface -- see bin/install-kyverno-scan.py and bin/report-kyverno-scan.py.
+# Runs this scenario's tests against a real, live Kyverno admission controller
+# (installed audit-only, so it only reports policy violations and never blocks
+# anything). See bin/install-kyverno-scan.py and bin/report-kyverno-scan.py for the
+# mechanism. This scenario was chosen to carry that scan, rather than adding a new
+# dedicated scenario, because it already creates a real Airflow Deployment covering
+# both dagDeployment types, which gives the scan more real pods to evaluate than most
+# other scenarios would.
 kyverno_scan: true
 values:
   - configs/enable-auth-sidecar.yaml
@@ -32,6 +34,10 @@ namespace_labels:
   pod-security.kubernetes.io/enforce-version: latest
   pod-security.kubernetes.io/audit: restricted
   pod-security.kubernetes.io/warn: restricted
-  # See configs/enable-kyverno-scan.yaml -- this half covers the platform namespace,
-  # that file's global.namespaceLabels covers Airflow Deployment namespaces.
+  # Labels this scenario's platform namespace (where the Astronomer chart itself is
+  # installed) so the Kyverno policies from bin/install-kyverno-scan.py, which match
+  # on this label, actually evaluate pods here too. This only covers the platform
+  # namespace; configs/enable-kyverno-scan.yaml's global.namespaceLabels value
+  # applies the same label to the separate namespaces Commander creates for each
+  # Airflow Deployment -- both are needed to cover every pod this scenario creates.
   platform: astronomer


### PR DESCRIPTION
## What

Adds a reusable, audit-only Kyverno policy-scanning mechanism to the functional-test scenario framework. A scenario opts in with `kyverno_scan: true` in its `test_profile.yaml`; `auth-sidecar` is the first (and so far only) one that does.

- `bin/install-kyverno-scan.py` installs the real Kyverno Helm chart before the scenario provisions anything, sparse-clones the policies from the private `apc-terraform-modules` repo, and force-overrides every policy's `validationFailureAction` to `Audit` so this can never actually reject anything the scenario creates.
- `bin/report-kyverno-scan.py` runs after the scenario's own tests pass. It reads `PolicyReport`/`ClusterPolicyReport` objects instead of running a point-in-time scan, so a resource that's already completed and been cleaned up (a one-shot Job like `migrateDatabaseJob`) still shows up if it violated something while it existed. It also prints each policy's real evaluation count, so a policy whose `namespaceSelector` matched zero resources is visible instead of looking identical to a policy with zero violations.
- `bin/report-kyverno-scan.py --verbose` (on by default in CI) prints every individual scanned object -- namespace, name, and result, pass or fail -- column-aligned and sorted so every result for one object reads together. Useful for confirming a namespace was actually scanned at all, not just that it had no violations.
- Never fails the build over a violation. Only fails over a genuine failure to read reports at all.

## Why

PINF-1034. A live admission controller catches violations for the scenario's whole lifetime; a `kyverno apply --cluster` scan run only at the end can't see anything that already came and went.

One design question worth calling out for review: `bin/install-kyverno-scan.py` runs *after* the scenario's platform chart is already installed (it has to -- there's no earlier hook without changing `reset-local-dev`/`bin/helm-install.py`, which every scenario shares). That raised a real concern: does the platform namespace's own pods and install-time Jobs (e.g. `houston-db-migrations`, a Helm `post-install` hook) ever actually get evaluated, since they exist before Kyverno's admission webhook does? Checked via the `--verbose` output above -- yes: Kyverno's background scanner (`spec.background: true` on all 3 policies) evaluates pre-existing resources on its own initial sync when it starts, not gated behind the documented 1-hour periodic re-scan interval. The verbose output from a real run shows `astronomer-houston-db-migrations-*` pods evaluated with real PASS results, confirming both namespace tiers (platform + Airflow Deployment) get real coverage.

## Related Issues

- <https://linear.app/astronomer/issue/PINF-1034>

## Testing

Ran on this branch's own CI (`scenario-auth-sidecar`, currently green). Real Kyverno install, real `GITHUB_TOKEN` clone of the private policies repo, real admission-time + background-scan evaluation:

```
--- Kyverno policy evaluation counts ---
disallow-privilege-escalation: {'pass': 26}
require-drop-all-capabilities: {'pass': 26}
require-read-only-root-filesystem: {'pass': 73}
--- Kyverno policy report findings (0) ---
No non-passing results found.
```

The 73-vs-26 gap is expected: `disallow-privilege-escalation` and `require-drop-all-capabilities` both exclude `component: vector` pods; `require-read-only-root-filesystem` doesn't.

`--verbose` output from that same run confirms the platform namespace is genuinely covered, not just the Airflow Deployment it creates -- e.g.:

```
PASS  astronomer  astronomer-houston-db-migrations-l9qbb  disallow-privilege-escalation/privilege-escalation
PASS  astronomer  astronomer-houston-db-migrations-l9qbb  require-drop-all-capabilities/require-drop-all-capabilities
PASS  astronomer  astronomer-houston-db-migrations-l9qbb  require-read-only-root-filesystem/check-read-only-root-filesystem
```