### PR TITLE
[release-2.1] PINF-955: fix stale complete_condition assertion in pod-mutation-hook test (addresses #3538's known issue)

### DIFF
--- a/tests/chart_tests/test_houston_configmap.py
+++ b/tests/chart_tests/test_houston_configmap.py
@@ -1089,9 +1089,10 @@ def test_houston_configmap_pod_mutation_hook_airflow_compatibility():
     assert airflow3_pattern in airflow_local_settings, "Airflow 3.x task execution pattern should be supported"
     assert version_check in airflow_local_settings, "Version comparison logic should be present"
 
-    # Check that the complete condition includes both patterns
-    complete_condition = 'if container.args[0:3] == ["airflow", "tasks", "run"] or (int(version.split(\'.\')[0]) >= 3 and container.args[0:3] == ["python", "-m", "airflow.sdk.execution_time.execute_workload"]):'
-    assert complete_condition in airflow_local_settings, "Complete condition should include both Airflow 2.x and 3.x patterns"
+    # Check that the two patterns are combined via OR into the branch that triggers the redirect logic.
+    # (Written as named is_af2/is_af3 variables, not one inlined boolean expression.)
+    complete_condition = "if is_af2 or is_af3:"
+    assert complete_condition in airflow_local_settings, "Complete condition should combine both Airflow 2.x and 3.x checks"
 
     # Check that the logging command is present
     log_cmd = 'log_cmd = " 1> >( tee -a /var/log/sidecar-log-consumer/out.log ) 2> >( tee -a /var/log/sidecar-log-consumer/err.log >&2 ) ; "'


### PR DESCRIPTION
## Description

Addresses the "Known issue" called out in #3538: the cherry-picked `test_houston_configmap_pod_mutation_hook_airflow_compatibility` test fails, because its `complete_condition` assertion checks for a pre-refactor inlined boolean expression that the actual shipped code (named `is_af2`/`is_af3` variables) never produces. Cherry-picks the same fix already merged to `main` via #3539 (`fix-pinf955-stale-test-assertion`), plus its own follow-up commit that cleared two more pre-existing `run_pre_commit` failures on the same file (a `codespell` false-positive on the pre-existing `als` variable name, and a `ruff-format` re-wrap of an unrelated assert in a neighboring test).

**This PR is based on #3538's branch (`cherrypick-PINF-955-release-2.1`), not `release-2.1` directly** — it depends on that PR's changes (the actual `is_af2`/`is_af3` fix) being present first. GitHub will retarget this to `release-2.1` automatically once #3538 merges and its branch is deleted.

## Verification

- `uv run pytest tests/chart_tests/test_houston_configmap.py` — **57/57 passing** (stacked on #3538; without #3538's changes this test fails, confirming the fix depends on it as expected).
- Full `pre-commit run` on the touched files — clean.

## Related Issues

- [PINF-955](https://linear.app/astronomer/issue/PINF-955/af3-kubernetesexecutor-task-logs-are-ingested-twice) (test regression from #3391)
- Depends on: #3538
- Same fix already on `main`: #3539

## Feature Flags

- [ ] Not applicable — this PR does not introduce or modify feature flags

## Merging

`release-2.1` (via #3538).
