### PR TITLE
PINF-955: fix stale complete_condition assertion in pod-mutation-hook test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v2.4.3
     hooks:
       - id: codespell
-        args: ["-L", "AKS,aks,showIn,NotIn,templateAs"]
+        args: ["-L", "AKS,aks,showIn,NotIn,templateAs,als"]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.5.6
     hooks:

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -369,7 +369,10 @@ def test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2():
 
     # Version split is present.
     assert 'is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]' in als
-    assert 'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]' in als
+    assert (
+        'is_af3 = int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]'
+        in als
+    )
     assert "if is_af2 or is_af3:" in als
 
     # The tee is only wired in for Airflow 2; Airflow 3 gets a plain terminator.

--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1086,9 +1086,10 @@ def test_houston_configmap_pod_mutation_hook_airflow_compatibility():
     assert airflow3_pattern in airflow_local_settings, "Airflow 3.x task execution pattern should be supported"
     assert version_check in airflow_local_settings, "Version comparison logic should be present"
 
-    # Check that the complete condition includes both patterns
-    complete_condition = 'if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):'
-    assert complete_condition in airflow_local_settings, "Complete condition should include both Airflow 2.x and 3.x patterns"
+    # Check that the two patterns are combined via OR into the branch that triggers the redirect logic.
+    # (Written as named is_af2/is_af3 variables, not one inlined boolean expression.)
+    complete_condition = "if is_af2 or is_af3:"
+    assert complete_condition in airflow_local_settings, "Complete condition should combine both Airflow 2.x and 3.x checks"
 
     # Check that the logging command is present
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'


### PR DESCRIPTION
## Description

`test_houston_configmap_pod_mutation_hook_airflow_compatibility` (added by #3391 / PINF-955) has a stale assertion that currently fails on `master`.

`complete_condition` checks for the pre-refactor inlined boolean expression:
```
if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split('.')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):
```
but the shipped code in `houston-configmap.yaml` refactored this into named variables:
```python
is_af2 = container.args[0:3] == ["airflow", "tasks", "run"]
is_af3 = int(version.split('.')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]
if is_af2 or is_af3:
```
so the literal string the test looks for never appears, and the assertion fails every run. It went unnoticed because the three assertions above it (`airflow2_pattern`, `airflow3_pattern`, `version_check`) are just substrings of the `is_af2`/`is_af3` assignment lines, so they still pass — only the one checking the *combined* condition was affected.

This surfaced while cherry-picking #3391 to `release-2.1` (astronomer/astronomer#3538) — verified it fails identically on a clean `origin/master` worktree, independent of that cherry-pick.

## Fix

Update `complete_condition` to `"if is_af2 or is_af3:"`, matching the actual shipped branch condition. No product code changes.

## Testing

`uv run pytest tests/chart_tests/test_houston_configmap.py` — 57 passed (was 1 failed / 56 passed before this fix).

## Related Issues

[PINF-955](https://linear.app/astronomer/issue/PINF-955/af3-kubernetesexecutor-task-logs-are-ingested-twice) (test regression from #3391)

## Feature Flags

- [ ] Not applicable — this PR does not introduce or modify feature flags

## Merging

`master`.


## Update: `run_pre_commit` was failing

Two more pre-existing issues on this same file, both verified as already failing identically against a clean `origin/master` checkout — unrelated to the fix above, but blocking this PR's own `run_pre_commit` check:

- **codespell** flagged the pre-existing `als` variable (an `airflowLocalSettings` abbreviation used throughout this file's other tests) as a typo for "also". Added `als` to the existing short-identifier ignore list in `.pre-commit-config.yaml`, alongside `AKS`/`aks`/`showIn`/`NotIn`/`templateAs`.
- **ruff-format** wanted to re-wrap one long `assert` in a neighboring, untouched test function (`test_houston_configmap_loggingsidecar_scopes_stdout_tee_to_airflow2`) onto multiple lines. Applied ruff's own formatting; no logic change.

Full `pre-commit run` on the touched files is clean, and `test_houston_configmap.py` is still 57/57 passing after the reformat.
