### PR TITLE
Local k3d setup: self-heal Docker-stubbed bind mounts, fix DP install ordering, de-duplicate registry helpers

### DIFF
--- a/bin/k3d_setup_shared.py
+++ b/bin/k3d_setup_shared.py
@@ -324,20 +324,22 @@ proxy:
 """
 
 
-def _write_registry_config(config_path: Path, content: str) -> None:
-    """Write a registry proxy config file, clearing a directory left behind at that path.
+def _write_bind_mount_file(path: Path, content: str) -> None:
+    """Write a file that is bind-mounted into a container, clearing a directory left at that path.
 
-    Docker creates the source of a bind mount as an empty directory when the source does not
-    exist. If the config file goes missing while the container is registered (a wiped
-    `~/.local/share`, a Docker/OrbStack restart that re-runs `--restart always` containers), the
-    daemon recreates the path as a directory. That wedges the setup permanently: the container
-    can no longer mount a directory onto a file and exits 127, and writing the config here fails
-    with `[Errno 21] Is a directory`. Removing the stub restores a plain file.
+    Use this for every host file mounted with `-v <host file>:<container file>`, never a plain
+    `write_text`. Docker creates the source of a bind mount as an empty directory when the source
+    does not exist. If the file goes missing while its container still exists (a wiped
+    `~/.local/share`, a Docker/OrbStack restart that re-runs `--restart` containers), the daemon
+    recreates the path as a directory. That wedges the setup permanently: the container can no
+    longer mount a directory onto a file and exits 127, and writing the file here fails with
+    `[Errno 21] Is a directory`. Removing the stub restores a plain file.
     """
-    if config_path.is_dir() and not config_path.is_symlink():
-        _print(f"  Removing stale directory left at {config_path} (expected a file)")
-        shutil.rmtree(config_path)
-    config_path.write_text(content)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_dir() and not path.is_symlink():
+        _print(f"  Removing stale directory left at {path} (expected a file)")
+        shutil.rmtree(path)
+    path.write_text(content)
 
 
 def _container_state(name: str) -> str | None:
@@ -412,7 +414,7 @@ def _ensure_local_registries(docker_network: str) -> None:
     REGISTRY_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     for spec in _REGISTRY_SPECS:
         config_path = REGISTRY_CONFIG_DIR / f"{spec.name}.yml"
-        _write_registry_config(config_path, _registry_docker_config(spec))
+        _write_bind_mount_file(config_path, _registry_docker_config(spec))
         _ensure_registry(spec, docker_network)
 
 

--- a/bin/k3d_setup_shared.py
+++ b/bin/k3d_setup_shared.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import time
 from dataclasses import dataclass
@@ -27,6 +28,8 @@ HELPER_BIN_DIR = HELPER_DIR / "bin"
 REGISTRY_CONFIG_DIR = HELPER_DIR / "registry-configs"
 K3D_REGISTRY_CONFIG_PATH = HELPER_DIR / "k3d-registry.yaml"
 REGISTRY_IMAGE = "registry:2"
+
+DEFAULT_DOCKER_NETWORK = "astronomer-net"
 
 HELM_REPO_NAME = "astronomer-internal"
 HELM_CHART = f"{HELM_REPO_NAME}/astronomer"
