### PR TITLE
PINF-1202 Unify mkcert-root-ca / private-ca secret naming across dev topologies

### DIFF
--- a/bin/certs.py
+++ b/bin/certs.py
@@ -14,8 +14,6 @@ cert_dir = Path.home() / ".local" / "share" / "astronomer-software" / "certs"
 cert_dir.mkdir(parents=True, exist_ok=True)
 astronomer_tls_cert_file = cert_dir / "astronomer-tls.pem"
 astronomer_tls_key_file = cert_dir / "astronomer-tls.key"
-astronomer_private_ca_cert_file = cert_dir / "astronomer-private-ca.pem"
-astronomer_private_ca_key_file = cert_dir / "astronomer-private-ca.key"
 MKCERT_EXE = str(Path.home() / ".local" / "share" / "astronomer-software" / "bin" / "mkcert")
 
 
@@ -58,7 +56,6 @@ def cleanup_old_certificates(cert_dir=cert_dir):
 
     cert_files = [
         (astronomer_tls_cert_file, astronomer_tls_key_file),
-        (astronomer_private_ca_cert_file, astronomer_private_ca_key_file),
     ]
 
     now = datetime.now(UTC)
@@ -132,61 +129,12 @@ def create_astronomer_tls_certificates():
     print(f"astronomer-tls certificate and key generated:\n  Cert: {astronomer_tls_cert_file}\n  Key: {astronomer_tls_key_file}")
 
 
-def create_astronomer_private_ca_certificates():
-    """Use mkcert to create the certificate and key for the astronomer-private-ca secret.
-
-    We use mkcert because it integrates with the system's trust store, allowing
-    browsers to trust the generated certificates. This is useful for local
-    development and testing, and because it makes this whole process easy.
-    """
-
-    cert_dir = Path.home() / ".local" / "share" / "astronomer-software" / "certs"
-    astronomer_private_ca_cert_file = cert_dir / "astronomer-private-ca.pem"
-    astronomer_private_ca_key_file = cert_dir / "astronomer-private-ca.key"
-    ca_root = subprocess.check_output([MKCERT_EXE, "-CAROOT"], text=True).strip()
-    ca_root_pem = Path(ca_root) / "rootCA.pem"
-
-    # Clean up old certificates
-    cleanup_old_certificates(cert_dir)
-
-    if astronomer_private_ca_key_file.exists() and astronomer_private_ca_cert_file.exists():
-        print("Using existing astronomer-private-ca certificates")
-        return
-
-    # Generate the private CA certificate and key.
-    subprocess.run(
-        [
-            MKCERT_EXE,
-            f"-cert-file={astronomer_private_ca_cert_file}",
-            f"-key-file={astronomer_private_ca_key_file}",
-            "server.example.org",
-        ],
-        check=True,
-    )
-
-    # Error checking
-    if not astronomer_private_ca_cert_file.exists():
-        raise FileNotFoundError(f"Certificate file not found: {astronomer_private_ca_cert_file}")
-    if not astronomer_private_ca_key_file.exists():
-        raise FileNotFoundError(f"Key file not found: {astronomer_private_ca_key_file}")
-    if not ca_root_pem.exists():
-        raise FileNotFoundError(f"CA root PEM file not found: {ca_root_pem}")
-
-    # Validate the generated certificate
-    is_valid, message = validate_certificate(astronomer_private_ca_cert_file)
-    if not is_valid:
-        raise RuntimeError(f"Generated certificate is invalid: {message}")
-
-    print(f"Certificate and key generated:\n  Cert: {astronomer_private_ca_cert_file}\n  Key: {astronomer_private_ca_key_file}")
-
-
 def main():
     parser = argparse.ArgumentParser(description="Astronomer Software Certificate Manager using mkcert")
     subparsers = parser.add_subparsers(dest="command", required=True, help="Action to perform")
 
     subparsers.add_parser("cleanup", help="Remove expiring certificates")
     subparsers.add_parser("generate-tls", help="Create astronomer-tls certificates")
-    subparsers.add_parser("generate-private-ca", help="Create astronomer-private-ca certificates")
     validate_parser = subparsers.add_parser("validate", help="Validate a certificate")
     validate_parser.add_argument("cert_path", type=str, help="Path to the certificate file")
 
@@ -197,8 +145,6 @@ def main():
             cleanup_old_certificates(cert_dir)
         case "generate-tls":
             create_astronomer_tls_certificates()
