### PR TITLE
Fix `release_bom` on release-1.2: Python 3.12 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
   release_bom:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-05
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - checkout
       - run:
@@ -70,7 +70,7 @@ jobs:
 
   run_pre_commit:
     docker:
-      - image: quay.io/astronomer/ci-pre-commit:2026-05
+      - image: quay.io/astronomer/ci-pre-commit:2026-08
     resource_class: small
     steps:
       - checkout
@@ -95,7 +95,7 @@ jobs:
 
   test-unit:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-05
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     # https://circleci.com/docs/using-docker/#x86
     resource_class: large
     parallelism: 4
@@ -131,7 +131,7 @@ jobs:
 
   build-artifact:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-05
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     parameters:
       qa_release:
         type: boolean
@@ -150,7 +150,7 @@ jobs:
 
   release-to-internal:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-05
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -189,7 +189,7 @@ jobs:
 
   release-to-public:
     docker:
-      - image: quay.io/astronomer/ci-helm-release:2026-05
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/bin/generate_circleci_config.py
+++ b/bin/generate_circleci_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""This script is used to create the circle config file so that we can stay
-DRY."""
+"""Generate the CircleCI config."""
 
+import datetime
 import subprocess
 from pathlib import Path
 
@@ -12,7 +12,7 @@ git_root_dir = next(iter([x for x in Path(__file__).resolve().parents if (x / ".
 metadata = yaml.safe_load((git_root_dir / "metadata.yaml").read_text())
 kube_versions = metadata["test_k8s_versions"]
 
-ci_runner_version = "2026-05"  # This should be the current YYYY-MM
+ci_runner_version = (datetime.datetime.now()).strftime("%Y-%m")
 machine_image_version = "ubuntu-2404:2026.05.1"  # https://circleci.com/developer/machine/image/ubuntu-2404
 
 


### PR DESCRIPTION
## Description

This PR fixes `release_bom` failure on this branch:
```
ERROR: Package 'astronomer-bom-generator' requires a different Python: 3.12.3 not in '>=3.13'
```

## Related Issues

Related astronomer/issues#XXXX


## Merging

1.2,1.1