### PR TITLE
APC-1615: Expose worker queue feature flag and per-deployment cap <DO NOT MERGE>

### DIFF
--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -121,6 +121,10 @@ data:
         dagOnlyDeployment:
           enabled: {{ .Values.global.deployMechanisms.dagOnlyDeployment.enabled }}
 
+      workerQueues:
+        enabled: {{ .Values.global.workerQueues.enabled }}
+        maxPerDeployment: {{ .Values.global.workerQueues.maxPerDeployment }}
+
       {{- $grafanaLinkEnabled := true }}
       {{- if and (hasKey .Values.global "grafana") (kindIs "map" .Values.global.grafana) (hasKey .Values.global.grafana "enabled") }}
       {{- $grafanaLinkEnabled = .Values.global.grafana.enabled }}

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -277,6 +277,36 @@ def test_houston_configmap_with_config_syncer_disabled():
     assert "extraVolumes" not in prod_yaml["deployments"]["helm"]["airflow"]["webserver"]
 
 
+def test_houston_configmap_worker_queues_disabled_by_default():
+    """Worker queues currently ships off by default."""
+    docs = render_chart(
+        values={},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    worker_queues = prod_yaml["deployments"]["workerQueues"]
+    assert worker_queues["enabled"] is False
+    assert worker_queues["maxPerDeployment"] == 10
+
+
+def test_houston_configmap_worker_queues_enabled():
+    """Validate worker queues can be enabled and the cap overridden."""
+    docs = render_chart(
+        values={"global": {"workerQueues": {"enabled": True, "maxPerDeployment": 5}}},
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    doc = docs[0]
+    prod_yaml = yaml.safe_load(doc["data"]["production.yaml"])
+    worker_queues = prod_yaml["deployments"]["workerQueues"]
+    assert worker_queues["enabled"] is True
+    assert worker_queues["maxPerDeployment"] == 5
+
+
 def test_houston_configmap_with_vector_index_prefix_defaults():
     """Validate the houston configmap and its embedded data with configSyncer
     disabled."""

--- a/tests/enable_all_features.yaml
+++ b/tests/enable_all_features.yaml
@@ -69,6 +69,8 @@ global:
   deployMechanisms:
     dagOnlyDeployment:
       enabled: true
+  workerQueues:
+    enabled: true
   logging:
     loggingSidecar:
       enabled: true

--- a/values.yaml
+++ b/values.yaml
@@ -179,6 +179,18 @@ global:
       dagTarballVersionValidation:
         enabled: true
 
+  # Worker queues: multiple named Celery worker groups per Airflow deployment.
+  workerQueues:
+    enabled: false
+    # Maximum worker queues per deployment. This is not resource protection --
+    # per-queue CPU, memory and replica bounds already come from
+    # resourceManagement.components[workers]. The cap exists because every queue
+    # adds a full podTemplateSpec to the Airflow CR's spec.workers[] array, and a
+    # Kubernetes object has a hard ceiling of roughly 1.5 MiB. Past it the apply
+    # is rejected outright, so the deployment stops reconciling. Raise at your
+    # own risk.
+    maxPerDeployment: 10
+
   # Deploy mechanisms
   deployMechanisms:
     dagOnlyDeployment:


### PR DESCRIPTION
## Description

This PR Adds global.workerQueues and renders it into the Houston ConfigMap, so platform admins can turn the Worker Queues feature on at install/upgrade time.
```
global:
  workerQueues:
    enabled: false
    maxPerDeployment: 10
```
## Related Issues

https://linear.app/astronomer/issue/APC-1615/wq-04-add-worker-queue-feature-flag-and-per-deployment-cap-config-keys

## Testing

- Added Testcases

## Merging

Master