### PR TITLE
PINF-955: Vector Daemonset improvements

### DIFF
--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -122,6 +122,8 @@ data:
           type: "vrl"
           source: |
             is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)
+            is_kubernetes_executor_pod = exists(.kubernetes.pod_labels.dag_id)
+
             !is_task_output || is_kubernetes_executor_pod
 
       transform_add_timestamp:

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -116,14 +116,13 @@ data:
         type: filter
         inputs:
           - transform_task_logs
-        # Airflow 3 task processes echo their structured task log lines to stdout in
-        # addition to writing them to /usr/local/airflow/logs/**/attempt=N.log. The
-        # airflow_3_task_logs (file) source already ships those lines with full
-        # dag_id/run_id/task_id/attempt metadata parsed from the path, so shipping the
-        # stdout copy here as well double-ingests every task log line into
-        # Elasticsearch. Only pass through component/system logs, which have no
-        # file-based equivalent.
-        condition: '.log_type != "task"'
+        # AF3 tasks write each line to both stdout and attempt=N.log, so the file source
+        # and this one carry the same line to the sink. Drop the stdout copy.
+        condition:
+          type: "vrl"
+          source: |
+            is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)
+            !is_task_output || is_kubernetes_executor_pod
 
       transform_add_timestamp:
         type: remap
@@ -305,7 +304,10 @@ data:
         type: filter
         inputs:
           - handle_error_details
-        condition: '.log_type == "task"'
+        condition:
+          type: "vrl"
+          source: |
+            .log_type == "task" && .release != "unknown"
 
       transform_remove_fields:
         type: remap

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -116,15 +116,13 @@ data:
         type: filter
         inputs:
           - transform_task_logs
-        # AF3 tasks write each line to both stdout and attempt=N.log, so the file source
-        # and this one carry the same line to the sink. Drop the stdout copy.
         condition:
           type: "vrl"
           source: |
+            is_ke_task_pod = exists(.kubernetes.pod_labels.dag_id)
             is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)
-            is_kubernetes_executor_pod = exists(.kubernetes.pod_labels.dag_id)
 
-            !is_task_output || is_kubernetes_executor_pod
+            !(is_ke_task_pod && is_task_output)
 
       transform_add_timestamp:
         type: remap
@@ -306,10 +304,7 @@ data:
         type: filter
         inputs:
           - handle_error_details
-        condition:
-          type: "vrl"
-          source: |
-            .log_type == "task" && .release != "unknown"
+        condition: '.log_type == "task"'
 
       transform_remove_fields:
         type: remap

--- a/charts/vector/templates/vector-configmap.yaml
+++ b/charts/vector/templates/vector-configmap.yaml
@@ -112,10 +112,23 @@ data:
             .log_type = "system"
           }
 
+      filter_k8s_task_logs:
+        type: filter
+        inputs:
+          - transform_task_logs
+        # Airflow 3 task processes echo their structured task log lines to stdout in
+        # addition to writing them to /usr/local/airflow/logs/**/attempt=N.log. The
+        # airflow_3_task_logs (file) source already ships those lines with full
+        # dag_id/run_id/task_id/attempt metadata parsed from the path, so shipping the
+        # stdout copy here as well double-ingests every task log line into
+        # Elasticsearch. Only pass through component/system logs, which have no
+        # file-based equivalent.
+        condition: '.log_type != "task"'
+
       transform_add_timestamp:
         type: remap
         inputs:
-          - transform_task_logs
+          - filter_k8s_task_logs
         source: |
           .@timestamp = format_timestamp!(now(), format: "%Y-%m-%dT%H:%M:%S.%3fZ")
           .date_nano = format_timestamp!(now(), format: "%Y-%m-%dT%H:%M:%S.%9fZ")

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -369,7 +369,10 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
 
     # Version split is present.
     assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
-    assert 'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]' in als
+    assert (
+        'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
+        in als
+    )
     assert "if is_af2 or is_af3:" in als
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -365,24 +365,25 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
     )
 
     common_test_cases(docs)
