### PR TITLE
APC-1771: Make the Houston database schema configurable instead of hardcoded

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -171,6 +171,16 @@ gcp_cloud_logging:
 {{ default (printf "%s-houston-backend" .Release.Name) .Values.houston.backendSecretName }}
 {{- end }}
 
+{{/*
+Percent-encode a value for a URI userinfo or path component. urlquery targets
+query strings, where a space is "+", but in userinfo a "+" is a literal plus, so
+spaces have to be %20. A real "+" is already %2B by then and the replace leaves
+it alone.
+*/}}
+{{ define "houston.uriComponent" -}}
+{{ urlquery . | replace "+" "%20" }}
+{{- end }}
+
 {{ define "houston.airflowBackendSecret" -}}
 {{ default (printf "%s" (include "houston.backendSecret" .)) .Values.houston.airflowBackendSecretName }}
 {{- end }}

--- a/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
@@ -2,7 +2,15 @@
 ## Houston Bootstrap Secrets ##
 ###############################
 {{- if or (eq .Values.global.plane.mode "control") (eq .Values.global.plane.mode "unified") }}
-{{- if and (not .Values.houston.backendSecretName) (not .Values.houston.backendConnection) }}
+{{- /*
+  Rendered when the customer is not bringing their own secret. The
+  backendSecretConnection clause below builds the connection string from
+  backendConnection, so allow that combination through too -- it used to be
+  excluded by the (not .Values.houston.backendConnection) test, which made the
+  clause unreachable (APC-859). Supplying backendConnection without the opt-in
+  still skips this template, as before.
+*/}}
+{{- if and (not .Values.houston.backendSecretName) (or (not .Values.houston.backendConnection) .Values.houston.backendSecretConnection) }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (include "houston.backendSecret" .)) | default dict }}
 {{- $existingConnection := dig "data" "connection" "" $existingSecret }}
 kind: Secret
@@ -22,8 +30,14 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.houston.backendSecretConnection }}
-  # in prisma1 has hardcoded schema, so for now to migrate to prisma2 we need to hardcode it too.
-  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=houston%24default" .Values.houston.backendConnection.user .Values.houston.backendConnection.pass .Values.houston.backendConnection.host (.Values.houston.backendConnection.port | toString) .Values.houston.backendConnection.db) | b64enc | quote }}
+  {{- /*
+    The schema goes through urlquery because Prisma reads it from this query
+    parameter, and the default contains a "$" that has to arrive as %24. Passing
+    it as a %s argument rather than writing it into the format string also keeps
+    printf from reading the escape as a width specifier -- "%24default" was
+    parsed as a width-24 %d verb and rendered "%!d(MISSING)".
+  */}}
+  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=%s" .Values.houston.backendConnection.user .Values.houston.backendConnection.pass .Values.houston.backendConnection.host (.Values.houston.backendConnection.port | toString) .Values.houston.backendConnection.db (urlquery .Values.global.houston.schemaName)) | b64enc | quote }}
   {{- else if $existingConnection }}
   connection: {{ $existingConnection | quote }}
   {{- else }}

--- a/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
@@ -31,13 +31,21 @@ type: Opaque
 data:
   {{- if .Values.houston.backendSecretConnection }}
   {{- /*
-    The schema goes through urlquery because Prisma reads it from this query
-    parameter, and the default contains a "$" that has to arrive as %24. Passing
-    it as a %s argument rather than writing it into the format string also keeps
-    printf from reading the escape as a width specifier -- "%24default" was
-    parsed as a width-24 %d verb and rendered "%!d(MISSING)".
+    Every interpolated component is percent-encoded, because a "/", "?", "#" or
+    "@" in a password would otherwise be read as URI structure and the
+    connection would fail. This is also what the bootstrapper expects of a
+    connection string it is handed -- it calls unquote() on the password.
+
+    userinfo and the path use houston.uriComponent rather than urlquery, since
+    urlquery renders a space as "+" and a "+" in userinfo is a literal plus. The
+    schema keeps urlquery because it really is a query parameter.
+
+    Passing the schema as a %s argument rather than writing it into the format
+    string also keeps printf away from the escape -- "%24default" was parsed as
+    a width-24 %d verb and rendered "%!d(MISSING)".
   */}}
-  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=%s" .Values.houston.backendConnection.user .Values.houston.backendConnection.pass .Values.houston.backendConnection.host (.Values.houston.backendConnection.port | toString) .Values.houston.backendConnection.db (urlquery .Values.global.houston.schemaName)) | b64enc | quote }}
+  {{- $conn := .Values.houston.backendConnection }}
+  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=%s" (include "houston.uriComponent" $conn.user) (include "houston.uriComponent" $conn.pass) $conn.host ($conn.port | toString) (include "houston.uriComponent" $conn.db) (urlquery .Values.global.houston.schemaName)) | b64enc | quote }}
   {{- else if $existingConnection }}
   connection: {{ $existingConnection | quote }}
   {{- else }}

