### PR TITLE
PINF-1147 - fixes the openshift flagging 

### DIFF
--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -29,4 +29,6 @@ data:
     {{- end }}
     externalSecretManager:
       isClusterSecretStore: {{ ternary "false" "true" .Values.global.namespaceManagement.namespacePools.enabled }}
+    openshift:
+      enabled: {{ ternary "false" "true" .Values.global.openshift.enabled }}
 {{- end }}

--- a/charts/astronomer/templates/commander/commander-metadata.yaml
+++ b/charts/astronomer/templates/commander/commander-metadata.yaml
@@ -30,5 +30,5 @@ data:
     externalSecretManager:
       isClusterSecretStore: {{ ternary "false" "true" .Values.global.namespaceManagement.namespacePools.enabled }}
     openshift:
-      enabled: {{ ternary "false" "true" .Values.global.openshift.enabled }}
+      enabled: {{ ternary "true" "false" .Values.global.openshift.enabled }}
 {{- end }}

--- a/tests/chart_tests/test_astronomer_commander.py
+++ b/tests/chart_tests/test_astronomer_commander.py
@@ -54,6 +54,7 @@ class TestAstronomerCommander:
                 "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
                 "externalSecretManager": {"isClusterSecretStore": True},
+                "openshift": {"enabled": False},
             }
         else:
             assert metadata_file_contents == {
@@ -62,6 +63,7 @@ class TestAstronomerCommander:
                 "registry": {"version": "99.88.77"},
                 "customLogging": {"enabled": False},
                 "externalSecretManager": {"isClusterSecretStore": True},
+                "openshift": {"enabled": False},
             }
 
     @pytest.mark.parametrize("enabled", [True, False], ids=["custom_logging_enabled", "custom_logging_disabled"])
@@ -93,6 +95,7 @@ class TestAstronomerCommander:
             "customLogging": {"enabled": enabled},
             "registry": {"version": "99.88.77"},
             "externalSecretManager": {"isClusterSecretStore": True},
+            "openshift": {"enabled": False},
         }
 
     def test_commander_metadata_extra_annotations(self, kube_version):


### PR DESCRIPTION
## Description

fix openshift flag configuration 

## Related Issues

https://linear.app/astronomer/issue/PINF-1147/switching-deployment-to-dod-fails-on-aro-openshift-scc-validation

## Testing

QA should no longer see the openshift scc issue while switching to DOD 

## Merging

merge to master and release-2.1
