### PR TITLE
Fix airflow-operator broken webhook TLS default

### DIFF
--- a/charts/airflow-operator/templates/validate-webhook-tls.yaml
+++ b/charts/airflow-operator/templates/validate-webhook-tls.yaml
@@ -1,0 +1,20 @@
+{{- /*
+Airflow Operator webhook TLS value validation.
+
+The webhook server needs a TLS certificate from exactly one source: either
+cert-manager provisions it (certManager.enabled) or the operator supplies its
+own (webhooks.useCustomTlsCerts).
+*/ -}}
+{{- if (include "operator.enabled" .) }}
+{{- if and (not .Values.certManager.enabled) (not .Values.webhooks.useCustomTlsCerts) }}
+{{- fail "airflow-operator: the webhook needs a TLS certificate source — set certManager.enabled=true (default) or webhooks.useCustomTlsCerts=true; they cannot both be disabled" }}
+{{- end }}
+{{- if .Values.webhooks.useCustomTlsCerts }}
+{{- if not .Values.webhooks.customCertsSecretName }}
+{{- fail "airflow-operator: webhooks.customCertsSecretName is required when webhooks.useCustomTlsCerts is true" }}
+{{- end }}
+{{- if not .Values.webhooks.caBundle }}
+{{- fail "airflow-operator: webhooks.caBundle is required when webhooks.useCustomTlsCerts is true" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/airflow-operator/values.yaml
+++ b/charts/airflow-operator/values.yaml
@@ -9,7 +9,11 @@ crd:
   create: true
 
 certManager:
-  enabled: false
+  # When true, cert-manager provisions the webhook server's TLS
+  # certificate. Set to false only if you supply your own certificates via
+  # webhooks.useCustomTlsCerts (then customCertsSecretName and caBundle are
+  # required).
+  enabled: true
 
 
 # Restrict the Airflow Operator to only send network requests to Kubernetes API, and read available astro-runtime versions from a local file instead of retrieving it dynamically online.
@@ -45,12 +49,14 @@ webhooks:
   # Enables the webhook service for mutating and validating configurations.
   enabled: true
   # Set to true to use your own TLS certificates for the webhooks instead of
-  # cert-manager-provisioned ones. When true, you must provide both
-  # customCertsSecretName and caBundle below.
+  # cert-manager-provisioned ones. When true, both customCertsSecretName and
+  # caBundle below are required — the chart fails to render otherwise. Requires
+  # certManager.enabled=false is acceptable, but at least one of certManager or
+  # useCustomTlsCerts must be enabled.
   useCustomTlsCerts: false
   # Name of a pre-created Secret (in the release namespace) that holds the
-  # webhook server's TLS certificate and key (tls.crt / tls.key). Only used
-  # when useCustomTlsCerts is true.
+  # webhook server's TLS certificate and key (tls.crt / tls.key). Required when
+  # useCustomTlsCerts is true.
   customCertsSecretName: ""
   # PEM-encoded CA bundle used to validate the webhook server certificate.
   # Injected into the webhook configurations' clientConfig when

--- a/tests/chart_tests/test_airflow_operator.py
+++ b/tests/chart_tests/test_airflow_operator.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from subprocess import CalledProcessError
 
 import pytest
 
@@ -56,6 +57,118 @@ class TestAirflowOperator:
         assert "cert-manager.io/v1" == docs[1]["apiVersion"]
         assert "release-name-airflow-operator-serving-cert" == docs[1]["metadata"]["name"]
         assert "release-name-airflow-operator-selfsigned-issuer" == docs[0]["metadata"]["name"]
+
+    def test_airflow_operator_webhook_tls_default_uses_cert_manager(self, kube_version):
+        """With shipped defaults (certManager.enabled=true) the manager mounts the cert-manager
+        secret, not the broken empty custom-certs volume."""
+        docs = render_chart(
+            validate_objects=False,
+            kube_version=kube_version,
+            values={
+                "global": {"airflowOperator": {"enabled": True}},
+            },
+            show_only=["charts/airflow-operator/templates/manager/controller-manager-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        volumes = {v["name"]: v for v in docs[0]["spec"]["template"]["spec"]["volumes"]}
+        assert "cert" in volumes
+        assert volumes["cert"]["secret"]["secretName"] == "release-name-webhook-server-cert"
+        assert "custom-certs" not in volumes
+
+    def test_airflow_operator_webhook_tls_custom_certs(self, kube_version):
+        """certManager off + useCustomTlsCerts on (with both required fields) mounts the
+        user-supplied secret and points the manager at /tmp/custom-certs."""
+        docs = render_chart(
+            validate_objects=False,
+            kube_version=kube_version,
+            values={
+                "global": {"airflowOperator": {"enabled": True}},
+                "airflow-operator": {
+                    "certManager": {"enabled": False},
+                    "webhooks": {
+                        "useCustomTlsCerts": True,
+                        "customCertsSecretName": "my-tls",
+                        "caBundle": "dGVzdA==",
+                    },
+                },
+            },
+            show_only=["charts/airflow-operator/templates/manager/controller-manager-deployment.yaml"],
+        )
+        assert len(docs) == 1
+        pod_spec = docs[0]["spec"]["template"]["spec"]
+        volumes = {v["name"]: v for v in pod_spec["volumes"]}
+        assert volumes["custom-certs"]["secret"]["secretName"] == "my-tls"
+        env = {e["name"]: e.get("value") for e in get_containers_by_name(docs[0])["manager"]["env"]}
+        assert env["WEBHOOK_CERT_DIRECTORY"] == "/tmp/custom-certs"
+
+    def test_airflow_operator_webhook_tls_requires_a_cert_source(self, kube_version):
+        """Disabling both certManager and useCustomTlsCerts fails the render with a clear message
+        instead of emitting a custom-certs volume with an empty secret name."""
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                validate_objects=False,
+                kube_version=kube_version,
+                values={
+                    "global": {"airflowOperator": {"enabled": True}},
+                    "airflow-operator": {
+                        "certManager": {"enabled": False},
+                        "webhooks": {"useCustomTlsCerts": False},
+                    },
+                },
+            )
+        assert "the webhook needs a TLS certificate source" in excinfo.value.stderr.decode("utf-8")
+
+    def test_airflow_operator_custom_certs_requires_secret_name(self, kube_version):
+        """useCustomTlsCerts without customCertsSecretName fails the render with a clear message."""
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                validate_objects=False,
+                kube_version=kube_version,
+                values={
+                    "global": {"airflowOperator": {"enabled": True}},
+                    "airflow-operator": {
+                        "certManager": {"enabled": False},
+                        "webhooks": {"useCustomTlsCerts": True, "caBundle": "dGVzdA=="},
+                    },
+                },
+            )
+        assert "webhooks.customCertsSecretName is required" in excinfo.value.stderr.decode("utf-8")
+
+    def test_airflow_operator_custom_certs_requires_ca_bundle(self, kube_version):
+        """useCustomTlsCerts without caBundle fails the render with a clear message."""
+        with pytest.raises(CalledProcessError) as excinfo:
+            render_chart(
+                validate_objects=False,
+                kube_version=kube_version,
+                values={
+                    "global": {"airflowOperator": {"enabled": True}},
+                    "airflow-operator": {
+                        "certManager": {"enabled": False},
+                        "webhooks": {"useCustomTlsCerts": True, "customCertsSecretName": "my-tls"},
+                    },
+                },
+            )
+        assert "webhooks.caBundle is required" in excinfo.value.stderr.decode("utf-8")
+
+    def test_airflow_operator_webhook_tls_not_validated_on_control_plane(self, kube_version):
+        """The TLS guard is gated on operator.enabled, so a both-disabled config on the control
+        plane (where the operator does not render) must not fail the render."""
+        docs = render_chart(
+            validate_objects=False,
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "airflowOperator": {"enabled": True},
+                    "plane": {"mode": "control"},
+                },
+                "airflow-operator": {
+                    "certManager": {"enabled": False},
+                    "webhooks": {"useCustomTlsCerts": False},
+                },
+            },
+        )
+        operator_docs = [f"{doc.get('kind')}/{doc.get('metadata', {}).get('name')}" for doc in docs if _is_operator_doc(doc)]
+        assert operator_docs == [], f"control plane must not render operator resources, got: {operator_docs}"
 
     def test_airflow_operator_crd(self, kube_version):
         """Test Airflow Operator crd template"""

