### PR TITLE
Fix `sign-released-image`: pyenv shim breaks after cosign orb install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,8 @@ parameters:
 
 jobs:
   sign-released-image:
-    executor: docker-executor
+    docker:
+      - image: quay.io/astronomer/ci-helm-release:2026-08
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -36,7 +36,8 @@ parameters:
 
 jobs:
   sign-released-image:
-    executor: docker-executor
+    docker:
+      - image: quay.io/astronomer/ci-helm-release:{{ ci_runner_version }}
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
## Description

The "Install Python dependencies" step fails on every branch:
```
/home/circleci/.pyenv/libexec/pyenv-exec: line 24: pyenv-version-name: command not found
Exited with code exit status 127
```

## Related Issues

Related astronomer/issues#XXXX



## Merging

Master, 1.1,1.2,2.0,2.1