-        case "generate-private-ca":
-            create_astronomer_private_ca_certificates()
         case "validate":
             path = Path(args.cert_path)
             is_valid, message = validate_certificate(path)

--- a/bin/k3d_setup_shared.py
+++ b/bin/k3d_setup_shared.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Shared helpers for the local k3d setup scripts (setup-cp-dp-k3d.py, setup-037x-k3d.py).
+Shared helpers for the local k3d setup scripts (setup-cp-dp-k3d.py, setup-037x-k3d.py), plus
+the mkcert helpers (_mkcert_path, _mkcert_caroot) also used by the KIND-topology setup-kind.py.
 
-Not a standalone entry point — imported directly (both scripts live in this same `bin/`
+Not a standalone entry point — imported directly (all these scripts live in this same `bin/`
 directory, which Python puts on `sys.path` automatically when the script is run, matching the
 existing `helm_chart_values_migration_shared.py` / `certs.py` sibling-import pattern in this repo).
 

--- a/bin/reset-local-dev
+++ b/bin/reset-local-dev
@@ -38,10 +38,12 @@ set -ex
 # bare `helm template` call). Export it here so it's on PATH for the rest of this script.
 export PATH="${HOME}/.local/share/astronomer-software/bin:${PATH}"
 
-# Generate certificates in ~/.local/share/astronomer-software/certs
+# Generate certificates in ~/.local/share/astronomer-software/certs. (No separate
+# "private CA" step: setup-kind.py resolves mkcert's own root CA directly, via the same
+# mkcert -CAROOT mechanism the k3d CP/DP topology's setup script uses, and generate-tls
+# above already ran `mkcert -install` so that CA root exists.)
 "${BIN_DIR}/certs.py" cleanup
 "${BIN_DIR}/certs.py" generate-tls
-"${BIN_DIR}/certs.py" generate-private-ca
 
 # Create a KIND cluster and configure it for testing
 "${BIN_DIR}/setup-kind.py" "--topology=${TOPOLOGY}"

--- a/bin/setup-kind.py
+++ b/bin/setup-kind.py
@@ -11,10 +11,10 @@ from pathlib import Path
 
 import yaml
 from certs import (
-    astronomer_private_ca_cert_file,
     astronomer_tls_cert_file,
     astronomer_tls_key_file,
 )
+from k3d_setup_shared import _mkcert_caroot, _mkcert_path
 from kubernetes import client, config
 from kubernetes.client.exceptions import ApiException
 
@@ -280,16 +280,22 @@ def setup_common_cluster_configs() -> None:
     """
     create_namespace()
     create_astronomer_tls_secret()
-    create_private_ca_secret()
+    create_mkcert_root_ca_secret()
 
 
-def create_private_ca_secret() -> None:
+def create_mkcert_root_ca_secret() -> None:
     """
-    Create the private-ca secret in the KIND cluster using self-signed certificates.
+    Create the mkcert-root-ca secret in the KIND cluster: mkcert's own root CA (the same
+    CA that signs astronomer-tls, via create_astronomer_tls_certificates()'s `mkcert -install`),
+    so the platform trusts its own dev TLS chain -- the identical role the k3d CP/DP topology's
+    `--mkcert-root-ca-secret-name` secret plays via _mkcert_caroot() in k3d_setup_shared.py.
+    Both topologies now share that one helper and one secret name/content; there is no separate
+    KIND-only "private CA" concept.
 
     Raises:
         RuntimeError: If secret creation fails.
     """
+    root_ca = _mkcert_caroot(_mkcert_path())
 
     cmd = [
         KUBECTL_EXE,
@@ -298,14 +304,19 @@ def create_private_ca_secret() -> None:
         "create",
         "secret",
         "generic",
-        "private-ca",
-        f"--from-file={astronomer_private_ca_cert_file}",
+        "mkcert-root-ca",
+        # Every consumer of global.privateCaCerts (custom_ca_volume_mounts / custom_ca_volumes
+        # in charts/astronomer/templates/_helpers.yaml, plus the copies in the alertmanager,
+        # prometheus, and vector subcharts) mounts each secret with `subPath: cert.pem`, per the
+        # contract documented in configs/local-dev.yaml ("Each secret must have one data entry
+        # 'cert.pem'"), so the key= prefix here is required, not optional.
+        f"--from-file=cert.pem={root_ca}",
     ]
     if DEBUG:
         cmd.append("-v=9")
     result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
-        raise RuntimeError(f"Failed to create secret private-ca in namespace astronomer: {result.stderr}")
+        raise RuntimeError(f"Failed to create secret mkcert-root-ca in namespace astronomer: {result.stderr}")
 
 
 def wait_for_pods_ready(timeout: int = 300) -> None:

--- a/configs/enable-git-sync-deploys.yaml
+++ b/configs/enable-git-sync-deploys.yaml
@@ -36,6 +36,12 @@ global:
   # must re-list mkcert-root-ca here or the DP commander stops trusting houston
   # and its JWKS hook fails with CERTIFICATE_VERIFY_FAILED / self-signed
   # certificate in chain.
+  #
+  # mkcert-root-ca is the same secret name/content/mechanism topology=unified (KIND) uses too
+  # (bin/setup-kind.py, via the shared _mkcert_caroot() helper in k3d_setup_shared.py) -- see
+  # configs/enable-git-sync-private-ca.yaml. The two topologies used to have separately-named,
+  # separately-generated secrets for this, which is what let PR #3494 accidentally swap the
+  # wrong one in over there; they're unified onto this one name now.
   # privateCaCerts:
   #   - mkcert-root-ca
   #   - git-forgejo-ca

--- a/configs/enable-git-sync-private-ca.yaml
+++ b/configs/enable-git-sync-private-ca.yaml
@@ -29,10 +29,18 @@ astronomer:
 
 global:
   # Helm REPLACES list values across -f files. configs/local-dev.yaml (applied earlier in
-  # the values order) sets [private-ca], so it MUST be re-listed here or the platform stops
+  # the values order) sets [mkcert-root-ca], so it MUST be re-listed here or the platform stops
   # trusting its own astronomer-tls CA. forgejo-ca is added so commander trusts it too, which
   # is what config-time credential validation against the private-CA Forgejo host needs
   # (TC-CA-12) -- a distinct trust layer from the relay's deployment-namespace mount.
+  #
+  # mkcert-root-ca is the SAME secret name/content/mechanism the k3d CP/DP topology uses
+  # (bin/setup-cp-dp-k3d.py's --mkcert-root-ca-secret-name) -- bin/setup-kind.py creates it here
+  # via the same _mkcert_caroot() helper. It used to be a separately-named, separately-generated
+  # `private-ca` fixture unique to this KIND topology; that duplication is what let PR #3494
+  # accidentally swap in the (at the time, different and nonexistent-here) k3d name, hanging
+  # every pod that mounts global.privateCaCerts until the install timed out (reverted in
+  # 11c238ebd, then unified for real by collapsing both topologies onto this one name/mechanism).
   privateCaCerts:
-    - private-ca
+    - mkcert-root-ca
     - forgejo-ca

--- a/configs/enable-git-sync-private-ca.yaml
+++ b/configs/enable-git-sync-private-ca.yaml
@@ -26,7 +26,6 @@ astronomer:
             metrics:
               enabled: true
 
-
 global:
   # Helm REPLACES list values across -f files. configs/local-dev.yaml (applied earlier in
   # the values order) sets [mkcert-root-ca], so it MUST be re-listed here or the platform stops

--- a/configs/enable-psa.yaml
+++ b/configs/enable-psa.yaml
@@ -18,5 +18,5 @@ global:
     # sysctl init); disable those or keep the platform ns on audit/warn only.
     pod-security.kubernetes.io/enforce: "restricted"
     pod-security.kubernetes.io/enforce-version: "latest"
-    pod-security.kubernetes.io/audit: "restricted"  # check the audit logs. This is nontrivial in k3d.
-    pod-security.kubernetes.io/warn: "restricted"  # check commander logs for `"msg"="Warning`
+    pod-security.kubernetes.io/audit: "restricted" # check the audit logs. This is nontrivial in k3d.
+    pod-security.kubernetes.io/warn: "restricted" # check commander logs for `"msg"="Warning`

--- a/configs/local-dev-ha.yaml
+++ b/configs/local-dev-ha.yaml
@@ -60,7 +60,6 @@ astronomer:
         cpu: "0m"
         memory: "0Mi"
 
-
 #################################
 ## Nginx configuration
 #################################

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -33,10 +33,15 @@ global:
     enabled: true
   ssl:
     enabled: false
-  # Custom CA TLS certificates
-  # Each secret must have one data entry 'cert.pem'
+  # Custom CA TLS certificates. Each secret must have one data entry 'cert.pem'.
+  # mkcert-root-ca (bin/setup-kind.py) is mkcert's own root CA -- the same CA that signs
+  # astronomer-tls above -- so the platform trusts its own dev TLS chain. This is the same
+  # secret name/content/mechanism the k3d CP/DP topology uses (bin/setup-cp-dp-k3d.py's
+  # --mkcert-root-ca-secret-name, default mkcert-root-ca) -- keep the two in sync; do not
+  # reintroduce a separately-named KIND-only secret here (see PR #3494 / commit 11c238ebd for
+  # the regression that shipped from having two names for this one concept).
   privateCaCerts:
-  - private-ca
+  - mkcert-root-ca
   deployMechanisms:
     dagOnlyDeployment:
       enabled: true

--- a/configs/local-dev.yaml
+++ b/configs/local-dev.yaml
@@ -41,7 +41,7 @@ global:
   # reintroduce a separately-named KIND-only secret here (see PR #3494 / commit 11c238ebd for
   # the regression that shipped from having two names for this one concept).
   privateCaCerts:
-  - mkcert-root-ca
+    - mkcert-root-ca
   deployMechanisms:
     dagOnlyDeployment:
       enabled: true
@@ -118,7 +118,6 @@ astronomer:
       requests:
         cpu: "0m"
         memory: "0Mi"
-
 
 #################################
 ## Nginx configuration


### PR DESCRIPTION
## Description

`topology=unified`/KIND (`bin/setup-kind.py`) and the k3d CP/DP topology (`bin/setup-cp-dp-k3d.py`) each independently built their own "mint a locally-trusted CA via mkcert and register it as a Secret" step, under two different names: `private-ca` (KIND) and `mkcert-root-ca` (k3d). No shared code, no shared convention.

That let PR #3494 accidentally swap `private-ca` for `mkcert-root-ca` in `configs/enable-git-sync-private-ca.yaml`, which doesn't exist as a secret under `topology=unified`. Every pod mounting `global.privateCaCerts` (`commander`, `houston`, `registry`, `alertmanager`, `prometheus`, `vector`) hit `FailedMount` and hung until the install timed out. Sudarshan reverted the name in `11c238ebd`.

Diagnosing that turned up two more bugs in the KIND-side fixture:
- `bin/setup-kind.py` created the `private-ca` secret via `--from-file={path}` with no `cert.pem=` key prefix, so the data key defaulted to the file's basename instead of the `cert.pem` key every consumer's `subPath` mount requires.
- The fixture's content was a leaf certificate for a fake hostname (`server.example.org`), not a CA at all, so it couldn't have been doing what `configs/local-dev.yaml`'s own comment claimed ("or the platform stops trusting its own astronomer-tls CA").

This PR collapses both topologies onto one name, one mechanism:

- `bin/setup-kind.py` now resolves the CA via `_mkcert_caroot()`/`_mkcert_path()` (`bin/k3d_setup_shared.py`), the same helper the k3d topology already used, instead of minting its own leaf-cert fixture.
- Removed `bin/certs.py`'s `create_astronomer_private_ca_certificates()` and the `generate-private-ca` subcommand (and its call in `bin/reset-local-dev`) as dead code now that KIND doesn't mint its own cert.
- Secret is `mkcert-root-ca` in both topologies now. Updated `configs/local-dev.yaml`, `configs/enable-git-sync-private-ca.yaml`, `configs/enable-git-sync-deploys.yaml` with comments on the history so this doesn't regrow a second name.

## Related Issues

https://linear.app/astronomer/issue/PINF-1202

## Testing

`bin/certs.py`, `bin/setup-kind.py`, `bin/k3d_setup_shared.py` parse; `bin/reset-local-dev` passes `bash -n`; the three edited YAML configs parse. `uv run pytest tests/chart_tests/test_privateca.py tests/chart_tests/test_containerd_privateca.py tests/chart_tests/test_security_context_override.py tests/chart_tests/test_default_chart.py` — 295 passed, 48 skipped, unaffected as expected since none of this touches chart templates. Haven't re-run the `git-sync-private-ca` CI scenario itself yet against this branch.

I have also tested this in my private-ca git-sync https+pat setup locally and it works.