@@ -256,23 +259,51 @@ def _ensure_helm_repo(repo_name: str = HELM_REPO_NAME, repo_url: str = HELM_REPO
 
 # ---------------------------------------------------------------------------
 # Local pull-through registry helpers
-# (See bin/setup-local-registry.py for the standalone management script.)
+# (bin/setup-local-registry.py is the standalone CLI over these same helpers.)
 # ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class _RegistrySpec:
-    name: str
-    upstream: str
-    host_port: int
+    name: str  # Docker container name
+    upstream: str  # Full upstream URL the proxy caches
+    host_port: int  # Port published on the host for direct `docker pull`
+    mirror_hosts: tuple[str, ...]  # Registry hostnames containerd routes to this proxy
 
 
 _REGISTRY_SPECS: tuple[_RegistrySpec, ...] = (
-    _RegistrySpec(name="astronomer-registry-proxy-quay", upstream="https://quay.io", host_port=15001),
-    _RegistrySpec(name="astronomer-registry-proxy-docker", upstream="https://registry-1.docker.io", host_port=15002),
-    _RegistrySpec(name="astronomer-registry-proxy-elastic", upstream="https://docker.elastic.co", host_port=15003),
-    _RegistrySpec(name="astronomer-registry-proxy-k8s", upstream="https://registry.k8s.io", host_port=15004),
-    _RegistrySpec(name="astronomer-registry-proxy-astrocrpublic", upstream="https://astrocrpublic.azurecr.io", host_port=15005),
+    _RegistrySpec(
+        name="astronomer-registry-proxy-quay",
+        upstream="https://quay.io",
+        host_port=15001,
+        mirror_hosts=("quay.io",),
+    ),
+    # `docker.io` and `index.docker.io` are two aliases Docker clients use for Docker Hub; both
+    # are mirrored so pulls from either path are intercepted.
+    _RegistrySpec(
+        name="astronomer-registry-proxy-docker",
+        upstream="https://registry-1.docker.io",
+        host_port=15002,
+        mirror_hosts=("docker.io", "index.docker.io"),
+    ),
+    _RegistrySpec(
+        name="astronomer-registry-proxy-elastic",
+        upstream="https://docker.elastic.co",
+        host_port=15003,
+        mirror_hosts=("docker.elastic.co",),
+    ),
+    _RegistrySpec(
+        name="astronomer-registry-proxy-k8s",
+        upstream="https://registry.k8s.io",
+        host_port=15004,
+        mirror_hosts=("registry.k8s.io",),
+    ),
+    _RegistrySpec(
+        name="astronomer-registry-proxy-astrocrpublic",
+        upstream="https://astrocrpublic.azurecr.io",
+        host_port=15005,
+        mirror_hosts=("astrocrpublic.azurecr.io",),
+    ),
 )
 
 
@@ -291,6 +322,22 @@ http:
 proxy:
   remoteurl: {spec.upstream}
 """
+
+
+def _write_registry_config(config_path: Path, content: str) -> None:
+    """Write a registry proxy config file, clearing a directory left behind at that path.
+
+    Docker creates the source of a bind mount as an empty directory when the source does not
+    exist. If the config file goes missing while the container is registered (a wiped
+    `~/.local/share`, a Docker/OrbStack restart that re-runs `--restart always` containers), the
+    daemon recreates the path as a directory. That wedges the setup permanently: the container
+    can no longer mount a directory onto a file and exits 127, and writing the config here fails
+    with `[Errno 21] Is a directory`. Removing the stub restores a plain file.
+    """
+    if config_path.is_dir() and not config_path.is_symlink():
+        _print(f"  Removing stale directory left at {config_path} (expected a file)")
+        shutil.rmtree(config_path)
+    config_path.write_text(content)
 
 
 def _container_state(name: str) -> str | None:
@@ -325,10 +372,17 @@ def _ensure_registry(spec: _RegistrySpec, docker_network: str) -> None:
 
     if state is not None:
         _print(f"  Starting stopped registry container: {spec.name}")
-        _run(["docker", "start", spec.name])
-        if docker_network not in _container_networks(spec.name):
-            _run(["docker", "network", "connect", docker_network, spec.name])
-        return
+        _run(["docker", "start", spec.name], check=False)
+        time.sleep(1)
+        if _container_state(spec.name) == "running":
+            if docker_network not in _container_networks(spec.name):
+                _run(["docker", "network", "connect", docker_network, spec.name])
+            return
+        # The container will not come back up — its mounts or network no longer resolve. The
+        # image cache lives in a named volume, so recreating the container keeps every cached
+        # layer; only the container itself is thrown away.
+        _print(f"  {spec.name} did not stay running; recreating it")
+        _run(["docker", "rm", "-f", spec.name], check=False)
 
     _print(f"  Creating registry proxy: {spec.name} -> {spec.upstream} (host port {spec.host_port})")
     _run(
@@ -358,35 +412,27 @@ def _ensure_local_registries(docker_network: str) -> None:
     REGISTRY_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     for spec in _REGISTRY_SPECS:
         config_path = REGISTRY_CONFIG_DIR / f"{spec.name}.yml"
-        config_path.write_text(_registry_docker_config(spec))
+        _write_registry_config(config_path, _registry_docker_config(spec))
         _ensure_registry(spec, docker_network)
 
 
-def _get_registry_config_path(_docker_network: str = "") -> Path:
+def _k3d_registry_config_yaml() -> str:
+    """Render the k3d `--registry-config` YAML from the registry specs.
+
+    Maps each upstream registry hostname to its local pull-through proxy, so that containerd
+    inside every k3d node pulls through the cache.
+    """
+    lines = ["mirrors:"]
+    for spec in _REGISTRY_SPECS:
+        for host in spec.mirror_hosts:
+            lines += [f'  "{host}":', "    endpoint:", f'      - "http://{spec.name}:5000"']
+    return "\n".join(lines) + "\n"
+
+
+def _get_registry_config_path() -> Path:
     """Write the k3d registry mirror config and return its path."""
-    content = """\
-mirrors:
-  "quay.io":
-    endpoint:
-      - "http://astronomer-registry-proxy-quay:5000"
-  "docker.io":
-    endpoint:
-      - "http://astronomer-registry-proxy-docker:5000"
-  "index.docker.io":
-    endpoint:
-      - "http://astronomer-registry-proxy-docker:5000"
-  "docker.elastic.co":
-    endpoint:
-      - "http://astronomer-registry-proxy-elastic:5000"
-  "registry.k8s.io":
-    endpoint:
-      - "http://astronomer-registry-proxy-k8s:5000"
-  "astrocrpublic.azurecr.io":
-    endpoint:
-      - "http://astronomer-registry-proxy-astrocrpublic:5000"
-"""
     HELPER_DIR.mkdir(parents=True, exist_ok=True)
-    K3D_REGISTRY_CONFIG_PATH.write_text(content)
+    K3D_REGISTRY_CONFIG_PATH.write_text(_k3d_registry_config_yaml())
     return K3D_REGISTRY_CONFIG_PATH
 
 

--- a/bin/setup-037x-k3d.py
+++ b/bin/setup-037x-k3d.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from k3d_setup_shared import (
     CERT_MANAGER_VERSION,
+    DEFAULT_DOCKER_NETWORK,
     HELM_CHART,
     HELM_REPO_NAME,
     Milestones,
@@ -381,7 +382,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-domain", default="localtest.me")
     parser.add_argument("--namespace", default="astronomer")
     parser.add_argument("--release-name", default="astronomer")
-    parser.add_argument("--docker-network", default="astronomer-net")
+    parser.add_argument("--docker-network", default=DEFAULT_DOCKER_NETWORK)
     parser.add_argument("--cluster-name", default="astro037")
     parser.add_argument("--https-port", type=int, default=443, help="HTTPS port. Default: '%(default)s'")
     parser.add_argument("--http-port", type=int, default=80, help="HTTP port. Default: '%(default)s'")
@@ -471,7 +472,7 @@ def main() -> int:
         if not args.no_local_registry:
             h = ms.start("Ensure local pull-through registry proxy containers are running")
             _ensure_local_registries(settings.docker_network)
-            registry_config = _get_registry_config_path(settings.docker_network)
+            registry_config = _get_registry_config_path()
             ms.done(h, detail=f"config={registry_config}")
         else:
             ms.skip("Local registry proxy setup", reason="--no-local-registry set")

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -72,6 +72,7 @@ from k3d_setup_shared import (
     _run,
     _validate_prereqs,
     _wait_for_cert_manager,
+    _write_bind_mount_file,
 )
 
 GIT_ROOT_DIR = next(iter([x for x in Path(__file__).resolve().parents if (x / ".git").exists()]))
@@ -800,8 +801,7 @@ def _write_dnsmasq_conf(base_domain: str) -> None:
         f"local=/{base_domain}/",
         f"address=/{base_domain}/127.0.0.1",
     ]
-    HELPER_DIR.mkdir(parents=True, exist_ok=True)
-    DNSMASQ_CONF_PATH.write_text("\n".join(lines) + "\n")
+    _write_bind_mount_file(DNSMASQ_CONF_PATH, "\n".join(lines) + "\n")
 
 
 def _ensure_dnsmasq_container() -> None:
@@ -872,8 +872,7 @@ stream {{
     }}
 }}
 """
-    HELPER_DIR.mkdir(parents=True, exist_ok=True)
-    PROXY_CONF_PATH.write_text(conf)
+    _write_bind_mount_file(PROXY_CONF_PATH, conf)
 
 
 def _ensure_proxy_container() -> None:
@@ -925,8 +924,14 @@ def _ensure_resolver_file(base_domain: str) -> bool:
     return True
 
 
-def _verify_local_networking(base_domain: str, hosts: list[str]) -> None:
-    """Best-effort end-to-end check: name -> 127.0.0.1 (dnsmasq) -> :443 proxy -> right cluster."""
+def _verify_local_networking(settings: Settings) -> None:
+    """Best-effort end-to-end check: name -> 127.0.0.1 (dnsmasq) -> :443 proxy -> right cluster.
+
+    Only meaningful once the platform is installed and serving, so it runs at the end of a run
+    rather than as part of `_setup_local_networking`. Never raises — it prints per-host markers.
+    """
+    base_domain = settings.base_domain
+    hosts = [f"houston.{base_domain}"] + [f"commander.{dp.domain_prefix}.{base_domain}" for dp in settings.data_planes]
     for host in hosts:
         dns = _run(["dscacheutil", "-q", "host", "-a", "name", host], check=False)
         ips = [ln.split(":", 1)[1].strip() for ln in (dns.stdout or "").splitlines() if ln.startswith("ip_address")]
@@ -949,6 +954,9 @@ def _setup_local_networking(settings: Settings) -> str:
     `DataPlane.https_port`, fixed at cluster-creation time — no container-IP lookup needed).
     Raises on failure; the caller falls back to `_print_manual_etc_hosts_fallback` so a dev is
     never fully blocked.
