### PR TITLE
PINF-1109: gate custom CI scenarios by branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ workflows:
       # Manual gate for the custom functional scenarios on non-release branches.
       # On master and release-X.Y they run automatically (below) and gate the
       # release; on every other branch they wait on this approval before running.
-      - hold-scenarios:
+      - approve-scenarios:
           type: approval
           filters:
             branches:
@@ -481,12 +481,12 @@ workflows:
               only:
                 - master
                 - '/^release-\d+\.\d+$/'
-      # every other branch: gated behind the manual hold-scenarios approval.
+      # every other branch: gated behind the manual approve-scenarios approval.
       - scenario-auth-sidecar:
           name: scenario-auth-sidecar-approved
           requires:
             - build-artifact
-            - hold-scenarios
+            - approve-scenarios
           context:
             - github-repo
           filters:
@@ -503,12 +503,12 @@ workflows:
               only:
                 - master
                 - '/^release-\d+\.\d+$/'
-      # every other branch: gated behind the manual hold-scenarios approval.
+      # every other branch: gated behind the manual approve-scenarios approval.
       - scenario-deployment-lifecycle:
           name: scenario-deployment-lifecycle-approved
           requires:
             - build-artifact
-            - hold-scenarios
+            - approve-scenarios
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,14 +459,61 @@ workflows:
       - scenario-unified-1-35-1:
           requires:
             - build-artifact
+      # Manual gate for the custom functional scenarios on non-release branches.
+      # On master and release-X.Y they run automatically (below) and gate the
+      # release; on every other branch they wait on this approval before running.
+      - hold-scenarios:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - master
+                - '/^release-\d+\.\d+$/'
+
+      # master + release-X.Y: run automatically, and gate release-to-internal.
       - scenario-auth-sidecar:
           requires:
             - build-artifact
           context:
             - github-repo
+          filters:
+            branches:
+              only:
+                - master
+                - '/^release-\d+\.\d+$/'
+      # every other branch: gated behind the manual hold-scenarios approval.
+      - scenario-auth-sidecar:
+          name: scenario-auth-sidecar-approved
+          requires:
+            - build-artifact
+            - hold-scenarios
+          context:
+            - github-repo
+          filters:
+            branches:
+              ignore:
+                - master
+                - '/^release-\d+\.\d+$/'
+      # master + release-X.Y: run automatically, and gate release-to-internal.
       - scenario-deployment-lifecycle:
           requires:
             - build-artifact
+          filters:
+            branches:
+              only:
+                - master
+                - '/^release-\d+\.\d+$/'
+      # every other branch: gated behind the manual hold-scenarios approval.
+      - scenario-deployment-lifecycle:
+          name: scenario-deployment-lifecycle-approved
+          requires:
+            - build-artifact
+            - hold-scenarios
+          filters:
+            branches:
+              ignore:
+                - master
+                - '/^release-\d+\.\d+$/'
       - approve-stage-cluster-test:
           type: approval
           filters:
@@ -519,6 +566,8 @@ workflows:
             - approve-internal-release
             - scenario-unified-1-31-14
             - scenario-unified-1-35-1
+            - scenario-auth-sidecar
+            - scenario-deployment-lifecycle
       - approve-public-release:
           type: approval
           requires:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -332,7 +332,19 @@ workflows:
           requires:
             - build-artifact
             - approve-test-all-platforms
-{% endif %}{% endfor %}{% for scenario in scenarios %}
+{% endif %}{% endfor %}
+      # Manual gate for the custom functional scenarios on non-release branches.
+      # On master and release-X.Y they run automatically (below) and gate the
+      # release; on every other branch they wait on this approval before running.
+      - hold-scenarios:
+          type: approval
+          filters:
+            branches:
+              ignore:
+                - master
+                - '/^release-\d+\.\d+$/'
+{% for scenario in scenarios %}
+      # master + release-X.Y: run automatically, and gate release-to-internal.
       - scenario-{{ scenario.name }}:
           requires:
             - build-artifact
@@ -340,6 +352,26 @@ workflows:
           context:
             - github-repo
 {%- endif %}
+          filters:
+            branches:
+              only:
+                - master
+                - '/^release-\d+\.\d+$/'
+      # every other branch: gated behind the manual hold-scenarios approval.
+      - scenario-{{ scenario.name }}:
+          name: scenario-{{ scenario.name }}-approved
+          requires:
+            - build-artifact
+            - hold-scenarios
+{%- if scenario.kyverno_scan %}
+          context:
+            - github-repo
+{%- endif %}
+          filters:
+            branches:
+              ignore:
+                - master
+                - '/^release-\d+\.\d+$/'
 {%- endfor %}
       - approve-stage-cluster-test:
           type: approval
@@ -393,6 +425,9 @@ workflows:
             - approve-internal-release
 {%- for version in [kube_versions[0], kube_versions[-1]] %}
             - scenario-unified-{{ version | replace(".", "-") }}
+{%- endfor %}
+{%- for scenario in scenarios %}
+            - scenario-{{ scenario.name }}
 {%- endfor %}
       - approve-public-release:
           type: approval

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -336,7 +336,7 @@ workflows:
       # Manual gate for the custom functional scenarios on non-release branches.
       # On master and release-X.Y they run automatically (below) and gate the
       # release; on every other branch they wait on this approval before running.
-      - hold-scenarios:
+      - approve-scenarios:
           type: approval
           filters:
             branches:
@@ -357,12 +357,12 @@ workflows:
               only:
                 - master
                 - '/^release-\d+\.\d+$/'
