### PR TITLE
PINF-1121 - disable houston scrape for non control plane 

### DIFF
--- a/charts/prometheus/templates/prometheus-config-configmap.yaml
+++ b/charts/prometheus/templates/prometheus-config-configmap.yaml
@@ -498,6 +498,7 @@ data:
 
       {{- end }}
 
+      {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
       - job_name: houston-api
         metrics_path: /v1/metrics
         kubernetes_sd_configs:
@@ -518,6 +519,7 @@ data:
           - source_labels: [__meta_kubernetes_endpoint_ready]
             action: keep
             regex: "^true"
+      {{- end }}
 
 
     {{- with .Values.additionalScrapeJobs }}


### PR DESCRIPTION
## Description

disable houston scrape for non control plane 

## Related Issues

https://linear.app/astronomer/issue/PINF-1121/hide-houston-scrape-targets-on-dataplane-prometheus

## Testing

QA should not see empty houston targets in prometheus

## Merging

merge to master and release-2.1