+
+    Needs nothing but `settings`, so it runs before the Helm installs — the DP install depends on
+    the proxy (see the call site).
     """
     base = settings.base_domain
     primary_cp = settings.control_planes[0]
@@ -964,9 +972,6 @@ def _setup_local_networking(settings: Settings) -> str:
     _print(f"  dnsmasq `{DNSMASQ_CONTAINER_NAME}`: *.{base} -> 127.0.0.1 (127.0.0.1:{LOCAL_DNS_PORT})")
     dp_summary = ", ".join(f"{prefix}->:{port}" for prefix, port in dp_entries) or "<none>"
     _print(f"  proxy `{PROXY_CONTAINER_NAME}` on :443 by SNI: {dp_summary} (DP), else -> :{primary_cp.https_port} (CP)")
-
-    check_hosts = [f"houston.{base}"] + [f"commander.{prefix}.{base}" for prefix, _ in dp_entries]
-    _verify_local_networking(base, check_hosts)
     return f"resolver {'created' if changed else 'present'}; proxy CP:{primary_cp.https_port} DP:{[p for _, p in dp_entries]}"
 
 
@@ -1549,6 +1554,25 @@ def main() -> int:  # noqa: C901
                 _deploy_mysql(context=dp_ctx, namespace=settings.namespace, release_name=settings.release_name)
                 ms.done(h, detail=f"svc={_mysql_service_name(settings.release_name)}")
 
+        # Step: local DNS + SNI proxy (replaces manual host /etc/hosts editing).
+        # Runs BEFORE the Helm installs, not just for the developer's browser: from the second run
+        # onward the DP's `coredns-custom` override (written at the end of the previous run)
+        # resolves houston.<baseDomain> to the astronomer-net gateway, so the DP's pre-upgrade
+        # JWKS hook reaches the CP only through this proxy. With the proxy down, that hook fails
+        # (`BackoffLimitExceeded`) and takes the whole DP install with it.
+        if not args.skip_local_networking:
+            h = ms.start(f"Configure local DNS + SNI proxy for `{settings.base_domain}` (no /etc/hosts editing)")
+            try:
+                detail = _setup_local_networking(settings)
+                ms.done(h, detail=detail)
+            except Exception as e:  # noqa: BLE001
+                ms.fail(h, error=str(e))
+                _print(f"\n⚠️  Local networking setup failed ({e}); falling back to manual /etc/hosts instructions.")
+                _print_manual_etc_hosts_fallback(settings)
+        else:
+            ms.skip("Configure local DNS + SNI proxy", reason="--skip-local-networking set")
+            _print_manual_etc_hosts_fallback(settings)
+
         # Step: values files
         h = ms.start("Write CP/DP Helm values files")
         values_dir: Path
@@ -1733,26 +1757,12 @@ def main() -> int:  # noqa: C901
                 reason="--skip-node-registry-check set",
             )
 
-        # Step: local DNS + SNI proxy (replaces manual host /etc/hosts editing)
-        if not args.skip_local_networking:
-            h = ms.start(f"Configure local DNS + SNI proxy for `{settings.base_domain}` (no /etc/hosts editing)")
-            try:
-                detail = _setup_local_networking(settings)
-                ms.done(h, detail=detail)
-            except Exception as e:  # noqa: BLE001
-                ms.fail(h, error=str(e))
-                _print(f"\n⚠️  Local networking setup failed ({e}); falling back to manual /etc/hosts instructions.")
-                _print_manual_etc_hosts_fallback(settings)
-        else:
-            ms.skip("Configure local DNS + SNI proxy", reason="--skip-local-networking set")
-            _print_manual_etc_hosts_fallback(settings)
-
         # Step: drift-free cross-cluster POD DNS. The reconcile pins NodeHosts to node/LB IPs that
         # drift on OrbStack restart AND that k3s rewrites away; this instead writes a coredns-custom
         # template resolving the peer plane's hostnames to the fixed astronomer-net gateway (-> the
-        # SNI proxy set up above), so CP<->DP pod traffic (e.g. Houston->Commander) keeps working
-        # across restarts without re-running the reconcile. Requires the SNI proxy, so it is gated on
-        # (and runs after) local networking.
+        # SNI proxy set up before the Helm installs), so CP<->DP pod traffic (e.g. Houston->Commander)
+        # keeps working across restarts without re-running the reconcile. Requires the SNI proxy, so
+        # it is gated on local networking.
         if not args.skip_local_networking:
             h = ms.start("Drift-free cross-cluster pod DNS (coredns-custom -> gateway -> SNI proxy)")
             _ensure_cross_cluster_coredns_routing(settings)
@@ -1762,6 +1772,15 @@ def main() -> int:  # noqa: C901
                 "Drift-free cross-cluster pod DNS (coredns-custom -> gateway -> SNI proxy)",
                 reason="--skip-local-networking set",
             )
+
+        # Step: end-to-end check of the local DNS + proxy path. Deferred to here because it only
+        # means anything once the platform is installed and serving.
+        if not args.skip_local_networking:
+            h = ms.start("Verify local DNS + SNI proxy end-to-end (name -> dnsmasq -> :443 proxy -> cluster)")
+            _verify_local_networking(settings)
+            ms.done(h)
+        else:
+            ms.skip("Verify local DNS + SNI proxy end-to-end", reason="--skip-local-networking set")
 
         ms.print_summary_table()
         _print("\n✅ Completed.")

--- a/bin/setup-cp-dp-k3d.py
+++ b/bin/setup-cp-dp-k3d.py
@@ -40,6 +40,7 @@ from pathlib import Path
 
 from k3d_setup_shared import (
     CERT_MANAGER_VERSION,
+    DEFAULT_DOCKER_NETWORK,
     HELM_CHART,
     HELM_REPO_NAME,
     HELM_REPO_URL,
@@ -1059,7 +1060,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--base-domain", default="localtest.me")
     parser.add_argument("--namespace", default="astronomer")
     parser.add_argument("--release-name", default="astronomer")
-    parser.add_argument("--docker-network", default="astronomer-net")
+    parser.add_argument("--docker-network", default=DEFAULT_DOCKER_NETWORK)
     parser.add_argument(
         "--cp-count",
         type=int,
@@ -1439,7 +1440,7 @@ def main() -> int:  # noqa: C901
         if not args.no_local_registry:
             h = ms.start("Ensure local pull-through registry proxy containers are running")
             _ensure_local_registries(settings.docker_network)
-            registry_config = _get_registry_config_path(settings.docker_network)
+            registry_config = _get_registry_config_path()
             ms.done(h, detail=f"config={registry_config}")
         else:
             ms.skip("Local registry proxy setup", reason="--no-local-registry set")

--- a/bin/setup-local-registry.py
+++ b/bin/setup-local-registry.py
@@ -2,14 +2,18 @@
 """
 Manage persistent local pull-through caching registry containers for k3d development.
 
