### PR TITLE
PINF-1236: Fix sign-released-image version resolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,28 +32,24 @@ jobs:
             echo "$DOCKER_PASSWORD" | cosign login docker.io --username $DOCKER_USERNAME --password-stdin
             echo "$QUAY_PASSWORD" | cosign login quay.io --username $QUAY_USERNAME --password-stdin
       - run:
-          name: Set image tag to sign
-          command: |
-            set -xe
-            # Only sign tagged releases or specific QA releases
-            # For regular release job
-            if [ -n "$NEXT_TAG" ]; then
-              echo "export IMAGE_TAG=$NEXT_TAG" >> $BASH_ENV
-            # For custom QA release job
-            elif [ -n "$IMG_TAG" ]; then
-              echo "export IMAGE_TAG=$IMG_TAG" >> $BASH_ENV
-            else
-              echo "No specific release tag found, skipping image signing"
-              exit 0
-            fi
-      - run:
           name: Install Python dependencies
           command: pip install requests
       - run:
           name: Sign Docker images with cosign
           command: |
-            # Execute the signing script with version from environment
-            python bin/sign-images.py --version "${IMAGE_TAG}"
+            set -xe
+            # This job runs only from release-bom-workflow, which is tag-triggered, so
+            # CIRCLE_TAG is always set. Fail loudly rather than silently skipping if it
+            # is not: the previous "exit 0" guard ended only this step, so the job went
+            # on to run sign-images.py with an empty --version and died there instead.
+            if [ -z "$CIRCLE_TAG" ]; then
+              echo "CIRCLE_TAG is not set; sign-released-image only runs on tag builds" >&2
+              exit 1
+            fi
+            # sign-images.py reads the published BOM at
+            # updates.astronomer.io/astronomer-software/releases/astronomer-<version>.json,
+            # which is keyed by chart version, so drop the tag's leading "v".
+            python bin/sign-images.py --version "${CIRCLE_TAG#v}"
 
   release_bom:
     docker:
@@ -665,18 +661,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-      - sign-released-image:
-          name: sign-release-image
-          context:
-            - quay.io
-            - docker.io
-            - software-cosign-keys
-          requires:
-            - release-to-public
-          filters:
-            branches:
-              only:
-                - '/^release-\d+\.\d+$/'
 
   release-bom-workflow:
     jobs:
@@ -689,6 +673,20 @@ workflows:
           context:
             - github-repo
             - gcp-astronomer-prod
+      # Signing consumes the BOM that release_bom publishes, so it must run after it.
+      - sign-released-image:
+          name: sign-release-image
+          requires:
+            - release_bom
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-?(rc(\.\d+)?|alpha(\.\d+)?)?)?$/
+            branches:
+              ignore: /.*/
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
 
   qa-build-and-release-helm-chart:
     when: << pipeline.parameters.qa-release >>

--- a/.circleci/config.yml.j2
+++ b/.circleci/config.yml.j2
@@ -48,28 +48,24 @@ jobs:
             echo "$DOCKER_PASSWORD" | cosign login docker.io --username $DOCKER_USERNAME --password-stdin
             echo "$QUAY_PASSWORD" | cosign login quay.io --username $QUAY_USERNAME --password-stdin
       - run:
-          name: Set image tag to sign
-          command: |
-            set -xe
-            # Only sign tagged releases or specific QA releases
-            # For regular release job
-            if [ -n "$NEXT_TAG" ]; then
-              echo "export IMAGE_TAG=$NEXT_TAG" >> $BASH_ENV
-            # For custom QA release job
-            elif [ -n "$IMG_TAG" ]; then
-              echo "export IMAGE_TAG=$IMG_TAG" >> $BASH_ENV
-            else
-              echo "No specific release tag found, skipping image signing"
-              exit 0
-            fi
-      - run:
           name: Install Python dependencies
           command: pip install requests
       - run:
           name: Sign Docker images with cosign
           command: |
-            # Execute the signing script with version from environment
-            python bin/sign-images.py --version "${IMAGE_TAG}"
+            set -xe
+            # This job runs only from release-bom-workflow, which is tag-triggered, so
+            # CIRCLE_TAG is always set. Fail loudly rather than silently skipping if it
+            # is not: the previous "exit 0" guard ended only this step, so the job went
+            # on to run sign-images.py with an empty --version and died there instead.
+            if [ -z "$CIRCLE_TAG" ]; then
+              echo "CIRCLE_TAG is not set; sign-released-image only runs on tag builds" >&2
+              exit 1
+            fi
+            # sign-images.py reads the published BOM at
+            # updates.astronomer.io/astronomer-software/releases/astronomer-<version>.json,
+            # which is keyed by chart version, so drop the tag's leading "v".
+            python bin/sign-images.py --version "${CIRCLE_TAG#v}"
 
   release_bom:
     docker:
@@ -465,18 +461,6 @@ workflows:
             branches:
               only:
                 - '/^release-\d+\.\d+$/'
-      - sign-released-image:
-          name: sign-release-image
-          context:
-            - quay.io
-            - docker.io
-            - software-cosign-keys
-          requires:
-            - release-to-public
-          filters:
-            branches:
-              only:
-                - '/^release-\d+\.\d+$/'
 
   release-bom-workflow:
     jobs:
@@ -489,6 +473,20 @@ workflows:
           context:
             - github-repo
             - gcp-astronomer-prod
+      # Signing consumes the BOM that release_bom publishes, so it must run after it.
+      - sign-released-image:
+          name: sign-release-image
+          requires:
+            - release_bom
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+(-?(rc(\.\d+)?|alpha(\.\d+)?)?)?$/
+            branches:
+              ignore: /.*/
+          context:
+            - quay.io
+            - docker.io
+            - software-cosign-keys
 
   qa-build-and-release-helm-chart:
     when: << pipeline.parameters.qa-release >>


### PR DESCRIPTION
## Description

PR Fixes `sign-released-image`: derive version from CIRCLE_TAG, run after release_bom.

## Changes
- Moved sign-released-image out of build-and-release-helm-chart (branch-filtered) into release-bom-workflow (tag-filtered), with requires: release_bom so the BOM exists before signing reads it.
- Version now comes from CIRCLE_TAG with the leading v stripped (--version "${CIRCLE_TAG#v}"), matching the BOM's chart-version key.
- Removed the Set image tag to sign step and its ineffective exit 0 guard. If CIRCLE_TAG is somehow unset the job now fails loudly instead of falling through to an empty --version.

## Related Issues

https://linear.app/astronomer/issue/PINF-1236/release-pipeline-release-bom-and-sign-released-image-failures-root


## Testing

- Not verifiable pre-merge: an actual signing run requires a real release tag, since the job is now tag-triggered by design.

## Merging

Main, 1.x, 2.x