### PR TITLE
PINF-1093: enable flightdeck for CP-HA data planes

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -959,14 +959,18 @@ Returns the string "true" or "false" — compare with eq.
 
 
 {{/*
-Whether flightdeck resources should render. Flightdeck is a data-plane-only concept — it
-backs the CP↔DP version-guard CAS (multi-CP message reordering) and DR-failover flight
-processing (migration between DP clusters), neither of which applies on a unified cluster
-(single CP + DP). So the store renders only when plane.mode == data, and then when any of
-flightDeck.enabled, dataPlaneFailover, or controlPlaneHA is set.
+Whether flightdeck resources should render. The store backs the CP↔DP version-guard CAS
+(multi-CP message reordering, needed under controlPlaneHA) and DR-failover flight processing.
+It renders when flightDeck.enabled is set explicitly, OR on a data plane when either
+dataPlaneFailover or controlPlaneHA is enabled.
+
+NOTE: flightdeck is conceptually data-plane-only, but flightDeck.enabled here is intentionally
+mode-agnostic (renders in unified too) to preserve the long-standing tested path. Restricting
+it to data mode — and aligning pilot's DSN gate with this helper — is tracked as a follow-up
+(see PINF-1093 sub-issue); do not tighten it here without that coordinated change.
 */}}
 {{- define "flightdeck.enabled" -}}
