### PR TITLE
Bump houston to 2.1.21 for beta5

### DIFF
--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -24,7 +24,7 @@ images:
     # httpSecret: ~
   houston:
     repository: quay.io/astronomer/ap-houston-api
-    tag: 2.1.20
+    tag: 2.1.21
     pullPolicy: IfNotPresent
   astroUI:
     repository: quay.io/astronomer/ap-astro-ui


### PR DESCRIPTION
## Description

- houston:2.1.21

## Related Issues

https://linear.app/astronomer/issue/PLX-866/cluster-scope-role-assignments-are-visible-and-manageable-from-any

## Testing

N/A

## Merging

- master
- release-2.1