### PR TITLE
[release-2.1] PINF-1148: allow jwks hook job service account overrides (#3483)

### DIFF
--- a/charts/astronomer/templates/_helpers.yaml
+++ b/charts/astronomer/templates/_helpers.yaml
@@ -240,10 +240,10 @@ gcp_cloud_logging:
 {{- end }}
 
 {{ define "commander.jwksServiceAccountName" -}}
-{{- if and .Values.commander.serviceAccount.create .Values.global.rbac.enabled -}}
-{{ default (printf "%s-commander-jwks-hook-sa" .Release.Name ) .Values.commander.serviceAccount.name }}
+{{- if and .Values.commander.jwksHook.serviceAccount.create .Values.global.rbac.enabled -}}
+{{ default (printf "%s-commander-jwks-hook-sa" .Release.Name ) .Values.commander.jwksHook.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.commander.serviceAccount.name }}
+    {{ default "default" .Values.commander.jwksHook.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-serviceaccount.yaml
+++ b/charts/astronomer/templates/commander/jwks-hooks/commander-jwks-serviceaccount.yaml
@@ -1,11 +1,11 @@
 ##################################
 ## Commander JWKS ServiceAccount ##
 ##################################
-{{- if and .Values.commander.serviceAccount.create .Values.global.rbac.enabled  }}
+{{- if and .Values.commander.jwksHook.serviceAccount.create .Values.global.rbac.enabled  }}
 {{- if eq .Values.global.plane.mode "data" }}
 kind: ServiceAccount
 apiVersion: v1
-automountServiceAccountToken: {{ .Values.commander.serviceAccount.automountServiceAccountToken }}
+automountServiceAccountToken: {{ .Values.commander.jwksHook.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "commander.jwksServiceAccountName" . }}
   labels:
@@ -18,7 +18,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-2"
-  {{- with .Values.commander.serviceAccount.annotations }}
+  {{- with .Values.commander.jwksHook.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{ if .Values.global.argoCD.annotation.enabled }}

--- a/charts/astronomer/values.yaml
+++ b/charts/astronomer/values.yaml
@@ -786,6 +786,17 @@ commander:
     retryAttempts: 2
     retryDelay: 10
     extraEnv: []
+    # -- Service account configuration
+    serviceAccount:
+      # -- Specifies whether a service account should be created
+      create: true
+      # -- Annotations to add to the service account
+      annotations: {}
+      # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+      name: ""
+      # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+      automountServiceAccountToken: true
+
 
 pilot:
   # -- Enable Pilot deployment (data plane only)

--- a/tests/chart_tests/test_astronomer_commander_hook_job.py
+++ b/tests/chart_tests/test_astronomer_commander_hook_job.py
@@ -77,6 +77,30 @@ class TestCommanderJWKSHookJob:
         assert configmap_doc["metadata"]["name"] == "release-name-commander-jwks-hook-config"
         assert "commander-jwks.py" in configmap_doc["data"]
 
+    def test_jwks_hook_job_service_account_overrides(self, kube_version):
+        """jwksHook service account name overrides to assert again Role, RoleBinding and ServiceAccount."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {"plane": {"mode": "data"}},
+                "astronomer": {"commander": {"jwksHook": {"serviceAccount": {"create": True, "name": "jwks-custom-sa"}}}},
+            },
+            show_only=sorted(
+                [
+                    str(x.relative_to(git_root_dir))
+                    for x in Path(f"{git_root_dir}/charts/astronomer/templates/commander/jwks-hooks").glob("*")
+                ]
+            ),
+        )
+        docs_by_kind = {doc["kind"]: doc for doc in docs}
+
+        assert len(docs) == 5
+        # the custom name flows into the SA and the binding subject
+        assert docs_by_kind["ServiceAccount"]["metadata"]["name"] == "jwks-custom-sa"
+        assert docs_by_kind["RoleBinding"]["subjects"][0]["name"] == "jwks-custom-sa"
+        # roleRef is unaffected by the SA name override
+        assert docs_by_kind["RoleBinding"]["roleRef"]["name"] == "release-name-commander-jwks-role"
+
     def test_jwks_hook_job_control_plane_endpoint_cp_ha(self, kube_version):
         """CP-HA: the JWKS bootstrap hook's CONTROL_PLANE_ENDPOINT must target the
         GLOBAL control-plane host so it health-routes to the active CP, not a pinned per-CP host.

--- a/tests/chart_tests/test_byo_sa.py
+++ b/tests/chart_tests/test_byo_sa.py
@@ -393,7 +393,7 @@ custom_service_account_names = {
         "astronomer": {"commander": {"serviceAccount": {"create": True, "name": "prothean"}}}
     },
     "charts/astronomer/templates/commander/jwks-hooks/commander-jwks-hooks.yaml": {
-        "astronomer": {"commander": {"serviceAccount": {"create": True, "name": "prothean"}}}
+        "astronomer": {"commander": {"jwksHook": {"serviceAccount": {"create": True, "name": "prothean"}}}}
     },
     "charts/astronomer/templates/config-syncer/config-syncer-cronjob.yaml": {
         "astronomer": {"configSyncer": {"serviceAccount": {"create": True, "name": "prothean"}}}


### PR DESCRIPTION
## Description

Clean cherry-pick of #3483 (PINF-1148) from `master` to `release-2.1`. No conflicts, no adaptation needed.

Splits the jwks-hook job's service account config out from the main commander deployment's service account (`commander.serviceAccount.*`), into its own `commander.jwksHook.serviceAccount.*` block — so the two can be configured (or overridden) independently.

## Verification specific to this branch

- `git cherry-pick -x` applied cleanly across all 5 changed files (`_helpers.yaml`, `commander-jwks-serviceaccount.yaml`, `values.yaml`, plus the new and updated test files) with no conflicts.
- Confirmed the new `commander.jwksHook.serviceAccount` block in `values.yaml` sits correctly under `commander.jwksHook`, distinct from the pre-existing `commander.serviceAccount` block — no collision between the two.
- Ran the affected suites post-cherry-pick: `test_astronomer_commander_hook_job.py` + `test_byo_sa.py` — **172 passed, 1 skipped** (the skip is unrelated/pre-existing).

## Related Issues

- [PINF-1148](https://linear.app/astronomer/issue/PINF-1148/separate-jwks-hook-job-service-account-config-from-commander)
- Original PR on `master`: #3483

## Feature Flags

- [ ] Not applicable — this PR does not introduce or modify feature flags

## Merging

`release-2.1`.
