### PR TITLE
[release-2.1] PINF-1182: Fix eso pdb service configuration (#3493)

### DIFF
--- a/charts/external-secrets/templates/poddisruptionbudget.yaml
+++ b/charts/external-secrets/templates/poddisruptionbudget.yaml
@@ -2,8 +2,9 @@
 ##########################
 ## external-secrets PDB ##
 ##########################
+{{- if .Values.global.podDisruptionBudgets.enabled }}
 {{- if and (include "external-secrets.enabled" .) .Values.podDisruptionBudget.enabled }}
-apiVersion: policy/v1
+apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "external-secrets.pdbName" . | quote }}
@@ -19,4 +20,5 @@ spec:
   selector:
     matchLabels:
       {{- include "external-secrets.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/pgbouncer/templates/pgbouncer-poddisruptionbudget.yaml
+++ b/charts/pgbouncer/templates/pgbouncer-poddisruptionbudget.yaml
@@ -1,9 +1,10 @@
-###################################
+#####################################
 ## Pgbouncer Pod Disruption Budget ##
-###################################
+#####################################
+{{- if .Values.global.podDisruptionBudgets.enabled }}
 {{- if and .Values.global.pgbouncer.enabled .Values.podDisruptionBudget.enabled }}
 kind: PodDisruptionBudget
-apiVersion: policy/v1beta1
+apiVersion: {{ include "apiVersion.PodDisruptionBudget" . }}
 metadata:
   name: {{ .Release.Name }}-pgbouncer-pdb
   labels:
@@ -19,4 +20,5 @@ spec:
       component: pgbouncer
       release: {{ .Release.Name }}
 {{ toYaml .Values.podDisruptionBudget.config | indent 2 }}
+{{- end }}
 {{- end }}

--- a/tests/chart_tests/test_external_secrets.py
+++ b/tests/chart_tests/test_external_secrets.py
@@ -19,6 +19,7 @@ ROLE_TEMPLATE = "charts/external-secrets/templates/role.yaml"
 ROLEBINDING_TEMPLATE = "charts/external-secrets/templates/rolebinding.yaml"
 CLUSTER_SECRET_STORE_TEMPLATE = "charts/external-secrets/templates/cluster-secret-store.yaml"
 SECRETS_BACKEND_CREDENTIALS_TEMPLATE = "charts/external-secrets/templates/secrets-backend-credentials.yaml"
+PDB_TEMPLATE = "charts/external-secrets/templates/poddisruptionbudget.yaml"
 
 
 @pytest.mark.parametrize("kube_version", supported_k8s_versions)
@@ -367,3 +368,44 @@ class TestExternalSecretsDataPlaneMode:
             pod_labels = doc["spec"]["template"]["metadata"]["labels"]
             for key, value in custom_labels.items():
                 assert pod_labels.get(key) == value, f"Label {key}={value} missing from {doc['metadata']['name']}"
+
+
+@pytest.mark.parametrize("kube_version", supported_k8s_versions)
+class TestExternalSecretsPodDisruptionBudget:
+    @pytest.mark.parametrize(
+        "values,expected_docs",
+        [
+            pytest.param(
+                {
+                    **ESO_VALUES,
+                    "external-secrets": {"enabled": True},
+                },
+                0,
+                id="eso-pdb-defaults",
+            ),
+            pytest.param(
+                {
+                    **ESO_VALUES,
+                    "external-secrets": {"enabled": True, "podDisruptionBudget": {"enabled": True}},
+                },
+                1,
+                id="eso-pdb-overrides",
+            ),
+            pytest.param(
+                {
+                    **ESO_VALUES,
+                    "global": {**ESO_VALUES["global"], "podDisruptionBudgets": {"enabled": False}},
+                    "external-secrets": {"enabled": True, "podDisruptionBudget": {"enabled": True}},
+                },
+                0,
+                id="global-pdb-overrides",
+            ),
+        ],
+    )
+    def test_pdb(self, kube_version, values, expected_docs):
+        docs = render_chart(
+            kube_version=kube_version,
+            values=values,
+            show_only=[PDB_TEMPLATE],
+        )
+        assert len(docs) == expected_docs

--- a/tests/chart_tests/test_pgbouncer.py
+++ b/tests/chart_tests/test_pgbouncer.py
@@ -343,3 +343,19 @@ class TestPGBouncerNetworkPolicy:
             doc for doc in docs if doc["kind"] == "NetworkPolicy" and doc["metadata"]["name"] == "release-name-pgbouncer-policy"
         ]
         assert len(pgbouncer_policies) == 0
+
+    def test_pgbouncer_pdb_overrides(self, kube_version):
+        """Test that the pgbouncer PodDisruptionBudget Not created when disabled globally with  global.podDisruptionBudget set to false."""
+        docs = render_chart(
+            kube_version=kube_version,
+            values={
+                "global": {
+                    "pgbouncer": {"enabled": True},
+                    "podDisruptionBudgets": {
+                        "enabled": False,
+                    },
+                }
+            },
+            show_only=["charts/pgbouncer/templates/pgbouncer-poddisruptionbudget.yaml"],
+        )
+        assert len(docs) == 0


### PR DESCRIPTION
## Description

Clean cherry-pick of #3493 (PINF-1182) from `master` to `release-2.1`. `git cherry-pick -x` applied all 4 changed files with no conflicts.

Gates the ESO and PgBouncer `PodDisruptionBudget` templates on `.Values.global.podDisruptionBudgets.enabled`, matching the rest of the platform's PDB templates — previously they rendered unconditionally regardless of that flag.

## Verification specific to this branch

- Confirmed both templates now read `{{- if .Values.global.podDisruptionBudgets.enabled }}`, matching `master`.
- `uv run pytest tests/chart_tests/test_external_secrets.py tests/chart_tests/test_pgbouncer.py` — **183/183 passing**.
- `pre-commit run` on the touched files: clean.

## Related Issues

- [PINF-1182](https://linear.app/astronomer/issue/PINF-1182/make-eso-and-pgbouncer-poddisruptionbudgets-respect-global)
- Original PR on `master`: #3493

## Feature Flags

- [ ] Not applicable — this PR does not introduce or modify feature flags

## Merging

`release-2.1`.
