### PR TITLE
kuiper-reloader 0.2.12

### DIFF
--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -42,7 +42,7 @@ images:
     pullPolicy: IfNotPresent
   filesdReloader:
     repository: quay.io/astronomer/ap-kuiper-reloader
-    tag: 0.2.11
+    tag: 0.2.12
     pullPolicy: IfNotPresent
   promproxy:
     repository: quay.io/astronomer/ap-openresty


### PR DESCRIPTION
## Description

Follow-up to <https://github.com/astronomer/kuiper-reloader/pull/83>

## Related Issues

- <https://linear.app/astronomer/issue/PINF-1133>

## Testing

prom proxy targets should be accurate

## Merging

master, release-2.1