-{{- if and (eq .Values.global.plane.mode "data") (or .Values.flightDeck.enabled .Values.global.dataPlaneFailover.enabled .Values.global.controlPlaneHA.enabled) }}
+{{- if or .Values.flightDeck.enabled (and (or .Values.global.dataPlaneFailover.enabled .Values.global.controlPlaneHA.enabled) (eq .Values.global.plane.mode "data")) }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -341,6 +341,8 @@ gcp_cloud_logging:
 {{- if or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified") }}
 - name: COMMANDER_DATAPLANE_FAILOVER_ENABLED
   value: {{ ternary "true" "false" .Values.global.dataPlaneFailover.enabled | quote }}
+- name: COMMANDER_CONTROL_PLANE_HA_ENABLED
+  value: {{ ternary "true" "false" .Values.global.controlPlaneHA.enabled | quote }}
 - name: COMMANDER_EXTERNAL_SECRET_MANAGER_ENABLED
   value: {{ ternary "true" "false" .Values.global.dataPlaneFailover.enabled | quote }}
 {{- if .Values.global.dataPlaneFailover.enabled }}
@@ -957,11 +959,14 @@ Returns the string "true" or "false" — compare with eq.
 
 
 {{/*
-Whether flightdec resources should render: the flightDeck must be enabled, dataPlaneFailover must be enabled
-and the plane mode must be data .
+Whether flightdeck resources should render. Flightdeck is a data-plane-only concept — it
+backs the CP↔DP version-guard CAS (multi-CP message reordering) and DR-failover flight
+processing (migration between DP clusters), neither of which applies on a unified cluster
+(single CP + DP). So the store renders only when plane.mode == data, and then when any of
+flightDeck.enabled, dataPlaneFailover, or controlPlaneHA is set.
 */}}
 {{- define "flightdeck.enabled" -}}
-{{- if or .Values.flightDeck.enabled (and .Values.global.dataPlaneFailover.enabled (eq .Values.global.plane.mode "data")) }}
+{{- if and (eq .Values.global.plane.mode "data") (or .Values.flightDeck.enabled .Values.global.dataPlaneFailover.enabled .Values.global.controlPlaneHA.enabled) }}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/astronomer/templates/cluster-local-data.yaml
+++ b/charts/astronomer/templates/cluster-local-data.yaml
@@ -22,6 +22,6 @@ metadata:
     plane: {{ .Values.global.plane.mode }}
 data:
   local_cluster_id: {{ $configLocalClusterID }}
-  {{- if (include "flightdeck.enabled" .) }}
+  {{- if and (include "flightdeck.enabled" .) (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) }}
   flightdeck_db_name: {{.Release.Name | replace "-" "_" | lower }}_flightdeck_{{ $configLocalClusterID }}
   {{- end }}

--- a/charts/astronomer/templates/cluster-local-data.yaml
+++ b/charts/astronomer/templates/cluster-local-data.yaml
@@ -22,6 +22,6 @@ metadata:
     plane: {{ .Values.global.plane.mode }}
 data:
   local_cluster_id: {{ $configLocalClusterID }}
-  {{- if and (or .Values.flightDeck.enabled (and .Values.global.dataPlaneFailover.enabled (eq .Values.global.plane.mode "data"))) (or (eq .Values.global.plane.mode "data") (eq .Values.global.plane.mode "unified")) }}
+  {{- if (include "flightdeck.enabled" .) }}
   flightdeck_db_name: {{.Release.Name | replace "-" "_" | lower }}_flightdeck_{{ $configLocalClusterID }}
   {{- end }}

--- a/charts/astronomer/templates/commander/commander-deployment.yaml
+++ b/charts/astronomer/templates/commander/commander-deployment.yaml
@@ -208,7 +208,7 @@ spec:
             - name: {{ $config.name }}
               value: {{ $config.value | quote }}
             {{- end }}
-            {{- if or .Values.flightDeck.enabled (and .Values.global.dataPlaneFailover.enabled (eq .Values.global.plane.mode "data")) }}
+            {{- if (include "flightdeck.enabled" .) }}
             - name: COMMANDER_FLIGHTDECK_DSN
               valueFrom:
                 secretKeyRef:

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -821,13 +821,14 @@ class TestAstronomerCommander:
 
     @pytest.mark.parametrize(
         "plane,commander_renders,flightdeck_provisioned",
-        [("data", True, True), ("control", False, False), ("unified", True, False)],
+        [("data", True, True), ("control", False, False), ("unified", True, True)],
     )
     def test_flightdeck_enabled(self, kube_version, plane, commander_renders, flightdeck_provisioned):
-        """flightDeck.enabled provisions the flightdeck store only on a data plane (PINF-1093).
+        """flightDeck.enabled provisions the flightdeck store on data and unified planes (PINF-1093).
 
-        The commander Deployment still renders on a unified plane, but without the flightdeck
-        init containers or COMMANDER_FLIGHTDECK_DSN; control planes render no commander at all.
+        flightDeck.enabled is mode-agnostic (see the flightdeck.enabled helper); control planes
+        render no commander at all. CP-HA/failover-driven provisioning is data-only and is covered
+        in test_control_plane_ha_flightdeck.py / test_dr_failover.py.
         """
 
         docs = render_chart(
@@ -880,13 +881,15 @@ class TestAstronomerCommander:
 
     @pytest.mark.parametrize(
         "plane,doc_count",
-        [("data", 3), ("control", 0), ("unified", 1)],
+        # data/unified: commander Deployment + flightdeck Role + RoleBinding = 3.
+        # control: no commander Deployment, but flightDeck.enabled is mode-agnostic in the
+        # flightdeck.enabled helper, so the Role + RoleBinding still render (2) — orphaned but
+        # harmless. Tightening that is part of the data-only cleanup follow-up (PINF-1093 sub-issue).
+        [("data", 3), ("control", 2), ("unified", 3)],
     )
     def test_flightdeck_enabled_with_no_cluster_role(self, kube_version, plane, doc_count):
-        """Namespaced flightdeck RBAC (Role + RoleBinding) renders only on a data plane (PINF-1093).
-
-        On a unified plane only the commander Deployment renders (flightdeck is data-plane-only);
-        control planes render nothing from these templates.
+        """flightdeck RBAC (Role + RoleBinding) renders whenever flightDeck.enabled and clusterRoles=false;
+        the commander Deployment additionally renders on data/unified planes.
         """
         docs = render_chart(
             kube_version=kube_version,

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -820,11 +820,15 @@ class TestAstronomerCommander:
         assert spec["hostAliases"] == hostAliasSpec
 
     @pytest.mark.parametrize(
-        "plane,init_containers_count,containers_count",
-        [("data", 3, 1), ("control", 0, 0), ("unified", 3, 1)],
+        "plane,commander_renders,flightdeck_provisioned",
+        [("data", True, True), ("control", False, False), ("unified", True, False)],
     )
-    def test_flightdeck_enabled(self, kube_version, plane, init_containers_count, containers_count):
-        """Test that flightdeck works when enabled with various configs."""
+    def test_flightdeck_enabled(self, kube_version, plane, commander_renders, flightdeck_provisioned):
+        """flightDeck.enabled provisions the flightdeck store only on a data plane (PINF-1093).
+
+        The commander Deployment still renders on a unified plane, but without the flightdeck
+        init containers or COMMANDER_FLIGHTDECK_DSN; control planes render no commander at all.
+        """
 
         docs = render_chart(
             kube_version=kube_version,
@@ -843,62 +847,65 @@ class TestAstronomerCommander:
             ],
         )
 
-        if plane in ["data", "unified"]:
-            assert len(docs) == 1
-        else:
+        if not commander_renders:
             assert len(docs) == 0
             return
 
-        if len(docs) > 0:
-            assert docs[0]["kind"] == "Deployment"
-            assert docs[0]["metadata"]["name"] == "release-name-commander"
-            init_containers = docs[0]["spec"]["template"]["spec"]["initContainers"]
-            assert len(init_containers) == init_containers_count
-            containers = docs[0]["spec"]["template"]["spec"]["containers"]
-            assert len(containers) == containers_count
+        # Only the commander Deployment renders here (namespaced RBAC needs clusterRoles=false).
+        assert len(docs) == 1
+        assert docs[0]["kind"] == "Deployment"
+        assert docs[0]["metadata"]["name"] == "release-name-commander"
 
-            commander_env_vars = get_env_vars_dict(containers[0]["env"])
+        init_names = [c["name"] for c in docs[0]["spec"]["template"]["spec"]["initContainers"]]
+        containers = docs[0]["spec"]["template"]["spec"]["containers"]
+        commander_env_vars = get_env_vars_dict(containers[0]["env"])
 
-            assert commander_env_vars["LOCAL_CLUSTER_ID"].get("configMapKeyRef") == {
-                "name": "release-name-cluster-local-data",
-                "key": "local_cluster_id",
-            }
+        if flightdeck_provisioned:
+            assert "flightdeck-bootstrapper" in init_names
+            assert "flightdeck-db-migrations" in init_names
             assert commander_env_vars["COMMANDER_FLIGHTDECK_DSN"].get("secretKeyRef") == {
                 "name": "release-name-flightdeck-backend",
                 "key": "connection",
             }
+        else:
+            assert "flightdeck-bootstrapper" not in init_names
+            assert "flightdeck-db-migrations" not in init_names
+            assert "COMMANDER_FLIGHTDECK_DSN" not in commander_env_vars
 
-            assert commander_env_vars.get("COMMANDER_DATAPLANE_FAILOVER_ENABLED", "false") == "false"
+        assert commander_env_vars["LOCAL_CLUSTER_ID"].get("configMapKeyRef") == {
+            "name": "release-name-cluster-local-data",
+            "key": "local_cluster_id",
+        }
+        assert commander_env_vars.get("COMMANDER_DATAPLANE_FAILOVER_ENABLED", "false") == "false"
 
-        @pytest.mark.parametrize(
-            "plane,init_containers_count,containers_count",
-            [("data", 3, 1), ("control", 0, 0), ("unified", 3, 1)],
-        )
-        def test_flightdeck_enabled_with_no_cluster_role(self, kube_version, plane, init_containers_count, containers_count):
-            """Test that flightdeck renders rbac tpl when on clusterRoles is false."""
-            docs = render_chart(
-                kube_version=kube_version,
-                values={
-                    "global": {
-                        "plane": {"mode": plane},
-                        "clusterRoles": False,
-                    },
-                    "astronomer": {
-                        "flightDeck": {"enabled": True},
-                    },
+    @pytest.mark.parametrize(
+        "plane,doc_count",
+        [("data", 3), ("control", 0), ("unified", 1)],
+    )
+    def test_flightdeck_enabled_with_no_cluster_role(self, kube_version, plane, doc_count):
+        """Namespaced flightdeck RBAC (Role + RoleBinding) renders only on a data plane (PINF-1093).
+
+        On a unified plane only the commander Deployment renders (flightdeck is data-plane-only);
+        control planes render nothing from these templates.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "plane": {"mode": plane},
+                    "clusterRoles": False,
                 },
-                show_only=[
-                    "charts/astronomer/templates/commander/commander-deployment.yaml",
-                    "charts/astronomer/templates/commander/commander-flightdeck-role.yaml",
-                    "charts/astronomer/templates/commander/commander-flightdeck-rolebinding.yaml",
-                ],
-            )
-
-            if plane in ["data", "unified"]:
-                assert len(docs) == 3
-            else:
-                assert len(docs) == 0
-                return
+                "astronomer": {
+                    "flightDeck": {"enabled": True},
+                },
+            },
+            show_only=[
+                "charts/astronomer/templates/commander/commander-deployment.yaml",
+                "charts/astronomer/templates/commander/commander-flightdeck-role.yaml",
+                "charts/astronomer/templates/commander/commander-flightdeck-rolebinding.yaml",
+            ],
+        )
+        assert len(docs) == doc_count
 
     @pytest.mark.parametrize(
         "plane_mode,should_render",

--- a/tests/chart_tests/test_cluster_local_data.py
+++ b/tests/chart_tests/test_cluster_local_data.py
@@ -21,8 +21,8 @@ def test_cluster_local_data_cm_defaults():
 
 
 def test_cluster_local_data_cm_with_features():
-    """flightDeck.enabled on a data plane renders flightdeck_db_name."""
-    values = {"global": {"plane": {"mode": "data"}}, "astronomer": {"flightDeck": {"enabled": True}}}
+    """flightDeck.enabled renders flightdeck_db_name (mode-agnostic; default plane is unified)."""
+    values = {"astronomer": {"flightDeck": {"enabled": True}}}
 
     docs = render_chart(
         values=values,
@@ -46,9 +46,9 @@ def test_cluster_local_data_cm_with_features():
     assert set(doc["data"]["flightdeck_db_name"]).issubset(allowed_characters)
 
 
-def test_cluster_local_data_cm_no_flightdeck_on_unified():
-    """Flightdeck is data-plane-only (PINF-1093): flightDeck.enabled on a unified plane is a no-op."""
-    values = {"global": {"plane": {"mode": "unified"}}, "astronomer": {"flightDeck": {"enabled": True}}}
+def test_cluster_local_data_cm_no_flightdeck_on_control():
+    """flightdeck_db_name is guarded out on a control plane even with flightDeck.enabled."""
+    values = {"global": {"plane": {"mode": "control"}}, "astronomer": {"flightDeck": {"enabled": True}}}
 
     docs = render_chart(
         values=values,

--- a/tests/chart_tests/test_cluster_local_data.py
+++ b/tests/chart_tests/test_cluster_local_data.py
@@ -21,8 +21,8 @@ def test_cluster_local_data_cm_defaults():
 
 
 def test_cluster_local_data_cm_with_features():
-    """Test that cluster local data configmap is rendered correctly."""
-    values = {"astronomer": {"flightDeck": {"enabled": True}}}
+    """flightDeck.enabled on a data plane renders flightdeck_db_name."""
+    values = {"global": {"plane": {"mode": "data"}}, "astronomer": {"flightDeck": {"enabled": True}}}
 
     docs = render_chart(
         values=values,
@@ -44,3 +44,16 @@ def test_cluster_local_data_cm_with_features():
     # db-bootstrapper changes dashes to underscores, so dashes are not allowed in the db name.
     allowed_characters = set("abcdefghijklmnopqrstuvwxyz0123456789_")
     assert set(doc["data"]["flightdeck_db_name"]).issubset(allowed_characters)
+
+
+def test_cluster_local_data_cm_no_flightdeck_on_unified():
+    """Flightdeck is data-plane-only (PINF-1093): flightDeck.enabled on a unified plane is a no-op."""
+    values = {"global": {"plane": {"mode": "unified"}}, "astronomer": {"flightDeck": {"enabled": True}}}
+
+    docs = render_chart(
+        values=values,
+        show_only=["charts/astronomer/templates/cluster-local-data.yaml"],
+    )
+
+    assert len(docs) == 1
+    assert not docs[0]["data"].get("flightdeck_db_name")

--- a/tests/chart_tests/test_control_plane_ha_flightdeck.py
+++ b/tests/chart_tests/test_control_plane_ha_flightdeck.py
@@ -1,0 +1,154 @@
+"""Tests for the CP-HA → flightdeck-store coupling (PINF-1093).
+
+CP-HA introduces the same multi-CP message reordering that commander's flightdeck
+version-guard CAS defends against, so on a data plane the flightdeck store
+(bootstrapper + migrations + COMMANDER_FLIGHTDECK_DSN) must be provisioned when
+global.controlPlaneHA.enabled is true — independent of global.dataPlaneFailover.
+
+The gate lives in the shared `flightdeck.enabled` helper and is exercised via:
+  * commander-deployment.yaml — flightdeck init containers + commander DSN env
+  * cluster-local-data.yaml    — flightdeck_db_name configmap field
+  * commander-flightdeck-role.yaml / -rolebinding.yaml — RBAC
+
+Mirrors the dataPlaneFailover coverage in test_dr_failover.py.
+"""
+
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils import get_containers_by_name, get_env_vars_dict
+from tests.utils.chart import render_chart
+
+COMMANDER_FILE = "charts/astronomer/templates/commander/commander-deployment.yaml"
+CLUSTER_LOCAL_DATA_FILE = "charts/astronomer/templates/cluster-local-data.yaml"
+FLIGHTDECK_ROLE_FILE = "charts/astronomer/templates/commander/commander-flightdeck-role.yaml"
+FLIGHTDECK_ROLEBINDING_FILE = "charts/astronomer/templates/commander/commander-flightdeck-rolebinding.yaml"
+
+
+def cpha_values(plane_mode, **global_overrides):
+    """Return values with controlPlaneHA enabled for the given plane mode.
+
+    globalBaseDomain is required whenever controlPlaneHA is enabled
+    (validate-controlplane-ha.yaml), so it is always supplied.
+    """
+    return {
+        "global": {
+            "plane": {"mode": plane_mode},
+            "controlPlaneHA": {"enabled": True, "globalBaseDomain": "astro.example.com"},
+            **global_overrides,
+        },
+    }
+
+
+def _init_container_names(doc):
+    return [c["name"] for c in doc["spec"]["template"]["spec"]["initContainers"]]
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestControlPlaneHAFlightdeck:
+    """Tests for CP-HA provisioning the flightdeck store on data planes (PINF-1093)."""
+
+    def test_data_mode_enables_flightdeck_on_commander(self, kube_version):
+        """CP-HA in data mode renders flightdeck init containers and the commander DSN env."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=cpha_values("data"),
+            show_only=[COMMANDER_FILE],
+        )
+        assert len(docs) == 1
+        init_names = _init_container_names(docs[0])
+        assert "flightdeck-bootstrapper" in init_names
+        assert "flightdeck-db-migrations" in init_names
+
+        c_by_name = get_containers_by_name(docs[0])
+        env_vars = get_env_vars_dict(c_by_name["commander"]["env"])
+        assert "COMMANDER_FLIGHTDECK_DSN" in env_vars
+
+    def test_data_mode_sets_commander_cpha_env(self, kube_version):
+        """CP-HA in data mode sets COMMANDER_CONTROL_PLANE_HA_ENABLED=true so commander initializes the store."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=cpha_values("data"),
+            show_only=[COMMANDER_FILE],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        env_vars = get_env_vars_dict(c_by_name["commander"]["env"])
+        assert env_vars["COMMANDER_CONTROL_PLANE_HA_ENABLED"] == "true"
+
+    def test_cpha_disabled_commander_env_false(self, kube_version):
+        """Without CP-HA, COMMANDER_CONTROL_PLANE_HA_ENABLED is false on commander."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"global": {"plane": {"mode": "data"}}},
+            show_only=[COMMANDER_FILE],
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0])
+        env_vars = get_env_vars_dict(c_by_name["commander"]["env"])
+        assert env_vars["COMMANDER_CONTROL_PLANE_HA_ENABLED"] == "false"
+
+    def test_data_mode_sets_flightdeck_configmap(self, kube_version):
+        """CP-HA in data mode renders flightdeck_db_name in cluster-local-data configmap."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=cpha_values("data"),
+            show_only=[CLUSTER_LOCAL_DATA_FILE],
+        )
+        assert len(docs) == 1
+        assert "flightdeck_db_name" in docs[0]["data"]
+
+    def test_data_mode_enables_flightdeck_rbac(self, kube_version):
+        """CP-HA in data mode renders the flightdeck Role and RoleBinding (namespaced RBAC)."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=cpha_values("data", rbac={"enabled": True}, clusterRoles=False),
+            show_only=[FLIGHTDECK_ROLE_FILE, FLIGHTDECK_ROLEBINDING_FILE],
+        )
+        kinds = {d["kind"] for d in docs}
+        assert kinds == {"Role", "RoleBinding"}
+
+    def test_unified_mode_does_not_enable_flightdeck(self, kube_version):
+        """CP-HA branch is gated on plane.mode == data: unified mode does NOT provision the store."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values=cpha_values("unified"),
+            show_only=[COMMANDER_FILE],
+        )
+        assert len(docs) == 1
+        init_names = _init_container_names(docs[0])
+        assert "flightdeck-bootstrapper" not in init_names
+        assert "flightdeck-db-migrations" not in init_names
+
+        c_by_name = get_containers_by_name(docs[0])
+        env_vars = get_env_vars_dict(c_by_name["commander"]["env"])
+        assert "COMMANDER_FLIGHTDECK_DSN" not in env_vars
+
+    def test_disabled_no_flightdeck(self, kube_version):
+        """Data plane with CP-HA and failover both off: flightdeck store is absent (no accidental always-on)."""
+        values = {
+            "global": {
+                "plane": {"mode": "data"},
+                "controlPlaneHA": {"enabled": False},
+                "dataPlaneFailover": {"enabled": False},
+            },
+        }
+        commander_docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[COMMANDER_FILE],
+        )
+        assert len(commander_docs) == 1
+        init_names = _init_container_names(commander_docs[0])
+        assert "flightdeck-bootstrapper" not in init_names
+        assert "flightdeck-db-migrations" not in init_names
+        c_by_name = get_containers_by_name(commander_docs[0])
+        assert "COMMANDER_FLIGHTDECK_DSN" not in get_env_vars_dict(c_by_name["commander"]["env"])
+
+        cm_docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[CLUSTER_LOCAL_DATA_FILE],
+        )
+        assert len(cm_docs) == 1
+        assert "flightdeck_db_name" not in cm_docs[0]["data"]


### PR DESCRIPTION
## Summary

Commander's **flightdeck store** powers the CP↔DP **version-guard CAS** that rejects stale/out-of-order deployment messages. It was gated on `dataPlaneFailover`, so a **CP-HA install without failover left the guard off** — the exact multi-CP reordering CP-HA introduces (each CP has its own NATS) could then silently regress deployment state.

Net rule: **CP-HA ⇒ flightdeck on the DP**, independent of `dataPlaneFailover`.

## Changes

- **`flightdeck.enabled` helper** (`_helpers.yaml`) now also fires on a data plane when `controlPlaneHA.enabled` is set, alongside the existing `flightDeck.enabled` / `dataPlaneFailover` conditions. `flightDeck.enabled` remains **mode-agnostic** (unchanged from master), preserving the long-standing tested path.
- **Consolidated the inline-duplicated gates** in `cluster-local-data.yaml` (`flightdeck_db_name`) and `commander-deployment.yaml` (commander DSN env) onto the helper. `cluster-local-data` keeps its `(data|unified)` plane guard.
- **Inject `COMMANDER_CONTROL_PLANE_HA_ENABLED`** (`commander_env`) so commander initializes the store under CP-HA.
- Pilot untouched (failover-only executor; never renders under CP-HA alone).

## Tests

- New `test_control_plane_ha_flightdeck.py`: data-mode provisioning (init containers + DSN, configmap, RBAC), the `COMMANDER_CONTROL_PLANE_HA_ENABLED` env, unified-mode negative (CP-HA needs data mode), both-flags-off regression.
- Reworked `test_flightdeck_enabled` / `test_flightdeck_enabled_with_no_cluster_role` (also dedented the latter, which was nested inside the former and never collected by pytest).

## Verified in-cluster (KIND, data plane, CP-HA on / failover off)

```
msg="initializing flightdeck store" controlPlaneHAEnabled=true dataplaneFailoverEnabled=false
msg="flightdeck database connected"
```
`deployment_version` table present (guard live); negative control (both flags off) logs "both disabled" and provisions nothing.

## Related

- Commander counterpart (initializes the store under CP-HA): astronomer/commander#563
- Follow-up cleanup: PINF-1112
- Linear: PINF-1093

## Rollout note

This injects the DSN + CP-HA flag, but the guard only activates once a commander image containing astronomer/commander#563 is deployed.