-    als = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    prod_yaml = yaml.safe_load(docs[0]["data"]["production.yaml"])
+    airflow_local_settings = prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
 
     # Version split is present.
-    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in airflow_local_settings
     assert (
         'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
-        in als
+        in airflow_local_settings
     )
-    assert "if is_af2 or is_af3:" in als
+    assert "if is_af2 or is_af3:" in airflow_local_settings
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.
-    assert 'redirect = log_cmd if is_af2 else " ; "' in als
-    assert "+ redirect" in als
+    assert 'redirect = log_cmd if is_af2 else " ; "' in airflow_local_settings
+    assert "+ redirect" in airflow_local_settings
     # The old unconditional guard that appended log_cmd for both versions is gone.
-    assert "+ log_cmd" not in als
+    assert "+ log_cmd" not in airflow_local_settings
 
     # Termination shim still applies to every KubernetesExecutor worker pod.
-    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in als
+    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in airflow_local_settings
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -365,24 +365,24 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
     )
 
     common_test_cases(docs)
-    metadata = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    als = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
 
     # Version split is present.
-    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in metadata
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
     assert (
         'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
-        in metadata
+        in als
     )
-    assert "if is_af2 or is_af3:" in metadata
+    assert "if is_af2 or is_af3:" in als
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.
-    assert 'redirect = log_cmd if is_af2 else " ; "' in metadata
-    assert "+ redirect" in metadata
+    assert 'redirect = log_cmd if is_af2 else " ; "' in als
+    assert "+ redirect" in als
     # The old unconditional guard that appended log_cmd for both versions is gone.
-    assert "+ log_cmd" not in metadata
+    assert "+ log_cmd" not in als
 
     # Termination shim still applies to every KubernetesExecutor worker pod.
-    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in metadata
+    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in als
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1089,9 +1089,14 @@ def test_houston_configmap_pod_mutation_hook_airflow_compatibility():
     assert airflow3_pattern in airflow_local_settings, "Airflow 3.x task execution pattern should be supported"
     assert version_check in airflow_local_settings, "Version comparison logic should be present"
 
-    # Check that the complete condition includes both patterns
-    complete_condition = 'if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):'
-    assert complete_condition in airflow_local_settings, "Complete condition should include both Airflow 2.x and 3.x patterns"
+    # Check that both patterns feed a single gate. #3391 split the inline `or` into
+    # named is_af2 / is_af3 flags so the stdout tee could be scoped to Airflow 2.
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in airflow_local_settings
+    assert (
+        'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
+        in airflow_local_settings
+    )
+    assert "if is_af2 or is_af3:" in airflow_local_settings, "Complete condition should include both Airflow 2.x and 3.x patterns"
 
     # Check that the logging command is present
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -365,24 +365,24 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
     )
 
     common_test_cases(docs)
-    als = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    metadata = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
 
     # Version split is present.
-    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in metadata
     assert (
         'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
-        in als
+        in metadata
     )
-    assert "if is_af2 or is_af3:" in als
+    assert "if is_af2 or is_af3:" in metadata
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.
-    assert 'redirect = log_cmd if is_af2 else " ; "' in als
-    assert "+ redirect" in als
+    assert 'redirect = log_cmd if is_af2 else " ; "' in metadata
+    assert "+ redirect" in metadata
     # The old unconditional guard that appended log_cmd for both versions is gone.
-    assert "+ log_cmd" not in als
+    assert "+ log_cmd" not in metadata
 
     # Termination shim still applies to every KubernetesExecutor worker pod.
-    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in als
+    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in metadata
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -365,25 +365,24 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
     )
 
     common_test_cases(docs)