--- a/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
+++ b/charts/astronomer/templates/houston/api/houston-backend-secret.yaml
@@ -7,7 +7,7 @@
   backendSecretConnection clause below builds the connection string from
   backendConnection, so allow that combination through too -- it used to be
   excluded by the (not .Values.houston.backendConnection) test, which made the
-  clause unreachable (APC-859). Supplying backendConnection without the opt-in
+  clause unreachable. Supplying backendConnection without the opt-in
   still skips this template, as before.
 */}}
 {{- if and (not .Values.houston.backendSecretName) (or (not .Values.houston.backendConnection) .Values.houston.backendSecretConnection) }}
@@ -45,7 +45,7 @@ data:
     a width-24 %d verb and rendered "%!d(MISSING)".
   */}}
   {{- $conn := .Values.houston.backendConnection }}
-  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=%s" (include "houston.uriComponent" $conn.user) (include "houston.uriComponent" $conn.pass) $conn.host ($conn.port | toString) (include "houston.uriComponent" $conn.db) (urlquery .Values.global.houston.schemaName)) | b64enc | quote }}
+  connection: {{ (printf "postgresql://%s:%s@%s:%s/%s?schema=%s" (include "houston.uriComponent" $conn.user) (include "houston.uriComponent" $conn.pass) $conn.host ($conn.port | toString) (include "houston.uriComponent" $conn.db) (urlquery .Values.global.houston.database.schemaName)) | b64enc | quote }}
   {{- else if $existingConnection }}
   connection: {{ $existingConnection | quote }}
   {{- else }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -109,7 +109,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/api/houston-deployment.yaml
+++ b/charts/astronomer/templates/houston/api/houston-deployment.yaml
@@ -109,7 +109,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
@@ -116,7 +116,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml
@@ -115,9 +115,8 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
-            # we need to hardcode it to be able to upgrade from prisma1 to prisma2
             - name: SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -92,9 +92,8 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
-            # we need to hardcode it to be able to upgrade from prisma1 to prisma2
             - name: SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml
@@ -93,7 +93,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -96,9 +96,8 @@ spec:
                 secretKeyRef:
                   name: astronomer-bootstrap
                   key: connection
-            # we need to hardcode it to be able to upgrade from prisma1 to prisma2
             - name: SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
+++ b/charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml
@@ -97,7 +97,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -109,7 +109,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
+++ b/charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml
@@ -109,7 +109,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             {{- if and .Values.global.ssl.enabled .Values.global.ssl.mode }}
             - name: SSLMODE
               value: {{ .Values.global.ssl.mode }}

--- a/charts/prometheus-postgres-exporter/templates/configmap.yaml
+++ b/charts/prometheus-postgres-exporter/templates/configmap.yaml
@@ -15,6 +15,6 @@ data:
   {{- /*
     tpl rather than a plain copy so the queries can reach global values -- the
     Houston schema in particular, since these queries read Houston's tables and
-    have to look in whichever schema it is using (APC-859).
+    have to look in whichever schema it is using.
   */}}
 {{ tpl .Values.config.queries . | indent 4 }}

--- a/charts/prometheus-postgres-exporter/templates/configmap.yaml
+++ b/charts/prometheus-postgres-exporter/templates/configmap.yaml
@@ -12,4 +12,9 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
   config.yaml: |
-{{ printf .Values.config.queries | indent 4 }}
+  {{- /*
+    tpl rather than a plain copy so the queries can reach global values -- the
+    Houston schema in particular, since these queries read Houston's tables and
+    have to look in whichever schema it is using (APC-859).
+  */}}
+{{ tpl .Values.config.queries . | indent 4 }}

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -102,7 +102,7 @@ config:
   queries: |-
     airflow_chart_version:
       query: |
-        SET search_path TO houston$default, public; select count(*) from "Deployment" where version != (select mode() within group (order by version) as version_group FROM "Deployment")
+        SET search_path TO "{{ .Values.global.houston.schemaName }}", public; select count(*) from "Deployment" where version != (select mode() within group (order by version) as version_group FROM "Deployment")
       master: false
       cache_seconds: 30
       metrics:

--- a/charts/prometheus-postgres-exporter/values.yaml
+++ b/charts/prometheus-postgres-exporter/values.yaml
@@ -102,7 +102,7 @@ config:
   queries: |-
     airflow_chart_version:
       query: |
-        SET search_path TO "{{ .Values.global.houston.schemaName }}", public; select count(*) from "Deployment" where version != (select mode() within group (order by version) as version_group FROM "Deployment")
+        SET search_path TO "{{ .Values.global.houston.database.schemaName }}", public; select count(*) from "Deployment" where version != (select mode() within group (order by version) as version_group FROM "Deployment")
       master: false
       cache_seconds: 30
       metrics:

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -191,7 +191,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: DATABASE_SCHEMA_NAME
-              value: "houston$default"
+              value: {{ .Values.global.houston.schemaName | quote }}
             - name: CLUSTER_TABLE_NAME
               value: Cluster
             - name: DEPLOYMENT_TABLE_NAME

--- a/charts/prometheus/templates/prometheus-statefulset.yaml
+++ b/charts/prometheus/templates/prometheus-statefulset.yaml
@@ -191,7 +191,7 @@ spec:
                   name: astronomer-bootstrap
                   key: connection
             - name: DATABASE_SCHEMA_NAME
-              value: {{ .Values.global.houston.schemaName | quote }}
+              value: {{ .Values.global.houston.database.schemaName | quote }}
             - name: CLUSTER_TABLE_NAME
               value: Cluster
             - name: DEPLOYMENT_TABLE_NAME

--- a/tests/chart_tests/test_houston_backend_secret.py
+++ b/tests/chart_tests/test_houston_backend_secret.py
@@ -1,4 +1,5 @@
 import base64
+from urllib.parse import unquote, urlparse
 
 import pytest
 
@@ -127,6 +128,67 @@ class TestHoustonBackendSecret:
         assert len(docs) == 1
         connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
         assert connection.endswith("?schema=my%24schema")
+
+    def test_houston_backend_secret_percent_encodes_credentials(self, kube_version):
+        """Test that credentials are percent-encoded rather than interpolated verbatim.
+
+        A "/", "?", "#" or "@" in a valid password is URI structure once it reaches
+        a connection string. Unencoded, "p/a?s#s" does not merely misparse -- the
+        host:port split lands on the password and the URL is rejected outright.
+        """
+        values = {
+            "astronomer": {
+                "houston": {
+                    "backendSecretConnection": True,
+                    "backendConnection": {
+                        "user": "svc@corp",
+                        "pass": "p/a?s#s",
+                        "host": "pg.example.com",
+                        "port": 5432,
+                        "db": "houston",
+                    },
+                }
+            }
+        }
+        docs = render_chart(kube_version=kube_version, values=values, show_only=[BACKEND_SECRET_FILE])
+
+        assert len(docs) == 1
+        connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
+        assert connection == "postgresql://svc%40corp:p%2Fa%3Fs%23s@pg.example.com:5432/houston?schema=houston%24default"
+
+        # The point of the encoding: it has to parse back to what was configured.
+        parsed = urlparse(connection)
+        assert parsed.hostname == "pg.example.com"
+        assert parsed.port == 5432
+        assert unquote(parsed.username) == "svc@corp"
+        assert unquote(parsed.password) == "p/a?s#s"
+
+    def test_houston_backend_secret_encodes_space_as_percent_20(self, kube_version):
+        """Test that a space in a password becomes %20 and not "+".
+
+        urlquery alone renders a space as "+", which is a literal plus in userinfo
+        rather than a space, so the password would arrive wrong.
+        """
+        values = {
+            "astronomer": {
+                "houston": {
+                    "backendSecretConnection": True,
+                    "backendConnection": {
+                        "user": "houston",
+                        "pass": "pa ss+word",
+                        "host": "pg.example.com",
+                        "port": 5432,
+                        "db": "houston",
+                    },
+                }
+            }
+        }
+        docs = render_chart(kube_version=kube_version, values=values, show_only=[BACKEND_SECRET_FILE])
+
+        assert len(docs) == 1
+        connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
+        assert "pa%20ss%2Bword" in connection
+        assert unquote(urlparse(connection).password) == "pa ss+word"
 
     def test_houston_backend_secret_not_rendered_for_connection_without_opt_in(self, kube_version):
         """Test that backendConnection alone still suppresses the managed secret.

--- a/tests/chart_tests/test_houston_backend_secret.py
+++ b/tests/chart_tests/test_houston_backend_secret.py
@@ -7,6 +7,17 @@ from tests.utils.chart import render_chart
 
 BACKEND_SECRET_FILE = "charts/astronomer/templates/houston/api/houston-backend-secret.yaml"
 
+BACKEND_CONNECTION_VALUES = {
+    "backendSecretConnection": True,
+    "backendConnection": {
+        "user": "houston",
+        "pass": "s3cr3t",
+        "host": "pg.example.com",
+        "port": 5432,
+        "db": "houston",
+    },
+}
+
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
 class TestHoustonBackendSecret:
@@ -64,3 +75,72 @@ class TestHoustonBackendSecret:
         assert len(docs) == 1
         assert docs[0]["kind"] == "Secret"
         assert "connection" in docs[0]["data"]
+
+    def test_houston_backend_secret_builds_connection_from_backend_connection(self, kube_version):
+        """Test that backendSecretConnection builds a usable URL from backendConnection.
+
+        Regression test for APC-859. This clause used to be unreachable, because the
+        template only rendered when backendConnection was empty, and its printf wrote
+        the schema escape into the format string, so "%24default" was read as a
+        width-24 %d verb and rendered "%!d(MISSING)".
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={"astronomer": {"houston": BACKEND_CONNECTION_VALUES}},
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 1
+        connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
+        assert connection == "postgresql://houston:s3cr3t@pg.example.com:5432/houston?schema=houston%24default"
+
+    def test_houston_backend_secret_honours_custom_schema_name(self, kube_version):
+        """Test that global.houston.schemaName reaches the connection URL."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"houston": {"schemaName": "public"}},
+                "astronomer": {"houston": BACKEND_CONNECTION_VALUES},
+            },
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 1
+        connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
+        assert connection.endswith("?schema=public")
+
+    def test_houston_backend_secret_url_encodes_schema_name(self, kube_version):
+        """Test that a schema name containing "$" is percent-encoded.
+
+        Prisma reads the schema from this query parameter, so a literal "$" has to
+        arrive as %24. The default name contains one, which is why this matters.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"houston": {"schemaName": "my$schema"}},
+                "astronomer": {"houston": BACKEND_CONNECTION_VALUES},
+            },
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 1
+        connection = base64.b64decode(docs[0]["data"]["connection"]).decode()
+        assert connection.endswith("?schema=my%24schema")
+
+    def test_houston_backend_secret_not_rendered_for_connection_without_opt_in(self, kube_version):
+        """Test that backendConnection alone still suppresses the managed secret.
+
+        Only backendSecretConnection opts into building the URL. Without it the
+        template stays skipped, as it was before APC-859, so an install relying on
+        the bootstrapper to write this secret is unaffected.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "astronomer": {"houston": {k: v for k, v in BACKEND_CONNECTION_VALUES.items() if k != "backendSecretConnection"}}
+            },
+            show_only=[BACKEND_SECRET_FILE],
+        )
+
+        assert len(docs) == 0

--- a/tests/chart_tests/test_houston_backend_secret.py
+++ b/tests/chart_tests/test_houston_backend_secret.py
@@ -80,7 +80,7 @@ class TestHoustonBackendSecret:
     def test_houston_backend_secret_builds_connection_from_backend_connection(self, kube_version):
         """Test that backendSecretConnection builds a usable URL from backendConnection.
 
