### PR TITLE
Upgrade airflow operator version to v1.6

### DIFF
--- a/charts/airflow-operator/templates/_helpers.yaml
+++ b/charts/airflow-operator/templates/_helpers.yaml
@@ -139,7 +139,7 @@ Name of the controller-manager ServiceAccount. Defaults to
 
 {{ define "operator.image" -}}
 {{- if .Values.global.privateRegistry.enabled -}}
-{{ .Values.global.privateRegistry.repository }}/airflow-operator-dev:{{ .Values.images.manager.tag }}
+{{ .Values.global.privateRegistry.repository }}/airflow-operator-controller:{{ .Values.images.manager.tag }}
 {{- else -}}
 {{ .Values.images.manager.repository }}:{{ .Values.images.manager.tag }}
 {{- end }}

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -1,6 +1,5 @@
 images:
   manager:
-    # TODO: Change it to public image once 1.6.0 is released
     repository: quay.io/astronomer/airflow-operator-controller
     tag: 1.6.0
     pullPolicy: IfNotPresent

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -1,8 +1,8 @@
 images:
   manager:
     # TODO: Change it to public image once 1.6.0 is released
-    repository: quay.io/astronomer/airflow-operator-dev
-    tag: 1.6.0-rc5
+    repository: quay.io/astronomer/airflow-operator-controller
+    tag: 1.6.0
     pullPolicy: IfNotPresent
 # Whether the chart should create the Airflow Operator CRDs. Set to false if the CRDs are managed
 # out-of-band (e.g. installed separately by a cluster admin or via GitOps).

--- a/configs/pull-main-master-tags.yaml
+++ b/configs/pull-main-master-tags.yaml
@@ -4,7 +4,7 @@ airflow-operator:
   images:
     manager:
       pullPolicy: IfNotPresent
-      repository: quay.io/astronomer/airflow-operator-dev
+      repository: quay.io/astronomer/airflow-operator-controller
       # tag: This has no floating tag
 alertmanager:
   images:

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -344,7 +344,7 @@ class TestAirflowOperator:
         c_by_name = get_containers_by_name(docs[0], include_init_containers=False)
         image = c_by_name["manager"]["image"]
         # When privateRegistry is enabled the image is built from the private repo + the dev image name.
-        assert image.startswith("my.private.registry/astronomer/airflow-operator-dev:")
+        assert image.startswith("my.private.registry/astronomer/airflow-operator-controller:")
 
     def test_airflow_operator_pod_annotations_merge(self, kube_version):
         """The controller pod merges global.podAnnotations with the operator-local podAnnotations.


### PR DESCRIPTION
## Description

Upgrade airflow operator version to 1.6
Repository to quay.io/astronomer/airflow-operator-dev (Public repository)

## Related Issues

NA

## Testing

Local tested 

## Merging

main and 2.1
