### PR TITLE
[release-2.1] PINF-955: Scope worker stdout tee to Airflow 2 to stop AF3 task-log duplication in Elasticsearch (#3391)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v2.4.3
     hooks:
       - id: codespell
-        args: ["-L", "AKS,aks,showIn,NotIn,templateAs"]
+        args: ["-L", "AKS,aks,showIn,NotIn,templateAs,als"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:

--- a/charts/astronomer/templates/houston/houston-configmap.yaml
+++ b/charts/astronomer/templates/houston/houston-configmap.yaml
@@ -533,14 +533,22 @@ data:
                       ' | python3 - """
                   )
                   log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "
-                  if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split('.')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):
+                  is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]
+                  is_af3 = int(version.split('.')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]
+                  if is_af2 or is_af3:
                       container.command = ["tini", "--"]
                       new_args = ["bash", "-c"]
+                      # Airflow 3 writes structured task logs to /usr/local/airflow/logs/**/*.log,
+                      # which the sidecar already ships to Elasticsearch. Teeing stdout to out.log
+                      # would ingest every task log line a second time. Airflow 2 still needs the tee
+                      # because out.log is its only path to Elasticsearch after the broad log path was
+                      # version-gated out of the Airflow 2 sidecar config.
+                      redirect = log_cmd if is_af2 else " ; "
                       command_str = (
                           cmd_init
                           + " /entrypoint "
                           + shlex.join([str(arg) for arg in container.args])
-                          + log_cmd
+                          + redirect
                       )
                       new_args.append(command_str)
                       container.args = new_args

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -342,6 +342,46 @@ def test_houston_configmap_with_loggingsidecar_enabled():
     assert "vector" in prod_yaml["deployments"]["logging"]["loggingSidecar"]["image"]
 
 
+def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
+    """The pod_mutation_hook must only tee worker stdout to out.log for Airflow 2.
+
+    Airflow 3 writes structured task logs to /usr/local/airflow/logs/**/*.log which
+    the sidecar already ships, so applying the out.log tee to Airflow 3 workers
+    double-ingests every task log line into Elasticsearch. The wrapper (including the
+    finished-file termination shim) must still be applied to both versions."""
+    docs = render_chart(
+        values={
+            "global": {
+                "logging": {
+                    "loggingSidecar": {
+                        "enabled": True,
+                        "repository": "quay.io/astronomer/ap-vector",
+                        "tag": "0.22.3",
+                    },
+                },
+            },
+        },
+        show_only=["charts/astronomer/templates/houston/houston-configmap.yaml"],
+    )
+
+    common_test_cases(docs)
+    als = yaml.safe_load(docs[0]["data"]["production.yaml"])["deployments"]["helm"]["airflow"]["airflowLocalSettings"]
+
+    # Version split is present.
+    assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
+    assert 'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]' in als
+    assert "if is_af2 or is_af3:" in als
+
+    # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.
+    assert 'redirect = log_cmd if is_af2 else " ; "' in als
+    assert "+ redirect" in als
+    # The old unconditional guard that appended log_cmd for both versions is gone.
+    assert "+ log_cmd" not in als
+
+    # Termination shim still applies to every KubernetesExecutor worker pod.
+    assert 'Path("/var/log/sidecar-log-consumer/finished").touch()' in als
+
+
 def test_houston_configmap_with_loggingsidecar_enabled_with_index_prefix_overrides():
     """Validate the houston configmap and its embedded data with
     loggingSidecar."""

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1089,9 +1089,10 @@ def test_houston_configmap_pod_mutation_hook_airflow_compatibility():
     assert airflow3_pattern in airflow_local_settings, "Airflow 3.x task execution pattern should be supported"
     assert version_check in airflow_local_settings, "Version comparison logic should be present"
 
-    # Check that the complete condition includes both patterns
-    complete_condition = 'if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):'
-    assert complete_condition in airflow_local_settings, "Complete condition should include both Airflow 2.x and 3.x patterns"
+    # Check that the two patterns are combined via OR into the branch that triggers the redirect logic.
+    # (Written as named is_af2/is_af3 variables, not one inlined boolean expression.)
+    complete_condition = "if is_af2 or is_af3:"
+    assert complete_condition in airflow_local_settings, "Complete condition should combine both Airflow 2.x and 3.x checks"
 
     # Check that the logging command is present
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -369,7 +369,10 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
 
     # Version split is present.
     assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
-    assert 'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]' in als
+    assert (
+        'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
+        in als
+    )
     assert "if is_af2 or is_af3:" in als
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.


### PR DESCRIPTION
## Description

Clean cherry-pick of #3391 (PINF-955) from `master` to `release-2.1`. `git cherry-pick -x` applied both changed files with no conflicts.

Scopes the sidecar-logging pod-mutation hook's stdout tee to Airflow 2 only. Airflow 3 already writes structured task logs to `/usr/local/airflow/logs/**/*.log`, which the sidecar ships to Elasticsearch on its own — teeing stdout too was ingesting every AF3 task log line twice. AF2 still needs the tee, since `out.log` is its only path to Elasticsearch after the broad log path was version-gated out of the AF2 sidecar config.

## Also folded in: two pre-existing test/pre-commit fixes, unrelated to the cherry-pick itself

All three verified as already broken identically against a clean `origin/master` checkout — none caused by this cherry-pick:

- `test_houston_configmap_pod_mutation_hook_airflow_compatibility`'s `complete_condition` assertion checked for a literal inlined condition string that predates a later refactor in the same PR (#3391) to named `is_af2`/`is_af3` variables; the assertion was never updated to match. Fixed to `"if is_af2 or is_af3:"`, matching the actual shipped code. Same fix as `main`'s #3539.
- `codespell` flagged the pre-existing `als` variable name (an `airflowLocalSettings` abbreviation used throughout this file's other tests) as a typo for "also". Added to the existing short-identifier ignore list in `.pre-commit-config.yaml`.
- `ruff-format` wanted to re-wrap one long `assert` in a neighboring, untouched test function.

## Verification specific to this branch

- Confirmed the actual product fix (the `is_af2`/`is_af3` distinction and the conditional `redirect`) is present and correct in the rendered template, matching `main` exactly.
- Full `test_houston_configmap.py` suite: **57/57 passing**.
- `pre-commit run` on the touched files: clean.

## Related Issues

- [PINF-955](https://linear.app/astronomer/issue/PINF-955/af3-kubernetesexecutor-task-logs-are-ingested-twice)
- Original PR on `master`: #3391
- Test-fix equivalent on `main`: #3539

## Feature Flags

- [ ] Not applicable — this PR does not introduce or modify feature flags

## Merging

`release-2.1`.