-    prod_yaml = yaml.safe_load(docs[0]["data"]["production.yaml"])
-    airflow_local_settings = prod_yaml["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+    als = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
 
     # Version split is present.
-    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in airflow_local_settings
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
     assert (
         'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
-        in airflow_local_settings
+        in als
     )
-    assert "if is_af2 or is_af3:" in airflow_local_settings
+    assert "if is_af2 or is_af3:" in als
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.
-    assert 'redirect = log_cmd if is_af2 else " ; "' in airflow_local_settings
-    assert "+ redirect" in airflow_local_settings
+    assert 'redirect = log_cmd if is_af2 else " ; "' in als
+    assert "+ redirect" in als
     # The old unconditional guard that appended log_cmd for both versions is gone.
-    assert "+ log_cmd" not in airflow_local_settings
+    assert "+ log_cmd" not in als
 
     # Termination shim still applies to every KubernetesExecutor worker pod.
-    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in airflow_local_settings
+    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in als
 
 
 def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():

--- a/tests/chart_tests/test_vector_cm.py
+++ b/tests/chart_tests/test_vector_cm.py
@@ -195,10 +195,11 @@ class TestVectorConfigmap:
         assert transforms["filter_k8s_task_logs"]["condition"]["type"] == "vrl"
         assert transforms["transform_add_timestamp"]["inputs"] == ["filter_k8s_task_logs"]
 
-    def test_vector_configmap_k8s_task_log_filter_requires_full_task_identity(self, kube_version):
-        """The log_type tag is set on the mere presence of a dag_id, which scheduler and
-        dag-processor lines also carry. Keying the drop off it loses those from both
-        pipelines, so the filter must require full task identity."""
+    def test_vector_configmap_k8s_task_log_filter_drops_only_ke_task_pod_output(self, kube_version):
+        """The duplicate is the KubernetesExecutor task pod's stdout copy, whose file
+        copy resolves a release and carries a log_id. Both halves of the condition are
+        required: without is_ke_task_pod the drop also takes Celery worker stdout, and
+        without is_task_output it takes the KE pod's non-task lines."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/vector/templates/vector-configmap.yaml"],
@@ -207,29 +208,30 @@ class TestVectorConfigmap:
         config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
         source = config_dict["transforms"]["filter_k8s_task_logs"]["condition"]["source"]
 
+        assert "is_ke_task_pod = exists(.kubernetes.pod_labels.dag_id)" in source
         assert "is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)" in source
-        # The loose log_type tag must not be what decides the drop.
+        assert "!(is_ke_task_pod && is_task_output)" in source
+
+    def test_vector_configmap_k8s_task_log_filter_keys_on_pod_label_not_payload(self, kube_version):
+        """Scheduler, dag-processor and triggerer lines about a task instance carry
+        dag_id/task_id/run_id in their payload, and their file-sourced equivalent is
+        dropped as dag_parse. Only the pod label distinguishes a KE task pod, so the
+        drop must not be decided by the payload field or the log_type tag alone."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
+        source = config_dict["transforms"]["filter_k8s_task_logs"]["condition"]["source"]
+
+        assert ".kubernetes.pod_labels.dag_id" in source
         assert '.log_type != "task"' not in source
 
-    def test_vector_configmap_k8s_task_log_filter_exempts_kubernetes_executor_pods(self, kube_version):
-        """KubernetesExecutor task pods name their logs emptyDir "logs", not
-        "logs-<release>", so their file copy is indexed as <prefix>.unknown.* and never
-        read. The stdout copy is the only readable one and must survive the drop."""
-        docs = render_chart(
-            kube_version=kube_version,
-            show_only=["charts/vector/templates/vector-configmap.yaml"],
-        )
-
-        config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
-        source = config_dict["transforms"]["filter_k8s_task_logs"]["condition"]["source"]
-
-        assert "is_kubernetes_executor_pod = exists(.kubernetes.pod_labels.dag_id)" in source
-        assert "!is_task_output || is_kubernetes_executor_pod" in source
-
-    def test_vector_configmap_file_pipeline_drops_unresolvable_release(self, kube_version):
-        """extract_release falls back to "unknown" when the path has no "logs-<release>"
-        segment. Those events would be indexed as <prefix>.unknown.* and never read, and
-        the stdout pipeline already carries them with correct pod labels."""
+    def test_vector_configmap_file_pipeline_ships_all_task_logs(self, kube_version):
+        """The file pipeline is authoritative for task logs and must not filter on a
+        resolved release: extract_release returns "unknown" for every logs-named volume,
+        which on operator-managed deployments includes the Celery worker."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/vector/templates/vector-configmap.yaml"],
@@ -238,5 +240,4 @@ class TestVectorConfigmap:
         config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
         condition = config_dict["transforms"]["filter_task_logs_only"]["condition"]
 
-        assert condition["type"] == "vrl"
-        assert '.log_type == "task" && .release != "unknown"' in condition["source"]
+        assert condition == '.log_type == "task"'

--- a/tests/chart_tests/test_vector_cm.py
+++ b/tests/chart_tests/test_vector_cm.py
@@ -176,13 +176,8 @@ class TestVectorConfigmap:
         assert ".level = to_string!(.level)" in source
 
     def test_vector_configmap_filters_task_logs_out_of_k8s_logs_pipeline(self, kube_version):
-        """Airflow 3 task processes echo their structured task log lines to stdout in
-        addition to writing them to /usr/local/airflow/logs/**/attempt=N.log. The
-        airflow_3_task_logs (file) pipeline already ships those lines with full
-        dag_id/run_id/task_id/attempt metadata, so the airflow_k8s_logs (stdout)
-        pipeline must drop anything transform_task_logs tagged as log_type "task"
-        before it reaches the shared elasticsearch sink, or every task log line is
-        double-ingested."""
+        """AF3 tasks write each line to both stdout and attempt=N.log, so the stdout
+        pipeline must drop the duplicate before the shared elasticsearch sink."""
         docs = render_chart(
             kube_version=kube_version,
             show_only=["charts/vector/templates/vector-configmap.yaml"],
@@ -197,9 +192,51 @@ class TestVectorConfigmap:
         assert "filter_k8s_task_logs:" in config_yaml
         assert transforms["filter_k8s_task_logs"]["type"] == "filter"
         assert transforms["filter_k8s_task_logs"]["inputs"] == ["transform_task_logs"]
-        assert transforms["filter_k8s_task_logs"]["condition"] == '.log_type != "task"'
-
-        # transform_add_timestamp (and therefore the elasticsearch sink) must only
-        # see the k8s_logs pipeline through the new filter, not directly from
-        # transform_task_logs.
+        assert transforms["filter_k8s_task_logs"]["condition"]["type"] == "vrl"
         assert transforms["transform_add_timestamp"]["inputs"] == ["filter_k8s_task_logs"]
+
+    def test_vector_configmap_k8s_task_log_filter_requires_full_task_identity(self, kube_version):
+        """The log_type tag is set on the mere presence of a dag_id, which scheduler and
+        dag-processor lines also carry. Keying the drop off it loses those from both
+        pipelines, so the filter must require full task identity."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
+        source = config_dict["transforms"]["filter_k8s_task_logs"]["condition"]["source"]
+
+        assert "is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)" in source
+        # The loose log_type tag must not be what decides the drop.
+        assert '.log_type != "task"' not in source
+
+    def test_vector_configmap_k8s_task_log_filter_exempts_kubernetes_executor_pods(self, kube_version):
+        """KubernetesExecutor task pods name their logs emptyDir "logs", not
+        "logs-<release>", so their file copy is indexed as <prefix>.unknown.* and never
+        read. The stdout copy is the only readable one and must survive the drop."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
+        source = config_dict["transforms"]["filter_k8s_task_logs"]["condition"]["source"]
+
+        assert "is_kubernetes_executor_pod = exists(.kubernetes.pod_labels.dag_id)" in source
+        assert "!is_task_output || is_kubernetes_executor_pod" in source
+
+    def test_vector_configmap_file_pipeline_drops_unresolvable_release(self, kube_version):
+        """extract_release falls back to "unknown" when the path has no "logs-<release>"
+        segment. Those events would be indexed as <prefix>.unknown.* and never read, and
+        the stdout pipeline already carries them with correct pod labels."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        config_dict = yaml.safe_load(docs[0]["data"]["vector-config.yaml"])
+        condition = config_dict["transforms"]["filter_task_logs_only"]["condition"]
+
+        assert condition["type"] == "vrl"
+        assert '.log_type == "task" && .release != "unknown"' in condition["source"]

--- a/tests/chart_tests/test_vector_cm.py
+++ b/tests/chart_tests/test_vector_cm.py
@@ -174,3 +174,32 @@ class TestVectorConfigmap:
 
         assert "is_integer(.level)" in source
         assert ".level = to_string!(.level)" in source
+
+    def test_vector_configmap_filters_task_logs_out_of_k8s_logs_pipeline(self, kube_version):
+        """Airflow 3 task processes echo their structured task log lines to stdout in
+        addition to writing them to /usr/local/airflow/logs/**/attempt=N.log. The
+        airflow_3_task_logs (file) pipeline already ships those lines with full
+        dag_id/run_id/task_id/attempt metadata, so the airflow_k8s_logs (stdout)
+        pipeline must drop anything transform_task_logs tagged as log_type "task"
+        before it reaches the shared elasticsearch sink, or every task log line is
+        double-ingested."""
+        docs = render_chart(
+            kube_version=kube_version,
+            show_only=["charts/vector/templates/vector-configmap.yaml"],
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        config_yaml = doc["data"]["vector-config.yaml"]
+        config_dict = yaml.safe_load(config_yaml)
+        transforms = config_dict["transforms"]
+
+        assert "filter_k8s_task_logs:" in config_yaml
+        assert transforms["filter_k8s_task_logs"]["type"] == "filter"
+        assert transforms["filter_k8s_task_logs"]["inputs"] == ["transform_task_logs"]
+        assert transforms["filter_k8s_task_logs"]["condition"] == '.log_type != "task"'
+
+        # transform_add_timestamp (and therefore the elasticsearch sink) must only
+        # see the k8s_logs pipeline through the new filter, not directly from
+        # transform_task_logs.
+        assert transforms["transform_add_timestamp"]["inputs"] == ["filter_k8s_task_logs"]


### PR DESCRIPTION
## Description

This PR:

- **Scopes the default Vector daemonset pipeline to a single writer per task log
  line.** On Airflow 3, KubernetesExecutor task pods run the containerised entrypoint
  with `subprocess_logs_to_stdout=True`, so every task line is emitted twice — once to
  `/usr/local/airflow/logs/**/attempt=N.log`, picked up by the `airflow_3_task_logs`
  file source, and once to container stdout, picked up by `airflow_k8s_logs`. Both
  pipelines feed the shared Elasticsearch sink with `action: create` and no
  deterministic `_id`, so every line is indexed twice.

- **Introduces `filter_k8s_task_logs`**, a filter transform situated between
  `transform_task_logs` and `transform_add_timestamp` on the stdout pipeline. It drops
  the stdout copy for KubernetesExecutor task output only, letting the file pipeline
  serve as the single authoritative source for task logs while system and component
  logs continue to flow through the stdout pipeline untouched:
  
 ```
  is_ke_task_pod = exists(.kubernetes.pod_labels.dag_id)
  is_task_output = exists(.dag_id) && exists(.task_id) && exists(.run_id)

  !(is_ke_task_pod && is_task_output)
  ```

### Behaviour

| stdout event | before | after |
|---|---|---|
| KE task pod, task line | indexed (duplicate) | dropped |
| KE task pod, supervisor line | indexed | indexed |
| Celery worker task line | indexed | indexed |
| scheduler / dag-processor line about a TI | indexed | indexed |


## Related
https://linear.app/astronomer/issue/PINF-955/af3-kubernetesexecutor-task-logs-are-ingested-twice

## Testing
- Unitests added
- Confirmed logs with the change: 
<img width="1652" height="615" alt="Screenshot 2026-09-09 at 6 15 24 PM" src="https://github.com/user-attachments/assets/f85eec7d-98ce-47ea-a040-4590dea856ee" />

## Merge
Main, 2.1
