### PR TITLE
PINF-1231 git sync relay

### DIFF
--- a/.agents/skills/chart-tests/SKILL.md
+++ b/.agents/skills/chart-tests/SKILL.md
@@ -124,10 +124,14 @@ def test_secretstore_rule(kube_version):
     docs = render_chart(kube_version=kube_version, show_only=[ROLE_FILE])
     assert absent(docs[0])
 
-    docs = render_chart(kube_version=kube_version, values={"global": {"dataPlaneFailover": {"enabled": True}}}, show_only=[ROLE_FILE])
+    docs = render_chart(
+        kube_version=kube_version, values={"global": {"dataPlaneFailover": {"enabled": True}}}, show_only=[ROLE_FILE]
+    )
     assert present(docs[0])
 
-    docs = render_chart(kube_version=kube_version, values={"global": {"dataPlaneFailover": {"enabled": False}}}, show_only=[ROLE_FILE])
+    docs = render_chart(
+        kube_version=kube_version, values={"global": {"dataPlaneFailover": {"enabled": False}}}, show_only=[ROLE_FILE]
+    )
     assert absent(docs[0])
 ```
 
@@ -157,6 +161,7 @@ that template's doc in the existing `show_only` list over writing a new `render_
 
 ```python
 from tests.utils import get_all_features
+
 
 def test_with_all_features():
     docs = render_chart(values=get_all_features())

--- a/.agents/skills/functional-tests/SKILL.md
+++ b/.agents/skills/functional-tests/SKILL.md
@@ -158,6 +158,7 @@ from tests.utils.k8s import KUBECONFIG_UNIFIED, get_pod_running_containers
 
 container_ignore_list = ["kube-state", "houston", "astro-ui"]
 
+
 def test_container_user_is_not_root():
     containers = get_pod_running_containers(kubeconfig=KUBECONFIG_UNIFIED, namespace="astronomer")
     for container in containers.values():
@@ -190,10 +191,9 @@ def test_ensure_feature_disabled(k8s_core_v1_client):
 ```python
 import json
 
+
 def test_houston_config(houston_api):
-    data = houston_api.check_output(
-        "echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -"
-    )
+    data = houston_api.check_output("echo \"config = require('config'); console.log(JSON.stringify(config))\" | node -")
     config = json.loads(data)
     assert "url" not in config["nats"]
     assert len(config["nats"]["servers"]) > 0
@@ -208,9 +208,7 @@ Use `@pytest.mark.flaky` for tests that depend on eventually-consistent cluster 
 ```python
 @pytest.mark.flaky(reruns=20, reruns_delay=10)
 def test_houston_can_reach_prometheus(houston_api):
-    assert houston_api.check_output(
-        "wget --timeout=5 -qO- http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets"
-    )
+    assert houston_api.check_output("wget --timeout=5 -qO- http://astronomer-prometheus.astronomer.svc.cluster.local:9090/targets")
 ```
 
 - `reruns`: max retry attempts on failure

--- a/.agents/skills/tools/SKILL.md
+++ b/.agents/skills/tools/SKILL.md
@@ -43,9 +43,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--forgejo-namespace", required=True, help="...")
     return parser.parse_args()
 
+
 def main() -> None:
-    args = parse_args()          # aborts here on a bare run or --help, before any kubectl
-    ...                          # cluster mutations only happen after this line
+    args = parse_args()  # aborts here on a bare run or --help, before any kubectl
+    ...  # cluster mutations only happen after this line
 ```
 
 Now `--help` and a bare run both abort before touching the cluster, and any real run has to name its target namespaces on purpose.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 exclude: '(venv|\.vscode|tests/k8s_schema|tests/chart_tests/test_data)' # regex
-auto_update:
+update:
   cooldown_days: 7
 repos:
   - repo: local
@@ -53,7 +53,7 @@ repos:
       - id: remove-tabs
         exclude_types: [makefile, binary]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.16.0"
+    rev: "v0.16.5"
     hooks:
       - id: ruff-check
         args:
@@ -89,7 +89,7 @@ repos:
       - id: sort-simple-yaml
       - id: trailing-whitespace
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: v0.11.0.1-1
     hooks:
       - id: shellcheck
   - repo: https://github.com/astronomer/pre-commit-hooks

--- a/tests/functional/scenarios/deployment-lifecycle/test_deployment_lifecycle.py
+++ b/tests/functional/scenarios/deployment-lifecycle/test_deployment_lifecycle.py
@@ -23,7 +23,7 @@ assert the feature-OFF case -- the relay carries no private-CA wiring unless the
 configured -- as a live counterpart to the git-sync-private-ca scenario's positive tests.
 
 Mutation shapes and the createUser-then-createWorkspace bootstrap sequence
-(tests/utils/houston_graphql.py) are ported from software-upgrade-automation's
+(tests/utils/houston_graphql.py) are ported from apc-automation's
 bin/configure-k3d-for-tests.py and bin/create-git-sync-deployment.py (QA's own k3d
 CP/DP test tooling), adapted for the unified topology: no registerCluster call is
 needed here, because houston-api's populate-default-cluster script already creates a

--- a/values.yaml
+++ b/values.yaml
@@ -440,7 +440,7 @@ global:
         tag: 2026.8.24
       gitSync:
         repository: quay.io/astronomer/ap-git-sync-relay
-        tag: 0.5.2
+        tag: 0.6.0
     metrics:
       enabled: false
   certgenerator:


### PR DESCRIPTION
## Description

ap-git-sync-relay:0.6.0 which causes updates to be serialized, avoiding contention.

## Related Issues

https://linear.app/astronomer/issue/PINF-1231

## Testing

ap-git-sync-relay now has tests unit test that exercises the implementation logic by doing two successive commits, the first one slow, and asserts against the result. Further testing should do similar type of tests: make multiple quick commits, pushing after each one, and ensure that `ERROR` never shows up in the git-sync-relay logs.

## Merging

Master, release-2.1