### PR TITLE
PLX-860 - update commander version 2.1.18

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -15,7 +15,7 @@ tolerations: []
 images:
   commander:
     repository: quay.io/astronomer/ap-commander
-    tag: 2.1.17
+    tag: 2.1.18
     pullPolicy: IfNotPresent
   registry:
     repository: quay.io/astronomer/ap-registry


### PR DESCRIPTION
## Description

Fixes hard-delete leaving Airflow databases orphaned.

## Related Issues

https://linear.app/astronomer/issue/PLX-860/title-hard-delete-of-deployment-does-not-actually-remove-airflow

## Testing

refer linear issue

## Merging

merge to master and release-2.1