-Runs four Docker Registry v2 containers (one per upstream) on the shared Docker network.
-The containers survive k3d cluster destroy/recreate because they live outside any cluster.
+Runs one Docker Registry v2 container per upstream on the shared Docker network. The containers
+survive k3d cluster destroy/recreate because they live outside any cluster.
+
+The container set, their config, and the ensure logic live in `k3d_setup_shared.py`, so the k3d
+setup scripts and this CLI always manage exactly the same containers. This script adds only what
+is specific to managing them by hand: status and destroy.
 
 Registries managed:
   astronomer-registry-proxy-quay          -> quay.io                    (host port 15001)
   astronomer-registry-proxy-docker        -> docker.io                  (host port 15002)
   astronomer-registry-proxy-elastic       -> docker.elastic.co          (host port 15003)
-  astronomer-registry-proxy-k8s          -> registry.k8s.io             (host port 15004)
+  astronomer-registry-proxy-k8s           -> registry.k8s.io            (host port 15004)
   astronomer-registry-proxy-astrocrpublic -> astrocrpublic.azurecr.io   (host port 15005)
 
 Usage:
@@ -23,281 +27,29 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import json
-import os
-import shlex
-import subprocess
 import sys
-from dataclasses import dataclass
-from pathlib import Path
 
-HELPER_DIR = Path.home() / ".local" / "share" / "astronomer-software"
-REGISTRY_CONFIG_DIR = HELPER_DIR / "registry-configs"
-K3D_REGISTRY_CONFIG_PATH = HELPER_DIR / "k3d-registry.yaml"
-
-REGISTRY_IMAGE = "registry:2"
-
-DEFAULT_DOCKER_NETWORK = "astronomer-net"
-
-
-@dataclass(frozen=True)
-class RegistrySpec:
-    name: str  # Docker container name
-    upstream: str  # Full upstream URL (https://...)
-    host_port: int  # Port exposed on the host for direct docker pull
-
-
-REGISTRY_SPECS: tuple[RegistrySpec, ...] = (
-    RegistrySpec(
-        name="astronomer-registry-proxy-quay",
-        upstream="https://quay.io",
-        host_port=15001,
-    ),
-    RegistrySpec(
-        name="astronomer-registry-proxy-docker",
-        upstream="https://registry-1.docker.io",
-        host_port=15002,
-    ),
-    RegistrySpec(
-        name="astronomer-registry-proxy-elastic",
-        upstream="https://docker.elastic.co",
-        host_port=15003,
-    ),
-    RegistrySpec(
-        name="astronomer-registry-proxy-k8s",
-        upstream="https://registry.k8s.io",
-        host_port=15004,
-    ),
-    RegistrySpec(
-        name="astronomer-registry-proxy-astrocrpublic",
-        upstream="https://astrocrpublic.azurecr.io",
-        host_port=15005,
-    ),
+from k3d_setup_shared import (
+    _REGISTRY_SPECS,
+    DEFAULT_DOCKER_NETWORK,
+    _container_networks,
+    _container_state,
+    _ensure_docker_network,
+    _ensure_local_registries,
+    _get_registry_config_path,
+    _print,
+    _run,
 )
 
-
-def _print(msg: str) -> None:
-    print(msg, flush=True)
-
-
-def _debug_enabled() -> bool:
-    return os.environ.get("DEBUG", "").lower() in {"1", "true", "yes"}
-
-
-def _debug(msg: str) -> None:
-    if _debug_enabled():
-        _print(f"DEBUG: {msg}")
-
-
-def _run(
-    cmd: list[str],
-    *,
-    check: bool = True,
-    capture: bool = True,
-) -> subprocess.CompletedProcess[str]:
-    _debug(f"run: {shlex.join(cmd)}")
-    proc = subprocess.run(
-        cmd,
-        text=True,
-        check=False,
-        stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.PIPE if capture else None,
-    )
-    if check and proc.returncode != 0:
-        stderr = (proc.stderr or "").strip()
-        raise RuntimeError(f"Command failed ({proc.returncode}): {shlex.join(cmd)}\n{stderr}")
-    return proc
-
-
-def _docker_network_exists(name: str) -> bool:
-    return _run(["docker", "network", "inspect", name], check=False).returncode == 0
-
-
-def _ensure_docker_network(name: str) -> None:
-    if _docker_network_exists(name):
-        return
-    _print(f"Creating Docker network: {name}")
-    _run(["docker", "network", "create", name])
-
-
-def _container_state(name: str) -> str | None:
-    """Return container state string ('running', 'exited', …) or None if not found."""
-    proc = _run(
-        ["docker", "inspect", name, "--format", "{{.State.Status}}"],
-        check=False,
-    )
-    if proc.returncode != 0:
-        return None
-    return (proc.stdout or "").strip() or None
-
-
-def _container_networks(name: str) -> list[str]:
-    """Return list of network names the container is attached to."""
-    proc = _run(
-        ["docker", "inspect", name, "--format", "{{json .NetworkSettings.Networks}}"],
-        check=False,
-    )
-    if proc.returncode != 0:
-        return []
-    raw = (proc.stdout or "").strip()
-    if not raw:
-        return []
-    try:
-        nets = json.loads(raw)
-        return list(nets.keys())
-    except json.JSONDecodeError:
-        return []
-
-
-def _registry_docker_config(spec: RegistrySpec) -> str:
-    """Generate registry:2 YAML config for a pull-through proxy."""
-    return f"""\
-version: 0.1
-log:
-  level: warn
-storage:
-  filesystem:
-    rootdirectory: /var/lib/registry
-  delete:
-    enabled: true
-http:
-  addr: :5000
-proxy:
-  remoteurl: {spec.upstream}
-"""
-
-
-def _write_registry_configs() -> None:
-    """Write per-registry config files to the host filesystem."""
-    REGISTRY_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-    for spec in REGISTRY_SPECS:
-        config_path = REGISTRY_CONFIG_DIR / f"{spec.name}.yml"
-        config_path.write_text(_registry_docker_config(spec))
-        _debug(f"Wrote registry config: {config_path}")
-
-
-def _ensure_registry(spec: RegistrySpec, docker_network: str) -> None:
-    """Idempotently ensure a single registry proxy container is running."""
-    config_path = REGISTRY_CONFIG_DIR / f"{spec.name}.yml"
-    volume_name = f"{spec.name}-data"
-
-    state = _container_state(spec.name)
-
-    if state == "running":
-        # Make sure it's on the right network (could be missing after network recreation).
-        if docker_network not in _container_networks(spec.name):
-            _print(f"  Attaching {spec.name} to network {docker_network}")
-            _run(["docker", "network", "connect", docker_network, spec.name])
-        _debug(f"Registry already running: {spec.name}")
-        return
-
-    if state is not None:
-        # Container exists but is stopped — start it.
-        _print(f"  Starting stopped registry container: {spec.name}")
-        _run(["docker", "start", spec.name])
-        if docker_network not in _container_networks(spec.name):
-            _run(["docker", "network", "connect", docker_network, spec.name])
-        return
-
-    # Container does not exist — create it.
-    _print(f"  Creating registry proxy container: {spec.name} ({spec.upstream}) on port {spec.host_port}")
-    _run(
-        [
-            "docker",
-            "run",
-            "-d",
-            "--name",
-            spec.name,
-            "--network",
-            docker_network,
-            "--restart",
-            "always",
-            "-p",
-            f"{spec.host_port}:5000",
-            "-v",
-            f"{volume_name}:/var/lib/registry",
-            "-v",
-            f"{config_path}:/etc/docker/registry/config.yml:ro",
-            REGISTRY_IMAGE,
-        ]
-    )
-
-
-def _ensure_local_registries(docker_network: str = DEFAULT_DOCKER_NETWORK) -> None:
-    """Ensure all four registry proxy containers are running on the given Docker network.
-
-    This is the primary entry point called by the k3d setup scripts before cluster creation.
-    It is safe to call repeatedly (idempotent).
-    """
-    _ensure_docker_network(docker_network)
-    _write_registry_configs()
-    for spec in REGISTRY_SPECS:
-        _ensure_registry(spec, docker_network)
-
-
-def _k3d_registry_config_yaml(docker_network: str = DEFAULT_DOCKER_NETWORK) -> str:
-    """Generate the k3d --registry-config YAML content.
-
-    Maps each upstream registry hostname to the local pull-through proxy.
-    The file is passed to `k3d cluster create --registry-config <path>` so that
-    containerd inside each k3d node uses the local cache for all image pulls.
-
-    Note: `docker.io` and `index.docker.io` are two aliases Docker clients use for
-    Docker Hub; both are listed so pulls from either path are intercepted.
-    """
-    proxy_quay = "astronomer-registry-proxy-quay"
-    proxy_docker = "astronomer-registry-proxy-docker"
-    proxy_elastic = "astronomer-registry-proxy-elastic"
-    proxy_k8s = "astronomer-registry-proxy-k8s"
-    proxy_astrocrpublic = "astronomer-registry-proxy-astrocrpublic"
-
-    return f"""\
-mirrors:
-  "quay.io":
-    endpoint:
-      - "http://{proxy_quay}:5000"
-  "docker.io":
-    endpoint:
-      - "http://{proxy_docker}:5000"
-  "index.docker.io":
-    endpoint:
-      - "http://{proxy_docker}:5000"
-  "docker.elastic.co":
-    endpoint:
-      - "http://{proxy_elastic}:5000"
-  "registry.k8s.io":
-    endpoint:
-      - "http://{proxy_k8s}:5000"
-  "astrocrpublic.azurecr.io":
-    endpoint:
-      - "http://{proxy_astrocrpublic}:5000"
-"""
-
-
-def _write_k3d_registry_config(docker_network: str = DEFAULT_DOCKER_NETWORK) -> Path:
-    """Write the k3d registry config YAML to a stable path and return it."""
-    HELPER_DIR.mkdir(parents=True, exist_ok=True)
-    K3D_REGISTRY_CONFIG_PATH.write_text(_k3d_registry_config_yaml(docker_network))
-    return K3D_REGISTRY_CONFIG_PATH
-
-
-def get_registry_config_path(docker_network: str = DEFAULT_DOCKER_NETWORK) -> Path:
-    """Return the k3d registry config path, writing it first if needed.
-
-    Called by setup-037x-k3d.py and setup-cp-dp-k3d.py before cluster creation.
-    """
-    return _write_k3d_registry_config(docker_network)
-
-
 # ---------------------------------------------------------------------------
-# Status + destroy helpers (used by the standalone CLI only)
+# Status + destroy helpers (used by this CLI only)
 # ---------------------------------------------------------------------------
 
 
 def _status_table() -> None:
     """Print a human-readable status table of all registry containers."""
     rows = []
-    for spec in REGISTRY_SPECS:
+    for spec in _REGISTRY_SPECS:
         state = _container_state(spec.name) or "missing"
         nets = _container_networks(spec.name)
         rows.append((spec.name, spec.upstream, str(spec.host_port), state, ", ".join(nets) or "-"))
@@ -321,7 +73,7 @@ def _status_table() -> None:
 
 def _destroy(*, purge_volumes: bool = False) -> None:
     """Stop and remove all registry containers. Optionally purge cache volumes."""
-    for spec in REGISTRY_SPECS:
+    for spec in _REGISTRY_SPECS:
         state = _container_state(spec.name)
         if state is None:
             _print(f"  {spec.name}: not found, skipping")
@@ -330,7 +82,7 @@ def _destroy(*, purge_volumes: bool = False) -> None:
         _run(["docker", "rm", "-f", spec.name])
 
     if purge_volumes:
-        for spec in REGISTRY_SPECS:
+        for spec in _REGISTRY_SPECS:
             volume_name = f"{spec.name}-data"
             proc = _run(["docker", "volume", "inspect", volume_name], check=False)
             if proc.returncode != 0:
@@ -391,14 +143,15 @@ def main() -> int:
         return 0
 
     _print("Ensuring local registry proxy containers are running...")
+    _ensure_docker_network(args.docker_network)
     _ensure_local_registries(args.docker_network)
-    config_path = get_registry_config_path(args.docker_network)
+    config_path = _get_registry_config_path()
     _print(f"\nk3d registry config written to: {config_path}")
     _print("\nRegistry proxies are ready. Pass the following flag to k3d cluster create:")
     _print(f"  --registry-config {config_path}")
     _print("")
     _print("Direct pull access from host (after docker login if needed):")
-    for spec in REGISTRY_SPECS:
+    for spec in _REGISTRY_SPECS:
         _print(f"  {spec.upstream.replace('https://', '')}  ->  localhost:{spec.host_port}")
     return 0
 

--- a/docs/cp-dp-k3d-setup-guide.md
+++ b/docs/cp-dp-k3d-setup-guide.md
@@ -854,6 +854,29 @@ kubectl --context k3d-dp01 run test-curl --rm -it --restart=Never --image=curlim
 docker exec k3d-dp01-server-0 sh -c 'grep -n "houston.localtest.me" /etc/hosts || true'
 ```
 
+### Helper containers exit 127, or setup fails with `[Errno 21] Is a directory`
+
+Three helper containers bind-mount a single config file from `~/.local/share/astronomer-software/`:
+the DNS container (`cp-dp-dnsmasq.conf`), the SNI proxy (`cp-dp-proxy-nginx.conf`), and each registry
+proxy (`registry-configs/*.yml`).
+
+Docker creates the source of a bind mount as an empty directory when that source does not exist. If
+those files are removed while the containers still exist, the next Docker/OrbStack restart recreates
+each path as a directory. The containers then fail to start (`not a directory: Are you trying to
+mount a directory onto a file`), and the setup script fails to write its config over the directory.
+
+Re-running the setup repairs it — the stub directories are removed and the configs rewritten:
+
+```bash
+python3 bin/setup-cp-dp-k3d.py --interactive
+```
+
+To confirm the containers came back:
+
+```bash
+docker ps --filter name=astro-cp-dp --filter name=astronomer-registry-proxy
+```
+
 ### Browser works but CLI (`astro`, `curl`) fails
 
 If the browser can load `https://houston.localtest.me` but `astro login localtest.me` fails, it usually means the

--- a/docs/local-registry.md
+++ b/docs/local-registry.md
@@ -170,6 +170,23 @@ python3 bin/setup-local-registry.py --destroy
 python3 bin/setup-local-registry.py
 ```
 
+### Containers exit 127, or setup fails with `[Errno 21] Is a directory`
+
+Docker creates the source of a bind mount as an empty directory when that source does not exist.
+If the per-registry configs under `~/.local/share/astronomer-software/registry-configs/` are removed
+while the containers still exist, the next Docker/OrbStack restart recreates each `*.yml` path as a
+directory. The containers then fail to start (`not a directory: Are you trying to mount a directory
+onto a file`), and the setup scripts fail to write the config over it.
+
+Re-running the setup repairs this — the stub directories are removed, the configs rewritten, and any
+container that will not restart is recreated:
+
+```bash
+python3 bin/setup-local-registry.py
+```
+
+Cached layers live in the `*-data` volumes and survive the container being recreated.
+
 ### `Too Many Requests` from quay.io or docker.io
 
 The proxy is not being used. Verify:


### PR DESCRIPTION
## Description

Three related fixes to the local k3d dev setup, all surfaced by one broken run.

### 1. Setup wedges permanently when Docker stubs a bind-mounted config file

Docker creates the source of a bind mount as an empty directory when that source does not
exist. Three helper configs are bind-mounted as single files:

| File | Container |
|---|---|
| `registry-configs/*.yml` | the 5 pull-through registry proxies |
| `cp-dp-dnsmasq.conf` | `astro-cp-dp-dnsmasq` |
| `cp-dp-proxy-nginx.conf` | `astro-cp-dp-proxy` |

If those files go missing while the containers still exist, the next Docker/OrbStack restart
re-runs the containers and the daemon recreates each path as a directory. That wedges the
setup in both directions, and neither side recovers on its own:

- the containers can no longer mount a directory onto a file and exit 127
- the setup script then fails with `[Errno 21] Is a directory: '.../astronomer-registry-proxy-quay.yml'`

Adds `_write_bind_mount_file()` in `k3d_setup_shared.py`, which clears a stub directory before
writing, and routes all three sites through it. `_ensure_registry()` also no longer treats
`docker start` as success without checking: a container that will not stay running is now
recreated (cached layers live in the `*-data` volumes, so nothing is lost). Previously the
script reported success and continued to a cluster create whose image pulls had no working
mirror.

### 2. The DP Helm install ran before the SNI proxy it depends on

The DP's `astronomer-commander-jwks-hook` is a `pre-install,pre-upgrade` hook that fetches the
JWT signing key from `https://houston.<baseDomain>`. From inside the DP, that name resolves via
the `coredns-custom` override to the `astronomer-net` gateway, so the hook reaches the CP only
through the host's `astro-cp-dp-proxy`. That proxy was created four milestones *after* the DP
install.

A first-ever install works — no `coredns-custom` yet, so the hook resolves via the NodeHosts
pin. But that override is written at the end of every run and persists in the cluster, so from
the second run onward the DP install silently depends on a container the script starts later.
With the proxy down, the hook fails with `BackoffLimitExceeded` and takes the whole DP install
with it.

Moves `_setup_local_networking()` ahead of the Helm section (it only needs `settings` — the
published ports are fixed at cluster-creation time). The end-to-end check is split into
`_verify_local_networking(settings)` and stays at the end of the run, where it is meaningful.

### 3. `setup-local-registry.py` was a near-complete copy of the shared registry code

407 → 160 lines. It duplicated `_print`/`_debug`/`_run`, the container inspection helpers, the
spec table, the config generation, the ensure path, four path constants, and a second
hand-written copy of the k3d mirror map — which is why fix (1) had to be written twice.

The file cannot be imported (dash in the name), so the direction is one-way: `k3d_setup_shared`
owns the logic and the CLI keeps only `--status`, `--destroy/--purge`, and argparse. The mirror
map is now derived from the spec table via a `mirror_hosts` field, so adding a proxy is a single
tuple entry instead of edits in five places. Also drops a parameter `_get_registry_config_path()`
never used, and centralizes the `astronomer-net` literal as `DEFAULT_DOCKER_NETWORK`.

Docs: adds a troubleshooting entry for the 127 / `Errno 21` failure to
`docs/cp-dp-k3d-setup-guide.md` and `docs/local-registry.md`.

## Related Issues

NA

## Testing

- Generated k3d mirror config asserted byte-identical to the previous hardcoded string,
  including the `docker.io` / `index.docker.io` double alias.
- `_write_bind_mount_file()` exercised against a simulated Docker stub directory and against a
  missing parent directory.
- `--help` verified on all three entry points; each does no work before argparse.
- `setup-local-registry.py --status` run against live containers to exercise the new import path.
- Fix (1) confirmed against the real failure: the five registry proxies were dead at
  `Exited (127)` with stub directories on disk, and came back up on the next run with no manual
  cleanup.

```
Milestones summary:

+----+------------------------------------------------------------------------+------------+----------+------------------------------------------------------------------------------------+
| #  | Milestone                                                              | Status     | Duration | Details                                                                            |
+----+------------------------------------------------------------------------+------------+----------+------------------------------------------------------------------------------------+
| 1  | Validate prerequisites (docker/k3d/kubectl/helm)                       | ✅ Success  | 0.1s     |                                                                                    |
| 2  | Ensure Docker network `astronomer-net` exists                          | ✅ Success  | 0.1s     |                                                                                    |
| 3  | Ensure local pull-through registry proxy containers are running        | ✅ Success  | 0.3s     | config=/Users/karankhanchandani/.local/share/astronomer-software/k3d-registry.yaml |
| 4  | Generate TLS certs (mkcert) — one per plane, scoped to its own host... | ✅ Success  | 0.4s     | 2 cert(s): k3d-cp01, k3d-dp01                                                      |
| 5  | Ensure k3d clusters exist (CP=cp01, DP=dp01)                           | ✅ Success  | 37.8s    |                                                                                    |
| 6  | Apply namespace + secrets in all clusters (ns=astronomer)              | ✅ Success  | 0.6s     | tlsSecret=astronomer-tls caSecret=mkcert-root-ca                                   |
| 7  | Configure local DNS + SNI proxy for `localtest.me` (no /etc/hosts e... | ✅ Success  | 2.4s     | resolver present; proxy CP:8443 DP:[8444]                                          |
| 8  | Write CP/DP Helm values files                                          | ✅ Success  | 0.0s     | dir=/var/folders/1r/cdc2t03565l2h31qnmrt1yhw0000gn/T/astro-k3d-f3l31dr3            |
| 9  | Ensure Helm repo `astronomer-internal` is up-to-date                   | ✅ Success  | 2.4s     | version=2.1.0                                                                      |
| 10 | Helm install/upgrade Control Plane (context=k3d-cp01)                  | ⏳ Running  | -        |                                                                                    |
| 11 | Install cert-manager on cp01 (operator webhooks)                       | ✅ Success  | 11.7s    | version=v1.19.4                                                                    |
| 12 | Install ServiceMonitor CRD on cp01 (operator apiserver watch)          | ✅ Success  | 273.3s   | prometheus-operator v0.76.0                                                        |
| 13 | Create DP astronomer-bootstrap secrets                                 | ⏭️ Skipped | 0.0s     | postgresql subchart creates it automatically                                       |
| 14 | Pre-DP: update dp01 CoreDNS NodeHosts for CP ingress                   | ✅ Success  | 5.0s     |                                                                                    |
| 15 | Install cert-manager on dp01 (operator webhooks)                       | ✅ Success  | 12.6s    | version=v1.19.4                                                                    |
| 16 | Install ServiceMonitor CRD on dp01 (operator apiserver watch)          | ✅ Success  | 0.1s     | prometheus-operator v0.76.0                                                        |
| 17 | Helm install/upgrade Data Plane (context=k3d-dp01)                     | ✅ Success  | 63.8s    |                                                                                    |
| 18 | Reconcile cross-cluster DNS + node-level hosts pins (dp01)             | ✅ Success  | 2.9s     |                                                                                    |
| 19 | DP node: pin houston.<baseDomain> to CP ingress (dp01 /etc/hosts)      | ✅ Success  | 0.1s     |                                                                                    |
| 20 | Node /etc/hosts self-healing DaemonSets (CP + DP, survive OrbStack ... | ✅ Success  | 0.1s     |                                                                                    |
| 21 | Drift-free cross-cluster pod DNS (coredns-custom -> gateway -> SNI ... | ✅ Success  | 3.2s     |                                                                                    |
| 22 | Verify local DNS + SNI proxy end-to-end (name -> dnsmasq -> :443 pr... | ✅ Success  | 1.1s     |                                                                                    |
+----+------------------------------------------------------------------------+------------+----------+------------------------------------------------------------------------------------+

✅ Completed.
```
No chart templates changed; chart unit tests are unaffected.

## Merging

master