### PR TITLE
PINF-1139 - fix namespace pools deletion pilot config

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -331,10 +331,14 @@ gcp_cloud_logging:
   value: "{{ include "houston.authServiceURL" . }}"
 {{- end }}
 
-{{ define "commander_env" -}}
+{{ define "common_shared_env" -}}
 - name: COMMANDER_NAMESPACE_POOLS_ENABLED
   value: {{ ternary "true" "false" .Values.global.namespaceManagement.namespacePools.enabled | quote  }}
-{{- if .Values.global.namespaceManagement.namespacePools.enabled  }}
+{{ end }}
+
+{{ define "commander_env" -}}
+{{- include "common_shared_env" . -}}
+{{ if .Values.global.namespaceManagement.namespacePools.enabled -}}
 - name: COMMANDER_NAMESPACE_POOLS_LIST
   value: {{ .Values.global.namespaceManagement.namespacePools.namespaces.names | join "," | quote }}
 {{- end }}

--- a/charts/astronomer/templates/pilot/pilot-deployment.yaml
+++ b/charts/astronomer/templates/pilot/pilot-deployment.yaml
@@ -152,6 +152,7 @@ spec:
               value: {{ .Values.pilot.cbCooloffSeconds | quote }}
             - name: PILOT_CB_PROBE_MAX_INFLIGHT
               value: {{ .Values.pilot.cbProbeMaxInflight | quote }}
+            {{- include "common_shared_env" . | nindent 12  -}}
             {{- if .Values.pilot.env }}
             {{- tpl (toYaml .Values.pilot.env) $ | nindent 12 }}
             {{- end }}

--- a/tests/chart_tests/test_astronomer_pilot.py
+++ b/tests/chart_tests/test_astronomer_pilot.py
@@ -259,3 +259,45 @@ class TestAstronomerPilot:
 
         expected_addr = "release-name-commander-headless.default.svc.cluster.local.:50051"
         assert env_vars["PILOT_COMMANDER_ADDR"] == expected_addr
+
+    def test_pilot_namespace_pools_config_disabled(self, kube_version):
+        """Test that commander manual namespace config feature is disabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {"pilot": {"enabled": True}},
+                "global": {
+                    "namespaceManagement": {
+                        "namespacePools": {
+                            "enabled": False,
+                        }
+                    }
+                },
+            },
+            show_only=self.show_only,
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0], include_init_containers=False)
+        commander_env = get_env_vars_dict(c_by_name["pilot"]["env"])
+        assert commander_env.get("COMMANDER_NAMESPACE_POOLS_ENABLED") == "false"
+
+    def test_pilot_namespace_pools_config_enabled(self, kube_version):
+        """Test that commander manual namespace config feature is enabled."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {"pilot": {"enabled": True}},
+                "global": {
+                    "namespaceManagement": {
+                        "namespacePools": {
+                            "enabled": True,
+                        }
+                    }
+                },
+            },
+            show_only=self.show_only,
+        )
+        assert len(docs) == 1
+        c_by_name = get_containers_by_name(docs[0], include_init_containers=False)
+        commander_env = get_env_vars_dict(c_by_name["pilot"]["env"])
+        assert commander_env.get("COMMANDER_NAMESPACE_POOLS_ENABLED") == "true"


### PR DESCRIPTION
## Description

Pilot incorrectly passes namespace configuration for pools configuration - which deletes the underlying namespaces instead of skipping them

## Related Issues

https://linear.app/astronomer/issue/PINF-1139/pilot-deletes-namespaces-when-namespace-pools-are-enabled

## Testing

QA should not see namespace being deleted when nampace pools are configured when on failover testing

## Merging

merge to master , release-2.1
