### PR TITLE
PLX-800- fix cp release version rollback

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -468,6 +468,8 @@ s3:
   value: {{ template "houston.nats.servers" . }}
 - name: NATS__CLUSTER_ID
   value: {{ .Release.Name }}-stan
+- name: HELM__RELEASE_VERSION
+  value: {{ .Chart.Version | quote }}
 {{- if .Values.global.controlPlaneHA.enabled }}
 {{- include "houston.cpIdEnv" . | nindent 0 }}
 {{- end }}

--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -468,8 +468,6 @@ s3:
   value: {{ template "houston.nats.servers" . }}
 - name: NATS__CLUSTER_ID
   value: {{ .Release.Name }}-stan
-- name: HELM__RELEASE_VERSION
-  value: {{ .Chart.Version | quote }}
 {{- if .Values.global.controlPlaneHA.enabled }}
 {{- include "houston.cpIdEnv" . | nindent 0 }}
 {{- end }}
@@ -591,6 +589,8 @@ s3:
 - name: CB_PROBE_MAX_INFLIGHT
   value: {{ .Values.houston.worker.dispatcher.circuitBreaker.probeMaxInflight | quote }}
 {{- end }}
+- name: HELM__RELEASE_VERSION
+  value: {{ .Chart.Version | quote }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -83,7 +83,6 @@ data:
       {{- end }}
       releaseName: {{ .Release.Name }}
       releaseNamespace: {{ .Release.Namespace }}
-      releaseVersion: {{ .Chart.Version }}
       {{- if .Values.global.tlsSecret }}
       tlsSecretName: {{ .Values.global.tlsSecret }}
       {{- end }}

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -3,7 +3,7 @@ import pytest
 import yaml
 
 from tests import supported_k8s_versions
-from tests.utils import get_containers_by_name, get_env_vars_dict, get_chart_version
+from tests.utils import get_chart_version, get_containers_by_name, get_env_vars_dict
 from tests.utils.chart import render_chart
 
 

--- a/tests/chart_tests/test_houston_api_deployment.py
+++ b/tests/chart_tests/test_houston_api_deployment.py
@@ -3,7 +3,7 @@ import pytest
 import yaml
 
 from tests import supported_k8s_versions
-from tests.utils import get_containers_by_name, get_env_vars_dict
+from tests.utils import get_containers_by_name, get_env_vars_dict, get_chart_version
 from tests.utils.chart import render_chart
 
 
@@ -60,7 +60,7 @@ class TestHoustonApiDeployment:
         assert houston_container_env["DEPLOYMENTS__DATABASE__CONNECTION"] == {
             "secretKeyRef": {"key": "connection", "name": "release-name-houston-backend"}
         }
-
+        assert houston_container_env["HELM__RELEASE_VERSION"] == get_chart_version()
         assert wait_for_db_container["securityContext"]["readOnlyRootFilesystem"]
         wait_for_db_container_env = get_env_vars_dict(wait_for_db_container["env"])
         assert wait_for_db_container_env["COMMANDER_WAIT_ENABLED"] == "true"

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -114,6 +114,10 @@ def get_all_features():
     return yaml.safe_load((Path(__file__).parent.parent / "enable_all_features.yaml").read_text())
 
 
+def get_chart_version():
+    with open("charts/astronomer/Chart.yaml") as chart_file:
+       return yaml.safe_load(chart_file)["version"]
+
 def get_chart_containers(
     k8s_version: str,
     chart_values: dict,

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -116,7 +116,8 @@ def get_all_features():
 
 def get_chart_version():
     with open("charts/astronomer/Chart.yaml") as chart_file:
-       return yaml.safe_load(chart_file)["version"]
+        return yaml.safe_load(chart_file)["version"]
+
 
 def get_chart_containers(
     k8s_version: str,


### PR DESCRIPTION
## Description

This PR moves the platform version config to env vars - it no longer defined in the helm values to fix config deviation on cp ha rollback

## Related Issues

https://linear.app/astronomer/issue/PLX-800/cp-ha-helm-rollback-leaves-houston-config-configmap-and-reported

## Testing

QA should still the UI version shows the platform version as expected 

## Merging

merge to master and release-2.1