--- a/tests/utils/chart.py
+++ b/tests/utils/chart.py
@@ -74,8 +74,9 @@ def create_validator(api_version, kind, kube_version=default_version):
 
 def validate_k8s_object(instance, kube_version=default_version):
     """Validate the k8s object."""
-    # CRDs are not reliably present in the kubernetes-json-schema repository, so skip validation for them.
-    if instance.get("kind") == "CustomResourceDefinition":
+    # These kinds are not present in the kubernetes-json-schema repository, so skip validation
+    # for them: CRDs, and the cert-manager custom resources the airflow-operator renders.
+    if instance.get("kind") in ("CustomResourceDefinition", "Certificate", "Issuer"):
         return
     validate = create_validator(instance.get("apiVersion"), instance.get("kind"), kube_version=kube_version)
     validate.validate(instance)


### PR DESCRIPTION
## Description

With shipped defaults (certManager.enabled: false, no customCertsSecretName), the manager rendered a custom-certs volume pointing at an empty secret name, so the operator install failed out of the box.

This flips certManager.enabled to true by default and adds a template-time validation that fails fast with a clear message when: both cert sources are disabled, or useCustomTlsCerts is on without customCertsSecretName/caBundle. The guard is gated on operator.enabled.

## Related Issues

NA

## Testing

Unit test

## Merging

main and 2.1