-        Regression test for APC-859. This clause used to be unreachable, because the
+        Regression test: this clause used to be unreachable, because the
         template only rendered when backendConnection was empty, and its printf wrote
         the schema escape into the format string, so "%24default" was read as a
         width-24 %d verb and rendered "%!d(MISSING)".
@@ -96,11 +96,11 @@ class TestHoustonBackendSecret:
         assert connection == "postgresql://houston:s3cr3t@pg.example.com:5432/houston?schema=houston%24default"
 
     def test_houston_backend_secret_honours_custom_schema_name(self, kube_version):
-        """Test that global.houston.schemaName reaches the connection URL."""
+        """Test that global.houston.database.schemaName reaches the connection URL."""
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "global": {"houston": {"schemaName": "public"}},
+                "global": {"houston": {"database": {"schemaName": "public"}}},
                 "astronomer": {"houston": BACKEND_CONNECTION_VALUES},
             },
             show_only=[BACKEND_SECRET_FILE],
@@ -119,7 +119,7 @@ class TestHoustonBackendSecret:
         docs = render_chart(
             kube_version=kube_version,
             values={
-                "global": {"houston": {"schemaName": "my$schema"}},
+                "global": {"houston": {"database": {"schemaName": "my$schema"}}},
                 "astronomer": {"houston": BACKEND_CONNECTION_VALUES},
             },
             show_only=[BACKEND_SECRET_FILE],
@@ -194,7 +194,7 @@ class TestHoustonBackendSecret:
         """Test that backendConnection alone still suppresses the managed secret.
 
         Only backendSecretConnection opts into building the URL. Without it the
-        template stays skipped, as it was before APC-859, so an install relying on
+        template stays skipped, as it was before, so an install relying on
         the bootstrapper to write this secret is unaffected.
         """
         docs = render_chart(

--- a/tests/chart_tests/test_houston_db_schema.py
+++ b/tests/chart_tests/test_houston_db_schema.py
@@ -9,7 +9,7 @@ DEFAULT_SCHEMA = "houston$default"
 # Every template that has to agree on which Postgres schema Houston's tables live
 # in. The bootstrapper containers read SCHEMA_NAME to create the schema and to
 # write it into the connection secret; the prometheus filesd-reloader queries the
-# Houston tables directly and needs the same value (APC-859).
+# Houston tables directly and needs the same value.
 #
 # houston-cp-refresh-job is covered separately: it renders only in HA mode.
 SCHEMA_TEMPLATES = {
@@ -53,14 +53,14 @@ class TestHoustonDbSchema:
 
     @pytest.mark.parametrize("template", SCHEMA_TEMPLATES)
     def test_schema_honours_override(self, kube_version, template):
-        """Test that global.houston.schemaName overrides the default everywhere.
+        """Test that global.houston.database.schemaName overrides the default everywhere.
 
         The value is global because it spans the astronomer and prometheus
         subcharts, and a partial override would leave prometheus querying a schema
         Houston is not using.
         """
         container, env_var = SCHEMA_TEMPLATES[template]
-        values = {"global": {"houston": {"schemaName": "public"}}}
+        values = {"global": {"houston": {"database": {"schemaName": "public"}}}}
         assert _schema_value(kube_version, template, container, env_var, values) == "public"
 
     def test_schema_reaches_the_ha_only_cp_refresh_job(self, kube_version):
@@ -70,7 +70,7 @@ class TestHoustonDbSchema:
             "global": {
                 "plane": {"mode": "control"},
                 "controlPlaneHA": {"enabled": True, "globalBaseDomain": "astro.example.com"},
-                "houston": {"schemaName": "public"},
+                "houston": {"database": {"schemaName": "public"}},
             }
         }
         docs = render_chart(kube_version=kube_version, values=values, show_only=[template])
@@ -93,7 +93,7 @@ class TestHoustonDbSchema:
             values={
                 "global": {
                     "prometheusPostgresExporter": {"enabled": True},
-                    "houston": {"schemaName": schema_name},
+                    "houston": {"database": {"schemaName": schema_name}},
                 }
             },
             show_only=["charts/prometheus-postgres-exporter/templates/configmap.yaml"],
@@ -111,7 +111,7 @@ class TestHoustonDbSchema:
         The failure this guards against is a new template hardcoding the literal
         again, which would silently point one component at a different schema.
         """
-        docs = render_chart(kube_version=kube_version, values={"global": {"houston": {"schemaName": "public"}}})
+        docs = render_chart(kube_version=kube_version, values={"global": {"houston": {"database": {"schemaName": "public"}}}})
 
         found = set()
         for doc in docs:

--- a/tests/chart_tests/test_houston_db_schema.py
+++ b/tests/chart_tests/test_houston_db_schema.py
@@ -1,0 +1,99 @@
+import pytest
+
+from tests import supported_k8s_versions
+from tests.utils import get_containers_by_name, get_env_vars_dict
+from tests.utils.chart import render_chart
+
+DEFAULT_SCHEMA = "houston$default"
+
+# Every template that has to agree on which Postgres schema Houston's tables live
+# in. The bootstrapper containers read SCHEMA_NAME to create the schema and to
+# write it into the connection secret; the prometheus filesd-reloader queries the
+# Houston tables directly and needs the same value (APC-859).
+#
+# houston-cp-refresh-job is covered separately: it renders only in HA mode.
+SCHEMA_TEMPLATES = {
+    "charts/astronomer/templates/houston/api/houston-deployment.yaml": ("houston-bootstrapper", "SCHEMA_NAME"),
+    "charts/astronomer/templates/houston/worker/houston-worker-deployment.yaml": (
+        "houston-bootstrapper",
+        "SCHEMA_NAME",
+    ),
+    "charts/astronomer/templates/houston/helm-hooks/houston-db-migration-job.yaml": (
+        "houston-bootstrapper",
+        "SCHEMA_NAME",
+    ),
+    "charts/astronomer/templates/houston/helm-hooks/houston-upgrade-deployments-job.yaml": (
+        "houston-bootstrapper",
+        "SCHEMA_NAME",
+    ),
+    "charts/prometheus/templates/prometheus-statefulset.yaml": ("filesd-reloader", "DATABASE_SCHEMA_NAME"),
+}
+
+
+def _schema_value(kube_version, template, container, env_var, values=None):
+    """Render one template and return the schema env var on the given container."""
+    docs = render_chart(kube_version=kube_version, values=values, show_only=[template])
+    assert len(docs) == 1, f"{template} did not render"
+    containers = get_containers_by_name(docs[0], include_init_containers=True)
+    assert container in containers, f"{template} has no container named {container}"
+    return get_env_vars_dict(containers[container]["env"])[env_var]
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestHoustonDbSchema:
+    @pytest.mark.parametrize("template", SCHEMA_TEMPLATES)
+    def test_schema_defaults_to_houston_default(self, kube_version, template):
+        """Test that every template defaults to houston$default.
+
+        Existing installs have their tables in this schema, so the default must not
+        move. Changing it points Houston at an empty schema.
+        """
+        container, env_var = SCHEMA_TEMPLATES[template]
+        assert _schema_value(kube_version, template, container, env_var) == DEFAULT_SCHEMA
+
+    @pytest.mark.parametrize("template", SCHEMA_TEMPLATES)
+    def test_schema_honours_override(self, kube_version, template):
+        """Test that global.houston.schemaName overrides the default everywhere.
+
+        The value is global because it spans the astronomer and prometheus
+        subcharts, and a partial override would leave prometheus querying a schema
+        Houston is not using.
+        """
+        container, env_var = SCHEMA_TEMPLATES[template]
+        values = {"global": {"houston": {"schemaName": "public"}}}
+        assert _schema_value(kube_version, template, container, env_var, values) == "public"
+
+    def test_schema_reaches_the_ha_only_cp_refresh_job(self, kube_version):
+        """Test the HA-gated cp-refresh job, which the parametrised cases cannot render."""
+        template = "charts/astronomer/templates/houston/helm-hooks/houston-cp-refresh-job.yaml"
+        values = {
+            "global": {
+                "plane": {"mode": "control"},
+                "controlPlaneHA": {"enabled": True, "globalBaseDomain": "astro.example.com"},
+                "houston": {"schemaName": "public"},
+            }
+        }
+        docs = render_chart(kube_version=kube_version, values=values, show_only=[template])
+
+        assert len(docs) == 1
+        containers = get_containers_by_name(docs[0], include_init_containers=True)
+        assert get_env_vars_dict(containers["houston-bootstrapper"]["env"])["SCHEMA_NAME"] == "public"
+
+    def test_schema_is_consistent_across_the_whole_release(self, kube_version):
+        """Test that a full render never mixes schema values.
+
+        The failure this guards against is a new template hardcoding the literal
+        again, which would silently point one component at a different schema.
+        """
+        docs = render_chart(kube_version=kube_version, values={"global": {"houston": {"schemaName": "public"}}})
+
+        found = set()
+        for doc in docs:
+            pod_containers = get_containers_by_name(doc, include_init_containers=True) if "spec" in doc else {}
+            for container in pod_containers.values():
+                env = get_env_vars_dict(container.get("env") or [])
+                for name in ("SCHEMA_NAME", "DATABASE_SCHEMA_NAME"):
+                    if name in env:
+                        found.add(env[name])
+
+        assert found == {"public"}, f"schema values disagree across the release: {found}"

--- a/tests/chart_tests/test_houston_db_schema.py
+++ b/tests/chart_tests/test_houston_db_schema.py
@@ -79,6 +79,32 @@ class TestHoustonDbSchema:
         containers = get_containers_by_name(docs[0], include_init_containers=True)
         assert get_env_vars_dict(containers["houston-bootstrapper"]["env"])["SCHEMA_NAME"] == "public"
 
+    @pytest.mark.parametrize("schema_name", [DEFAULT_SCHEMA, "my_custom"])
+    def test_schema_reaches_the_postgres_exporter_queries(self, kube_version, schema_name):
+        """Test that the exporter's search_path follows the configured schema.
+
+        These queries read Houston's tables through search_path, so a stale
+        "houston$default, public" would find nothing on an install using another
+        schema -- the query errors rather than degrading. Only a "public" override
+        would have survived by coincidence.
+        """
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "prometheusPostgresExporter": {"enabled": True},
+                    "houston": {"schemaName": schema_name},
+                }
+            },
+            show_only=["charts/prometheus-postgres-exporter/templates/configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        queries = docs[0]["data"]["config.yaml"]
+        assert f'SET search_path TO "{schema_name}", public;' in queries
+        # The whole query must survive templating, not just the search_path.
+        assert 'from "Deployment"' in queries
+
     def test_schema_is_consistent_across_the_whole_release(self, kube_version):
         """Test that a full render never mixes schema values.
 

--- a/values.yaml
+++ b/values.yaml
@@ -15,6 +15,16 @@ global:
     mode: "unified"  # one of: control, data, unified
     domainPrefix: ""    # cluster-id
 
+  # Postgres schema Houston's tables live in. Global because both the astronomer
+  # and prometheus subcharts need it.
+  #
+  # Existing installs must leave this alone: their tables are already in
+  # houston$default, and changing it points Houston at an empty schema.
+  # Set it only on a fresh install, e.g. to "public" when the database does not
+  # permit creating schemas (APC-859).
+  houston:
+    schemaName: "houston$default"
+
   # Shared secret for internal service-to-service authentication (e.g. pilot -> commander gRPC).
   # Auto-generated on install if empty; preserved across upgrades.
   clusterLocalServiceAuth:

--- a/values.yaml
+++ b/values.yaml
@@ -15,15 +15,18 @@ global:
     mode: "unified"  # one of: control, data, unified
     domainPrefix: ""    # cluster-id
 
-  # Postgres schema Houston's tables live in. Global because both the astronomer
-  # and prometheus subcharts need it.
-  #
-  # Existing installs must leave this alone: their tables are already in
-  # houston$default, and changing it points Houston at an empty schema.
-  # Set it only on a fresh install, e.g. to "public" when the database does not
-  # permit creating schemas (APC-859).
+  # Houston's database. Global rather than under the astronomer subchart because
+  # the prometheus and prometheus-postgres-exporter subcharts read these too,
+  # and Helm does not share one subchart's values with another.
   houston:
-    schemaName: "houston$default"
+    database:
+      # The Postgres schema Houston's tables live in.
+      #
+      # Existing installs must leave this alone: their tables are already in
+      # houston$default, and changing it points Houston at an empty schema.
+      # Set it only on a fresh install, e.g. to "public" when the database does
+      # not permit creating schemas.
+      schemaName: "houston$default"
 
   # Shared secret for internal service-to-service authentication (e.g. pilot -> commander gRPC).
   # Auto-generated on install if empty; preserved across upgrades.


### PR DESCRIPTION
## Description

Installing APC fails on a database that does not permit creating the `houston$default` schema, because the chart hardcodes that name in seven places. houston-api's half of this shipped in astronomer/houston-api#2955, which stripped the schema qualifier from five migrations and from the one schema-sensitive raw query. That unblocked customers who bring their own `backendSecretName` and so supply their own connection string. This is the chart half: it makes the schema a value instead of a literal.

New value `global.houston.database.schemaName`, defaulting to `"houston$default"`. It sits under `global` because the `astronomer`, `prometheus` and `prometheus-postgres-exporter` subcharts all need it, and Helm does not share one subchart's values with another. Threaded through:

| Location | What reads it |
| --- | --- |
| `houston-deployment.yaml` | `SCHEMA_NAME` |
| `houston-worker-deployment.yaml` | `SCHEMA_NAME` |
| `houston-db-migration-job.yaml` | `SCHEMA_NAME` |
| `houston-cp-refresh-job.yaml` | `SCHEMA_NAME` |
| `houston-upgrade-deployments-job.yaml` | `SCHEMA_NAME` |
| `prometheus-statefulset.yaml` | `DATABASE_SCHEMA_NAME` |
| `prometheus-postgres-exporter` queries | `SET search_path` |
| `houston-backend-secret.yaml` | `?schema=` in the connection URL |

After this, the only remaining occurrences of the literal in the chart are the default itself and the comment above it.

The five `SCHEMA_NAME` values feed the `houston-bootstrapper` init container, which is what runs `CREATE SCHEMA` and writes the schema into the connection secret Houston reads. I confirmed against `ap-db-bootstrapper:2.0.13` that it already honours arbitrary values: `SCHEMA_NAME` is a `click` option with `envvar="SCHEMA_NAME"`, and running the image against a scratch Postgres with `SCHEMA_NAME=my_custom` creates `my_custom` and produces `?schema=my_custom`. So no bootstrapper change is needed for this, and PINF-275 is not a prerequisite.

I also dropped five stale `# we need to hardcode it to be able to upgrade from prisma1 to prisma2` comments, which no longer described anything true.

## The backend-secret fix is a behaviour change, please look at it

> [!IMPORTANT]
> `houston-backend-secret.yaml` held the `?schema=houston%24default` this ticket is about, and it was both **unreachable and malformed**. Fixing it changes when the template renders, so review that guard rather than reading this as a find-and-replace.

What it rendered before:

```
postgresql://%!s(<nil>):%!s(<nil>)@%!s(<nil>):<nil>/%!s(<nil>)?schema=houston%!d(MISSING)efault
```

Two independent bugs:

- **`%24` was eaten by printf.** In `printf "...?schema=houston%24default"`, Go reads `%24d` as a width-24 `%d` verb, consumes a sixth argument that does not exist, and emits `%!d(MISSING)`. The string `houston%24default` was never once produced.
- **The clause was mutually exclusive with its own data.** Line 5 only rendered the secret when `houston.backendConnection` was *empty*, and the clause then read `.Values.houston.backendConnection.user/pass/host/port/db`. Every field was nil whenever the line ran.

Now:

```
postgresql://houston:s3cr3t@pg.example.com:5432/houston?schema=houston%24default
```

The guard became `or (not backendConnection) backendSecretConnection`, which is deliberately surgical: it opens only the new working path.

**All three pre-existing render paths are unchanged**, which is the part worth checking:

| Values | Before | After |
| --- | --- | --- |
| nothing set | random placeholder | random placeholder |
| `backendSecretName` set | template skipped | template skipped |
| `backendConnection` without `backendSecretConnection` | template skipped | template skipped |
| `backendConnection` + `backendSecretConnection` | **template skipped** | **real connection URL** |

Only the last row changes, and it previously produced no secret at all.

## Review feedback addressed

**Credentials are now percent-encoded** (`aa73d79`). Interpolating `user`, `pass` and `db` verbatim was pre-existing, but making the clause reachable made it live. It is worse than misparsing: feeding the old form to a URL parser raises `Port could not be cast to integer value as 'p'`, because the host:port split lands inside the password. All three components now go through a new `houston.uriComponent` helper, which is `urlquery` piped through `replace "+" "%20"` — `urlquery` alone renders a space as `+`, and a `+` in userinfo is a literal plus rather than a space. sprig has no `urlEncode` in this Helm version. The schema keeps plain `urlquery`, where `+` for space is correct.

**The postgres exporter now follows the value** (`aa73d79`). My original claim that it "degrades gracefully" was wrong. Postgres does tolerate a missing schema in `search_path`, but that is beside the point: with the tables in `my_custom` and `search_path` set to `houston$default, public`, the table is not found and the query errors. Only a `public` override would have survived, by coincidence. The exporter configmap now uses `tpl` instead of `printf` — the idiom this repo already uses in 83 other places — so the query can read the value. The identifier is also quoted now, and I confirmed against real Postgres that `SET search_path TO "houston$default", public` still resolves an unqualified table.

**The value moved under a `database` namespace** (`4c528e7`). Now `global.houston.database.schemaName`, so future database values have somewhere to go. It has to stay under `global`: I checked with a scratch parent chart that from inside the `prometheus` subchart, a `global.*` key resolves while an `astronomer.houston.*` key comes back empty. Nesting it under the astronomer subchart would have worked for the five `SCHEMA_NAME` sites and silently failed for prometheus and the exporter.

**Ticket references removed from comments** (`4c528e7`). All six, including the two in test docstrings.

## Related Issues

- Fixes [APC-859](https://linear.app/astronomer/issue/APC-859/remove-unnecessary-houstondollardefault-schema-from-database) / astronomer/issues#8024
- Parent: [APC-1771](https://linear.app/astronomer/issue/APC-1771/apc-installation-and-db-migration-fails-if-schema-is-not)
- houston-api half: astronomer/houston-api#2955 (`main`), astronomer/houston-api#2972 (`release-2.1`)
- [PINF-275](https://linear.app/astronomer/issue/PINF-275/need-way-to-configure-the-schema-name-in-db-bootstrapper) — **not a prerequisite**, see above. Worth retitling: the schema name is already configurable in db-bootstrapper; the real defect is that omitting `SCHEMA_NAME` creates a schema literally named `None`, because `CREATE SCHEMA IF NOT EXISTS "{schema_name}"` has no falsy guard.

## Known issue found during review, not fixed here

The `randAlphaNum 5` fallback in `houston-backend-secret.yaml` can clobber a working connection secret. `lookup` returns an empty dict whenever Helm cannot query the cluster — `helm template`, `--dry-run`, and any GitOps flow that applies rendered output — so `$existingConnection` is empty and the else branch writes a five-character random value as the entire connection string. A real `helm upgrade` preserves it correctly because `lookup` works, which is why this would only surface in the render-then-apply path. This template is already ArgoCD-aware (it carries the sync-wave annotation), so that path is supported.

Left alone deliberately: the guard change here does not alter which value combinations reach that branch, and it deserves its own change rather than a footnote in a schema PR. Being tracked separately.

## Testing

**Full chart suite: 6464 passed**, exit 0.

```bash
pytest tests/chart_tests -q -n 4
```

`helm lint` clean with the default and with `schemaName=my_custom` plus the exporter enabled. A full render under both settings produces 129 documents each, with zero `%!` verbs and zero `<nil>` values.

New `tests/chart_tests/test_houston_db_schema.py` covers the cross-cutting contract in one place, since it spans three subcharts: the default on every template, the override on every template, the HA-gated cp-refresh job separately, the exporter queries with the exporter enabled, and a whole-release consistency check that fails if any component disagrees. Extended `test_houston_backend_secret.py` with the connection URL, a custom schema, `$` encoding, credential encoding for `/ ? # @` and a space, and the without-opt-in skip.

Three things I checked rather than assumed:

- **The default did not move.** The pre-existing `env_vars["DATABASE_SCHEMA_NAME"] == "houston$default"` assertion in `test_prometheus_statefulset.py` passes untouched, so I added coverage instead of editing it. That test failing would have been the signal that upgrades break.
- **The encoded URLs round-trip.** Each asserts back through `urlparse` to the values that were configured, not just to an expected string.
- **Both new guards are non-vacuous.** Reintroducing the literal in one template fails the consistency check with `schema values disagree across the release: {'public', 'houston$default'}`; restoring the hardcoded `search_path` fails the exporter test. Reverting each restores green.

Not covered: a live install on a non-default schema. The values-generation half is covered above, and the admission half was verified on the parent ticket against real Postgres (fresh installs on `public`, `my_custom` and `houston$default`, plus the 2.0.x upgrade path and `pg_dump` schema equivalence).

## Merging

`master`. APC-859 carries the **2.1.1** label, so this wants cherry-picking to `release-2.1` as well, alongside astronomer/houston-api#2972.

Backwards compatible by design: the default preserves current behaviour exactly, so existing installs are unaffected and only a fresh install would set the new value. Note that *changing* it on an existing install points Houston at an empty schema, which is why `values.yaml` documents it as fresh-install-only rather than a tunable.
