### PR TITLE
PINF-1143 - remove grafana link for dataplane

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -32,7 +32,6 @@ The control plane is responsible for platform management, orchestration, and use
 {{- if $domainPrefix }}
 You can access the data plane at:
 - Astronomer dashboard:   {{ if and $astronomerEnabled $platformEnabled }}https://{{ $domainPrefix }}.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
-- Grafana dashboard:      {{ if and $grafanaEnabled $monitoringEnabled }}https://grafana.{{ .Values.global.baseDomain }}{{ else }}Disabled{{ end }}
 {{ else }}
 - Commander API:      {{ if and $astronomerEnabled $platformEnabled }}commander.{{ .Values.global.baseDomain }}:443{{ else }}Disabled{{ end }}
 - Commander Metadata: {{ if and $astronomerEnabled $platformEnabled }}http://{{ .Release.Name}}-commander.{{ .Release.Namespace }}.svc.cluster.local.:8880{{ else }}Disabled{{ end }}


### PR DESCRIPTION
## Description

remove grafana link for dataplane

## Related Issues

https://linear.app/astronomer/issue/PINF-1143/fix-misleading-grafana-url-in-dataplane-installation-notes

## Testing

Before install template update

<img width="1051" height="184" alt="Screenshot 2026-08-05 at 5 52 33 PM" src="https://github.com/user-attachments/assets/315bf6bd-346e-4273-94d0-4012a7e100a5" />

After

<img width="1191" height="249" alt="image" src="https://github.com/user-attachments/assets/f2f5c333-f85c-44a2-94a8-f6c91598fb44" />



## Merging

merge to master and release-2.1
