### PR TITLE
PINF-1134 - fix hardcoded pilot network policy

### DIFF
--- a/charts/astronomer/templates/commander/commander-networkpolicy.yaml
+++ b/charts/astronomer/templates/commander/commander-networkpolicy.yaml
@@ -51,7 +51,7 @@ spec:
     - podSelector:
         matchLabels:
           component: pilot
-          release: astronomer
+          release: {{ .Release.Name }}
           tier: astronomer
     {{- end }}
     {{- end }}

--- a/tests/chart_tests/test_astronomer_commander_networkpolicy.py
+++ b/tests/chart_tests/test_astronomer_commander_networkpolicy.py
@@ -23,7 +23,7 @@ class TestCommanderNetworkPolicyDataplaneFailover:
         )
         assert len(docs) == 1
         ingress_from = docs[0]["spec"]["ingress"][0]["from"]
-        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "astronomer", "tier": "astronomer"}}}
+        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "release-name", "tier": "astronomer"}}}
         assert pilot_selector in ingress_from
 
     def test_dataplane_failover_disabled_omits_pilot_ingress_rule(self, kube_version):
@@ -78,7 +78,7 @@ class TestCommanderNetworkPolicyDataplaneFailover:
         )
         assert len(docs) == 1
         ingress_from = docs[0]["spec"]["ingress"][0]["from"]
-        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "astronomer", "tier": "astronomer"}}}
+        pilot_selector = {"podSelector": {"matchLabels": {"component": "pilot", "release": "release-name", "tier": "astronomer"}}}
         assert pilot_selector in ingress_from
 
 


### PR DESCRIPTION
## Description

fix hardcoded pilot network policy

## Related Issues

https://linear.app/astronomer/issue/PINF-1134/pilot-hardcoded-release-name-blocks-cpdp-failover

## Testing

QA should no longer see error while triggering the failover

## Merging

merge to master and release-2.1