-      # every other branch: gated behind the manual hold-scenarios approval.
+      # every other branch: gated behind the manual approve-scenarios approval.
       - scenario-{{ scenario.name }}:
           name: scenario-{{ scenario.name }}-approved
           requires:
             - build-artifact
-            - hold-scenarios
+            - approve-scenarios
 {%- if scenario.kyverno_scan %}
           context:
             - github-repo

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import yaml
 from jinja2 import Template
 
-git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+# Use .exists(), not .is_dir(): in a linked git worktree `.git` is a file, not a directory.
+git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 ci_runner_version = (datetime.datetime.now()).strftime("%Y-%m")

--- a/bin/helm-install.py
+++ b/bin/helm-install.py
@@ -11,7 +11,7 @@ import sys
 import time
 from pathlib import Path
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 HELPER_BIN_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "bin"
 KUBECTL_EXE = str(HELPER_BIN_DIR / "kubectl")
 HELM_EXE = str(HELPER_BIN_DIR / "helm")

--- a/bin/install-ci-tools.py
+++ b/bin/install-ci-tools.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import requests
 import yaml
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 CHART_METADATA = yaml.safe_load((Path(GIT_ROOT_DIR) / "metadata.yaml").read_text())
 KUBECTL_VERSION = os.environ.get("KUBE_VERSION", f"v{CHART_METADATA['test_k8s_versions'][-2]}").removeprefix("v")
 

--- a/bin/install-kyverno-scan.py
+++ b/bin/install-kyverno-scan.py
@@ -32,7 +32,7 @@ from pathlib import Path
 
 import yaml
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 HELM_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "helm"
 KUBECTL_EXE = Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "kubectl"
 

--- a/bin/run-scenario.py
+++ b/bin/run-scenario.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import yaml
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 SCENARIOS_DIR = GIT_ROOT_DIR / "tests" / "functional" / "scenarios"
 CHART_METADATA = yaml.safe_load((GIT_ROOT_DIR / "metadata.yaml").read_text())
 

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -73,7 +73,7 @@ from k3d_setup_shared import (
     _wait_for_cert_manager,
 )
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]))
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]))
 
 # ---------------------------------------------------------------------------
 # Local networking (dnsmasq + SNI reverse proxy) — replaces manual host /etc/hosts editing.

--- a/bin/setup-kind.py
+++ b/bin/setup-kind.py
@@ -18,7 +18,7 @@ from certs import (
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
 
-GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 HELPER_BIN_DIR = Path.home() / ".local" / "share" / "astronomer-software" / "bin"
 KIND_EXE = str(HELPER_BIN_DIR / "kind")
 KUBECTL_EXE = str(HELPER_BIN_DIR / "kubectl")

--- a/bin/show-docker-images.py
+++ b/bin/show-docker-images.py
@@ -71,7 +71,7 @@ def job_template_spec_parser(doc, args):
 def get_images_from_values_yaml():
     """Load values.yaml and all the images defined in it."""
     GIT_ROOT = next(
-        iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]),
+        iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]),
         None,
     )
     with open(GIT_ROOT / "values.yaml") as f:
@@ -133,7 +133,7 @@ def get_images_from_houston_configmap(doc, args):
 def helm_template(args, label, files):
     """Run helm template for the given value files and return the parsed yaml."""
     GIT_ROOT = next(
-        iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]),
+        iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]),
         None,
     )
 

--- a/bin/validate-helm-unittest-templates.py
+++ b/bin/validate-helm-unittest-templates.py
@@ -6,7 +6,8 @@ from pathlib import Path, PosixPath
 
 import yaml
 
-git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()]), None)
+# Use .exists(), not .is_dir(): in a linked git worktree `.git` is a file, not a directory.
+git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]), None)
 
 
 def validate_test_file(file: PosixPath) -> None:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import yaml
 
 # The top-level path of this repository
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
+git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").exists()][-1]
 
 chart_metadata = yaml.safe_load((Path(git_root_dir) / "metadata.yaml").read_text())
 # replace all patch versions with 0 so we end up with ['a.b.0', 'x.y.0']

--- a/tests/utils/chart.py
+++ b/tests/utils/chart.py
@@ -36,7 +36,7 @@ from tests import supported_k8s_versions
 api_client = ApiClient()
 
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master"
-git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").is_dir()][-1]
+git_root_dir = [x for x in Path(__file__).resolve().parents if (x / ".git").exists()][-1]
 DEBUG = os.getenv("DEBUG", "").lower() in ["yes", "true", "1"]
 default_version = supported_k8s_versions[-1]
 


### PR DESCRIPTION
## Description

Gate the custom functional-test scenarios (`scenario-<name>`: `auth-sidecar`, `deployment-lifecycle`, and future ones) so they:

- require a manual `hold-scenarios` approval to run on **non-release** branches,
- run **automatically** on `master` and `release-X.Y`,
- are **required to pass before `release-to-internal`** (and therefore before any release).
- make all git root dir detection functions git worktree safe

### After the change on a feature branch

You can see that this requires a manual approval on feature branches, which saves cost in circleCI credits

<img width="1110" height="562" alt="Screenshot 2026-07-30 at 15 47 33" src="https://github.com/user-attachments/assets/c8f6152b-7738-4377-a936-b8bc308b2eee" />

### After the change on a release branch

On a release branch, these steps are required before the internal release can be done

<img width="1907" height="726" alt="Screenshot 2026-07-30 at 15 49 33" src="https://github.com/user-attachments/assets/b2a97c84-0a4a-4917-b19c-b6c846977274" />

## Related Issues

- This is a general optimization for the new scenario feature, and the closest open issue for that is <https://linear.app/astronomer/issue/PINF-1109>

## Testing

These are all CI and test changes, no product testing is needed.

## Merging

release-2.1